### PR TITLE
fix(messaging): show sent message as pending until the tx confirms

### DIFF
--- a/src/services/messaging/index.ts
+++ b/src/services/messaging/index.ts
@@ -162,8 +162,10 @@ export class MessagingService {
         networkId: NetworkId.VOI_MAINNET,
       };
 
-      // Send the transaction (bare txId; confirmation state not needed here)
-      const { txId } = await TransactionService.sendTransaction(
+      // Send the transaction. `confirmed` reflects whether the note tx actually
+      // confirmed within the wait window; propagate it so a submitted-but-
+      // unconfirmed message shows as pending instead of a premature "confirmed".
+      const { txId, confirmed } = await TransactionService.sendTransaction(
         params,
         account as WalletAccount,
         pin
@@ -176,7 +178,10 @@ export class MessagingService {
         direction: 'sent',
         content: request.content,
         timestamp: encryptedPayload.t,
-        status: 'confirmed',
+        // Don't claim confirmation the network hasn't given us; a pending
+        // message resolves to confirmed when the thread is next loaded from
+        // chain (the receive path parses on-chain txns as confirmed).
+        status: confirmed ? 'confirmed' : 'pending',
         fee: MESSAGE_FEE_MICRO,
       };
 

--- a/src/store/messagesStore.ts
+++ b/src/store/messagesStore.ts
@@ -454,13 +454,11 @@ export const useMessagesStore = create<MessagesState>()(
           .getState()
           .friends.find((f) => f.address === friendAddress);
 
-        // Merge with existing messages (deduplicate by ID)
-        const allMessages = [...(existingThread?.messages || [])];
-        for (const msg of messages) {
-          if (!allMessages.some((m) => m.id === msg.id)) {
-            allMessages.push(msg);
-          }
-        }
+        // Merge with existing messages (dedupe by ID; reconcile pending->confirmed)
+        const allMessages = mergeMessagesById(
+          existingThread?.messages || [],
+          messages
+        );
         allMessages.sort((a, b) => a.timestamp - b.timestamp);
 
         const lastMsg = allMessages[allMessages.length - 1];
@@ -536,13 +534,11 @@ export const useMessagesStore = create<MessagesState>()(
           .getState()
           .friends.find((f) => f.address === friendAddress);
 
-        // Merge with existing messages (deduplicate by ID)
-        const allMessages = [...(existingThread?.messages || [])];
-        for (const msg of messages) {
-          if (!allMessages.some((m) => m.id === msg.id)) {
-            allMessages.push(msg);
-          }
-        }
+        // Merge with existing messages (dedupe by ID; reconcile pending->confirmed)
+        const allMessages = mergeMessagesById(
+          existingThread?.messages || [],
+          messages
+        );
         allMessages.sort((a, b) => a.timestamp - b.timestamp);
 
         const lastMsg = allMessages[allMessages.length - 1];
@@ -650,13 +646,11 @@ export const useMessagesStore = create<MessagesState>()(
             .getState()
             .friends.find((f) => f.address === friendAddress);
 
-          // Merge messages (deduplicate by ID)
-          const allMessages = [...(existing?.messages || [])];
-          for (const msg of messages) {
-            if (!allMessages.some((m) => m.id === msg.id)) {
-              allMessages.push(msg);
-            }
-          }
+          // Merge messages (dedupe by ID; reconcile pending->confirmed)
+          const allMessages = mergeMessagesById(
+            existing?.messages || [],
+            messages
+          );
           allMessages.sort((a, b) => a.timestamp - b.timestamp);
 
           const lastMsg = allMessages[allMessages.length - 1];
@@ -771,6 +765,41 @@ export const useMessagesStore = create<MessagesState>()(
     },
   }))
 );
+
+/**
+ * Merge chain-fetched messages into an existing list, deduplicating by ID.
+ *
+ * When an incoming message matches an existing one, the chain record is the
+ * source of truth for confirmation state: a locally pending (or failed)
+ * message is upgraded to the confirmed chain record (carrying confirmedRound).
+ * This is what resolves an optimistic "pending" sent message to "confirmed"
+ * on the next load — without it, the dedup would keep skipping the confirmed
+ * record and the message would stay pending forever.
+ */
+function mergeMessagesById(
+  existing: Message[],
+  incoming: Message[]
+): Message[] {
+  const merged = [...existing];
+  for (const msg of incoming) {
+    const idx = merged.findIndex((m) => m.id === msg.id);
+    if (idx === -1) {
+      merged.push(msg);
+    } else if (
+      merged[idx].status !== 'confirmed' &&
+      msg.status === 'confirmed'
+    ) {
+      merged[idx] = {
+        ...merged[idx],
+        status: 'confirmed',
+        ...(msg.confirmedRound !== undefined
+          ? { confirmedRound: msg.confirmedRound }
+          : {}),
+      };
+    }
+  }
+  return merged;
+}
 
 /**
  * Create an empty thread for a new conversation


### PR DESCRIPTION
## What
`sendMessage` hard-coded the sent `Message.status` to `'confirmed'` regardless of whether the 0-amount note transaction actually confirmed, so a submitted-but-unconfirmed message showed a premature "confirmed" in chat. Resolves **TASK-87** (follow-up from TASK-84's Codex review).

`TransactionService.sendTransaction` already returns `{ txId, confirmed }` (since #32), so we now thread it: `status: confirmed ? 'confirmed' : 'pending'`.

## Reconcile fix (folded in from Codex review)
Codex caught that the pending state would **never resolve**: the three message-merge sites in `messagesStore` only *added* unseen IDs, so a re-fetched confirmed chain record (same txId) was skipped → a pending sent message would stay pending forever. Fixed with a shared **`mergeMessagesById()`** that upgrades a local `pending`/`failed` message to the confirmed chain record (carrying `confirmedRound`) when the ID already exists — applied at all three sites.

`ChatScreen` replaces its optimistic pending message with the send result, and `MessageBubble` already renders a pending state, so the message now shows pending and resolves to confirmed on the next thread load/poll.

The other four `status: 'confirmed'` sites parse already-confirmed on-chain messages and are correct; unchanged. No signing/key/encryption logic touched (private-key zero-fill in `finally` preserved).

## Verification / gates
- `npm run typecheck`: **no new errors** (197, unchanged vs baseline).
- `npm run lint`: **0 new errors** on the changed files (lint now works as of #34).
- **Codex: CLEAN** (2 rounds; round 1 found the stuck-pending gap, round 2 clean after the reconcile fix).
- ⏳ **Manual in-app verification pending (owner: reviewer):** send a chat message and confirm it shows pending then resolves to confirmed; verify received/confirmed messages and unread counts are unaffected.