### PR TITLE
fix(tx): replace float base-unit conversion with BigInt string parsing (R-01, Q-03)

### DIFF
--- a/src/screens/wallet/SendScreen.tsx
+++ b/src/screens/wallet/SendScreen.tsx
@@ -38,6 +38,7 @@ import {
   formatNativeBalance,
   formatAssetBalance,
   subtractBigIntSafe,
+  parseAmountToBaseUnits,
 } from '@/utils/bigint';
 import { AccountType, type WalletAccount } from '@/types/wallet';
 import { useCurrentNetwork, useCurrentNetworkConfig } from '@/store/networkStore';
@@ -690,10 +691,9 @@ export default function SendScreen() {
     );
   };
 
-  const convertAmountToBaseUnits = (amount: string): number => {
-    const decimals = getAssetDecimals();
-    const multiplier = Math.pow(10, decimals);
-    return Math.floor(parseFloat(amount) * multiplier);
+  const convertAmountToBaseUnits = (amount: string): bigint => {
+    // Exact string -> base-units conversion (no float precision loss).
+    return parseAmountToBaseUnits(amount, getAssetDecimals());
   };
 
   // Removed problematic useEffect that was causing infinite balance reloading

--- a/src/screens/wallet/SwapScreen.tsx
+++ b/src/screens/wallet/SwapScreen.tsx
@@ -44,6 +44,7 @@ import tokenMappingService from '@/services/token-mapping';
 import { NetworkService } from '@/services/network';
 import algosdk from 'algosdk';
 import { getTokenImageSource } from '@/utils/tokenImages';
+import { parseAmountToBaseUnits } from '@/utils/bigint';
 import { NFTBackground } from '@/components/common/NFTBackground';
 import { GlassCard } from '@/components/common/GlassCard';
 import { GlassButton } from '@/components/common/GlassButton';
@@ -269,9 +270,10 @@ export default function SwapScreen() {
     try {
       const provider = SwapService.getProvider(selectedNetwork);
 
-      // Convert amount to base units
-      const amountInBaseUnits = BigInt(
-        Math.floor(amountValue * Math.pow(10, inputToken.decimals))
+      // Convert amount to base units (exact string parse, no float precision loss)
+      const amountInBaseUnits = parseAmountToBaseUnits(
+        inputAmount,
+        inputToken.decimals
       ).toString();
 
       const quoteResponse = await provider.getQuote({

--- a/src/screens/wallet/TransactionConfirmationScreen.tsx
+++ b/src/screens/wallet/TransactionConfirmationScreen.tsx
@@ -30,6 +30,7 @@ import { NFTToken } from '@/types/nft';
 import { NetworkId } from '@/types/network';
 import { getNetworkConfig } from '@/services/network/config';
 import { useCurrentNetwork } from '@/store/networkStore';
+import { parseAmountToBaseUnits } from '@/utils/bigint';
 // Removed TransactionConfirmationCard in favor of unified TransactionVerification
 import EnvoiProfileCard from '@/components/envoi/EnvoiProfileCard';
 import { useThemedStyles } from '@/hooks/useThemedStyles';
@@ -199,7 +200,21 @@ export default function TransactionConfirmationScreen() {
 
   const handleConfirm = () => {
     // Create unified transaction request
-    const amountInBaseUnits = params.assetType === 'arc72' ? 0 : convertAmountToBaseUnits(params.amount);
+    const decimals =
+      params.assetDecimals || (params.assetId === 0 || !params.assetId ? 6 : 0);
+    let amountInBaseUnits: number | bigint;
+    try {
+      amountInBaseUnits =
+        params.assetType === 'arc72'
+          ? 0
+          : parseAmountToBaseUnits(params.amount, decimals);
+    } catch (error) {
+      Alert.alert(
+        'Invalid amount',
+        error instanceof Error ? error.message : 'Please re-enter the amount.'
+      );
+      return;
+    }
 
     const request: UnifiedTransactionRequest = {
       type: params.assetType === 'arc200'
@@ -230,14 +245,6 @@ export default function TransactionConfirmationScreen() {
   const handleCancel = () => {
     navigation.goBack();
   };
-
-  const convertAmountToBaseUnits = (amount: string): number => {
-    const decimals =
-      params.assetDecimals || (params.assetId === 0 || !params.assetId ? 6 : 0);
-    const multiplier = Math.pow(10, decimals);
-    return Math.floor(parseFloat(amount) * multiplier);
-  };
-
 
   const handleAuthComplete = (success: boolean, result?: any) => {
     setShowAuthModal(false);

--- a/src/services/security/transactionTracker.ts
+++ b/src/services/security/transactionTracker.ts
@@ -11,7 +11,7 @@ const RATE_LIMIT_KEY = 'voi_rate_limits';
 interface TransactionRecord {
   txHash: string;
   timestamp: number;
-  amount: number;
+  amount: string;
   from: string;
   to: string;
 }
@@ -71,7 +71,7 @@ export class TransactionTracker {
   static async validateNewTransaction(
     from: string,
     to: string,
-    amount: number,
+    amount: string,
     txHash?: string
   ): Promise<string[]> {
     const errors: string[] = [];
@@ -106,7 +106,7 @@ export class TransactionTracker {
     txHash: string,
     from: string,
     to: string,
-    amount: number
+    amount: string
   ): Promise<void> {
     try {
       // Add to transaction cache
@@ -193,7 +193,7 @@ export class TransactionTracker {
   private static async checkTransactionPattern(
     from: string,
     to: string,
-    amount: number,
+    amount: string,
     errors: string[]
   ): Promise<void> {
     try {
@@ -208,7 +208,9 @@ export class TransactionTracker {
 
       // Check for rapid identical transactions (potential replay pattern)
       const identicalTransactions = recentTransactions.filter(
-        (tx) => tx.to === to && tx.amount === amount
+        // Coerce with String() so records persisted before the amount field
+        // migrated from number -> string still match after an app upgrade.
+        (tx) => tx.to === to && String(tx.amount) === amount
       );
 
       if (identicalTransactions.length >= 3) {

--- a/src/services/transactions/index.ts
+++ b/src/services/transactions/index.ts
@@ -11,6 +11,7 @@ import {
 import {
   toBigIntSafeNumber,
   compareBigIntSafe,
+  compareBigInt,
   addBigIntSafe,
   subtractBigIntSafe,
 } from '@/utils/bigint';
@@ -30,7 +31,7 @@ import { useWalletStore } from '@/store/walletStore';
 export interface TransactionParams {
   from: string;
   to: string;
-  amount: number;
+  amount: number | bigint;
   assetId?: number;
   assetType?: 'voi' | 'asa' | 'arc200' | 'arc72';
   contractId?: number;
@@ -73,7 +74,9 @@ export class TransactionService {
     const normalized = {
       from: params.from,
       to: params.to,
-      amount: params.amount,
+      // JSON.stringify throws on bigint; serialize to string so the cache key
+      // stays stable and serializable for both number and bigint amounts.
+      amount: params.amount?.toString() ?? null,
       assetId: params.assetId ?? null,
       assetType: params.assetType ?? null,
       contractId: params.contractId ?? null,
@@ -289,7 +292,7 @@ export class TransactionService {
         throw new Error('Invalid recipient address');
       }
 
-      if (params.amount < 0) {
+      if (BigInt(params.amount) < 0n) {
         throw new Error('Amount cannot be negative');
       }
 
@@ -335,7 +338,7 @@ export class TransactionService {
         throw new Error('Invalid recipient address');
       }
 
-      if (params.amount <= 0) {
+      if (BigInt(params.amount) <= 0n) {
         throw new Error('Amount must be greater than 0');
       }
 
@@ -679,12 +682,14 @@ export class TransactionService {
       const txId = await TransactionService.submitWithRetries(signedTxnBlob, params.networkId);
       callbacks?.onNetworkConfirmed?.(txId);
 
-      // Record successful transaction for replay protection
+      // Record successful transaction for replay protection.
+      // Pass the exact amount as a string so the tracker's identical-transaction
+      // dedup stays precise for high-decimal amounts above Number.MAX_SAFE_INTEGER.
       await TransactionTracker.recordTransaction(
         txId,
         params.from,
         params.to,
-        params.amount
+        params.amount.toString()
       );
 
       // Trigger balance refresh for affected accounts after successful transaction
@@ -728,7 +733,7 @@ export class TransactionService {
     const securityErrors = await TransactionTracker.validateNewTransaction(
       params.from,
       params.to,
-      params.amount
+      params.amount.toString()
     );
     errors.push(...securityErrors);
 
@@ -742,23 +747,29 @@ export class TransactionService {
     }
 
     // Skip amount validation for ARC-72 NFT transfers and allow 0-amount VOI transactions
-    if (params.assetType !== 'arc72' && params.assetType !== 'voi' && params.amount <= 0) {
+    if (
+      params.assetType !== 'arc72' &&
+      params.assetType !== 'voi' &&
+      BigInt(params.amount) <= 0n
+    ) {
       errors.push('Amount must be greater than 0');
     }
 
-    if (params.amount < 0) {
+    if (BigInt(params.amount) < 0n) {
       errors.push('Amount cannot be negative');
     }
 
     // Dust attack protection
     if (params.assetId) {
-      if (params.amount < SECURITY_CONFIG.MIN_ASSET_TRANSACTION) {
+      if (
+        BigInt(params.amount) < BigInt(SECURITY_CONFIG.MIN_ASSET_TRANSACTION)
+      ) {
         errors.push(
           `Minimum asset transaction amount is ${SECURITY_CONFIG.MIN_ASSET_TRANSACTION} units`
         );
       }
     } else if (params.assetType !== 'arc72') {
-      if (params.amount < SECURITY_CONFIG.MIN_VOI_TRANSACTION) {
+      if (BigInt(params.amount) < BigInt(SECURITY_CONFIG.MIN_VOI_TRANSACTION)) {
         errors.push(SECURITY_MESSAGES.DUST_ATTACK);
       }
     }
@@ -798,7 +809,7 @@ export class TransactionService {
           );
           if (!arc200Asset) {
             errors.push('ARC-200 token not found in account');
-          } else if (compareBigIntSafe(arc200Asset.amount, params.amount) < 0) {
+          } else if (compareBigInt(arc200Asset.amount, params.amount) < 0) {
             errors.push('Insufficient ARC-200 token balance');
           }
         }
@@ -869,7 +880,7 @@ export class TransactionService {
         );
         if (!asset) {
           errors.push('ASA not found in account');
-        } else if (compareBigIntSafe(asset.amount, params.amount) < 0) {
+        } else if (compareBigInt(asset.amount, params.amount) < 0) {
           errors.push('Insufficient ASA balance');
         }
 
@@ -904,24 +915,21 @@ export class TransactionService {
         }
 
         // Check if account has enough VOI for fees
-        if (compareBigIntSafe(accountBalance.amount, estimatedFee) < 0) {
+        if (compareBigInt(accountBalance.amount, estimatedFee) < 0) {
           errors.push('Insufficient VOI balance for transaction fee');
         }
       } else {
-        // VOI payment validation
-        const totalRequired = params.amount + estimatedFee;
-        if (compareBigIntSafe(accountBalance.amount, totalRequired) < 0) {
+        // VOI payment validation — keep the entire balance check in bigint so
+        // large balances/amounts are never downcast to Number.
+        const totalRequired =
+          BigInt(params.amount) + BigInt(Math.trunc(estimatedFee));
+        if (compareBigInt(accountBalance.amount, totalRequired) < 0) {
           errors.push('Insufficient VOI balance');
         }
 
         // Check minimum balance requirement
-        const remainingBalance = subtractBigIntSafe(
-          accountBalance.amount,
-          totalRequired
-        );
-        if (
-          compareBigIntSafe(remainingBalance, accountBalance.minBalance) < 0
-        ) {
+        const remainingBalance = BigInt(accountBalance.amount) - totalRequired;
+        if (compareBigInt(remainingBalance, accountBalance.minBalance) < 0) {
           errors.push('Transaction would violate minimum balance requirement');
         }
       }
@@ -937,7 +945,7 @@ export class TransactionService {
 
   static async estimateTransactionCost(params: TransactionParams): Promise<{
     fee: number;
-    total: number;
+    total: number | bigint;
   }> {
     try {
       const assetType = TransactionService.determineAssetType(params);
@@ -989,7 +997,9 @@ export class TransactionService {
         : VoiNetworkService;
 
       const fee = await networkService.estimateTransactionFee();
-      const total = params.assetId ? fee : params.amount + fee;
+      const total: number | bigint = params.assetId
+        ? fee
+        : BigInt(params.amount) + BigInt(Math.trunc(fee));
 
       return {
         fee,
@@ -1439,7 +1449,7 @@ export class TransactionService {
         txId,
         params.fromAddress,
         params.fromAddress, // Rekey transactions are to self
-        0 // Zero amount
+        '0' // Zero amount
       );
 
       // Trigger balance refresh
@@ -1583,7 +1593,7 @@ export class TransactionService {
         txId,
         params.fromAddress,
         params.fromAddress, // Reverse rekey transactions are to self
-        0 // Zero amount
+        '0' // Zero amount
       );
 
       // Trigger balance refresh

--- a/src/services/transactions/unifiedSigner.ts
+++ b/src/services/transactions/unifiedSigner.ts
@@ -582,7 +582,7 @@ export class UnifiedTransactionSigner {
    */
   async estimateTransactionCost(request: UnifiedTransactionRequest): Promise<{
     fee: number;
-    total: number;
+    total: number | bigint;
   }> {
     switch (request.type) {
       case 'voi_transfer':

--- a/src/utils/bigint.ts
+++ b/src/utils/bigint.ts
@@ -65,6 +65,102 @@ export const compareBigIntSafe = (
 };
 
 /**
+ * TRUE bigint comparison of two money values without any Number downcast.
+ *
+ * Unlike {@link compareBigIntSafe} (which downcasts bigint -> Number and can
+ * lose precision above Number.MAX_SAFE_INTEGER), this coerces `number` inputs
+ * to bigint via BigInt(Math.trunc(x)) and compares bigints directly. Use this
+ * on money-critical paths (balances / amounts for high-decimal ARC-200 tokens).
+ *
+ * @returns -1 if a < b, 0 if equal, 1 if a > b
+ */
+export const compareBigInt = (
+  a: number | bigint,
+  b: number | bigint
+): number => {
+  const bigA = typeof a === 'bigint' ? a : BigInt(Math.trunc(a));
+  const bigB = typeof b === 'bigint' ? b : BigInt(Math.trunc(b));
+  if (bigA < bigB) return -1;
+  if (bigA > bigB) return 1;
+  return 0;
+};
+
+/**
+ * Parse a user-entered decimal amount STRING into integer base units without
+ * any floating-point math.
+ *
+ * This replaces the lossy `Math.floor(parseFloat(amount) * 10 ** decimals)`
+ * pattern, which both loses precision (e.g. parseFloat('1.005') * 1e6 =>
+ * 1004999.9999… => 1004999) and overflows Number.MAX_SAFE_INTEGER for
+ * high-decimal ARC-200 tokens. String parsing yields the EXACT typed value:
+ * parseAmountToBaseUnits('1.005', 6) === 1005000n.
+ *
+ * Semantics:
+ * - Fractional digits beyond `decimals` are REJECTED (throws) rather than
+ *   truncated, so the signed amount always equals what the user was shown.
+ *   Trailing zeros beyond `decimals` are harmless and allowed.
+ * - `decimals === 0` allows no fractional part (a non-zero one throws).
+ * - Empty input, '' , '.' and '0' all resolve to 0n.
+ *
+ * The caller is responsible for normalizing the decimal separator to '.'
+ * (locale handling is a separate concern and intentionally NOT done here).
+ *
+ * @throws {Error} 'Invalid amount' on malformed numeric input (e.g. '1.2.3',
+ * 'abc', or a negative value like '-5'), or 'Amount has more decimal places
+ * than the asset supports' when the fractional precision exceeds `decimals`,
+ * so callers can surface a validation error instead of signing a wrong amount.
+ */
+export const parseAmountToBaseUnits = (
+  amount: string,
+  decimals: number
+): bigint => {
+  const trimmed = (amount ?? '').trim();
+
+  // Empty / bare decimal point represent "no amount".
+  if (trimmed === '' || trimmed === '.') {
+    return 0n;
+  }
+
+  // Only digits with at most a single decimal point are allowed. This rejects
+  // negatives ('-5'), multiple dots ('1.2.3'), exponents ('1e6'), thousands
+  // separators, and any other non-numeric input.
+  if (!/^\d*\.?\d*$/.test(trimmed)) {
+    throw new Error('Invalid amount');
+  }
+
+  const [intPartRaw, fracPartRaw = ''] = trimmed.split('.');
+  const intPart = intPartRaw;
+
+  // Reject amounts with more *significant* fractional digits than the asset
+  // supports, so the signed amount always equals the amount shown to the user
+  // (silently truncating here would sign a different value than displayed —
+  // e.g. '1.9' of a 0-decimal asset would send 1). Trailing zeros beyond the
+  // asset's precision are harmless and allowed.
+  const excessFraction = fracPartRaw.slice(decimals);
+  if (excessFraction.length > 0 && /[^0]/.test(excessFraction)) {
+    throw new Error('Amount has more decimal places than the asset supports');
+  }
+
+  let fracPart = '';
+  if (decimals > 0) {
+    fracPart = fracPartRaw.slice(0, decimals).padEnd(decimals, '0');
+  }
+
+  const combined = `${intPart}${fracPart}`;
+  if (combined === '') {
+    return 0n;
+  }
+
+  // BigInt() tolerates leading zeros ('007' => 7n).
+  return BigInt(combined);
+};
+
+/**
+ * Alias for {@link parseAmountToBaseUnits}.
+ */
+export const toBaseUnitsBigInt = parseAmountToBaseUnits;
+
+/**
  * Add BigInt or number values safely
  */
 export const addBigIntSafe = (


### PR DESCRIPTION
## What & why

Money amounts were converted to base units with `Math.floor(parseFloat(amount) * 10^decimals)`, which is **lossy** (`parseFloat('1.005')*1e6 → 1004999`, one microunit short of what the user typed) and **overflows `Number.MAX_SAFE_INTEGER`** for high-decimal ARC-200 tokens — silently sending wrong amounts. This migrates the send/swap money path to **exact string→BigInt parsing carried end-to-end**.

Resolves **R-01** and **Q-03**. Part of PLAN-9 (Transaction Safety & Money Math), TASK-18. Decision DR-3: full end-to-end BigInt.

## Changes
- **`utils/bigint.ts`**: new `parseAmountToBaseUnits(string, decimals): bigint` (no float math) + true-bigint `compareBigInt()` (no `Number` downcast). The parser **rejects** fractional precision beyond the asset's decimals (throws) rather than silently truncating, so the **signed amount always equals the displayed amount**.
- **`services/transactions/index.ts`**: `TransactionParams.amount` → `number | bigint`; amount carried as bigint to algosdk; tx cache-key serializes amount (`JSON.stringify` throws on bigint); all balance/amount comparisons and totals stay in bigint (no downcast); `estimateTransactionCost().total` widened.
- **`services/security/transactionTracker.ts`**: replay/dedup `amount` carried as an exact `string` (was `number`, which lost precision above 2^53 and could falsely reject a legitimate high-decimal transfer as a duplicate); compare coerces with `String()` so records persisted before the migration still match after upgrade.
- **`screens/wallet/{SendScreen,TransactionConfirmationScreen,SwapScreen}.tsx`**: use the shared parser; removed the duplicated `convertAmountToBaseUnits`; `handleConfirm` guards the parser throw with an Alert.

## Gates
- `npm run typecheck` — **net-zero new type errors** vs `main` (repo has 280 pre-existing `tsc` errors on both branches; verified identical error set modulo line-shift).
- Codex CLI review (money/crypto focus) — iterated to **CLEAN**; two findings fixed in-branch (Number-downcast in the tracker; truncate→reject in the parser).
- `npm run lint` is broken repo-wide (ESLint 9 needs flat config; repo ships legacy `.eslintrc.js`) — pre-existing, tracked separately; `utils/bigint.ts` is prettier-clean.

## ⚠️ Manual verification (post-merge, per DR-2 — no automated test suite)
Drive these on a dev client and confirm the **exact** amount:
1. **Send native VOI** `1.005` → recipient receives exactly `1.005` (not `1.004999`).
2. **Send a 6-decimal ASA/ARC-200** with a fractional amount → exact; try a very large high-decimal amount (no precision loss / no crash).
3. **Over-precision reject**: enter more decimals than the asset supports → clear "more decimal places than the asset supports" error, send blocked (does not silently truncate).
4. **Swap**: enter an input amount, confirm the quote reflects the exact base-unit amount.
5. **Rekey / zero-amount** transactions still submit (tracker now stores `'0'`).

## Out of scope (routed to their tasks, confirmed by Codex)
- Deep-link/ARC-0090 asset-amount double-conversion & 0-decimals assumption → **TASK-21** (R-09).
- SwapScreen `handleMaxPress` / reverse-quote `Number`/`parseFloat` conversions → **TASK-23** + display formatting.
- Locale decimal-separator normalization & SwapScreen comma-strip 10x bug → **TASK-19** (R-02).
