### PR TITLE
fix(assets): real ASA decimals for balances & URI prefill; ASA deeplink context (R-07, R-09)

### DIFF
--- a/src/screens/wallet/SendScreen.tsx
+++ b/src/screens/wallet/SendScreen.tsx
@@ -205,6 +205,7 @@ export default function SendScreen() {
 
   // Pre-fill form fields from payment request parameters
   useEffect(() => {
+    let cancelled = false;
     if (routeParams) {
       if (
         routeParams.recipient &&
@@ -213,29 +214,55 @@ export default function SendScreen() {
         setRecipientInput(routeParams.recipient);
       }
       if (routeParams.amount && /^\d+$/.test(routeParams.amount)) {
-        // Convert from smallest units to display format
-        // For native tokens (no asset parameter), use 6 decimals
-        // For assets, look up the asset or default to 0
-        const assetIdRaw = routeParams.asset ? parseInt(routeParams.asset) : undefined;
-        const decimals = assetIdRaw === undefined ? 6 : 0;
-
+        // routeParams.amount is RAW base units. Resolve the asset's real
+        // decimals and convert base -> display exactly once. Native tokens
+        // (no asset / asset 0) use 6 decimals; otherwise look up the ASA.
+        const assetIdRaw = routeParams.asset
+          ? parseInt(routeParams.asset)
+          : undefined;
         const rawAmount = BigInt(routeParams.amount);
-        const divisor = BigInt(10) ** BigInt(decimals);
-        const wholePart = rawAmount / divisor;
-        const fractionalPart = rawAmount % divisor;
 
-        let displayAmount = wholePart.toString();
-        if (fractionalPart > 0) {
-          const fractionalStr = fractionalPart
-            .toString()
-            .padStart(decimals, '0')
-            .replace(/0+$/, '');
-          if (fractionalStr) {
-            displayAmount += '.' + fractionalStr;
+        (async () => {
+          let decimals: number;
+          if (assetIdRaw === undefined || assetIdRaw === 0) {
+            decimals = 6;
+          } else {
+            try {
+              const info = await NetworkService.getInstance(
+                selectedNetworkId
+              ).getAssetInfo(assetIdRaw);
+              const rawDecimals = info?.params?.decimals;
+              if (rawDecimals === undefined || rawDecimals === null) {
+                // Params unavailable (e.g. a 404 resolves to null): don't
+                // prefill a wrong-magnitude amount.
+                return;
+              }
+              decimals = Number(rawDecimals);
+            } catch {
+              // Don't guess a wrong value: leave the field empty on failure.
+              return;
+            }
           }
-        }
 
-        setAmount(displayAmount);
+          const divisor = BigInt(10) ** BigInt(decimals);
+          const wholePart = rawAmount / divisor;
+          const fractionalPart = rawAmount % divisor;
+
+          let displayAmount = wholePart.toString();
+          if (fractionalPart > 0) {
+            const fractionalStr = fractionalPart
+              .toString()
+              .padStart(decimals, '0')
+              .replace(/0+$/, '');
+            if (fractionalStr) {
+              displayAmount += '.' + fractionalStr;
+            }
+          }
+
+          if (!cancelled) {
+            setAmount(displayAmount);
+          }
+        })();
       }
       if (routeParams.note) {
         // Sanitize note to prevent potential issues
@@ -260,6 +287,9 @@ export default function SendScreen() {
         }
       }
     }
+    return () => {
+      cancelled = true;
+    };
   }, [routeParams]);
 
   const activeAccount = useActiveAccount();
@@ -298,7 +328,11 @@ export default function SendScreen() {
     const fetchAssetOptions = async () => {
       if (!activeAccount) return;
 
-      const initialAssetId = routeParams?.assetId;
+      const initialAssetId = routeParams?.asset
+        ? isNaN(parseInt(routeParams.asset, 10))
+          ? undefined
+          : parseInt(routeParams.asset, 10)
+        : routeParams?.assetId;
 
       setIsLoadingOptions(true);
       try {

--- a/src/services/deeplink/index.ts
+++ b/src/services/deeplink/index.ts
@@ -17,7 +17,6 @@ import {
   parseArc0090Uri,
   getArc0090UriType,
   resolveNetworkFromAuthority,
-  convertAmountToDisplay,
   isLegacyVoiUri,
   Arc0090PaymentUri,
   Arc0090KeyregUri,
@@ -655,11 +654,10 @@ export class DeepLinkService {
       }
 
       if (parsed.params.amount) {
-        // Convert from smallest units to display format
-        const assetId = parsed.params.asset ? parseInt(parsed.params.asset) : 0;
-        const isNativeToken = assetId === 0;
-        const decimals = isNativeToken ? 6 : 0; // VOI/ALGO has 6 decimals, other assets default to 0
-        params.amount = convertAmountToDisplay(parsed.params.amount, decimals);
+        // Pass the raw base-unit amount through untouched. SendScreen resolves
+        // the asset's real decimals and converts to display exactly once. This
+        // matches the URI format and the legacy voi:// path (both raw).
+        params.amount = parsed.params.amount;
       }
 
       if (parsed.params.asset) {

--- a/src/services/network/index.ts
+++ b/src/services/network/index.ts
@@ -40,6 +40,13 @@ export class NetworkService {
   private mimirService?: MimirApiService;
   private rekeyInfoCache: Map<string, { info: RekeyInfo; timestamp: number }> = new Map();
   private rekeyInfoCacheTTL: number = 10000; // 10 second cache
+  // Cache of immutable ASA params (decimals/name/unitName). Cleared on
+  // switchNetwork (this instance is reused across networks). Keyed by the asset
+  // ID as a string so uint64 IDs above Number.MAX_SAFE_INTEGER can't collide.
+  private assetParamsCache: Map<
+    string,
+    { decimals: number; name?: string; unitName?: string }
+  > = new Map();
 
   private constructor(networkId: NetworkId = DEFAULT_NETWORK_ID) {
     this.currentNetworkId = networkId;
@@ -128,6 +135,11 @@ export class NetworkService {
       // Update internal state
       this.currentNetworkId = networkId;
       this.config = newConfig;
+
+      // This instance is reused across networks (instances.set below), so drop
+      // the per-network asset-params cache to avoid serving another network's
+      // decimals for a colliding asset ID.
+      this.assetParamsCache.clear();
 
       // Reinitialize clients with new configuration
       this.initializeClients();
@@ -237,16 +249,40 @@ export class NetworkService {
       const algodAssets: AssetBalance[] = [];
       if (accountInfo.value.assets) {
         for (const asset of accountInfo.value.assets) {
+          const assetId = Number(asset.assetId);
+          const assetKey = String(asset.assetId);
+
+          // Asset params are immutable: reuse the cached entry and skip the
+          // network call entirely once we've seen this asset before.
+          const cachedParams = this.assetParamsCache.get(assetKey);
+          if (cachedParams) {
+            algodAssets.push({
+              assetId,
+              amount: asset.amount,
+              decimals: cachedParams.decimals,
+              name: cachedParams.name,
+              unitName: cachedParams.unitName,
+              assetType: 'asa',
+            });
+            continue;
+          }
+
           try {
             const assetInfo = await this.algodClient
-              .getAssetByID(Number(asset.assetId))
+              .getAssetByID(assetId)
               .do();
-            algodAssets.push({
-              assetId: Number(asset.assetId),
-              amount: asset.amount,
-              decimals: assetInfo.params.decimals || 0,
+            const params = {
+              decimals: Number(assetInfo.params.decimals ?? 0),
               name: assetInfo.params.name,
               unitName: assetInfo.params.unitName,
+            };
+            this.assetParamsCache.set(assetKey, params);
+            algodAssets.push({
+              assetId,
+              amount: asset.amount,
+              decimals: params.decimals,
+              name: params.name,
+              unitName: params.unitName,
               assetType: 'asa',
             });
           } catch (assetError) {
@@ -254,12 +290,10 @@ export class NetworkService {
               `Failed to fetch asset info for ${asset.assetId}:`,
               assetError
             );
-            algodAssets.push({
-              assetId: Number(asset.assetId),
-              amount: asset.amount,
-              decimals: 0,
-              assetType: 'asa',
-            });
+            // Never fall back to decimals: 0 for an unknown asset — that would
+            // display a 10^N x inflated balance. Omit the asset until a later
+            // refresh can resolve its real params.
+            continue;
           }
         }
       }


### PR DESCRIPTION
## What & why
Resolves **R-07** and **R-09** (PLAN-9 / TASK-21), plus a related P1 surfaced in review.

**R-07 — balances inflated up to 10^N×.** `getAccountBalance` fell back to `decimals: 0` when an ASA's params fetch transiently failed. Now caches immutable asset params **per network** (keyed by `String(assetId)`; cleared on `switchNetwork` since the instance is reused) and, on failure, **omits** the asset instead of defaulting to 0. Cache hits also remove the N+1 refetch on every 30s refresh.

**R-09 — URI/deeplink amounts scaled with 0 decimals + double-converted.** The arc0090 path pre-converted base→display, then SendScreen re-converted (native `1000000` µVOI → `0.000001`); assets used 0 decimals. Standardized `routeParams.amount` to **raw base units** (arc0090 stops pre-converting) and SendScreen resolves the asset's **real** decimals via `getAssetInfo` before a single conversion (skips prefill if params are null/unresolvable).

**Also fixed (review P1) — ASA deeplinks sent native VOI.** `fetchAssetOptions` read only `routeParams.assetId`, but deeplinks set `routeParams.asset`, so the ASA context was dropped and the send used the native token. Now reads `routeParams.asset` first (mirrors `resolveAssetId`).

Plus: async prefill has a **cancellation guard** (no overwrite after unmount/edit), and `getAssetInfo` returning `null` (404) skips prefill rather than using 0 decimals.

## Gates
- `npm run typecheck`: net-zero new errors vs main.
- Codex CLI review → **CLEAN** after two rounds (fixed: cross-network cache leak, uint64 cache-key collision, ASA-deeplink native-send, null-params prefill, async race).

## ⚠️ Manual verification (post-merge)
1. Hold a 6-decimal ASA; force an asset-params fetch failure (offline blip) → balance **omits** the asset rather than showing it 10⁶× too large.
2. Switch networks with a same-numbered asset on both → no stale decimals.
3. Open an **arc0090/algorand payment URI for an ASA** (with amount) → Send prefills the correct amount **and** the ASA is selected (sends the ASA, not VOI).
4. Native payment URI (`1000000` µVOI) → prefills `1`, not `0.000001`.

## Separately tracked
Transaction-history decimals fallback (`asset?.decimals || 0` in TransactionListItem/TransactionHistoryScreen) filed as a follow-up task under PLAN-9.