### PR TITLE
fix(tx-history): resolve ASA decimals instead of 0-decimals fallback

### DIFF
--- a/src/components/transaction/TransactionListItem.tsx
+++ b/src/components/transaction/TransactionListItem.tsx
@@ -1,7 +1,7 @@
 import React, { useState } from 'react';
 import { View, Text, StyleSheet, TouchableOpacity, Image } from 'react-native';
 import { Ionicons } from '@expo/vector-icons';
-import { TransactionInfo, AssetBalance } from '@/types/wallet';
+import { TransactionInfo, AssetBalance, AssetParams } from '@/types/wallet';
 import { Arc200TokenMetadata } from '@/services/mimir';
 import { formatNativeBalance, formatAssetBalance } from '@/utils/bigint';
 import TransactionAddressDisplay from './TransactionAddressDisplay';
@@ -16,6 +16,8 @@ interface TransactionListItemProps {
   activeAccountAddress: string;
   assets?: AssetBalance[];
   tokenMetadata?: Arc200TokenMetadata | null;
+  /** Resolved ASA params for assets not in the active account's holdings. */
+  assetMetadata?: AssetParams | null;
   onPress: (transaction: TransactionInfo) => void;
 }
 
@@ -25,6 +27,7 @@ const TransactionListItem = React.memo(
     activeAccountAddress,
     assets,
     tokenMetadata,
+    assetMetadata,
     onPress,
   }: TransactionListItemProps) => {
     const [imageError, setImageError] = useState(false);
@@ -105,12 +108,26 @@ const TransactionListItem = React.memo(
       }
     };
 
