### PR TITLE
fix(tx): thread confirmed status through PIN-send to result screen

### DIFF
--- a/src/services/auth/transactionAuthController.ts
+++ b/src/services/auth/transactionAuthController.ts
@@ -1260,7 +1260,7 @@ export class TransactionAuthController {
           });
         },
 
-        onNetworkConfirmed: (txId) => {
+        onNetworkConfirmed: (txId, confirmed) => {
           this.isSigningInProgress = false;
           this.updateState({
             state: 'completed',
@@ -1268,6 +1268,10 @@ export class TransactionAuthController {
             result: {
               success: true,
               transactionId: txId,
+              // Propagate submit-vs-confirm so the result screen can show a
+              // pending state instead of a false "Transaction Sent!". Undefined
+              // stays backward-compatible (treated as confirmed success).
+              confirmed,
             },
           });
         },

--- a/src/services/messaging/index.ts
+++ b/src/services/messaging/index.ts
@@ -155,8 +155,8 @@ export class MessagingService {
         networkId: NetworkId.VOI_MAINNET,
       };
 
-      // Send the transaction
-      const txId = await TransactionService.sendTransaction(
+      // Send the transaction (bare txId; confirmation state not needed here)
+      const { txId } = await TransactionService.sendTransaction(
         params,
         account as WalletAccount,
         pin

--- a/src/services/messaging/keyRegistry.ts
+++ b/src/services/messaging/keyRegistry.ts
@@ -319,8 +319,8 @@ export async function registerMessagingKey(
     networkId: NetworkId.VOI_MAINNET,
   };
 
-  // Send the transaction
-  const txId = await TransactionService.sendTransaction(params, account, pin);
+  // Send the transaction (bare txId; confirmation state not needed for key reg)
+  const { txId } = await TransactionService.sendTransaction(params, account, pin);
 
   // Immediately update cache with the new registration
   const registration: MessagingKeyRegistration = {

--- a/src/services/secure/transactionManager.ts
+++ b/src/services/secure/transactionManager.ts
@@ -34,8 +34,9 @@ export class SecureTransactionManager {
         );
       }
 
-      // Send transaction using secure key access
-      const txId = await TransactionService.sendTransaction(
+      // Send transaction using secure key access. This path returns a bare txId
+      // string; the { confirmed } flag is intentionally not surfaced here.
+      const { txId } = await TransactionService.sendTransaction(
         params,
         account,
         pin,

--- a/src/services/transactions/index.ts
+++ b/src/services/transactions/index.ts
@@ -56,7 +56,10 @@ export interface SignProgressCallbacks {
   onLedgerSigned?: (ctx: { index: number; total: number }) => void;
   onLedgerRejected?: (ctx: { index: number; total: number; error: Error }) => void;
   onNetworkSubmit?: () => void;
-  onNetworkConfirmed?: (txId: string) => void;
+  // `confirmed` is false when the tx was submitted but not yet confirmed within
+  // the round window. Carried here (not just in the return value) because the
+  // auth modal consumes the result published from this callback.
+  onNetworkConfirmed?: (txId: string, confirmed?: boolean) => void;
 }
 
 export class TransactionService {
@@ -660,7 +663,7 @@ export class TransactionService {
     account: WalletAccount,
     pin?: string,
     callbacks?: SignProgressCallbacks
-  ): Promise<string> {
+  ): Promise<{ txId: string; confirmed: boolean }> {
     try {
       const cacheKey = TransactionService.getTransactionCacheKey(params);
 
@@ -679,12 +682,11 @@ export class TransactionService {
 
       // Submit to network with basic retry
       callbacks?.onNetworkSubmit?.();
-      // submitWithRetries now returns { txId, confirmed }. These send functions
-      // return a bare string txId to their callers (signature intentionally not
-      // widened), so `confirmed` is not propagated on this path — the UI's
-      // pending state defaults to the backward-compatible "success" view.
-      const { txId } = await TransactionService.submitWithRetries(signedTxnBlob, params.networkId);
-      callbacks?.onNetworkConfirmed?.(txId);
+      // submitWithRetries returns { txId, confirmed }; propagate `confirmed` so
+      // callers (and ultimately the UI) can distinguish a confirmed send from a
+      // submitted-but-still-pending one.
+      const { txId, confirmed } = await TransactionService.submitWithRetries(signedTxnBlob, params.networkId);
+      callbacks?.onNetworkConfirmed?.(txId, confirmed);
 
       // Record successful transaction for replay protection.
       // Pass the exact amount as a string so the tracker's identical-transaction
@@ -701,7 +703,7 @@ export class TransactionService {
 
       TransactionService.clearCachedTransaction(cacheKey);
 
-      return txId;
+      return { txId, confirmed };
     } catch (error) {
       const userRejected = TransactionService.isLedgerUserRejected(error);
       console.error('Failed to send transaction:', error);
@@ -1428,7 +1430,7 @@ export class TransactionService {
     account: Pick<WalletAccount, 'address'>,
     pin?: string,
     callbacks?: SignProgressCallbacks
-  ): Promise<string> {
+  ): Promise<{ txId: string; confirmed: boolean }> {
     try {
       const cacheKey = TransactionService.getRekeyCacheKey({
         fromAddress: params.fromAddress,
@@ -1452,12 +1454,11 @@ export class TransactionService {
 
       // Submit to network with basic retry
       callbacks?.onNetworkSubmit?.();
-      // submitWithRetries now returns { txId, confirmed }. These send functions
-      // return a bare string txId to their callers (signature intentionally not
-      // widened), so `confirmed` is not propagated on this path — the UI's
-      // pending state defaults to the backward-compatible "success" view.
-      const { txId } = await TransactionService.submitWithRetries(signedTxnBlob, params.networkId);
-      callbacks?.onNetworkConfirmed?.(txId);
+      // submitWithRetries returns { txId, confirmed }; propagate `confirmed` so
+      // callers (and ultimately the UI) can distinguish a confirmed send from a
+      // submitted-but-still-pending one.
+      const { txId, confirmed } = await TransactionService.submitWithRetries(signedTxnBlob, params.networkId);
+      callbacks?.onNetworkConfirmed?.(txId, confirmed);
 
       // Record successful transaction
       await TransactionTracker.recordTransaction(
@@ -1475,7 +1476,7 @@ export class TransactionService {
 
       TransactionService.clearCachedTransaction(cacheKey);
 
-      return txId;
+      return { txId, confirmed };
     } catch (error) {
       const userRejected = TransactionService.isLedgerUserRejected(error);
       console.error('Failed to send rekey transaction:', error);
@@ -1576,7 +1577,7 @@ export class TransactionService {
     account: Pick<WalletAccount, 'address'>,
     pin?: string,
     callbacks?: SignProgressCallbacks
-  ): Promise<string> {
+  ): Promise<{ txId: string; confirmed: boolean }> {
     try {
       const cacheKey = TransactionService.getRekeyCacheKey({
         fromAddress: params.fromAddress,
@@ -1600,12 +1601,11 @@ export class TransactionService {
 
       // Submit to network with basic retry
       callbacks?.onNetworkSubmit?.();
-      // submitWithRetries now returns { txId, confirmed }. These send functions
-      // return a bare string txId to their callers (signature intentionally not
-      // widened), so `confirmed` is not propagated on this path — the UI's
-      // pending state defaults to the backward-compatible "success" view.
-      const { txId } = await TransactionService.submitWithRetries(signedTxnBlob, params.networkId);
-      callbacks?.onNetworkConfirmed?.(txId);
+      // submitWithRetries returns { txId, confirmed }; propagate `confirmed` so
+      // callers (and ultimately the UI) can distinguish a confirmed send from a
+      // submitted-but-still-pending one.
+      const { txId, confirmed } = await TransactionService.submitWithRetries(signedTxnBlob, params.networkId);
+      callbacks?.onNetworkConfirmed?.(txId, confirmed);
 
       // Record successful transaction
       await TransactionTracker.recordTransaction(
@@ -1623,7 +1623,7 @@ export class TransactionService {
 
       TransactionService.clearCachedTransaction(cacheKey);
 
-      return txId;
+      return { txId, confirmed };
     } catch (error) {
       const userRejected = TransactionService.isLedgerUserRejected(error);
       console.error('Failed to send reverse rekey transaction:', error);

--- a/src/services/transactions/unifiedSigner.ts
+++ b/src/services/transactions/unifiedSigner.ts
@@ -44,7 +44,7 @@ export interface UnifiedSigningCallbacks {
 
   // Network phase
   onNetworkSubmit?: () => void;
-  onNetworkConfirmed?: (txId: string) => void;
+  onNetworkConfirmed?: (txId: string, confirmed?: boolean) => void;
   onNetworkError?: (error: Error) => void;
 
   // Completion
@@ -233,7 +233,7 @@ export class UnifiedTransactionSigner {
 
     try {
       // Use existing TransactionService with unified callbacks
-      const txId = await TransactionService.sendTransaction(
+      const { txId, confirmed } = await TransactionService.sendTransaction(
         request.transferParams,
         request.account,
         request.pin,
@@ -249,6 +249,7 @@ export class UnifiedTransactionSigner {
       return {
         success: true,
         transactionId: txId,
+        confirmed,
       };
 
     } catch (error) {
@@ -269,10 +270,11 @@ export class UnifiedTransactionSigner {
 
     try {
       let txId: string;
+      let confirmed: boolean;
 
       if (request.type === 'rekey_reverse') {
         // Reverse rekey - return authority to original account
-        txId = await TransactionService.sendRekeyReverseTransaction(
+        ({ txId, confirmed } = await TransactionService.sendRekeyReverseTransaction(
           {
             fromAddress: request.rekeyParams.fromAddress,
             note: request.rekeyParams.note,
@@ -287,14 +289,14 @@ export class UnifiedTransactionSigner {
             onNetworkSubmit: callbacks?.onNetworkSubmit,
             onNetworkConfirmed: callbacks?.onNetworkConfirmed,
           }
-        );
+        ));
       } else {
         // Standard rekey to another account
         if (!request.rekeyParams.rekeyToAddress) {
           throw new Error('Target rekey address required for rekey operation');
         }
 
-        txId = await TransactionService.sendRekeyTransaction(
+        ({ txId, confirmed } = await TransactionService.sendRekeyTransaction(
           {
             fromAddress: request.rekeyParams.fromAddress,
             rekeyToAddress: request.rekeyParams.rekeyToAddress,
@@ -310,12 +312,13 @@ export class UnifiedTransactionSigner {
             onNetworkSubmit: callbacks?.onNetworkSubmit,
             onNetworkConfirmed: callbacks?.onNetworkConfirmed,
           }
-        );
+        ));
       }
 
       return {
         success: true,
         transactionId: txId,
+        confirmed,
       };
 
     } catch (error) {


### PR DESCRIPTION
## What
Widen `sendTransaction` / `sendRekeyTransaction` / `sendRekeyReverseTransaction` from `Promise<string>` to `Promise<{ txId, confirmed }>`, and propagate the `confirmed` flag so the standard PIN-send path reports submit-vs-confirm state to the UI. A submitted-but-unconfirmed VOI/ASA send now shows a **pending** state instead of a false **"Transaction Sent!"**.

Resolves **TASK-84** (follow-up from TASK-22 / R-04, commit #29 which made `submitWithRetries` return `{ txId, confirmed }`).

## How the flag reaches the UI
- Send fns return `{ txId, confirmed }`; unified signer sets `UnifiedSigningResult.confirmed` on the standard-transfer and rekey paths.
- **Codex review caught a real gap (P1):** the auth modal locks in the *first* `state:'completed'` result via a `hasCalledOnComplete` guard, and that result is published by `onNetworkConfirmed` — which previously omitted `confirmed`. So return-value threading alone was dropped before reaching the screen. Fix: carry `confirmed` through the `onNetworkConfirmed(txId, confirmed?)` callback into the auth controller's published result.
- `TransactionConfirmationScreen` already forwards `result.confirmed` → `TransactionResultScreen` (`isPending`); no screen changes needed.

## Not changed
- No signing, key-handling, or submission logic touched — only propagates the `confirmed` value `submitWithRetries` already computes.
- Non-UI callers (`SecureTransactionManager`, messaging key registry, message send) just destructure `{ txId }`; behavior unchanged.

## Verification / gates
- `npm run typecheck`: **no new errors** (verified vs `main` baseline; repo has a pre-existing 275-error algosdk-v3/RN baseline, unchanged by this diff).
- `npm run lint`: **broken repo-wide** (ESLint 9 flat-config not migrated — see TASK-82); not gateable here.
- **Codex review: CLEAN** (2 rounds; round 1 found P1, round 2 clean after fix).
- ⏳ **Manual in-app verification pending (owner: reviewer):** send a VOI/ASA tx and confirm a still-pending submission shows the pending result state, and a confirmed one shows success.

## Follow-up (separate surface, not folded in)
Codex P2: `messaging/index.ts` sets the sent message `status:'confirmed'` unconditionally — independent chat-feature path; filed separately.