### PR TITLE
fix(algosdk): v3 camelCase fields for rekey verify & asset lookup (R-06)

### DIFF
--- a/src/screens/wallet/SendScreen.tsx
+++ b/src/screens/wallet/SendScreen.tsx
@@ -380,7 +380,12 @@ export default function SendScreen() {
                 });
               } else {
                 // Handle ASA token
-                const assetHolding = accountInfo.assets?.find((a: any) => a['asset-id'] === initialAssetId);
+                // algosdk v3: asset holdings expose `assetId` (a uint64 bigint),
+                // not the legacy 'asset-id'. Compare as strings so large IDs
+                // aren't collapsed by a lossy Number() cast.
+                const assetHolding = accountInfo.assets?.find(
+                  (a: any) => String(a.assetId) === String(initialAssetId)
+                );
 
                 if (assetHolding) {
                   const assetInfo = await networkService.getAlgodClient().getAssetByID(initialAssetId).do();

--- a/src/services/network/index.ts
+++ b/src/services/network/index.ts
@@ -958,10 +958,19 @@ export class NetworkService {
             .limit(50)
             .do();
 
-          // Look for the most recent transaction with rekey-to field
+          // Look for the most recent transaction with a rekey-to field.
+          // algosdk v3 exposes it as `rekeyTo` (string or Address), not the
+          // legacy kebab-case 'rekey-to'.
           if (txnResponse.transactions) {
             for (const txn of txnResponse.transactions) {
-              if (txn['rekey-to'] === authAddress) {
+              const rekeyTo = (txn as any).rekeyTo;
+              const rekeyToAddress =
+                typeof rekeyTo === 'string'
+                  ? rekeyTo
+                  : rekeyTo?.publicKey
+                    ? algosdk.encodeAddress(new Uint8Array(rekeyTo.publicKey))
+                    : undefined;
+              if (rekeyToAddress && rekeyToAddress === authAddress) {
                 rekeyedAt = txn.roundTime ? txn.roundTime * 1000 : undefined;
                 break;
               }

--- a/src/services/wallet/index.ts
+++ b/src/services/wallet/index.ts
@@ -33,6 +33,7 @@ import { AccountSecureStorage } from '../secure/AccountSecureStorage';
 import { ledgerTransportService } from '@/services/ledger/transport';
 import type { LedgerDeviceInfo } from '@/services/ledger/transport';
 import { ledgerAlgorandService } from '@/services/ledger/algorand';
+import { NetworkService } from '@/services/network';
 import type { LedgerAccountDerivation } from '@/services/ledger/algorand';
 
 export class MultiAccountWalletService {
@@ -1201,7 +1202,16 @@ export class MultiAccountWalletService {
         return false;
       }
 
-      const reportedAuthAddress = accountInfo['auth-addr'];
+      // algosdk v3 exposes the auth address as `authAddr` (an Address object
+      // with publicKey bytes), not the legacy kebab-case 'auth-addr' (which is
+      // always undefined in v3 — reading it made rekey verification always fail).
+      const authAddr = (accountInfo as any).authAddr;
+      const reportedAuthAddress =
+        typeof authAddr === 'string'
+          ? authAddr
+          : authAddr?.publicKey
+            ? algosdk.encodeAddress(new Uint8Array(authAddr.publicKey))
+            : undefined;
       if (!reportedAuthAddress) {
         return false;
       }


### PR DESCRIPTION
## What & why
algosdk v3 replaced kebab-case JSON fields with camelCase typed models, so several leftover reads were **always undefined**, silently dead-ending rekey verification and asset lookup. Resolves **R-06** (PLAN-9 / TASK-20).

- **`services/wallet/index.ts` — rekey verification.** `verifyRekeyRelationship` read `accountInfo['auth-addr']` (→ `authAddr`, an Address object) **and** referenced `NetworkService` without importing it (ReferenceError → caught → `false`). Net effect: importing a legitimately rekeyed account **could never succeed**. Both fixed — reads `authAddr` via `encodeAddress(publicKey)` (mirrors the working pattern in `getAccountRekeyInfo`) and imports `NetworkService`. Still fail-closed: only the real on-chain auth address matches.
- **`services/network/index.ts` — rekey timestamp.** `txn['rekey-to']` → `rekeyTo` (string | Address, normalized).
- **`screens/wallet/SendScreen.tsx` — asset fallback lookup.** `a['asset-id']` → `assetId` (uint64 bigint), compared via `String()` so large IDs aren't collapsed by a lossy `Number()` cast.

## Gates
- `npm run typecheck`: **net −2 errors** vs main (zero new; also clears the pre-existing `NetworkService`/`rekey-to` type errors). 
- Codex CLI review (rekey/security focus) → **CLEAN**; two findings fixed in-branch (missing `NetworkService` import; lossy assetId `Number()` cast). Codex empirically confirmed `encodeAddress(publicKey) === Address.toString()` and `String(assetId)` preserves values above 2^53.
- No key/secret leakage; no address-encoding false-pass.

## ⚠️ Manual verification (post-merge, no automated tests)
1. **Import a rekeyed account by relationship** (auth address you control) → now succeeds (previously always "Cannot verify rekey relationship").
2. **Rekeyed-account info** shows the correct rekey timestamp.
3. **Send screen** with a routeParams `assetId` for an ASA you hold → asset resolves (no false "Asset information not available").