### PR TITLE
fix(notifications): use EventSubscription.remove() for listener teardown (TASK-88)

### DIFF
--- a/src/services/notifications/index.ts
+++ b/src/services/notifications/index.ts
@@ -138,7 +138,9 @@ class NotificationService {
       }
     }
 
-    // Set up app state listener to update last_active_at
+    // Set up app state listener to update last_active_at (idempotent: drop any
+    // prior subscription so a repeated initialize() can't leak it).
+    this.appStateSubscription?.remove();
     this.appStateSubscription = AppState.addEventListener(
       'change',
       this.handleAppStateChange
@@ -150,11 +152,11 @@ class NotificationService {
    */
   cleanup(): void {
     if (this.notificationListener) {
-      Notifications.removeNotificationSubscription(this.notificationListener);
+      this.notificationListener.remove();
       this.notificationListener = null;
     }
     if (this.responseListener) {
-      Notifications.removeNotificationSubscription(this.responseListener);
+      this.responseListener.remove();
       this.responseListener = null;
     }
     if (this.appStateSubscription) {
@@ -590,6 +592,12 @@ class NotificationService {
   }
 
   private setupListeners(): void {
+    // Idempotent: drop any existing subscriptions before re-subscribing so a
+    // repeated initialize() (without an intervening cleanup()) can't leak the
+    // previous listeners.
+    this.notificationListener?.remove();
+    this.responseListener?.remove();
+
     // Handle notifications received while app is foregrounded
     this.notificationListener = Notifications.addNotificationReceivedListener(
       (notification) => {


### PR DESCRIPTION
## What
`NotificationService.cleanup()` called `Notifications.removeNotificationSubscription(...)`, which was **removed** from `expo-notifications` (installed 0.32.15 — now only in the CHANGELOG). The call was `undefined`, so teardown threw `TypeError: … is not a function`, leaking the notification/response listeners and crashing teardown.

## Fix
- `cleanup()` now calls `subscription.remove()` — the `EventSubscription` API these listeners actually return (same pattern already used for `appStateSubscription`).
- Folded in (same lifecycle concern, flagged by Codex): made `setupListeners()` and the `appStateSubscription` setup in `initialize()` **idempotent** — they drop any existing subscription before re-subscribing, so a repeated `initialize()` without an intervening `cleanup()` can no longer leak the previous listeners.

## Gates
- `npm run typecheck`: 275 → **273** (this fix also clears 2 pre-existing `tsc` errors; repo baseline is red — see TASK-93).
- `npm run lint`: clears the 2 `import/namespace` errors; file lints clean.
- Codex review (3 rounds): the teardown fix + idempotency guards confirmed correct for expo-notifications 0.32.15, no double-remove/ordering bug.
- ⚠️ **Device verification pending (owner):** exercise notification setup → teardown in the running app (no automated tests in this repo).

## Out of scope (tracked separately)
- **TASK-94** — pre-existing `initialize()`/`cleanup()` async race that can leak the appState subscription (needs a cancellation/generation guard; not a 1-liner).
- **TASK-93** — `npm run typecheck` is red on main (275 errors); this PR uses a delta gate (no new errors).

Refs TASK-88, PLAN-90.