### PR TITLE
fix(send/swap): normalize locale decimal separators in amount inputs (R-02)

### DIFF
--- a/src/screens/wallet/SendScreen.tsx
+++ b/src/screens/wallet/SendScreen.tsx
@@ -39,6 +39,7 @@ import {
   formatAssetBalance,
   subtractBigIntSafe,
   parseAmountToBaseUnits,
+  sanitizeAmountInput,
 } from '@/utils/bigint';
 import { AccountType, type WalletAccount } from '@/types/wallet';
 import { useCurrentNetwork, useCurrentNetworkConfig } from '@/store/networkStore';
@@ -1125,7 +1126,9 @@ export default function SendScreen() {
       }
 
       // Skip amount validation for NFT transfers
-      if (!contextNftToken && (!amount || parseFloat(amount) <= 0)) {
+      // Use !(x > 0) rather than (x <= 0) so a NaN amount (e.g. a bare '.')
+      // is rejected instead of slipping through as a zero-value transfer.
+      if (!contextNftToken && (!amount || !(parseFloat(amount) > 0))) {
         Alert.alert('Error', 'Please enter a valid amount');
         return;
       }
@@ -1483,7 +1486,9 @@ export default function SendScreen() {
                   placeholder={`0.${'0'.repeat(getAssetDecimals())}`}
                   placeholderTextColor={themeColors.placeholder}
                   value={amount}
-                  onChangeText={setAmount}
+                  onChangeText={(t) =>
+                    setAmount((prev) => sanitizeAmountInput(t) ?? prev)
+                  }
                   keyboardType="decimal-pad"
                   editable={!isSending}
                 />

--- a/src/screens/wallet/SwapScreen.tsx
+++ b/src/screens/wallet/SwapScreen.tsx
@@ -44,7 +44,7 @@ import tokenMappingService from '@/services/token-mapping';
 import { NetworkService } from '@/services/network';
 import algosdk from 'algosdk';
 import { getTokenImageSource } from '@/utils/tokenImages';
-import { parseAmountToBaseUnits } from '@/utils/bigint';
+import { parseAmountToBaseUnits, sanitizeAmountInput } from '@/utils/bigint';
 import { NFTBackground } from '@/components/common/NFTBackground';
 import { GlassCard } from '@/components/common/GlassCard';
 import { GlassButton } from '@/components/common/GlassButton';
@@ -323,14 +323,11 @@ export default function SwapScreen() {
   };
 
   const handleInputAmountChange = (text: string) => {
-    // Allow only numbers and decimal point
-    const cleaned = text.replace(/[^0-9.]/g, '');
-
-    // Prevent multiple decimal points
-    const parts = cleaned.split('.');
-    const formatted = parts.length > 2 ? `${parts[0]}.${parts.slice(1).join('')}` : cleaned;
-
-    setInputAmount(formatted);
+    // Normalize locale separator (',' -> '.'). The shared sanitizer avoids the
+    // previous bug where ',' was stripped entirely, turning '1,5' into '15' (a
+    // 10x error), and rejects ambiguous multi-separator paste (returns null),
+    // in which case we keep the previous well-formed value.
+    setInputAmount((prev) => sanitizeAmountInput(text) ?? prev);
   };
 
   const handleMaxPress = () => {

--- a/src/utils/bigint.ts
+++ b/src/utils/bigint.ts
@@ -161,6 +161,52 @@ export const parseAmountToBaseUnits = (
 export const toBaseUnitsBigInt = parseAmountToBaseUnits;
 
 /**
+ * Sanitize raw amount-input text into a single well-formed decimal string
+ * (using '.' as the separator) suitable for a controlled TextInput, for display,
+ * and for {@link parseAmountToBaseUnits}.
+ *
+ * Both ',' and '.' are accepted as the decimal separator and normalized to '.'
+ * — a `decimal-pad` keyboard emits ',' in many locales, and `parseFloat('1,5')
+ * === 1` would otherwise silently send 1.0 instead of 1.5 (and stripping ','
+ * turned '1,5' into '15', a 10x error, in Swap). Accepting either separator is
+ * required because this value is stored and re-fed to the field on every
+ * keystroke, so we cannot treat '.' (our own normalized separator) as grouping.
+ *
+ * Returns `null` — signalling the caller to keep the previous value — when the
+ * input is ambiguous or malformed:
+ * - it contains any character other than digits, ',', '.', or whitespace (e.g.
+ *   a pasted '-1', '1e3', or currency symbol), which could otherwise be silently
+ *   rewritten into a different valid amount; or
+ * - it contains more than one decimal separator (e.g. a pasted grouped number
+ *   like '1,234.56'), which is ambiguous.
+ *
+ * A single lone '.' is allowed as a valid typing intermediate for '.5'; the
+ * downstream positive-amount validation rejects a bare '.' as an amount.
+ *
+ * KNOWN LIMITATION: a paste of a *thousands-grouped* number that uses a single
+ * separator (e.g. US '1,234' meaning 1234) is read as a decimal (1.234). This
+ * is inherent to supporting ',' as a decimal separator and is visible to the
+ * user in the field before they confirm; full locale-aware grouping detection
+ * that does not break comma-decimal typing is tracked separately.
+ *
+ * @returns the sanitized decimal string, or `null` if the input is invalid.
+ */
+export const sanitizeAmountInput = (text: string): string | null => {
+  const raw = text ?? '';
+  // Reject anything that isn't a digit, a separator, or whitespace so a
+  // malformed paste ('-1', '1e3', '$1', '1,,2') isn't silently transformed.
+  if (/[^0-9.,\s]/.test(raw)) {
+    return null;
+  }
+  const normalized = raw.replace(/,/g, '.').replace(/[^0-9.]/g, '');
+  const dotCount = (normalized.match(/\./g) || []).length;
+  if (dotCount > 1) {
+    return null;
+  }
+  return normalized;
+};
+
+/**
  * Add BigInt or number values safely
  */
 export const addBigIntSafe = (


### PR DESCRIPTION
## What & why
`decimal-pad` keyboards emit `,` as the decimal key in many locales, so:
- SendScreen passed raw text to state → `parseFloat('1,5') === 1` **silently sent 1.0 instead of 1.5**;
- SwapScreen stripped `,` entirely → `'1,5'` became `'15'` (**a 10x error**);
- pasted multi-dot strings (`'1.2.3'`) slipped through.

Adds a shared `sanitizeAmountInput` and wires it into both amount inputs. Resolves **R-02** (PLAN-9 / TASK-19).

## `sanitizeAmountInput`
For a **controlled** TextInput (its output is stored and re-fed every keystroke):
- Accepts both `,` and `.` as decimal, normalized to `.`. (Treating `.` as grouping is intentionally avoided — it would corrupt the normalized value on re-feed, turning a typed `1,5`→`1.5`→`15`.)
- Returns `null` (caller keeps the previous value via `setAmount(prev => sanitizeAmountInput(t) ?? prev)`) when the raw text has any char other than digits/`,`/`.`/whitespace (`-1`, `1e3`, `$1`, `1,,2`) or **more than one** decimal separator (ambiguous grouped paste like `1,234.56`).
- Send guard changed to `!(parseFloat(amount) > 0)` so a bare `.` (NaN) is rejected instead of proceeding as a zero-value transfer.

## Gates
- `npm run typecheck`: net-zero new errors vs main.
- Codex CLI review → **CLEAN** after several rounds (fixed: a comma-locale controlled-input feedback regression, malformed-paste passthrough, bare-`.` validation).

## Known limitation (intentional tradeoff)
A single-separator thousands-grouped **paste** (US `1,234` meaning 1234) is read as `1.234`. This is inherent to supporting `,` as a decimal separator and is visible in the field before confirm. Full locale-aware grouping detection that doesn't break comma-decimal typing is a possible follow-up.

## ⚠️ Manual verification (post-merge)
1. On a **comma-locale** device (or set device region to one, e.g. German): type `1,5` in Send and Swap → field shows `1.5`, sends/quotes 1.5 (not 15, not 1.0).
2. Paste `1,234.56` → rejected (field unchanged), not shrunk.
3. Type a bare `.` → cannot submit ("enter a valid amount").
4. Normal `.`-locale typing (`1.5`) unchanged.