### PR TITLE
feat(arc0090): add payment URI parameter for app call transactions

### DIFF
--- a/src/navigation/AppNavigator.tsx
+++ b/src/navigation/AppNavigator.tsx
@@ -178,6 +178,7 @@ export type RootStackParamList = {
     fee?: number;
     note?: string;
     networkId?: NetworkId;
+    payment?: number; // Payment amount in atomic units to prepend to app call
   };
   AppInfoModal: {
     appId: number;

--- a/src/services/deeplink/index.ts
+++ b/src/services/deeplink/index.ts
@@ -793,6 +793,7 @@ export class DeepLinkService {
           fee: parsed.params.fee ? parseInt(parsed.params.fee) : undefined,
           note: parsed.params.xnote || parsed.params.note,
           networkId: currentNetwork,
+          payment: parsed.params.payment ? parseInt(parsed.params.payment) : undefined,
         },
       }, { replace: true });
 

--- a/src/utils/arc0090Uri.ts
+++ b/src/utils/arc0090Uri.ts
@@ -64,6 +64,7 @@ export interface Arc0090ApplUri extends Arc0090BaseUri {
     fee?: string;
     note?: string;
     xnote?: string;
+    payment?: string; // payment amount in atomic units to prepend to app call
   };
 }
 
@@ -555,6 +556,14 @@ function parseApplUri(uri: string): Arc0090ApplUri | null {
 
     if (searchParams.has('xnote')) {
       params.xnote = decodeURIComponent(searchParams.get('xnote')!);
+    }
+
+    // Payment amount (atomic units to prepend as payment to app escrow)
+    if (searchParams.has('payment')) {
+      const payment = searchParams.get('payment')!;
+      if (/^\d+$/.test(payment)) {
+        params.payment = payment;
+      }
     }
   }
 


### PR DESCRIPTION
Add support for a 'payment' URI argument when performing app call
transactions via ARC-0090 QR codes. When specified, this will prepend
a payment transaction (in atomic units) to the application's escrow
account address and form an atomic transaction group.

Changes:
- Add 'payment' parameter to Arc0090ApplUri interface and parser
- Update AppCallConfirm navigation params to include payment amount
- Update deeplink service to pass payment parameter
- Implement transaction group creation in signApplTransaction
- Add payment display UI in AppCallConfirmScreen