### PR TITLE
feat(security): rekey/close-out danger banner + required confirmation in signing UIs (S-01)

### DIFF
--- a/src/components/transaction/TransactionDangerBanner.tsx
+++ b/src/components/transaction/TransactionDangerBanner.tsx
@@ -1,0 +1,135 @@
+import React from 'react';
+import { View, Text, TouchableOpacity, StyleSheet } from 'react-native';
+import { Ionicons } from '@expo/vector-icons';
+
+import { useTheme } from '@/contexts/ThemeContext';
+import { useThemedStyles } from '@/hooks/useThemedStyles';
+import { Theme } from '@/constants/themes';
+import { truncateAddress } from '@/services/walletconnect/utils';
+import { TransactionDangers } from '@/utils/transactionDangers';
+
+interface Props {
+  dangers: TransactionDangers; // aggregated
+  acknowledged: boolean;
+  onToggleAcknowledged: () => void;
+}
+
+/**
+ * Presentational danger banner for authority-transfer / balance-sweep fields
+ * (S-01). Renders a prominent error-colored warning for each present danger and
+ * an acknowledgment checkbox. All gating/state is owned by the parent screen.
+ */
+export default function TransactionDangerBanner({
+  dangers,
+  acknowledged,
+  onToggleAcknowledged,
+}: Props) {
+  const { theme } = useTheme();
+  const styles = useThemedStyles(createStyles);
+
+  return (
+    <View style={styles.container}>
+      <View style={styles.header}>
+        <Ionicons
+          name="alert-circle"
+          size={24}
+          color={theme.colors.error}
+        />
+        <Text style={styles.headerText}>
+          Dangerous operation — review carefully
+        </Text>
+      </View>
+
+      {dangers.rekeyTo ? (
+        <Text style={styles.dangerLine}>
+          This REKEYS your account: signing authority is transferred to{' '}
+          {truncateAddress(dangers.rekeyTo)}. Whoever controls that address
+          controls your account.
+        </Text>
+      ) : null}
+
+      {dangers.closeRemainderTo ? (
+        <Text style={styles.dangerLine}>
+          This CLOSES your account: your entire remaining balance is sent to{' '}
+          {truncateAddress(dangers.closeRemainderTo)}.
+        </Text>
+      ) : null}
+
+      {dangers.assetCloseTo ? (
+        <Text style={styles.dangerLine}>
+          This CLOSES OUT the asset: your entire remaining asset balance is sent
+          to {truncateAddress(dangers.assetCloseTo)}.
+        </Text>
+      ) : null}
+
+      <TouchableOpacity
+        style={styles.acknowledgeRow}
+        onPress={onToggleAcknowledged}
+        accessibilityRole="checkbox"
+        accessibilityState={{ checked: acknowledged }}
+        accessibilityLabel="Acknowledge dangerous transaction warning"
+        activeOpacity={0.7}
+      >
+        <Ionicons
+          name={acknowledged ? 'checkbox' : 'square-outline'}
+          size={24}
+          color={theme.colors.error}
+        />
+        <Text style={styles.acknowledgeText}>
+          I understand this transfers control of / drains my account and want to
+          proceed.
+        </Text>
+      </TouchableOpacity>
+    </View>
+  );
+}
+
+const createStyles = (theme: Theme) =>
+  StyleSheet.create({
+    container: {
+      backgroundColor:
+        theme.mode === 'light'
+          ? 'rgba(255,69,58,0.08)'
+          : 'rgba(255,69,58,0.15)',
+      borderWidth: 2,
+      borderColor: theme.colors.error,
+      borderRadius: 12,
+      padding: 16,
+      marginBottom: 16,
+    },
+    header: {
+      flexDirection: 'row',
+      alignItems: 'center',
+      marginBottom: 12,
+    },
+    headerText: {
+      flex: 1,
+      fontSize: 16,
+      fontWeight: '700',
+      color: theme.colors.error,
+      marginLeft: 10,
+    },
+    dangerLine: {
+      fontSize: 14,
+      color: theme.colors.text,
+      fontWeight: '500',
+      lineHeight: 20,
+      marginBottom: 10,
+    },
+    acknowledgeRow: {
+      flexDirection: 'row',
+      alignItems: 'center',
+      marginTop: 4,
+      paddingTop: 12,
+      borderTopWidth: 1,
+      borderTopColor: theme.colors.error + '40',
+    },
+    acknowledgeText: {
+      flex: 1,
+      fontSize: 14,
+      fontWeight: '600',
+      color: theme.colors.text,
+      marginLeft: 10,
+      lineHeight: 20,
+    },
+  });

