### PR TITLE
fix(hooks): resolve react-hooks/rules-of-hooks + error-boundaries crash bugs (TASK-91)

### DIFF
--- a/src/hooks/useThemedStyles.ts
+++ b/src/hooks/useThemedStyles.ts
@@ -21,53 +21,11 @@ export const useThemedStyles = <T extends StyleSheet.NamedStyles<T>>(
 };
 
 export const useThemeColors = () => {
-  try {
-    const { theme } = useTheme();
-    return theme.colors;
-  } catch (error) {
-    console.warn(
-      'useThemeColors: Theme context not available, using default theme'
-    );
-    // Return a default theme to prevent crashes
-    return {
-      primary: '#007AFF',
-      primaryDark: '#0051D8',
-      secondary: '#5856D6',
-      background: '#FFFFFF',
-      surface: '#F8F9FA',
-      card: '#FFFFFF',
-      text: '#000000',
-      textSecondary: '#3C3C43',
-      textMuted: '#8E8E93',
-      placeholder: '#8E8E93',
-      border: '#C6C6C8',
-      borderLight: '#E5E5EA',
-      success: '#34C759',
-      warning: '#FF9500',
-      error: '#FF3B30',
-      info: '#007AFF',
-      statusBar: 'dark-content' as const,
-      tabIconActive: '#007AFF',
-      tabIconInactive: '#8E8E93',
-      tabBackground: '#FFFFFF',
-      inputBackground: '#FFFFFF',
-      inputBorder: '#C6C6C8',
-      buttonBackground: '#007AFF',
-      buttonText: '#FFFFFF',
-      modalBackground: '#FFFFFF',
-      overlay: 'rgba(0, 0, 0, 0.4)',
-      shadow: '#000000',
-      glassBackground: 'rgba(255, 255, 255, 0.72)',
-      glassBorder: 'rgba(255, 255, 255, 0.5)',
-      glassHighlight: 'rgba(255, 255, 255, 0.9)',
-      glassShadow: 'rgba(0, 0, 0, 0.08)',
-      glowPrimary: 'rgba(0, 122, 255, 0.35)',
-      glowSuccess: 'rgba(48, 209, 88, 0.35)',
-      glowError: 'rgba(255, 69, 58, 0.35)',
-      surfaceElevated: '#FFFFFF',
-      surfacePressed: 'rgba(0, 0, 0, 0.04)',
-    };
-  }
+  // useTheme() never throws — it already falls back to lightTheme when the
+  // ThemeProvider is absent (see ThemeContext) — so the previous try/catch was
+  // unreachable and violated rules-of-hooks (hook called inside a try block).
+  const { theme } = useTheme();
+  return theme.colors;
 };
 
 export const useThemeSpacing = () => {

--- a/src/screens/settings/SettingsScreen.tsx
+++ b/src/screens/settings/SettingsScreen.tsx
@@ -5,7 +5,6 @@ import {
   StyleSheet,
   Alert,
   ScrollView,
-  Modal,
   Pressable,
 } from 'react-native';
 import Slider from '@react-native-community/slider';
@@ -884,61 +883,13 @@ function SafeNetworkSwitcher({
   onClose: () => void;
   theme: Theme;
 }) {
-  try {
-    return (
-      <NetworkSwitcher visible={visible} onClose={onClose} theme={theme} />
-    );
-  } catch (error) {
-    console.error('NetworkSwitcher theme context error:', error);
-    // Return a simple modal with error message
-    return (
-      <Modal
-        visible={visible}
-        transparent
-        animationType="fade"
-        onRequestClose={onClose}
-      >
-        <View
-          style={{
-            flex: 1,
-            backgroundColor: 'rgba(0,0,0,0.5)',
-            justifyContent: 'center',
-            alignItems: 'center',
-          }}
-        >
-          <View
-            style={{
-              backgroundColor: 'white',
-              padding: 20,
-              borderRadius: 10,
-              margin: 20,
-              minWidth: 250,
-            }}
-          >
-            <Text
-              style={{ fontSize: 16, marginBottom: 10, fontWeight: 'bold' }}
-            >
-              Network Switcher Error
-            </Text>
-            <Text style={{ marginBottom: 20, color: '#666' }}>
-              Theme context not available. Please try again.
-            </Text>
-            <Pressable
-              style={{
-                backgroundColor: '#007AFF',
-                padding: 12,
-                borderRadius: 8,
-                alignItems: 'center',
-              }}
-              onPress={onClose}
-            >
-              <Text style={{ color: 'white', fontWeight: '600' }}>Close</Text>
-            </Pressable>
-          </View>
-        </View>
-      </Modal>
-    );
-  }
+  // NetworkSwitcher receives `theme` as a prop and useTheme() no longer throws
+  // (ThemeContext falls back to lightTheme), so this render can't throw. The
+  // previous try/catch could not have caught a child render error anyway — a
+  // try/catch only wraps React element creation, not the later reconciliation
+  // where children actually render — so the catch was dead code (flagged by
+  // react-hooks/error-boundaries). Render directly.
+  return <NetworkSwitcher visible={visible} onClose={onClose} theme={theme} />;
 }
 
 const createStyles = (theme: Theme) =>

--- a/src/screens/wallet/MultiNetworkAssetScreen.tsx
+++ b/src/screens/wallet/MultiNetworkAssetScreen.tsx
@@ -194,27 +194,6 @@ export default function MultiNetworkAssetScreen() {
     return [...balanceRows, ...algorandOptInRows, ...voiOptInRows];
   }, [mappedAsset, missingAlgorandOptIns, missingVoiOptIns]);
 
