### PR TITLE
chore(lint): mechanical cleanup — lint:fix auto-fixes + JSX entity escapes + ambient no-var (TASK-92)

### DIFF
--- a/src/components/UnifiedAuthModal.tsx
+++ b/src/components/UnifiedAuthModal.tsx
@@ -20,7 +20,7 @@ import { LedgerDeviceInfo } from '@/services/ledger/transport';
 const showAlert = (
   title: string,
   message: string,
-  buttons?: Array<{ text: string; onPress?: () => void }>
+  buttons?: { text: string; onPress?: () => void }[]
 ) => {
   if (Platform.OS === 'web') {
     window.alert(`${title}\n\n${message}`);

--- a/src/components/UnifiedAuthModal.tsx
+++ b/src/components/UnifiedAuthModal.tsx
@@ -476,7 +476,7 @@ export default function UnifiedAuthModal({
                 Authentication Successful
               </Text>
               <Text style={styles.confirmationMessage}>
-                Tap "Confirm" to proceed with the transaction
+                Tap &quot;Confirm&quot; to proceed with the transaction
               </Text>
             </View>
           ) : (

--- a/src/components/UnifiedTransactionAuthModal.tsx
+++ b/src/components/UnifiedTransactionAuthModal.tsx
@@ -13,14 +13,6 @@ import { Ionicons } from '@expo/vector-icons';
 import { useThemedStyles } from '@/hooks/useThemedStyles';
 import { useTheme } from '@/contexts/ThemeContext';
 import { Theme } from '@/constants/themes';
-
-// Cross-platform vibration helper
-const vibrate = (duration: number) => {
-  if (Platform.OS !== 'web') {
-    const { Vibration } = require('react-native');
-    Vibration.vibrate(duration);
-  }
-};
 import {
   TransactionAuthController,
   TransactionAuthState_Interface,
@@ -34,6 +26,14 @@ import {
   isRemoteSignerResponse,
   RemoteSignerResponse,
 } from '@/types/remoteSigner';
+
+// Cross-platform vibration helper
+const vibrate = (duration: number) => {
+  if (Platform.OS !== 'web') {
+    const { Vibration } = require('react-native');
+    Vibration.vibrate(duration);
+  }
+};
 
 interface UnifiedTransactionAuthModalProps {
   visible: boolean;

--- a/src/components/UnifiedTransactionAuthModal.tsx
+++ b/src/components/UnifiedTransactionAuthModal.tsx
@@ -628,7 +628,9 @@ export default function UnifiedTransactionAuthModal({
             <View style={styles.stepNumber}>
               <Text style={styles.stepNumberText}>3</Text>
             </View>
-            <Text style={styles.stepText}>Tap "Scan Response" below</Text>
+            <Text style={styles.stepText}>
+              Tap &quot;Scan Response&quot; below
+            </Text>
           </View>
         </View>
       </View>

--- a/src/components/account/AccountRecipientModal.tsx
+++ b/src/components/account/AccountRecipientModal.tsx
@@ -224,9 +224,10 @@ export default function AccountRecipientModal({
   }, [isVisible]);
 
   const isAccountsTab = activeTab === 'accounts';
-  const listData = (
-    isAccountsTab ? filteredAccounts : filteredFriends
-  ) as Array<AccountMetadata | Friend>;
+  const listData = (isAccountsTab ? filteredAccounts : filteredFriends) as (
+    | AccountMetadata
+    | Friend
+  )[];
 
   const renderListItem = useCallback<ListRenderItem<AccountMetadata | Friend>>(
     ({ item }) =>

--- a/src/components/assets/NetworkFilterToggle.tsx
+++ b/src/components/assets/NetworkFilterToggle.tsx
@@ -11,7 +11,7 @@ export default function NetworkFilterToggle() {
   );
   const styles = useThemedStyles(createStyles);
 
-  const filters: Array<{ key: 'all' | 'voi' | 'algorand'; label: string }> = [
+  const filters: { key: 'all' | 'voi' | 'algorand'; label: string }[] = [
     { key: 'all', label: 'All' },
     { key: 'voi', label: 'Voi' },
     { key: 'algorand', label: 'Algo' },

--- a/src/components/auth-account/AuthAccountPreview.tsx
+++ b/src/components/auth-account/AuthAccountPreview.tsx
@@ -150,7 +150,7 @@ const AuthAccountPreview: React.FC<AuthAccountPreviewProps> = ({
         />
         <Text style={styles.infoText}>
           This account has been rekeyed to use your Ledger device for signing.
-          You'll be able to manage this account using your Ledger hardware
+          You&apos;ll be able to manage this account using your Ledger hardware
           wallet.
         </Text>
       </View>

--- a/src/components/claimable/ClaimableBanner.tsx
+++ b/src/components/claimable/ClaimableBanner.tsx
@@ -2,7 +2,7 @@
  * ClaimableBanner - Banner shown on HomeScreen when claimable tokens are available
  */
 
-import React from 'react';
+import React, { useEffect } from 'react';
 import { View, Text, StyleSheet } from 'react-native';
 import { Ionicons } from '@expo/vector-icons';
 import Animated, {
@@ -16,7 +16,6 @@ import Animated, {
 import { useThemedStyles } from '@/hooks/useThemedStyles';
 import { Theme } from '@/constants/themes';
 import { GlassCard } from '@/components/common/GlassCard';
-import { useEffect } from 'react';
 
 interface ClaimableBannerProps {
   /** Number of claimable tokens */

--- a/src/components/common/LocaleSwitcher.tsx
+++ b/src/components/common/LocaleSwitcher.tsx
@@ -29,11 +29,11 @@ interface LocaleItemProps {
   styles: ReturnType<typeof createStyles>;
 }
 
-const LOCALE_OPTIONS: ReadonlyArray<{
+const LOCALE_OPTIONS: readonly {
   label: string;
   value: string | null;
   example: string;
-}> = [
+}[] = [
   { label: 'System Default', value: null, example: '1,234.56' },
   { label: 'English (United States)', value: 'en-US', example: '1,234.56' },
   { label: 'English (United Kingdom)', value: 'en-GB', example: '1,234.56' },

--- a/src/components/common/ThemeSwitcher.tsx
+++ b/src/components/common/ThemeSwitcher.tsx
@@ -32,10 +32,10 @@ interface ThemeItemProps {
   styles: ReturnType<typeof createStyles>;
 }
 
-const THEME_OPTIONS: ReadonlyArray<{
+const THEME_OPTIONS: readonly {
   label: string;
   value: ThemeMode;
-}> = [
+}[] = [
   { label: 'Light', value: 'light' },
   { label: 'Dark', value: 'dark' },
   { label: 'System Default', value: 'system' },

--- a/src/components/ledger/SimpleLedgerTransactionModal.tsx
+++ b/src/components/ledger/SimpleLedgerTransactionModal.tsx
@@ -9,9 +9,8 @@ import {
 } from 'react-native';
 import { Ionicons } from '@expo/vector-icons';
 
-import { useThemedStyles } from '@/hooks/useThemedStyles';
+import { useThemedStyles, useThemeColors } from '@/hooks/useThemedStyles';
 import { Theme } from '@/constants/themes';
-import { useThemeColors } from '@/hooks/useThemedStyles';
 import {
   SimpleLedgerAuthController,
   SimpleLedgerAuthStateData,

--- a/src/components/ledger/TransactionVerification.tsx
+++ b/src/components/ledger/TransactionVerification.tsx
@@ -131,7 +131,7 @@ const TransactionVerification: React.FC<TransactionVerificationProps> = ({
 
       {/* Prominent amount section */}
       <View style={styles.amountSection}>
-        <Text style={styles.amountLabel}>You're sending</Text>
+        <Text style={styles.amountLabel}>You&apos;re sending</Text>
 
         {renderAssetImage()}
 

--- a/src/components/onboarding/OnboardingOptionsModal.tsx
+++ b/src/components/onboarding/OnboardingOptionsModal.tsx
@@ -121,7 +121,7 @@ export default function OnboardingOptionsModal({
             <Text
               style={[styles.subtitle, { color: theme.colors.textSecondary }]}
             >
-              Choose how you'd like to set up your Voi Wallet
+              Choose how you&apos;d like to set up your Voi Wallet
             </Text>
           </View>
 

--- a/src/components/rekey/AirgapVerificationFlow.tsx
+++ b/src/components/rekey/AirgapVerificationFlow.tsx
@@ -315,7 +315,7 @@ export function AirgapVerificationFlow({
               <Text
                 style={[styles.instructionStep, { color: theme.colors.text }]}
               >
-                4. Tap "Scan Signed Response" below
+                4. Tap &quot;Scan Signed Response&quot; below
               </Text>
             </View>
 

--- a/src/components/remoteSigner/SignerModeBanner.tsx
+++ b/src/components/remoteSigner/SignerModeBanner.tsx
@@ -5,7 +5,7 @@
  * call-to-action button to scan signing requests.
  */
 
-import React from 'react';
+import React, { useEffect } from 'react';
 import { View, Text, StyleSheet, TouchableOpacity } from 'react-native';
 import { Ionicons } from '@expo/vector-icons';
 import Animated, {
@@ -19,7 +19,6 @@ import Animated, {
 import { useThemedStyles } from '@/hooks/useThemedStyles';
 import { Theme } from '@/constants/themes';
 import { GlassCard } from '@/components/common/GlassCard';
-import { useEffect } from 'react';
 
 interface SignerModeBannerProps {
   /** Called when scan button is pressed */

--- a/src/components/remoteSigner/TransferToAirgapFlow.tsx
+++ b/src/components/remoteSigner/TransferToAirgapFlow.tsx
@@ -287,8 +287,8 @@ export function TransferToAirgapFlow({
                   style={[styles.warningText, { color: theme.colors.warning }]}
                 >
                   For maximum security, we recommend creating a new account on
-                  your airgap device while it's in airplane mode. This feature
-                  is provided for convenience only.
+                  your airgap device while it&apos;s in airplane mode. This
+                  feature is provided for convenience only.
                 </Text>
               </View>
 
@@ -457,7 +457,7 @@ export function TransferToAirgapFlow({
               <Text
                 style={[styles.instructionStep, { color: theme.colors.text }]}
               >
-                2. Tap "Import from Online Wallet"
+                2. Tap &quot;Import from Online Wallet&quot;
               </Text>
               <Text
                 style={[styles.instructionStep, { color: theme.colors.text }]}

--- a/src/components/transaction/TransactionConfirmationCard.tsx
+++ b/src/components/transaction/TransactionConfirmationCard.tsx
@@ -32,7 +32,7 @@ export default function TransactionConfirmationCard({
 
       {/* Amount Section */}
       <View style={styles.amountSection}>
-        <Text style={styles.amountLabel}>You're sending</Text>
+        <Text style={styles.amountLabel}>You&apos;re sending</Text>
         <Text style={styles.amountValue}>
           {amount} {assetSymbol}
         </Text>

--- a/src/components/walletconnect/QRScanner.tsx
+++ b/src/components/walletconnect/QRScanner.tsx
@@ -33,7 +33,7 @@ import { CameraView, Camera } from 'expo-camera';
 const showAlert = (
   title: string,
   message: string,
-  buttons?: Array<{ text: string; onPress?: () => void; style?: string }>
+  buttons?: { text: string; onPress?: () => void; style?: string }[]
 ) => {
   if (Platform.OS === 'web') {
     if (buttons && buttons.length > 1) {

--- a/src/navigation/AppNavigator.tsx
+++ b/src/navigation/AppNavigator.tsx
@@ -3,6 +3,7 @@ import {
   NavigationContainer,
   StackActions,
   useFocusEffect,
+  useNavigation,
 } from '@react-navigation/native';
 import { createBottomTabNavigator } from '@react-navigation/bottom-tabs';
 import { createNativeStackNavigator } from '@react-navigation/native-stack';
@@ -11,7 +12,6 @@ import { GestureHandlerRootView } from 'react-native-gesture-handler';
 import { View, TouchableOpacity, StyleSheet, Platform } from 'react-native';
 import { detectPlatform } from '@/platform/detection';
 import { BottomSheetModalProvider } from '@gorhom/bottom-sheet';
-import { useNavigation } from '@react-navigation/native';
 import { useTheme } from '@/contexts/ThemeContext';
 import { useThemedStyles } from '@/hooks/useThemedStyles';
 import { Theme } from '@/constants/themes';
@@ -103,6 +103,18 @@ import { TransactionRequestQueue } from '@/services/walletconnect/TransactionReq
 import { FABRadialMenu } from '@/components/navigation/FABRadialMenu';
 import { useUpdates } from 'expo-updates';
 import { useUpdateStore } from '@/store/updateStore';
+
+// Import TransactionHistoryScreen directly to avoid async-require issues in EAS builds
+import TransactionHistoryScreen from '@/screens/wallet/TransactionHistoryScreen';
+import AccountInfoScreen from '@/screens/wallet/AccountInfoScreen';
+import AccountSearchScreen from '@/screens/wallet/AccountSearchScreen';
+import FriendsScreen from '@/screens/social/FriendsScreen';
+import AddFriendScreen from '@/screens/social/AddFriendScreen';
+import FriendProfileScreen from '@/screens/social/FriendProfileScreen';
+import MyProfileScreen from '@/screens/social/MyProfileScreen';
+import MessagesInboxScreen from '@/screens/social/MessagesInboxScreen';
+import NewMessageScreen from '@/screens/social/NewMessageScreen';
+import ChatScreen from '@/screens/social/ChatScreen';
 
 export type RootStackParamList = {
   Main: undefined;
@@ -422,18 +434,6 @@ export type AirgapStackParamList = {
     | { deviceId?: string; isOnboarding?: boolean }
     | undefined;
 };
-
-// Import TransactionHistoryScreen directly to avoid async-require issues in EAS builds
-import TransactionHistoryScreen from '@/screens/wallet/TransactionHistoryScreen';
-import AccountInfoScreen from '@/screens/wallet/AccountInfoScreen';
-import AccountSearchScreen from '@/screens/wallet/AccountSearchScreen';
-import FriendsScreen from '@/screens/social/FriendsScreen';
-import AddFriendScreen from '@/screens/social/AddFriendScreen';
-import FriendProfileScreen from '@/screens/social/FriendProfileScreen';
-import MyProfileScreen from '@/screens/social/MyProfileScreen';
-import MessagesInboxScreen from '@/screens/social/MessagesInboxScreen';
-import NewMessageScreen from '@/screens/social/NewMessageScreen';
-import ChatScreen from '@/screens/social/ChatScreen';
 
 const Stack = createNativeStackNavigator<RootStackParamList>();
 const WalletStack = createNativeStackNavigator<WalletStackParamList>();

--- a/src/platform/extension/chrome.d.ts
+++ b/src/platform/extension/chrome.d.ts
@@ -110,5 +110,6 @@ declare namespace chrome {
   }
 }
 
-// Make chrome available globally
+// Make chrome available globally.
+// eslint-disable-next-line no-var -- ambient global: `declare var` is the correct idiom for a runtime-provided global (as in lib.dom.d.ts); let/const would change the declaration semantics.
 declare var chrome: typeof chrome;

--- a/src/platform/index.ts
+++ b/src/platform/index.ts
@@ -14,9 +14,6 @@
  * ```
  */
 
-export * from './types';
-export * from './detection';
-
 import { isMobile, isExtension, getCachedPlatform } from './detection';
 import type {
   CryptoAdapter,
@@ -27,6 +24,9 @@ import type {
   ClipboardAdapter,
   AlertAdapter,
 } from './types';
+
+export * from './types';
+export * from './detection';
 
 // Lazy-loaded adapters to avoid importing platform-specific code on wrong platform
 let _crypto: CryptoAdapter | null = null;

--- a/src/screens/account/AccountImportPreviewScreen.tsx
+++ b/src/screens/account/AccountImportPreviewScreen.tsx
@@ -47,7 +47,7 @@ interface ImportResult {
   success: number;
   failed: number;
   skipped: number;
-  errors: Array<{ account: string; error: string }>;
+  errors: { account: string; error: string }[];
 }
 
 export default function AccountImportPreviewScreen({

--- a/src/screens/account/AddWatchAccountScreen.tsx
+++ b/src/screens/account/AddWatchAccountScreen.tsx
@@ -59,7 +59,7 @@ export default function AddWatchAccountScreen() {
   const showAlert = (
     title: string,
     message: string,
-    buttons?: Array<{ text: string; onPress?: () => void }>
+    buttons?: { text: string; onPress?: () => void }[]
   ) => {
     if (Platform.OS === 'web') {
       window.alert(`${title}\n\n${message}`);
@@ -79,7 +79,7 @@ export default function AddWatchAccountScreen() {
       const state = navigation.getState() as
         | {
             type?: string;
-            routes?: Array<{ name: string; params?: unknown }>;
+            routes?: { name: string; params?: unknown }[];
           }
         | undefined;
 

--- a/src/screens/account/CreateAccountScreen.tsx
+++ b/src/screens/account/CreateAccountScreen.tsx
@@ -34,7 +34,7 @@ export default function CreateAccountScreen() {
         | {
             type?: string;
             index?: number;
-            routes?: Array<{ name: string; params?: unknown }>;
+            routes?: { name: string; params?: unknown }[];
           }
         | undefined;
 

--- a/src/screens/account/CreateAccountScreen.tsx
+++ b/src/screens/account/CreateAccountScreen.tsx
@@ -183,7 +183,8 @@ export default function CreateAccountScreen() {
             <View style={styles.infoTextContainer}>
               <Text style={styles.infoTitle}>Unique Recovery Phrase</Text>
               <Text style={styles.infoText}>
-                You'll receive a unique 25-word recovery phrase for this account
+                You&apos;ll receive a unique 25-word recovery phrase for this
+                account
               </Text>
             </View>
           </View>

--- a/src/screens/account/MnemonicImportScreen.tsx
+++ b/src/screens/account/MnemonicImportScreen.tsx
@@ -69,7 +69,7 @@ export default function MnemonicImportScreen({ navigation, route }: Props) {
       const state = navigation.getState() as
         | {
             type?: string;
-            routes?: Array<{ name: string; params?: unknown }>;
+            routes?: { name: string; params?: unknown }[];
           }
         | undefined;
 

--- a/src/screens/auth/LockScreen.tsx
+++ b/src/screens/auth/LockScreen.tsx
@@ -19,7 +19,7 @@ import { MultiAccountWalletService } from '@/services/wallet';
 const showAlert = (
   title: string,
   message: string,
-  buttons?: Array<{ text: string; onPress?: () => void; style?: string }>
+  buttons?: { text: string; onPress?: () => void; style?: string }[]
 ) => {
   if (Platform.OS === 'web') {
     if (buttons && buttons.length > 1) {

--- a/src/screens/onboarding/CreateWalletScreen.tsx
+++ b/src/screens/onboarding/CreateWalletScreen.tsx
@@ -33,7 +33,7 @@ export default function CreateWalletScreen({ navigation }: Props) {
   const showAlert = (
     title: string,
     message: string,
-    buttons?: Array<{ text: string; onPress?: () => void; style?: string }>
+    buttons?: { text: string; onPress?: () => void; style?: string }[]
   ) => {
     if (Platform.OS === 'web') {
       if (buttons && buttons.length > 1) {

--- a/src/screens/onboarding/SecuritySetupScreen.tsx
+++ b/src/screens/onboarding/SecuritySetupScreen.tsx
@@ -28,8 +28,7 @@ import {
   clearAccountSecrets,
 } from '@/utils/accountQRParser';
 import { useTheme } from '@/contexts/ThemeContext';
-import { useThemeColors } from '@/hooks/useThemedStyles';
-import { useThemedStyles } from '@/hooks/useThemedStyles';
+import { useThemeColors, useThemedStyles } from '@/hooks/useThemedStyles';
 import { Theme } from '@/constants/themes';
 import KeyboardAwareScrollView from '@/components/common/KeyboardAwareScrollView';
 import UniversalHeader from '@/components/common/UniversalHeader';

--- a/src/screens/remoteSigner/ExportAccountsScreen.tsx
+++ b/src/screens/remoteSigner/ExportAccountsScreen.tsx
@@ -190,8 +190,8 @@ export default function ExportAccountsScreen() {
             <Text style={styles.infoTitle}>Export to Wallet</Text>
             <Text style={styles.infoDescription}>
               Scan this QR code with your online wallet device to import these
-              accounts as air-gapped signer accounts. You'll be able to approve
-              transactions from this device.
+              accounts as air-gapped signer accounts. You&apos;ll be able to
+              approve transactions from this device.
             </Text>
           </View>
         </View>

--- a/src/screens/remoteSigner/ImportRemoteSignerScreen.tsx
+++ b/src/screens/remoteSigner/ImportRemoteSignerScreen.tsx
@@ -42,7 +42,7 @@ const { width } = Dimensions.get('window');
 const showAlert = (
   title: string,
   message: string,
-  buttons?: Array<{ text: string; onPress?: () => void; style?: string }>
+  buttons?: { text: string; onPress?: () => void; style?: string }[]
 ) => {
   if (Platform.OS === 'web') {
     if (buttons && buttons.length > 1) {

--- a/src/screens/remoteSigner/RemoteSignerSettingsScreen.tsx
+++ b/src/screens/remoteSigner/RemoteSignerSettingsScreen.tsx
@@ -48,7 +48,7 @@ import { TransferToAirgapFlow } from '@/components/remoteSigner/TransferToAirgap
 const showAlert = (
   title: string,
   message: string,
-  buttons?: Array<{ text: string; onPress?: () => void; style?: string }>
+  buttons?: { text: string; onPress?: () => void; style?: string }[]
 ) => {
   if (Platform.OS === 'web') {
     if (buttons && buttons.length > 1) {

--- a/src/screens/remoteSigner/SignRequestDisplayScreen.tsx
+++ b/src/screens/remoteSigner/SignRequestDisplayScreen.tsx
@@ -109,7 +109,7 @@ export default function SignRequestDisplayScreen() {
               <Text style={styles.stepNumberText}>2</Text>
             </View>
             <Text style={styles.stepText}>
-              Tap "Scan Request" and scan this QR code
+              Tap &quot;Scan Request&quot; and scan this QR code
             </Text>
           </View>
           <View style={styles.stepRow}>
@@ -125,7 +125,7 @@ export default function SignRequestDisplayScreen() {
               <Text style={styles.stepNumberText}>4</Text>
             </View>
             <Text style={styles.stepText}>
-              Tap "Scan Response" below to complete
+              Tap &quot;Scan Response&quot; below to complete
             </Text>
           </View>
         </View>

--- a/src/screens/remoteSigner/SignRequestScannerScreen.tsx
+++ b/src/screens/remoteSigner/SignRequestScannerScreen.tsx
@@ -40,7 +40,7 @@ const { width } = Dimensions.get('window');
 const showAlert = (
   title: string,
   message: string,
-  buttons?: Array<{ text: string; onPress?: () => void; style?: string }>
+  buttons?: { text: string; onPress?: () => void; style?: string }[]
 ) => {
   if (Platform.OS === 'web') {
     if (buttons && buttons.length > 1) {

--- a/src/screens/remoteSigner/SignatureDisplayScreen.tsx
+++ b/src/screens/remoteSigner/SignatureDisplayScreen.tsx
@@ -38,7 +38,7 @@ import algosdk from 'algosdk';
 const showAlert = (
   title: string,
   message: string,
-  buttons?: Array<{ text: string; onPress?: () => void; style?: string }>
+  buttons?: { text: string; onPress?: () => void; style?: string }[]
 ) => {
   if (Platform.OS === 'web') {
     if (buttons && buttons.length > 1) {

--- a/src/screens/remoteSigner/SignatureScannerScreen.tsx
+++ b/src/screens/remoteSigner/SignatureScannerScreen.tsx
@@ -38,7 +38,7 @@ const { width } = Dimensions.get('window');
 const showAlert = (
   title: string,
   message: string,
-  buttons?: Array<{ text: string; onPress?: () => void; style?: string }>
+  buttons?: { text: string; onPress?: () => void; style?: string }[]
 ) => {
   if (Platform.OS === 'web') {
     if (buttons && buttons.length > 1) {

--- a/src/screens/remoteSigner/TransactionReviewScreen.tsx
+++ b/src/screens/remoteSigner/TransactionReviewScreen.tsx
@@ -41,7 +41,7 @@ import { formatVoiBalance } from '@/utils/bigint';
 const showAlert = (
   title: string,
   message: string,
-  buttons?: Array<{ text: string; onPress?: () => void; style?: string }>
+  buttons?: { text: string; onPress?: () => void; style?: string }[]
 ) => {
   if (Platform.OS === 'web') {
     if (buttons && buttons.length > 1) {

--- a/src/screens/settings/BackupWalletScreen.tsx
+++ b/src/screens/settings/BackupWalletScreen.tsx
@@ -376,7 +376,7 @@ export default function BackupWalletScreen() {
         </GlassCard>
 
         {/* What's Included */}
-        <Text style={styles.sectionTitle}>What's Included</Text>
+        <Text style={styles.sectionTitle}>What&apos;s Included</Text>
         <GlassCard variant="light" style={styles.card}>
           <View style={styles.includeRow}>
             <Ionicons name="wallet" size={20} color={colors.primary} />

--- a/src/screens/settings/ChangePinScreen.tsx
+++ b/src/screens/settings/ChangePinScreen.tsx
@@ -14,8 +14,7 @@ import { AccountSecureStorage } from '@/services/secure';
 import UniversalHeader from '@/components/common/UniversalHeader';
 import KeyboardAwareScrollView from '@/components/common/KeyboardAwareScrollView';
 import { useTheme } from '@/contexts/ThemeContext';
-import { useThemeColors } from '@/hooks/useThemedStyles';
-import { useThemedStyles } from '@/hooks/useThemedStyles';
+import { useThemeColors, useThemedStyles } from '@/hooks/useThemedStyles';
 import { Theme } from '@/constants/themes';
 import { useAuth } from '@/contexts/AuthContext';
 

--- a/src/screens/settings/SecuritySettingsScreen.tsx
+++ b/src/screens/settings/SecuritySettingsScreen.tsx
@@ -18,9 +18,8 @@ import { AppStorage } from '@/utils/storage';
 import UniversalHeader from '@/components/common/UniversalHeader';
 import KeyboardAwareScrollView from '@/components/common/KeyboardAwareScrollView';
 import * as LocalAuthentication from 'expo-local-authentication';
-import { useThemedStyles } from '@/hooks/useThemedStyles';
+import { useThemedStyles, useThemeColors } from '@/hooks/useThemedStyles';
 import { useTheme } from '@/contexts/ThemeContext';
-import { useThemeColors } from '@/hooks/useThemedStyles';
 import { Theme } from '@/constants/themes';
 
 type SecuritySettingsScreenNavigationProp =

--- a/src/screens/settings/SecuritySettingsScreen.tsx
+++ b/src/screens/settings/SecuritySettingsScreen.tsx
@@ -344,8 +344,8 @@ export default function SecuritySettingsScreen() {
         <View style={styles.noticeContainer}>
           <Text style={styles.noticeTitle}>Security Notice</Text>
           <Text style={styles.noticeText}>
-            Auto-lock helps protect your wallet when you're not actively using
-            the app. The timeout is based on user activity - navigation,
+            Auto-lock helps protect your wallet when you&apos;re not actively
+            using the app. The timeout is based on user activity - navigation,
             scrolling, and tapping will reset the timer.
           </Text>
           {currentTimeout === 'never' && (

--- a/src/screens/social/ChatScreen.tsx
+++ b/src/screens/social/ChatScreen.tsx
@@ -368,7 +368,7 @@ export default function ChatScreen() {
         <View style={styles.warningBanner}>
           <Ionicons name="warning" size={16} color="white" />
           <Text style={styles.warningText}>
-            {displayName} hasn't enabled encrypted messaging yet
+            {displayName} hasn&apos;t enabled encrypted messaging yet
           </Text>
         </View>
       )}

--- a/src/screens/social/FriendsScreen.tsx
+++ b/src/screens/social/FriendsScreen.tsx
@@ -186,7 +186,7 @@ export default function FriendsScreen() {
                 color={theme.colors.primary}
               />
               <Text style={styles.searchExpandText}>
-                Search Envoi for "{searchQuery.trim()}"
+                Search Envoi for &quot;{searchQuery.trim()}&quot;
               </Text>
             </TouchableOpacity>
           )}

--- a/src/screens/social/MessagesInboxScreen.tsx
+++ b/src/screens/social/MessagesInboxScreen.tsx
@@ -524,7 +524,7 @@ export default function MessagesInboxScreen() {
         <Text style={styles.emptyTitle}>Ledger Not Supported</Text>
         <Text style={styles.emptyText}>
           Encrypted messaging requires signing a challenge message, which the
-          Ledger Algorand app doesn't support. Please switch to a standard
+          Ledger Algorand app doesn&apos;t support. Please switch to a standard
           account to use messaging.
         </Text>
       </View>

--- a/src/screens/transaction/AppCallConfirmScreen.tsx
+++ b/src/screens/transaction/AppCallConfirmScreen.tsx
@@ -114,7 +114,7 @@ export default function AppCallConfirmScreen() {
     }
 
     // Build box references
-    let boxes: Array<{ appIndex: number; name: Uint8Array }> | undefined;
+    let boxes: { appIndex: number; name: Uint8Array }[] | undefined;
     if (params.boxes && params.boxes.length > 0) {
       try {
         boxes = params.boxes.map((box) => ({

--- a/src/screens/wallet/AccountInfoScreen.tsx
+++ b/src/screens/wallet/AccountInfoScreen.tsx
@@ -11,10 +11,9 @@ import {
   Alert,
   Linking,
 } from 'react-native';
-import { useNavigation } from '@react-navigation/native';
+import { useNavigation, RouteProp, useRoute } from '@react-navigation/native';
 import { Ionicons } from '@expo/vector-icons';
 import { SafeAreaView } from 'react-native-safe-area-context';
-import { RouteProp, useRoute } from '@react-navigation/native';
 import * as Clipboard from 'expo-clipboard';
 import { PieChart } from 'react-native-chart-kit';
 import { WalletStackParamList } from '@/navigation/AppNavigator';

--- a/src/screens/wallet/AccountSearchScreen.tsx
+++ b/src/screens/wallet/AccountSearchScreen.tsx
@@ -305,7 +305,7 @@ export default function AccountSearchScreen() {
           />
           <Text style={styles.emptyTitle}>No Results Found</Text>
           <Text style={styles.emptyText}>
-            We couldn't find any accounts matching your search
+            We couldn&apos;t find any accounts matching your search
           </Text>
         </View>
       );

--- a/src/screens/wallet/HomeScreen.tsx
+++ b/src/screens/wallet/HomeScreen.tsx
@@ -21,7 +21,7 @@ import Animated, {
   withTiming,
   Easing,
 } from 'react-native-reanimated';
-import { TransactionInfo } from '@/types/wallet';
+import { TransactionInfo, AssetBalance } from '@/types/wallet';
 import { useAuth } from '@/contexts/AuthContext';
 import {
   useActiveAccount,
@@ -56,7 +56,6 @@ import { Theme } from '@/constants/themes';
 import AssetOptInModal from '@/components/assets/AssetOptInModal';
 import AssetFilterModal from '@/components/assets/AssetFilterModal';
 import type { AssetFilterSettings } from '@/components/assets/AssetFilterModal';
-import { AssetBalance } from '@/types/wallet';
 import { MappedAsset } from '@/services/token-mapping/types';
 import { GlassCard } from '@/components/common/GlassCard';
 import { GlassButton } from '@/components/common/GlassButton';

--- a/src/screens/wallet/SendScreen.tsx
+++ b/src/screens/wallet/SendScreen.tsx
@@ -310,7 +310,7 @@ export default function SendScreen() {
 
   // State for all available versions of this asset across networks
   const [assetOptions, setAssetOptions] = useState<
-    Array<{
+    {
       networkId: NetworkId;
       assetId: number;
       balance: bigint;
@@ -320,7 +320,7 @@ export default function SendScreen() {
       assetType?: 'asa' | 'arc200' | 'arc72';
       contractId?: number;
       imageUrl?: string;
-    }>
+    }[]
   >([]);
   const [isLoadingOptions, setIsLoadingOptions] = useState(false);
 

--- a/src/screens/wallet/SwapScreen.tsx
+++ b/src/screens/wallet/SwapScreen.tsx
@@ -789,7 +789,7 @@ export default function SwapScreen() {
       const assetDetailParams = resolveAssetDetailParams();
 
       navigation.dispatch((state) => {
-        const routes: Array<{ name: string; params?: Record<string, any> }> = [
+        const routes: { name: string; params?: Record<string, any> }[] = [
           { name: 'HomeMain' },
         ];
 

--- a/src/services/auth/simpleLedgerAuthController.ts
+++ b/src/services/auth/simpleLedgerAuthController.ts
@@ -45,8 +45,7 @@ export interface SimpleLedgerAuthStateData {
  * Replaces the complex TransactionAuthController with a much simpler implementation
  */
 export class SimpleLedgerAuthController {
-  private stateListeners: Array<(state: SimpleLedgerAuthStateData) => void> =
-    [];
+  private stateListeners: ((state: SimpleLedgerAuthStateData) => void)[] = [];
   private currentState: SimpleLedgerAuthStateData = {
     state: 'idle',
     deviceConnected: false,

--- a/src/services/auth/transactionAuthController.ts
+++ b/src/services/auth/transactionAuthController.ts
@@ -114,9 +114,8 @@ export interface TransactionAuthState_Interface {
  */
 export class TransactionAuthController {
   private unifiedSigner = UnifiedTransactionSigner.getInstance();
-  private stateListeners: Array<
-    (state: TransactionAuthState_Interface) => void
-  > = [];
+  private stateListeners: ((state: TransactionAuthState_Interface) => void)[] =
+    [];
   private currentState: TransactionAuthState_Interface;
   private currentRequest: UnifiedTransactionRequest | null = null;
   private ledgerSigningInfo: LedgerSigningInfo | null = null;

--- a/src/services/deeplink/index.ts
+++ b/src/services/deeplink/index.ts
@@ -48,7 +48,7 @@ export interface DeepLinkRoute {
 const showAlert = (
   title: string,
   message: string,
-  buttons?: Array<{ text: string; onPress?: () => void; style?: string }>
+  buttons?: { text: string; onPress?: () => void; style?: string }[]
 ): Promise<boolean> => {
   return new Promise((resolve) => {
     if (Platform.OS === 'web') {

--- a/src/services/ledger/simpleLedgerSigner.ts
+++ b/src/services/ledger/simpleLedgerSigner.ts
@@ -130,7 +130,7 @@ export class SimpleLedgerSigner {
     count: number = 5,
     displayFirst: boolean = false
   ): Promise<
-    Array<{ address: string; publicKey: string; derivationIndex: number }>
+    { address: string; publicKey: string; derivationIndex: number }[]
   > {
     try {
       // Ensure device is connected and ready

--- a/src/services/ledger/transport.ts
+++ b/src/services/ledger/transport.ts
@@ -1025,7 +1025,7 @@ export class LedgerTransportService {
       });
 
       return await new Promise<LedgerDeviceInfo | null>((resolve) => {
-        const cleanupCallbacks: Array<() => void> = [];
+        const cleanupCallbacks: (() => void)[] = [];
         const cleanup = () => {
           while (cleanupCallbacks.length) {
             const fn = cleanupCallbacks.pop();
@@ -1159,11 +1159,11 @@ export class LedgerTransportService {
    * Remove all listeners registered on this service.
    */
   removeAllListeners(): void {
-    (
-      Object.keys(this.listeners) as Array<keyof LedgerTransportEventMap>
-    ).forEach((event) => {
-      this.listeners[event].clear();
-    });
+    (Object.keys(this.listeners) as (keyof LedgerTransportEventMap)[]).forEach(
+      (event) => {
+        this.listeners[event].clear();
+      }
+    );
   }
 
   /**

--- a/src/services/messaging/index.ts
+++ b/src/services/messaging/index.ts
@@ -27,22 +27,6 @@ import {
   EncryptedMessagePayloadV2,
   MessagingKeyPair,
 } from './types';
-
-/**
- * MIMIR messages table row structure
- */
-interface MimirMessage {
-  id: number;
-  sender: string;
-  receiver: string;
-  txid: string;
-  round: number;
-  intra: number;
-  timestamp: number;
-  version: number;
-  note: string;
-  created_at: string;
-}
 import {
   encryptMessageV2,
   decryptMessageV2,
@@ -63,6 +47,22 @@ import {
   isMessagingKeyRegistered,
   getMessagingPublicKey,
 } from './keyRegistry';
+
+/**
+ * MIMIR messages table row structure
+ */
+interface MimirMessage {
+  id: number;
+  sender: string;
+  receiver: string;
+  txid: string;
+  round: number;
+  intra: number;
+  timestamp: number;
+  version: number;
+  note: string;
+  created_at: string;
+}
 
 /**
  * MessagingService handles all messaging operations.

--- a/src/services/mimir/index.ts
+++ b/src/services/mimir/index.ts
@@ -46,10 +46,10 @@ export interface Arc200TokenMetadata {
   verified: number;
   mintRound: number;
   contractId: number;
-  globalState: Array<{
+  globalState: {
     key: string;
     value: any;
-  }>;
+  }[];
   totalSupply: string;
 }
 
@@ -78,11 +78,11 @@ export interface Arc200ApprovalsResponse {
 }
 
 export interface Arc200BalanceResponse {
-  balances: Array<{
+  balances: {
     accountId: string;
     contractId: number;
     balance: string;
-  }>;
+  }[];
   'current-round': number;
 }
 
@@ -531,7 +531,7 @@ export class MimirApiService {
    * More efficient than individual calls when validating multiple approvals
    */
   async batchGetArc200Balances(
-    pairs: Array<{ owner: string; contractId: number }>
+    pairs: { owner: string; contractId: number }[]
   ): Promise<Map<string, string>> {
     const balanceMap = new Map<string, string>();
 

--- a/src/services/network/multi-network.ts
+++ b/src/services/network/multi-network.ts
@@ -45,10 +45,10 @@ export class MultiNetworkBalanceService {
       const results = await Promise.allSettled(balancePromises);
 
       // Extract successful balances
-      const networkBalances: Array<{
+      const networkBalances: {
         networkId: NetworkId;
         balance: AccountBalance;
-      }> = [];
+      }[] = [];
 
       for (const result of results) {
         if (
@@ -88,7 +88,7 @@ export class MultiNetworkBalanceService {
    * Combine balances from multiple networks into a single view
    */
   private static combineBalances(
-    networkBalances: Array<{ networkId: NetworkId; balance: AccountBalance }>,
+    networkBalances: { networkId: NetworkId; balance: AccountBalance }[],
     tokenMappings: TokenMapping[],
     address: string
   ): MultiNetworkBalance {
@@ -147,7 +147,7 @@ export class MultiNetworkBalanceService {
    * into a single display item
    */
   private static combineAssets(
-    networkBalances: Array<{ networkId: NetworkId; balance: AccountBalance }>,
+    networkBalances: { networkId: NetworkId; balance: AccountBalance }[],
     tokenMappings: TokenMapping[]
   ): MappedAsset[] {
     const mappedAssets = new Map<string, MappedAsset>();

--- a/src/services/nft.ts
+++ b/src/services/nft.ts
@@ -218,9 +218,7 @@ export class NFTService {
   /**
    * Format properties for display
    */
-  static formatProperties(
-    nft: NFTToken
-  ): Array<{ key: string; value: string }> {
+  static formatProperties(nft: NFTToken): { key: string; value: string }[] {
     if (!nft.metadata.properties) {
       return [];
     }

--- a/src/services/remoteSigner/index.ts
+++ b/src/services/remoteSigner/index.ts
@@ -206,7 +206,7 @@ class RemoteSignerServiceClass {
   createPairingPayload(
     deviceId: string,
     deviceName: string | undefined,
-    accounts: Array<{ address: string; publicKey: string; label?: string }>
+    accounts: { address: string; publicKey: string; label?: string }[]
   ): RemoteSignerPairing {
     return {
       v: REMOTE_SIGNER_CONSTANTS.PROTOCOL_VERSION,

--- a/src/services/secure/simplifiedKeyManager.ts
+++ b/src/services/secure/simplifiedKeyManager.ts
@@ -323,13 +323,13 @@ export class SimplifiedKeyManager {
    * Get list of signing accounts (accounts that can sign transactions)
    */
   static async getSigningAccounts(): Promise<
-    Array<{
+    {
       id: string;
       address: string;
       type: AccountType;
       canSign: boolean;
       requiresLedger: boolean;
-    }>
+    }[]
   > {
     try {
       const wallet = await MultiAccountWalletService.getCurrentWallet();

--- a/src/services/snowball/types.ts
+++ b/src/services/snowball/types.ts
@@ -122,10 +122,10 @@ export interface QuoteRequest {
  */
 export interface UnwrapRequest {
   address: string;
-  items: Array<{
+  items: {
     wrappedTokenId: number;
     amount: string;
-  }>;
+  }[];
 }
 
 /**

--- a/src/services/transactions/arc200.ts
+++ b/src/services/transactions/arc200.ts
@@ -308,7 +308,7 @@ export class Arc200TransactionService {
         fixSigners: true, // Automatically resolve signers for rekeyed accounts
       });
 
-      let boxes: Array<{ appIndex: number; name: Uint8Array }> = [];
+      let boxes: { appIndex: number; name: Uint8Array }[] = [];
 
       try {
         const simulateResponse = await algodClient
@@ -567,7 +567,7 @@ export class Arc200TransactionService {
         fixSigners: true, // Automatically resolve signers for rekeyed accounts
       });
 
-      let boxes: Array<{ appIndex: number; name: Uint8Array }> = [];
+      let boxes: { appIndex: number; name: Uint8Array }[] = [];
 
       try {
         const simulateResponse = await algodClient

--- a/src/services/transactions/arc72.ts
+++ b/src/services/transactions/arc72.ts
@@ -255,7 +255,7 @@ export class Arc72TransactionService {
         fixSigners: true,
       });
 
-      let boxes: Array<{ appIndex: number; name: Uint8Array }> = [];
+      let boxes: { appIndex: number; name: Uint8Array }[] = [];
 
       try {
         const simulateResponse = await algodClient

--- a/src/services/transactions/unifiedSigner.ts
+++ b/src/services/transactions/unifiedSigner.ts
@@ -141,7 +141,7 @@ export interface UnifiedTransactionRequest {
     foreignApps?: number[];
     foreignAssets?: number[];
     accounts?: string[];
-    boxes?: Array<{ appIndex: number; name: Uint8Array }>;
+    boxes?: { appIndex: number; name: Uint8Array }[];
     fee?: number;
     note?: string;
     networkId?: NetworkId;

--- a/src/services/walletconnect/index.ts
+++ b/src/services/walletconnect/index.ts
@@ -126,10 +126,10 @@ export class WalletConnectService extends EventEmitter {
             }
           })
         )
-      ).filter(Boolean) as Array<{
+      ).filter(Boolean) as {
         key: string;
         session: WalletConnectV1StoredSession;
-      }>;
+      }[];
 
       if (sessions.length === 0) {
         return;

--- a/src/services/walletconnect/types.ts
+++ b/src/services/walletconnect/types.ts
@@ -25,9 +25,9 @@ export interface WalletTransaction {
   signers?: string[];
   authAddr?: string;
   msig?: {
-    subsig: Array<{
+    subsig: {
       pk: string;
-    }>;
+    }[];
     thr: number;
     v: number;
   };

--- a/src/store/walletStore.ts
+++ b/src/store/walletStore.ts
@@ -1549,8 +1549,7 @@ export const useWalletStore = create<WalletState>()(
       const updatedAccountStates: Record<string, AccountUIState> = {
         ...accountStates,
       };
-      const rekeyUpdates: Array<{ account: AccountMetadata; balance: any }> =
-        [];
+      const rekeyUpdates: { account: AccountMetadata; balance: any }[] = [];
       let updatedWallet = get().wallet;
 
       // Process all results
@@ -1812,11 +1811,11 @@ export const useWalletStore = create<WalletState>()(
         });
 
         const finalStates = { ...get().accountStates };
-        const metadataUpdates: Array<{
+        const metadataUpdates: {
           accountId: string;
           nextAvatarUrl: string | undefined;
           avatarUpdatedAt?: string;
-        }> = [];
+        }[] = [];
         const accountMetadataMap: Record<string, AccountMetadata> = {};
 
         for (const { id, address } of accountsToLoad) {

--- a/src/utils/accountQRParser.ts
+++ b/src/utils/accountQRParser.ts
@@ -43,7 +43,7 @@ export const clearAccountSecret = (id: string | undefined): void => {
   accountSecretStore.delete(id);
 };
 
-export const clearAccountSecrets = (ids: Array<string | undefined>): void => {
+export const clearAccountSecrets = (ids: (string | undefined)[]): void => {
   ids.forEach((entry) => clearAccountSecret(entry));
 };
 
@@ -72,12 +72,12 @@ export interface QRAccountData {
     | 'single-mnemonic'
     | 'single-private-key'
     | 'address-list';
-  accounts?: Array<{
+  accounts?: {
     address?: string;
     name?: string;
     mnemonic?: string;
     privateKey?: string;
-  }>;
+  }[];
   mnemonic?: string;
   privateKey?: string;
   addresses?: string[];

--- a/src/utils/arc0300.ts
+++ b/src/utils/arc0300.ts
@@ -12,11 +12,11 @@ export interface Arc0300Pagination {
 
 export interface Arc0300AccountImportResult {
   kind: 'standard' | 'watch';
-  entries: Array<{
+  entries: {
     privateKeyBase64?: string;
     name?: string;
     address?: string;
-  }>;
+  }[];
   pagination?: Arc0300Pagination;
   checksum?: string;
   scheme: string;
@@ -131,14 +131,12 @@ export function normalizeBase64ToHex(base64: string): string {
   );
 }
 
-export function collectArc0300Entries(
-  order: Arc0300AccountImportResult[]
-): Array<{
+export function collectArc0300Entries(order: Arc0300AccountImportResult[]): {
   name?: string;
   privateKeyBase64?: string;
   address?: string;
   kind: 'standard' | 'watch';
-}> {
+}[] {
   return order.flatMap((result) =>
     result.entries.map((entry) => ({
       kind: result.kind,

--- a/src/utils/assetImages.ts
+++ b/src/utils/assetImages.ts
@@ -109,7 +109,7 @@ export const normalizeAssetImageUrl = (
  * Prefers direct HTTPS URLs, then HTTP, then IPFS gateways.
  */
 export const selectBestAssetImageUrl = (
-  urls: Array<string | undefined | null>
+  urls: (string | undefined | null)[]
 ): string | undefined => {
   let bestUrl: string | undefined;
   let bestPriority = -1;


### PR DESCRIPTION
## What
Mechanical, behavior-neutral cleanup of the ESLint backlog TASK-82 surfaced. **No runtime behavior change** (Codex-verified).

**Commit 1 — `lint:fix` auto-fixes (53 files)**
- `@typescript-eslint/array-type` (51): `Array<T>` → `T[]`
- `import/first` (20): imports hoisted above module code
- `import/no-duplicates` (9): duplicate imports merged

**Commit 2 — manual (18 files)**
- `react/no-unescaped-entities` (26): `'` → `&apos;`, `"` → `&quot;` in JSX text (button labels, contractions). Renders identically. Reflowed with prettier where the longer entities crossed print width.
- `no-var` (chrome.d.ts): kept `declare var chrome` (correct ambient-global idiom) with a documented `eslint-disable` — a `let`/`const` conversion would be semantically wrong.

## Gates
- `npm run typecheck`: **272**, unchanged vs branch base (no new errors; repo baseline red — TASK-93).
- `npm run lint`: 0 `no-unescaped-entities` / `no-var` / `prettier/prettier` remain; **every touched file's error count reduced, none increased**.
- Codex review: **CLEAN** (confirmed purely mechanical, no semantic/side-effect changes).

## Deferred (TASK-89)
The ~204 React-Compiler-era `react-hooks` errors + remaining warning backlog (no-unused-vars, exhaustive-deps, no-require-imports, no-named-as-default) are untouched by design — they change render/effect behavior and need their own reviewed pass.

Refs TASK-92, PLAN-90.