+    // Render an asset amount only when decimals are known. Falling back to 0
+    // decimals renders raw base units as whole tokens (a 10^decimals display
+    // error), so when decimals are unresolved we show a placeholder instead.
+    const formatKnownAmount = (
+      sign: string,
+      decimals: number | undefined,
+      symbol: string
+    ) => {
+      if (decimals === undefined) {
+        return `${sign}… ${symbol}`;
+      }
+      return `${sign}${formatAssetBalance(transaction.amount, decimals)} ${symbol}`;
+    };
+
     const getTransactionAmount = () => {
       const sign = isOutgoing ? '-' : '+';
 
       if (transaction.isArc200 && transaction.contractId) {
         // For ARC-200 tokens, prefer cached metadata, fallback to assets
-        let decimals = 0;
+        let decimals: number | undefined;
         let symbol = 'TOKEN';
 
         if (tokenMetadata) {
@@ -122,19 +139,21 @@ const TransactionListItem = React.memo(
               a.assetType === 'arc200' &&
               a.contractId === transaction.contractId
           );
-          decimals = asset?.decimals || 0;
+          decimals = asset?.decimals;
           symbol = asset?.symbol || 'TOKEN';
         }
 
-        return `${sign}${formatAssetBalance(transaction.amount, decimals)} ${symbol}`;
+        return formatKnownAmount(sign, decimals, symbol);
       } else if (transaction.assetId && transaction.assetId !== 0) {
-        // For ASA tokens
+        // For ASA tokens: prefer holdings, fall back to resolved asset params.
+        // Use ?? so a legitimately 0-decimals asset is preserved (not treated
+        // as unknown).
         const asset = assets?.find(
           (a) => a.assetType === 'asa' && a.assetId === transaction.assetId
         );
-        const decimals = asset?.decimals || 0;
-        const symbol = asset?.symbol || 'TOKEN';
-        return `${sign}${formatAssetBalance(transaction.amount, decimals)} ${symbol}`;
+        const decimals = asset?.decimals ?? assetMetadata?.decimals;
+        const symbol = asset?.symbol || assetMetadata?.unitName || 'TOKEN';
+        return formatKnownAmount(sign, decimals, symbol);
       } else {
         // For native token
         return `${sign}${formatNativeBalance(transaction.amount, currentNetworkConfig.nativeToken)} ${currentNetworkConfig.nativeToken}`;

--- a/src/screens/wallet/TransactionDetailScreen.tsx
+++ b/src/screens/wallet/TransactionDetailScreen.tsx
@@ -250,7 +250,9 @@ export default function TransactionDetailScreen() {
               {isReceived ? '+' : isSent ? '-' : ''}
               {assetId === 0
                 ? formatBalance(transaction.amount)
-                : formatAssetBalance(transaction.amount, decimals || 0)}{' '}
+                : decimals === undefined
+                  ? '…'
+                  : formatAssetBalance(transaction.amount, decimals)}{' '}
               {assetName}
             </Text>
           </BlurredContainer>

--- a/src/screens/wallet/TransactionHistoryScreen.tsx
+++ b/src/screens/wallet/TransactionHistoryScreen.tsx
@@ -27,12 +27,14 @@ import { serializeTransactionForNavigation } from '@/utils/navigationParams';
 import { BlurredContainer } from '@/components/common/BlurredContainer';
 import { NFTBackground } from '@/components/common/NFTBackground';
 import { useTheme } from '@/contexts/ThemeContext';
+import { useCurrentNetwork } from '@/store/networkStore';
 
 export default function TransactionHistoryScreen() {
   const [refreshing, setRefreshing] = useState(false);
   const navigation = useNavigation<StackNavigationProp<any>>();
   const styles = useThemedStyles(createStyles);
   const { theme } = useTheme();
+  const currentNetwork = useCurrentNetwork();
 
   const { updateActivity } = useAuth();
   const activeAccount = useActiveAccount();
@@ -45,6 +47,11 @@ export default function TransactionHistoryScreen() {
   );
   const loadTokenMetadata = useWalletStore((state) => state.loadTokenMetadata);
   const getTokenMetadata = useWalletStore((state) => state.getTokenMetadata);
+  const loadAssetMetadata = useWalletStore((state) => state.loadAssetMetadata);
+  const getAssetMetadata = useWalletStore((state) => state.getAssetMetadata);
+  // Subscribe to the cache itself so rows re-render when ASA params resolve
+  // (getAssetMetadata is a stable selector and wouldn't trigger a re-render).
+  const assetMetadataCache = useWalletStore((state) => state.assetMetadataCache);
 
   useEffect(() => {
     if (activeAccount) {
@@ -65,6 +72,22 @@ export default function TransactionHistoryScreen() {
       loadTokenMetadata(arc200ContractIds);
     }
   }, [accountState.recentTransactions, loadTokenMetadata]);
+
+  // Resolve ASA params for transactions whose asset isn't in current holdings,
+  // so amounts render with correct decimals instead of a 0-decimals fallback.
+  useEffect(() => {
+    const transactions = accountState.recentTransactions || [];
+    const asaAssetIds = transactions
+      .filter((tx) => !tx.isArc200 && tx.assetId && tx.assetId !== 0)
+      .map((tx) => tx.assetId!)
+      .filter((id, index, arr) => arr.indexOf(id) === index); // Remove duplicates
+
+    if (asaAssetIds.length > 0) {
+      loadAssetMetadata(asaAssetIds);
+    }
+    // currentNetwork: re-resolve for the new network after a switch even if the
+    // transaction list reference hasn't changed (cache is network-scoped).
+  }, [accountState.recentTransactions, loadAssetMetadata, currentNetwork]);
 
   const loadTransactions = async () => {
     if (!activeAccount) return;
@@ -111,7 +134,9 @@ export default function TransactionHistoryScreen() {
         // Get the asset symbol and ID for the transaction
         let assetName = 'VOI';
         let assetId = 0;
-        let assetDecimals = 0;
+        // Undefined = decimals unresolved; the detail screen shows a placeholder
+        // rather than scaling by 0 (which renders the wrong magnitude).
+        let assetDecimals: number | undefined = 0;
 
         if (transaction.isArc200 && transaction.contractId) {
           // For ARC-200 tokens, use contractId and find the asset symbol
@@ -121,7 +146,7 @@ export default function TransactionHistoryScreen() {
           const tokenMetadata = getTokenMetadata(transaction.contractId);
           if (tokenMetadata) {
             assetName = tokenMetadata.symbol || 'TOKEN';
-            assetDecimals = tokenMetadata.decimals ?? 0;
+            assetDecimals = tokenMetadata.decimals;
           } else {
             const asset = accountState.balance?.assets?.find(
               (a) =>
@@ -129,16 +154,17 @@ export default function TransactionHistoryScreen() {
                 a.contractId === transaction.contractId
             );
             assetName = asset?.symbol || 'TOKEN';
-            assetDecimals = asset?.decimals || 0;
+            assetDecimals = asset?.decimals;
           }
         } else if (transaction.assetId && transaction.assetId !== 0) {
-          // For ASA tokens
+          // For ASA tokens: prefer holdings, fall back to resolved asset params
           assetId = transaction.assetId;
           const asset = accountState.balance?.assets?.find(
             (a) => a.assetType === 'asa' && a.assetId === transaction.assetId
           );
-          assetName = asset?.symbol || 'TOKEN';
-          assetDecimals = asset?.decimals || 0;
+          const resolved = getAssetMetadata(transaction.assetId);
+          assetName = asset?.symbol || resolved?.unitName || 'TOKEN';
+          assetDecimals = asset?.decimals ?? resolved?.decimals;
         }
 
         navigation.navigate('TransactionDetail', {
@@ -152,7 +178,13 @@ export default function TransactionHistoryScreen() {
         console.error('Failed to navigate to transaction detail:', error);
       }
     },
-    [activeAccount, accountState.balance?.assets, getTokenMetadata, navigation]
+    [
+      activeAccount,
+      accountState.balance?.assets,
+      getTokenMetadata,
+      getAssetMetadata,
+      navigation,
+    ]
   );
 
   const renderTransaction: ListRenderItem<TransactionInfo> = useCallback(
@@ -162,6 +194,11 @@ export default function TransactionHistoryScreen() {
         item.isArc200 && item.contractId
           ? getTokenMetadata(item.contractId)
           : null;
+      // Get resolved ASA params for non-ARC-200 asset transfers
+      const assetMetadata =
+        !item.isArc200 && item.assetId && item.assetId !== 0
+          ? getAssetMetadata(item.assetId)
+          : null;
 
       return (
         <TransactionListItem
@@ -169,6 +206,7 @@ export default function TransactionHistoryScreen() {
           activeAccountAddress={activeAccount?.address || ''}
           assets={accountState.balance?.assets}
           tokenMetadata={tokenMetadata}
+          assetMetadata={assetMetadata}
           onPress={handleTransactionPress}
         />
       );
@@ -178,6 +216,9 @@ export default function TransactionHistoryScreen() {
       accountState.balance?.assets,
       handleTransactionPress,
       getTokenMetadata,
+      getAssetMetadata,
+      // Recompute rows when resolved ASA params land in the cache
+      assetMetadataCache,
     ]
   );
 

--- a/src/services/network/index.ts
+++ b/src/services/network/index.ts
@@ -1,5 +1,10 @@
 import algosdk from 'algosdk';
-import { AccountBalance, AssetBalance, TransactionInfo } from '@/types/wallet';
+import {
+  AccountBalance,
+  AssetBalance,
+  AssetParams,
+  TransactionInfo,
+} from '@/types/wallet';
 import {
   NetworkId,
   NetworkConfiguration,
@@ -47,6 +52,13 @@ export class NetworkService {
     string,
     { decimals: number; name?: string; unitName?: string }
   > = new Map();
+
+  // Bumped on every network switch (when assetParamsCache is cleared). An
+  // in-flight asset-params fetch captures the generation before awaiting and
+  // discards its result if the generation changed — so a response that lands
+  // after a switch (or a switch-and-back) can't poison the cleared cache with
+  // another network's decimals.
+  private assetCacheGeneration = 0;
 
   private constructor(networkId: NetworkId = DEFAULT_NETWORK_ID) {
     this.currentNetworkId = networkId;
@@ -140,6 +152,7 @@ export class NetworkService {
       // the per-network asset-params cache to avoid serving another network's
       // decimals for a colliding asset ID.
       this.assetParamsCache.clear();
+      this.assetCacheGeneration++;
 
       // Reinitialize clients with new configuration
       this.initializeClients();
@@ -283,6 +296,11 @@ export class NetworkService {
       }
 
       const algodAssets: AssetBalance[] = [];
+      // Guard the cache writes below against a network switch during this
+      // refresh: switchNetwork clears assetParamsCache and bumps the
+      // generation, so a stale response can't repopulate the cleared cache
+      // (holds even across a switch-and-back within the loop).
+      const requestGeneration = this.assetCacheGeneration;
       if (accountInfo.value.assets) {
         for (const asset of accountInfo.value.assets) {
           const assetId = Number(asset.assetId);
@@ -313,7 +331,9 @@ export class NetworkService {
               name: assetInfo.params.name,
               unitName: assetInfo.params.unitName,
             };
-            this.assetParamsCache.set(assetKey, params);
+            if (this.assetCacheGeneration === requestGeneration) {
+              this.assetParamsCache.set(assetKey, params);
+            }
             algodAssets.push({
               assetId,
               amount: asset.amount,
@@ -1139,6 +1159,49 @@ export class NetworkService {
       throw new Error(
         `Failed to check rekey statuses: ${error instanceof Error ? error.message : 'Unknown error'}`
       );
+    }
+  }
+
+  /**
+   * Resolve an ASA's immutable params (decimals/name/unitName), preferring the
+   * process-wide assetParamsCache populated during balance refreshes. Falls back
+   * to a single getAssetByID fetch and caches the result. Returns null when the
+   * asset can't be resolved (not found / network error) so callers can render a
+   * safe placeholder instead of assuming 0 decimals (which inflates displayed
+   * amounts by up to 10^decimals).
+   */
+  async getCachedAssetParams(assetId: number): Promise<AssetParams | null> {
+    const assetKey = String(assetId);
+
+    const cached = this.assetParamsCache.get(assetKey);
+    if (cached) {
+      return cached;
+    }
+
+    // Capture the switch generation before the fetch. switchNetwork() clears
+    // this cache and bumps the generation, so if it changed while we awaited,
+    // this response belongs to a network we've since left — discard it (don't
+    // cache OR return it) so callers never see another network's params.
+    const requestGeneration = this.assetCacheGeneration;
+
+    try {
+      const assetInfo = await this.getAssetInfo(assetId);
+      if (!assetInfo?.params) {
+        return null;
+      }
+      if (this.assetCacheGeneration !== requestGeneration) {
+        return null;
+      }
+      const params: AssetParams = {
+        decimals: Number(assetInfo.params.decimals ?? 0),
+        name: assetInfo.params.name,
+        unitName: assetInfo.params.unitName,
+      };
+      this.assetParamsCache.set(assetKey, params);
+      return params;
+    } catch (error) {
+      console.error(`Failed to resolve asset params for ${assetId}:`, error);
+      return null;
     }
   }
 

--- a/src/store/walletStore.ts
+++ b/src/store/walletStore.ts
@@ -17,6 +17,7 @@ import {
   DetectRekeyedAccountRequest,
   ImportRemoteSignerAccountRequest,
   AccountBalance,
+  AssetParams,
   TransactionInfo,
   AccountNotFoundError,
   AccountExistsError,
@@ -91,6 +92,11 @@ interface WalletState {
   tokenMetadataCache: Record<number, Arc200TokenMetadata>;
   pendingTokenRequests: Set<number>;
 
+  // ASA params cache keyed by `${networkId}:${assetId}` — asset IDs are per
+  // network, so the same numeric ID can be a different asset on Voi vs Algorand.
+  assetMetadataCache: Record<string, AssetParams>;
+  pendingAssetRequests: Set<string>;
+
   // Multi-network view mode
   viewMode: 'single-network' | 'multi-network';
   assetNetworkFilter: 'all' | 'voi' | 'algorand';
@@ -162,6 +168,10 @@ interface WalletState {
   // Token metadata cache management
   loadTokenMetadata: (contractIds: number[]) => Promise<void>;
   getTokenMetadata: (contractId: number) => Arc200TokenMetadata | null;
+
+  // ASA params cache management
+  loadAssetMetadata: (assetIds: number[]) => Promise<void>;
+  getAssetMetadata: (assetId: number) => AssetParams | null;
 
   // Multi-network view mode management
   setViewMode: (mode: 'single-network' | 'multi-network') => Promise<void>;
@@ -376,6 +386,8 @@ export const useWalletStore = create<WalletState>()(
     accountStates: {},
     tokenMetadataCache: {},
     pendingTokenRequests: new Set(),
+    assetMetadataCache: {},
+    pendingAssetRequests: new Set(),
     viewMode: 'multi-network', // Default to multi-network view
     assetNetworkFilter: 'all', // Default to showing all networks
     tokenMappings: [],
@@ -1887,6 +1899,78 @@ export const useWalletStore = create<WalletState>()(
     getTokenMetadata: (contractId: number) => {
       const { tokenMetadataCache } = get();
       return tokenMetadataCache[contractId] || null;
+    },
+
+    loadAssetMetadata: async (assetIds: number[]) => {
+      const networkService = NetworkService.getInstance();
+      const networkId = networkService.getCurrentNetworkId();
+      const keyFor = (id: number) => `${networkId}:${id}`;
+
+      try {
+        const { assetMetadataCache, pendingAssetRequests } = get();
+
+        // Filter out invalid, already-cached, or in-flight asset IDs (scoped to
+        // the current network so a switch can't reuse another network's params)
+        const uncachedAssetIds = assetIds.filter(
+          (id) =>
+            id > 0 &&
+            !assetMetadataCache[keyFor(id)] &&
+            !pendingAssetRequests.has(keyFor(id))
+        );
+
+        if (uncachedAssetIds.length === 0) {
+          return;
+        }
+
+        // Mark as pending
+        const newPendingRequests = new Set(pendingAssetRequests);
+        uncachedAssetIds.forEach((id) => newPendingRequests.add(keyFor(id)));
+        set({ pendingAssetRequests: newPendingRequests });
+
+        // Resolve params (NetworkService prefers its immutable-params cache)
+        const resolved = await Promise.all(
+          uncachedAssetIds.map(async (id) => ({
+            id,
+            params: await networkService.getCachedAssetParams(id),
+          }))
+        );
+
+        // Discard results if the network switched mid-flight —
+        // getCachedAssetParams resolves against the now-current network, so the
+        // params wouldn't belong to the network we started for.
+        const stillCurrent =
+          networkService.getCurrentNetworkId() === networkId;
+
+        // Re-read state after the await so we don't clobber concurrent updates
+        const current = get();
+        const updatedCache = { ...current.assetMetadataCache };
+        const updatedPendingRequests = new Set(current.pendingAssetRequests);
+        resolved.forEach(({ id, params }) => {
+          if (params && stillCurrent) {
+            updatedCache[keyFor(id)] = params;
+          }
+          updatedPendingRequests.delete(keyFor(id));
+        });
+
+        set({
+          assetMetadataCache: updatedCache,
+          pendingAssetRequests: updatedPendingRequests,
+        });
+      } catch (error) {
+        console.error('Failed to load asset metadata:', error);
+
+        // Clear pending on error so a later call can retry
+        const { pendingAssetRequests } = get();
+        const updatedPendingRequests = new Set(pendingAssetRequests);
+        assetIds.forEach((id) => updatedPendingRequests.delete(keyFor(id)));
+        set({ pendingAssetRequests: updatedPendingRequests });
+      }
+    },
+
+    getAssetMetadata: (assetId: number) => {
+      const networkId = NetworkService.getInstance().getCurrentNetworkId();
+      const { assetMetadataCache } = get();
+      return assetMetadataCache[`${networkId}:${assetId}`] || null;
     },
 
     // Multi-network view mode management

--- a/src/types/wallet.ts
+++ b/src/types/wallet.ts
@@ -153,6 +153,16 @@ export interface AssetBalance {
   contractId?: number;
 }
 
+/**
+ * Immutable on-chain parameters for an ASA, used to resolve display decimals
+ * for assets that aren't in the active account's holdings (e.g. in tx history).
+ */
+export interface AssetParams {
+  decimals: number;
+  name?: string;
+  unitName?: string;
+}
+
 export interface TransactionInfo {
   id: string;
   from: string;


### PR DESCRIPTION
## What
Transaction-history (and tx-detail) rows formatted asset amounts with `asset?.decimals || 0` when the asset wasn't in the active account's holdings, rendering raw base units as whole tokens — a **10^decimals magnitude error** for ASAs the user doesn't currently hold.

Resolves **TASK-83** (discovered during TASK-21 Codex review, R-07-adjacent).

## How
- **`NetworkService.getCachedAssetParams(assetId)`** — resolves immutable ASA params, preferring the process-wide `assetParamsCache` (added in TASK-21) and caching a single `getAssetByID` fetch; returns `null` when unresolvable so callers can render a placeholder.
- **walletStore ASA metadata cache** — `loadAssetMetadata` / `getAssetMetadata`, mirroring the ARC-200 `tokenMetadata` pattern. Keyed by `${networkId}:${assetId}` (asset IDs are per-network; Voi/Algorand IDs can collide).
- **TransactionHistoryScreen** preloads params for the ASA IDs in recent transactions, subscribes to `assetMetadataCache` so rows re-render when params resolve, and re-resolves on network switch.
- **TransactionListItem / TransactionDetailScreen** render an amount only when decimals are known; otherwise a placeholder (`…`) instead of a wrong magnitude. Uses `??` (not `|| 0`) so a legitimately 0-decimals asset is preserved.

## Network-switch hardening (folded in from Codex review)
Codex found the shared `assetParamsCache` could be poisoned by an in-flight fetch completing after a mid-flight `switchNetwork()` (which clears it). Closed with a **switch-generation counter**: `switchNetwork` bumps `assetCacheGeneration`; both writers (`getAccountBalance` loop and `getCachedAssetParams`) capture it before their fetch and discard the result if it changed — holds even across an A→B→A switch-and-back. The store cache additionally discards mid-flight results and is network-scoped.

## Verification / gates
- `npm run typecheck`: **no new errors** (verified vs `main` baseline; repo has a pre-existing ~275-error algosdk-v3/RN baseline, unchanged by this diff).
- `npm run lint`: **broken repo-wide** (ESLint 9 flat-config not migrated — see TASK-82); not gateable here.
- **Codex review: CLEAN** (5 rounds; the network-switch race was hardened to convergence).
- ⏳ **Manual in-app verification pending (owner: reviewer):** view history containing an ASA you don't hold and confirm the amount shows correct decimals (or a `…` placeholder while resolving), not a 10^N-inflated number; sanity-check a network switch.