-  if (!mappedAsset) {
-    return (
-      <NFTBackground>
-        <SafeAreaView style={styles.container} edges={['top']}>
-          <UniversalHeader
-            title="Asset Not Found"
-            showBackButton
-            onBackPress={() => navigation.goBack()}
-            showAccountSelector={false}
-            onAccountSelectorPress={() => {}}
-          />
-          <View style={styles.emptyContainer}>
-            <Text style={styles.emptyText}>
-              This asset could not be found in your balance.
-            </Text>
-          </View>
-        </SafeAreaView>
-      </NFTBackground>
-    );
-  }
-
   const calculateTotalUsdValue = useMemo(() => {
     if (!mappedAsset) return formatCurrency(0);
 
@@ -468,6 +447,27 @@ export default function MultiNetworkAssetScreen() {
       )
       .join(' + ');
   }, [mappedAsset]);
+
+  if (!mappedAsset) {
+    return (
+      <NFTBackground>
+        <SafeAreaView style={styles.container} edges={['top']}>
+          <UniversalHeader
+            title="Asset Not Found"
+            showBackButton
+            onBackPress={() => navigation.goBack()}
+            showAccountSelector={false}
+            onAccountSelectorPress={() => {}}
+          />
+          <View style={styles.emptyContainer}>
+            <Text style={styles.emptyText}>
+              This asset could not be found in your balance.
+            </Text>
+          </View>
+        </SafeAreaView>
+      </NFTBackground>
+    );
+  }
 
   return (
     <NFTBackground>

--- a/src/screens/wallet/ReceiveScreen.tsx
+++ b/src/screens/wallet/ReceiveScreen.tsx
@@ -90,6 +90,8 @@ export default function ReceiveScreen() {
     return formatVoiBalance(amount);
   };
 
+  const { theme } = useTheme();
+
   if (isLoading) {
     return (
       <SafeAreaView style={styles.container} edges={['top']}>
@@ -113,8 +115,6 @@ export default function ReceiveScreen() {
     setIsAccountModalVisible(false);
     setIsAddAccountModalVisible(true);
   };
-
-  const { theme } = useTheme();
 
   return (
     <NFTBackground>

--- a/src/screens/wallet/SwapScreen.tsx
+++ b/src/screens/wallet/SwapScreen.tsx
@@ -28,7 +28,6 @@ import {
 } from '@react-navigation/native';
 import { useThemedStyles, useThemeColors } from '@/hooks/useThemedStyles';
 import { Theme } from '@/constants/themes';
-import { useTheme } from '@/contexts/ThemeContext';
 import { useActiveAccount, useWalletStore } from '@/store/walletStore';
 import { AccountBalance } from '@/types/wallet';
 import UniversalHeader from '@/components/common/UniversalHeader';
@@ -1028,8 +1027,6 @@ export default function SwapScreen() {
       </SafeAreaView>
     );
   }
-
-  const { theme } = useTheme();
 
   return (
     <NFTBackground>

--- a/src/screens/walletconnect/SessionProposalScreen.tsx
+++ b/src/screens/walletconnect/SessionProposalScreen.tsx
@@ -64,31 +64,6 @@ export default function SessionProposalScreen({ navigation, route }: Props) {
   // Determine which version we're handling
   const isV1 = version === 1 || v1SessionRequest;
 
-  if (!proposal && !v1SessionRequest) {
-    return (
-      <SafeAreaView style={styles.container} edges={['top', 'bottom']}>
-        <UniversalHeader
-          title="WalletConnect"
-          showBackButton
-          onBackPress={() => navigation.goBack()}
-        />
-        <View style={[styles.scrollView, { justifyContent: 'center' }]}>
-          <View style={{ alignItems: 'center' }}>
-            <Ionicons name="warning" size={32} color={theme.colors.error} />
-            <Text style={[styles.sectionTitle, { marginTop: 12 }]}>
-              No proposal data
-            </Text>
-            <Text
-              style={{ color: theme.colors.textMuted, textAlign: 'center' }}
-            >
-              Waiting for a WalletConnect session proposal...
-            </Text>
-          </View>
-        </View>
-      </SafeAreaView>
-    );
-  }
-
   const [isLoading, setIsLoading] = useState(false);
   const [accounts, setAccounts] = useState<AccountMetadata[]>([]);
   const [selectedAccountIds, setSelectedAccountIds] = useState<Set<string>>(
@@ -96,7 +71,13 @@ export default function SessionProposalScreen({ navigation, route }: Props) {
   );
 
   useEffect(() => {
+    // Only load accounts when there's actually a proposal to act on. The
+    // no-proposal early return now sits below the hooks (to keep hook order
+    // unconditional), so without this guard loadAccounts() — and its error
+    // Alerts — would fire on the "No proposal data" screen too.
+    if (!proposal && !v1SessionRequest) return;
     loadAccounts();
+    // eslint-disable-next-line react-hooks/exhaustive-deps -- run once on mount; proposal/v1SessionRequest are stable route params
   }, []);
 
   const loadAccounts = async () => {
@@ -389,6 +370,31 @@ export default function SessionProposalScreen({ navigation, route }: Props) {
       ))}
     </View>
   );
+
+  if (!proposal && !v1SessionRequest) {
+    return (
+      <SafeAreaView style={styles.container} edges={['top', 'bottom']}>
+        <UniversalHeader
+          title="WalletConnect"
+          showBackButton
+          onBackPress={() => navigation.goBack()}
+        />
+        <View style={[styles.scrollView, { justifyContent: 'center' }]}>
+          <View style={{ alignItems: 'center' }}>
+            <Ionicons name="warning" size={32} color={theme.colors.error} />
+            <Text style={[styles.sectionTitle, { marginTop: 12 }]}>
+              No proposal data
+            </Text>
+            <Text
+              style={{ color: theme.colors.textMuted, textAlign: 'center' }}
+            >
+              Waiting for a WalletConnect session proposal...
+            </Text>
+          </View>
+        </View>
+      </SafeAreaView>
+    );
+  }
 
   return (
     <SafeAreaView style={styles.container} edges={['top', 'bottom']}>

--- a/src/utils/animations.ts
+++ b/src/utils/animations.ts
@@ -248,64 +248,6 @@ export function useShimmer(duration: number = 1500) {
 }
 
 /**
- * Hook for staggered list entrance animations
- * Returns a function that creates delayed entrance for each item
- */
-export function useStaggeredEntrance(
-  itemCount: number,
-  baseDelay: number = 50
-) {
-  const opacities = Array.from({ length: itemCount }, () => useSharedValue(0));
-  const translations = Array.from({ length: itemCount }, () =>
-    useSharedValue(20)
-  );
-
-  const animateIn = useCallback(() => {
-    opacities.forEach((opacity, index) => {
-      const delay = index * baseDelay;
-      opacity.value = withTiming(1, {
-        ...timingConfigs.normal,
-        duration: timingConfigs.normal.duration + delay,
-      });
-    });
-    translations.forEach((translation, index) => {
-      const delay = index * baseDelay;
-      setTimeout(() => {
-        translation.value = withSpring(0, springConfigs.smooth);
-      }, delay);
-    });
-  }, [opacities, translations, baseDelay]);
-
-  const reset = useCallback(() => {
-    opacities.forEach((opacity) => {
-      opacity.value = 0;
-    });
-    translations.forEach((translation) => {
-      translation.value = 20;
-    });
-  }, [opacities, translations]);
-
-  const getItemStyle = useCallback(
-    (index: number) => {
-      const opacity = opacities[index];
-      const translateY = translations[index];
-
-      return useAnimatedStyle(() => ({
-        opacity: opacity?.value ?? 1,
-        transform: [{ translateY: translateY?.value ?? 0 }],
-      }));
-    },
-    [opacities, translations]
-  );
-
-  return {
-    animateIn,
-    reset,
-    getItemStyle,
-  };
-}
-
-/**
  * Interpolation helpers for common animation patterns
  */
 export const interpolations = {


### PR DESCRIPTION
## What
The ESLint 9 flat-config migration (TASK-82, #34) surfaced **22 `react-hooks/rules-of-hooks` + 1 `error-boundaries`** errors — hooks called conditionally / after early returns, which corrupt hook order and can crash at runtime. Each fix preserves behavior (changes *when* hooks run, not what renders).

| File | Sites | Fix |
|------|------|-----|
| `useThemedStyles.ts` | 1 | Drop unreachable `try/catch` around `useTheme()` — it never throws (ThemeContext falls back to `lightTheme`), so the catch was dead & made the hook conditional. |
| `utils/animations.ts` | 3 | Delete `useStaggeredEntrance` — **unused** (zero callers); it called `useSharedValue` in an `Array.from` loop + `useAnimatedStyle` in a `useCallback`. Dead code. |
| `MultiNetworkAssetScreen.tsx` | 12 | Move `if (!mappedAsset) return <Not Found>` below all 12 `useMemo`/`useCallback` (each already guards `!mappedAsset`). |
| `ReceiveScreen.tsx` | 1 | Hoist `const { theme } = useTheme()` above the `isLoading` early return. |
| `SwapScreen.tsx` | 1 | Delete dead `const { theme } = useTheme()` (unused at component scope) + now-unused import. |
| `SessionProposalScreen.tsx` | 4 | Move `if (!proposal…) return` below the state hooks + effect (after `loadAccounts` is defined). Guard the effect so `loadAccounts` (and its error Alerts) don't fire on the no-proposal screen. |
| `SettingsScreen.tsx` | 1 (err-bnd) | Remove ineffective `try/catch` in `SafeNetworkSwitcher` — a try/catch can't catch a child's render error; fallback Modal was dead. Drop now-unused `Modal` import. |

## Gates
- `npm run typecheck`: 275 → **272** (dead-code removal; **no new errors**, no touched file increased vs baseline). Baseline is red — see TASK-93.
- `npm run lint`: **0** `rules-of-hooks` / `error-boundaries` remain in touched files; no new warnings (one `exhaustive-deps` suppressed with a documented per-line reason; the 204 compiler-era rules stay **deferred** per TASK-89).
- Codex review: **CLEAN** (2 rounds; caught + fixed the SessionProposalScreen no-proposal `loadAccounts` behavior change).

## ⚠️ Device verification needed (owner — no automated tests in this repo)
Please exercise on a dev-client build before/after merge — these touch signing-adjacent screens:
- [ ] Multi-network asset detail (valid asset **and** a not-found asset → "Asset Not Found")
- [ ] Receive screen (incl. loading state)
- [ ] **Swap** screen (renders + a swap)
- [ ] **WalletConnect** session proposal (valid proposal handshake **and** the no-proposal state)
- [ ] Settings → Network Switcher
- [ ] Theming still correct app-wide (`useThemeColors` change)

Refs TASK-91, PLAN-90.