--- a/src/screens/wallet/UniversalTransactionSigningScreen.tsx
+++ b/src/screens/wallet/UniversalTransactionSigningScreen.tsx
@@ -32,6 +32,13 @@ import { useTheme } from '@/contexts/ThemeContext';
 import { useThemedStyles } from '@/hooks/useThemedStyles';
 import { Theme } from '@/constants/themes';
 import { NetworkId } from '@/types/network';
+import TransactionDangerBanner from '@/components/transaction/TransactionDangerBanner';
+import {
+  detectTransactionDangers,
+  aggregateDangers,
+  hasAnyDanger,
+  TransactionDangers,
+} from '@/utils/transactionDangers';
 import {
   getNavigationCallbacks,
   clearNavigationCallbacks,
@@ -59,6 +66,7 @@ interface ParsedTransaction {
   note?: string;
   assetId?: number;
   type: string;
+  dangers?: TransactionDangers;
 }
 
 export default function UniversalTransactionSigningScreen({ navigation, route }: Props) {
@@ -84,6 +92,7 @@ export default function UniversalTransactionSigningScreen({ navigation, route }:
   const [decodedTransactions, setDecodedTransactions] = useState<algosdk.Transaction[]>([]);
   const [networkName, setNetworkName] = useState<string>('Unknown Network');
   const [networkCurrency, setNetworkCurrency] = useState<string>('VOI');
+  const [dangerAcknowledged, setDangerAcknowledged] = useState(false);
 
   const { theme } = useTheme();
   const styles = useThemedStyles(createStyles);
@@ -191,6 +200,8 @@ export default function UniversalTransactionSigningScreen({ navigation, route }:
             note: txnAny.note ? Buffer.from(txnAny.note).toString() : undefined,
             assetId: txnAny.assetIndex,
             type: isAlreadySigned ? `${txnType} (pre-signed)` : txnType,
+            // Only surface danger fields for transactions we are about to sign.
+            dangers: isAlreadySigned ? undefined : detectTransactionDangers(txn),
           });
         } catch (error) {
           console.error('Failed to parse transaction:', error);
@@ -212,7 +223,23 @@ export default function UniversalTransactionSigningScreen({ navigation, route }:
     }
   };
 
+  // S-01: aggregate authority-transfer / balance-sweep dangers across all
+  // transactions. Declared before handleApprove so the guard and the render
+  // gating share the same scope.
+  const aggregatedDangers = aggregateDangers(
+    parsedTransactions.map((t) => t.dangers ?? {})
+  );
+  const hasDanger = hasAnyDanger(aggregatedDangers);
+
   const handleApprove = () => {
+    if (hasDanger && !dangerAcknowledged) {
+      Alert.alert(
+        'Confirmation required',
+        'Please acknowledge the highlighted account-security warning before signing.'
+      );
+      return;
+    }
+
     if (!account) {
       Alert.alert('Error', 'Account information is missing');
       return;
@@ -354,6 +381,15 @@ export default function UniversalTransactionSigningScreen({ navigation, route }:
         )}
 
         {renderTransactionSummary()}
+
+        {hasDanger && (
+          <TransactionDangerBanner
+            dangers={aggregatedDangers}
+            acknowledged={dangerAcknowledged}
+            onToggleAcknowledged={() => setDangerAcknowledged((v) => !v)}
+          />
+        )}
+
         {renderAccountSelector()}
 
         <View style={styles.warningContainer}>
@@ -377,7 +413,7 @@ export default function UniversalTransactionSigningScreen({ navigation, route }:
         <TouchableOpacity
           style={[styles.button, styles.approveButton]}
           onPress={handleApprove}
-          disabled={!account}
+          disabled={!account || (hasDanger && !dangerAcknowledged)}
         >
           <Text style={styles.approveButtonText}>Sign</Text>
         </TouchableOpacity>

--- a/src/screens/walletconnect/TransactionRequestScreen.tsx
+++ b/src/screens/walletconnect/TransactionRequestScreen.tsx
@@ -43,6 +43,13 @@ import { useThemedStyles } from '@/hooks/useThemedStyles';
 import { Theme } from '@/constants/themes';
 import { TransactionRequestQueue } from '@/services/walletconnect/TransactionRequestQueue';
 import { registerNavigationCallbacks } from '@/services/navigation/callbackRegistry';
+import TransactionDangerBanner from '@/components/transaction/TransactionDangerBanner';
+import {
+  detectTransactionDangers,
+  aggregateDangers,
+  hasAnyDanger,
+  TransactionDangers,
+} from '@/utils/transactionDangers';
 
 type TransactionRequestScreenNavigationProp = StackNavigationProp<
   RootStackParamList,
@@ -66,6 +73,7 @@ interface ParsedTransaction {
   note?: string;
   assetId?: number;
   type: string;
+  dangers?: TransactionDangers;
 }
 
 export default function TransactionRequestScreen({ navigation, route }: Props) {
@@ -89,9 +97,28 @@ export default function TransactionRequestScreen({ navigation, route }: Props) {
   const [accounts, setAccounts] = useState<AccountMetadata[]>([]);
   const [networkName, setNetworkName] = useState<string>('Unknown Network');
   const [networkCurrency, setNetworkCurrency] = useState<string>('TOKEN');
+  const [dangerAcknowledged, setDangerAcknowledged] = useState(false);
 
   // Use the unified auth controller
   const authController = useTransactionAuthController();
+
+  // S-01: derive authority-transfer / balance-sweep dangers directly from the
+  // WalletConnect transactions that would be signed on this screen's direct path.
+  // (parsedTransactions/decodedTransactions are not populated in this screen.)
+  const aggregatedDangers = useMemo<TransactionDangers>(() => {
+    const list: TransactionDangers[] = [];
+    for (const wtxn of transactions) {
+      try {
+        const txnBytes = Buffer.from(wtxn.txn, 'base64');
+        const decoded = algosdk.decodeUnsignedTransaction(txnBytes);
+        list.push(detectTransactionDangers(decoded));
+      } catch {
+        // Pre-signed / undecodable transaction — no danger fields surfaced.
+      }
+    }
+    return aggregateDangers(list);
+  }, [transactions]);
+  const hasDanger = hasAnyDanger(aggregatedDangers);
 
   useEffect(() => {
     loadAccountsAndTransactions();
@@ -241,6 +268,14 @@ export default function TransactionRequestScreen({ navigation, route }: Props) {
   };
 
   const handleApprove = () => {
+    if (hasDanger && !dangerAcknowledged) {
+      Alert.alert(
+        'Confirmation required',
+        'Please acknowledge the highlighted account-security warning before signing.'
+      );
+      return;
+    }
+
     if (!selectedAccount) {
       Alert.alert('Error', 'Please select an account to sign with');
       return;
@@ -528,6 +563,15 @@ export default function TransactionRequestScreen({ navigation, route }: Props) {
         </View>
 
         {renderTransactionSummary()}
+
+        {hasDanger && (
+          <TransactionDangerBanner
+            dangers={aggregatedDangers}
+            acknowledged={dangerAcknowledged}
+            onToggleAcknowledged={() => setDangerAcknowledged((v) => !v)}
+          />
+        )}
+
         {renderAccountSelector()}
 
         <View style={styles.warningContainer}>
@@ -551,7 +595,7 @@ export default function TransactionRequestScreen({ navigation, route }: Props) {
         <TouchableOpacity
           style={[styles.button, styles.approveButton]}
           onPress={handleApprove}
-          disabled={!selectedAccount}
+          disabled={!selectedAccount || (hasDanger && !dangerAcknowledged)}
         >
           <Text style={styles.approveButtonText}>Sign</Text>
         </TouchableOpacity>

--- a/src/utils/transactionDangers.ts
+++ b/src/utils/transactionDangers.ts
@@ -1,0 +1,50 @@
+import algosdk from 'algosdk';
+
+export interface TransactionDangers {
+  /** Account's signing authority is transferred to this address (takeover). */
+  rekeyTo?: string;
+  /** Entire remaining native balance is swept here and the account closed. */
+  closeRemainderTo?: string;
+  /** Entire remaining balance of the asset is swept to this address. */
+  assetCloseTo?: string;
+}
+
+const encodeMaybeAddress = (value: any): string | undefined => {
+  if (!value) return undefined;
+  if (typeof value === 'string') return value || undefined;
+  if (value.publicKey) {
+    try {
+      return algosdk.encodeAddress(new Uint8Array(value.publicKey));
+    } catch {
+      return undefined;
+    }
+  }
+  return undefined;
+};
+
+/**
+ * Extract the authority-transfer / balance-sweep fields from a decoded algosdk
+ * v3 Transaction. These are the fields a malicious dApp/deeplink can hide behind
+ * a normal-looking payment (S-01). Robust to Address objects or string addrs.
+ */
+export const detectTransactionDangers = (txn: any): TransactionDangers => {
+  if (!txn) return {};
+  return {
+    rekeyTo: encodeMaybeAddress(txn.rekeyTo),
+    closeRemainderTo: encodeMaybeAddress(txn.payment?.closeRemainderTo),
+    // NOTE: algosdk v3 stores the asset close-out under assetTransfer.closeRemainderTo
+    // (same field name as a payment close), NOT `assetCloseTo`. Reading the wrong
+    // name would silently miss asset-drain transactions.
+    assetCloseTo: encodeMaybeAddress(txn.assetTransfer?.closeRemainderTo),
+  };
+};
+
+export const hasAnyDanger = (d?: TransactionDangers | null): boolean =>
+  !!(d && (d.rekeyTo || d.closeRemainderTo || d.assetCloseTo));
+
+/** Aggregate the first target of each danger kind across many transactions. */
+export const aggregateDangers = (list: TransactionDangers[]): TransactionDangers => ({
+  rekeyTo: list.find((d) => d.rekeyTo)?.rekeyTo,
+  closeRemainderTo: list.find((d) => d.closeRemainderTo)?.closeRemainderTo,
+  assetCloseTo: list.find((d) => d.assetCloseTo)?.assetCloseTo,
+});


### PR DESCRIPTION
## What & why
Both signing UIs (`UniversalTransactionSigningScreen`, WalletConnect `TransactionRequestScreen`) decoded a transaction and displayed only type/from/to/amount/fee/note — **neither surfaced**:
- `rekeyTo` — transfers your account's **signing authority** (account takeover),
- `closeRemainderTo` — sweeps your **entire native balance** and closes the account,
- asset close-out — sweeps your **entire ASA balance**.

So a malicious WalletConnect peer or ARC-0090 deeplink could present a normal-looking "payment of 0.001 VOI" that also rekeys or drains the account, with no indication. Resolves **S-01** (PLAN-9 / TASK-17). Decision **DR-4 (strictest)**: banner + **required** acknowledgment for rekey AND close-out.

## Changes
- **`utils/transactionDangers.ts`** — `detectTransactionDangers()` reads `rekeyTo`, `payment.closeRemainderTo`, and `assetTransfer.closeRemainderTo`. ⚠️ The asset close-out field is `closeRemainderTo` (not `assetCloseTo`) in algosdk v3 — **verified empirically** by encoding/decoding real txns (an initial `assetCloseTo` path silently missed asset-drain txns).
- **`components/transaction/TransactionDangerBanner.tsx`** — prominent error-colored banner listing each danger + its target address, with a tappable acknowledgment checkbox.
- **Both signing screens** — dangers detected per to-be-signed txn and aggregated; the banner shows when any danger is present; the **Sign button is disabled AND `handleApprove` is guarded** until acknowledged (defense in depth). The WC auto-approve path funnels through the same guard.

## Gates
- `npm run typecheck`: net-zero new errors.
- Empirical algosdk-v3 verification: rekey+close on payment ✓, rekey+asset-close on axfer ✓, clean txns → no banner ✓.
- Codex CLI **adversarial security review** → **CLEAN** (hunted for detection gaps, bypasses, auto-approve/ledger/remote-signer paths, un-aggregated batch dangers).

## ⚠️ Manual verification
1. From a dApp/deeplink, present a payment with `rekeyTo` set → red **REKEY** banner; Sign disabled until you check the box.
2. A payment with `closeRemainderTo` → **CLOSE** banner + required ack.
3. An asset transfer with a close-out → **asset close-out** banner + required ack.
4. A normal payment → no banner, signs as before.