### PR TITLE
test: jest-expo unit tests for money/crypto pure utils + CI

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,0 +1,36 @@
+name: CI
+
+on:
+  push:
+    branches: [main]
+  pull_request:
+
+# Cancel superseded runs on the same ref.
+concurrency:
+  group: ci-${{ github.ref }}
+  cancel-in-progress: true
+
+jobs:
+  test:
+    name: Lint & unit tests
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+
+      - uses: actions/setup-node@v4
+        with:
+          node-version: 20
+          cache: npm
+
+      - name: Install dependencies
+        run: npm ci
+
+      - name: Lint
+        run: npm run lint
+
+      - name: Unit tests
+        run: npm test -- --ci
+
+      # NOTE: `npm run typecheck` is intentionally NOT gated yet — there is a
+      # large pre-existing tsc backlog (see TASK-93). Add it here once that is
+      # burned down so a green typecheck becomes a required check too.

--- a/eslint.config.js
+++ b/eslint.config.js
@@ -44,6 +44,29 @@ module.exports = [
     },
   },
   {
+    // Test files: jest globals, and allow jest.mock() calls above the imports
+    // they hoist over (which otherwise trips import/first).
+    files: ['**/*.test.ts', '**/*.test.tsx', '**/__tests__/**'],
+    languageOptions: {
+      globals: {
+        describe: 'readonly',
+        it: 'readonly',
+        test: 'readonly',
+        expect: 'readonly',
+        beforeEach: 'readonly',
+        afterEach: 'readonly',
+        beforeAll: 'readonly',
+        afterAll: 'readonly',
+        jest: 'readonly',
+      },
+    },
+    rules: {
+      'import/first': 'off',
+      // Tests import default exports (services/stores) to jest.mock them.
+      'import/no-named-as-default': 'off',
+    },
+  },
+  {
     ignores: ['dist/**', 'node_modules/**', '.expo/**', 'android/**', 'ios/**'],
   },
 ];

--- a/jest.config.js
+++ b/jest.config.js
@@ -1,0 +1,17 @@
+// Jest config for unit tests (Layer 1: pure utils). Uses the jest-expo preset
+// so the RN/Expo module graph resolves the same way the app does.
+module.exports = {
+  preset: 'jest-expo',
+  setupFiles: ['<rootDir>/jest.setup.js'],
+  moduleNameMapper: {
+    // Mirror the tsconfig `@/*` path alias.
+    '^@/(.*)$': '<rootDir>/src/$1',
+  },
+  // jest-expo's default only allow-transpiles RN/Expo packages; several deps
+  // these utils import ship as untranspiled ESM and must also be transformed.
+  transformIgnorePatterns: [
+    'node_modules/(?!(?:jest-)?react-native|@react-native(?:-community)?|expo(?:nent)?|@expo(?:nent)?/.*|@expo-google-fonts/.*|react-navigation|@react-navigation/.*|@scure/.*|@noble/.*|algosdk|tweetnacl|@walletconnect/.*|uint8arrays|multiformats|micro-.*)',
+  ],
+  testMatch: ['<rootDir>/src/**/*.test.ts', '<rootDir>/src/**/*.test.tsx'],
+  clearMocks: true,
+};

--- a/jest.setup.js
+++ b/jest.setup.js
@@ -1,0 +1,7 @@
+// Crypto polyfills for the test environment, mirroring index.ts so algosdk and
+// the crypto utils behave the same under jest. Buffer is required by algosdk;
+// getRandomValues is provided by Node in the test runtime.
+const { Buffer } = require('buffer');
+if (typeof global.Buffer === 'undefined') {
+  global.Buffer = Buffer;
+}

--- a/package-lock.json
+++ b/package-lock.json
@@ -79,6 +79,7 @@
       "devDependencies": {
         "@eslint/js": "^9.35.0",
         "@types/crypto-js": "^4.2.2",
+        "@types/jest": "29.5.14",
         "@types/react": "~19.1.0",
         "@typescript-eslint/eslint-plugin": "^8.43.0",
         "@typescript-eslint/parser": "^8.43.0",
@@ -89,6 +90,8 @@
         "eslint-plugin-prettier": "^5.5.4",
         "expo-build-properties": "~1.0.10",
         "globals": "17.7.0",
+        "jest": "~29.7.0",
+        "jest-expo": "~54.0.17",
         "prettier": "^3.6.2",
         "typescript": "~5.9.2"
       }
@@ -1589,6 +1592,13 @@
       "engines": {
         "node": ">=6.9.0"
       }
+    },
+    "node_modules/@bcoe/v8-coverage": {
+      "version": "0.2.3",
+      "resolved": "https://registry.npmjs.org/@bcoe/v8-coverage/-/v8-coverage-0.2.3.tgz",
+      "integrity": "sha512-0hYQ8SB4Db5zvZB4axdMHGwEaQjkZzFjQiN9LVYvIFB2nSUHW9tYpxWriPrWDASIxiaXax83REcLxuSdnGPZtw==",
+      "dev": true,
+      "license": "MIT"
     },
     "node_modules/@egjs/hammerjs": {
       "version": "2.0.17",
@@ -3287,6 +3297,85 @@
         "node": ">=8"
       }
     },
+    "node_modules/@jest/console": {
+      "version": "29.7.0",
+      "resolved": "https://registry.npmjs.org/@jest/console/-/console-29.7.0.tgz",
+      "integrity": "sha512-5Ni4CU7XHQi32IJ398EEP4RrB8eV09sXP2ROqD4bksHrnTree52PsxvX8tpL8LvTZ3pFzXyPbNQReSN41CAhOg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@jest/types": "^29.6.3",
+        "@types/node": "*",
+        "chalk": "^4.0.0",
+        "jest-message-util": "^29.7.0",
+        "jest-util": "^29.7.0",
+        "slash": "^3.0.0"
+      },
+      "engines": {
+        "node": "^14.15.0 || ^16.10.0 || >=18.0.0"
+      }
+    },
+    "node_modules/@jest/core": {
+      "version": "29.7.0",
+      "resolved": "https://registry.npmjs.org/@jest/core/-/core-29.7.0.tgz",
+      "integrity": "sha512-n7aeXWKMnGtDA48y8TLWJPJmLmmZ642Ceo78cYWEpiD7FzDgmNDV/GCVRorPABdXLJZ/9wzzgZAlHjXjxDHGsg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@jest/console": "^29.7.0",
+        "@jest/reporters": "^29.7.0",
+        "@jest/test-result": "^29.7.0",
+        "@jest/transform": "^29.7.0",
+        "@jest/types": "^29.6.3",
+        "@types/node": "*",
+        "ansi-escapes": "^4.2.1",
+        "chalk": "^4.0.0",
+        "ci-info": "^3.2.0",
+        "exit": "^0.1.2",
+        "graceful-fs": "^4.2.9",
+        "jest-changed-files": "^29.7.0",
+        "jest-config": "^29.7.0",
+        "jest-haste-map": "^29.7.0",
+        "jest-message-util": "^29.7.0",
+        "jest-regex-util": "^29.6.3",
+        "jest-resolve": "^29.7.0",
+        "jest-resolve-dependencies": "^29.7.0",
+        "jest-runner": "^29.7.0",
+        "jest-runtime": "^29.7.0",
+        "jest-snapshot": "^29.7.0",
+        "jest-util": "^29.7.0",
+        "jest-validate": "^29.7.0",
+        "jest-watcher": "^29.7.0",
+        "micromatch": "^4.0.4",
+        "pretty-format": "^29.7.0",
+        "slash": "^3.0.0",
+        "strip-ansi": "^6.0.0"
+      },
+      "engines": {
+        "node": "^14.15.0 || ^16.10.0 || >=18.0.0"
+      },
+      "peerDependencies": {
+        "node-notifier": "^8.0.1 || ^9.0.0 || ^10.0.0"
+      },
+      "peerDependenciesMeta": {
+        "node-notifier": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@jest/core/node_modules/strip-ansi": {
+      "version": "6.0.1",
+      "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-6.0.1.tgz",
+      "integrity": "sha512-Y38VPSHcqkFrCpFnQ9vuSXmquuv5oXOKpGeT6aGrr3o3Gc9AlVa6JBfUSOCnbxGGZF+/0ooI7KrPuUSztUdU5A==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "ansi-regex": "^5.0.1"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
     "node_modules/@jest/create-cache-key-function": {
       "version": "29.7.0",
       "resolved": "https://registry.npmjs.org/@jest/create-cache-key-function/-/create-cache-key-function-29.7.0.tgz",
@@ -3314,6 +3403,33 @@
         "node": "^14.15.0 || ^16.10.0 || >=18.0.0"
       }
     },
+    "node_modules/@jest/expect": {
+      "version": "29.7.0",
+      "resolved": "https://registry.npmjs.org/@jest/expect/-/expect-29.7.0.tgz",
+      "integrity": "sha512-8uMeAMycttpva3P1lBHB8VciS9V0XAr3GymPpipdyQXbBcuhkLQOSe8E/p92RyAdToS6ZD1tFkX+CkhoECE0dQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "expect": "^29.7.0",
+        "jest-snapshot": "^29.7.0"
+      },
+      "engines": {
+        "node": "^14.15.0 || ^16.10.0 || >=18.0.0"
+      }
+    },
+    "node_modules/@jest/expect-utils": {
+      "version": "29.7.0",
+      "resolved": "https://registry.npmjs.org/@jest/expect-utils/-/expect-utils-29.7.0.tgz",
+      "integrity": "sha512-GlsNBWiFQFCVi9QVSx7f5AgMeLxe9YCCs5PuP2O2LdjDAA8Jh9eX7lA1Jq/xdXw3Wb3hyvlFNfZIfcRetSzYcA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "jest-get-type": "^29.6.3"
+      },
+      "engines": {
+        "node": "^14.15.0 || ^16.10.0 || >=18.0.0"
+      }
+    },
     "node_modules/@jest/fake-timers": {
       "version": "29.7.0",
       "resolved": "https://registry.npmjs.org/@jest/fake-timers/-/fake-timers-29.7.0.tgz",
@@ -3331,6 +3447,155 @@
         "node": "^14.15.0 || ^16.10.0 || >=18.0.0"
       }
     },
+    "node_modules/@jest/globals": {
+      "version": "29.7.0",
+      "resolved": "https://registry.npmjs.org/@jest/globals/-/globals-29.7.0.tgz",
+      "integrity": "sha512-mpiz3dutLbkW2MNFubUGUEVLkTGiqW6yLVTA+JbP6fI6J5iL9Y0Nlg8k95pcF8ctKwCS7WVxteBs29hhfAotzQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@jest/environment": "^29.7.0",
+        "@jest/expect": "^29.7.0",
+        "@jest/types": "^29.6.3",
+        "jest-mock": "^29.7.0"
+      },
+      "engines": {
+        "node": "^14.15.0 || ^16.10.0 || >=18.0.0"
+      }
+    },
+    "node_modules/@jest/reporters": {
+      "version": "29.7.0",
+      "resolved": "https://registry.npmjs.org/@jest/reporters/-/reporters-29.7.0.tgz",
+      "integrity": "sha512-DApq0KJbJOEzAFYjHADNNxAE3KbhxQB1y5Kplb5Waqw6zVbuWatSnMjE5gs8FUgEPmNsnZA3NCWl9NG0ia04Pg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@bcoe/v8-coverage": "^0.2.3",
+        "@jest/console": "^29.7.0",
+        "@jest/test-result": "^29.7.0",
+        "@jest/transform": "^29.7.0",
+        "@jest/types": "^29.6.3",
+        "@jridgewell/trace-mapping": "^0.3.18",
+        "@types/node": "*",
+        "chalk": "^4.0.0",
+        "collect-v8-coverage": "^1.0.0",
+        "exit": "^0.1.2",
+        "glob": "^7.1.3",
+        "graceful-fs": "^4.2.9",
+        "istanbul-lib-coverage": "^3.0.0",
+        "istanbul-lib-instrument": "^6.0.0",
+        "istanbul-lib-report": "^3.0.0",
+        "istanbul-lib-source-maps": "^4.0.0",
+        "istanbul-reports": "^3.1.3",
+        "jest-message-util": "^29.7.0",
+        "jest-util": "^29.7.0",
+        "jest-worker": "^29.7.0",
+        "slash": "^3.0.0",
+        "string-length": "^4.0.1",
+        "strip-ansi": "^6.0.0",
+        "v8-to-istanbul": "^9.0.1"
+      },
+      "engines": {
+        "node": "^14.15.0 || ^16.10.0 || >=18.0.0"
+      },
+      "peerDependencies": {
+        "node-notifier": "^8.0.1 || ^9.0.0 || ^10.0.0"
+      },
+      "peerDependenciesMeta": {
+        "node-notifier": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@jest/reporters/node_modules/brace-expansion": {
+      "version": "1.1.16",
+      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.16.tgz",
+      "integrity": "sha512-IDw48K2/2kRkg9LdJxurvq3lV3aBgq0REY89duEqFRthjlPdXHKMj7EnQOXVckxzgisinf3nHfrcE2FufFLXMw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "balanced-match": "^1.0.0",
+        "concat-map": "0.0.1"
+      }
+    },
+    "node_modules/@jest/reporters/node_modules/glob": {
+      "version": "7.2.3",
+      "resolved": "https://registry.npmjs.org/glob/-/glob-7.2.3.tgz",
+      "integrity": "sha512-nFR0zLpU2YCaRxwoCJvL6UvCH2JFyFVIvwTLsIf21AuHlMskA1hhTdk+LlYJtOlYt9v6dvszD2BGRqBL+iQK9Q==",
+      "deprecated": "Old versions of glob are not supported, and contain widely publicized security vulnerabilities, which have been fixed in the current version. Please update. Support for old versions may be purchased (at exorbitant rates) by contacting i@izs.me",
+      "dev": true,
+      "license": "ISC",
+      "dependencies": {
+        "fs.realpath": "^1.0.0",
+        "inflight": "^1.0.4",
+        "inherits": "2",
+        "minimatch": "^3.1.1",
+        "once": "^1.3.0",
+        "path-is-absolute": "^1.0.0"
+      },
+      "engines": {
+        "node": "*"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/isaacs"
+      }
+    },
+    "node_modules/@jest/reporters/node_modules/istanbul-lib-instrument": {
+      "version": "6.0.3",
+      "resolved": "https://registry.npmjs.org/istanbul-lib-instrument/-/istanbul-lib-instrument-6.0.3.tgz",
+      "integrity": "sha512-Vtgk7L/R2JHyyGW07spoFlB8/lpjiOLTjMdms6AFMraYt3BaJauod/NGrfnVG/y4Ix1JEuMRPDPEj2ua+zz1/Q==",
+      "dev": true,
+      "license": "BSD-3-Clause",
+      "dependencies": {
+        "@babel/core": "^7.23.9",
+        "@babel/parser": "^7.23.9",
+        "@istanbuljs/schema": "^0.1.3",
+        "istanbul-lib-coverage": "^3.2.0",
+        "semver": "^7.5.4"
+      },
+      "engines": {
+        "node": ">=10"
+      }
+    },
+    "node_modules/@jest/reporters/node_modules/minimatch": {
+      "version": "3.1.5",
+      "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-3.1.5.tgz",
+      "integrity": "sha512-VgjWUsnnT6n+NUk6eZq77zeFdpW2LWDzP6zFGrCbHXiYNul5Dzqk2HHQ5uFH2DNW5Xbp8+jVzaeNt94ssEEl4w==",
+      "dev": true,
+      "license": "ISC",
+      "dependencies": {
+        "brace-expansion": "^1.1.7"
+      },
+      "engines": {
+        "node": "*"
+      }
+    },
+    "node_modules/@jest/reporters/node_modules/semver": {
+      "version": "7.8.5",
+      "resolved": "https://registry.npmjs.org/semver/-/semver-7.8.5.tgz",
+      "integrity": "sha512-Y7/KDsb8LjooZpwaqGyulO6DQlksgCncchHGk+sZIY4SBvUocMBEFH5Ur1fI4dV+Jvl0w6cjvucaIi40puRioA==",
+      "dev": true,
+      "license": "ISC",
+      "bin": {
+        "semver": "bin/semver.js"
+      },
+      "engines": {
+        "node": ">=10"
+      }
+    },
+    "node_modules/@jest/reporters/node_modules/strip-ansi": {
+      "version": "6.0.1",
+      "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-6.0.1.tgz",
+      "integrity": "sha512-Y38VPSHcqkFrCpFnQ9vuSXmquuv5oXOKpGeT6aGrr3o3Gc9AlVa6JBfUSOCnbxGGZF+/0ooI7KrPuUSztUdU5A==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "ansi-regex": "^5.0.1"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
     "node_modules/@jest/schemas": {
       "version": "29.6.3",
       "resolved": "https://registry.npmjs.org/@jest/schemas/-/schemas-29.6.3.tgz",
@@ -3338,6 +3603,53 @@
       "license": "MIT",
       "dependencies": {
         "@sinclair/typebox": "^0.27.8"
+      },
+      "engines": {
+        "node": "^14.15.0 || ^16.10.0 || >=18.0.0"
+      }
+    },
+    "node_modules/@jest/source-map": {
+      "version": "29.6.3",
+      "resolved": "https://registry.npmjs.org/@jest/source-map/-/source-map-29.6.3.tgz",
+      "integrity": "sha512-MHjT95QuipcPrpLM+8JMSzFx6eHp5Bm+4XeFDJlwsvVBjmKNiIAvasGK2fxz2WbGRlnvqehFbh07MMa7n3YJnw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@jridgewell/trace-mapping": "^0.3.18",
+        "callsites": "^3.0.0",
+        "graceful-fs": "^4.2.9"
+      },
+      "engines": {
+        "node": "^14.15.0 || ^16.10.0 || >=18.0.0"
+      }
+    },
+    "node_modules/@jest/test-result": {
+      "version": "29.7.0",
+      "resolved": "https://registry.npmjs.org/@jest/test-result/-/test-result-29.7.0.tgz",
+      "integrity": "sha512-Fdx+tv6x1zlkJPcWXmMDAG2HBnaR9XPSd5aDWQVsfrZmLVT3lU1cwyxLgRmXR9yrq4NBoEm9BMsfgFzTQAbJYA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@jest/console": "^29.7.0",
+        "@jest/types": "^29.6.3",
+        "@types/istanbul-lib-coverage": "^2.0.0",
+        "collect-v8-coverage": "^1.0.0"
+      },
+      "engines": {
+        "node": "^14.15.0 || ^16.10.0 || >=18.0.0"
+      }
+    },
+    "node_modules/@jest/test-sequencer": {
+      "version": "29.7.0",
+      "resolved": "https://registry.npmjs.org/@jest/test-sequencer/-/test-sequencer-29.7.0.tgz",
+      "integrity": "sha512-GQwJ5WZVrKnOJuiYiAF52UNUJXgTZx1NHjFSEB0qEMmSZKAkdMoIzw/Cj6x6NF4AvV23AUqDpFzQkN/eYCYTxw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@jest/test-result": "^29.7.0",
+        "graceful-fs": "^4.2.9",
+        "jest-haste-map": "^29.7.0",
+        "slash": "^3.0.0"
       },
       "engines": {
         "node": "^14.15.0 || ^16.10.0 || >=18.0.0"
@@ -4446,6 +4758,16 @@
       "integrity": "sha512-OvjF+z51L3ov0OyAU0duzsYuvO01PH7x4t6DJx+guahgTnBHkhJdG7soQeTSFLWN3efnHyibZ4Z8l2EuWwJN3A==",
       "license": "MIT"
     },
+    "node_modules/@tootallnate/once": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/@tootallnate/once/-/once-2.0.1.tgz",
+      "integrity": "sha512-HqmEUIGRJ5fSXchkVgR5F7qn48bDBzv0kWj/Kfu5e6uci4UlEeng4331LnBkWffb++Ei3FOVLxo8JJWMFBDMeQ==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">= 10"
+      }
+    },
     "node_modules/@txnlab/deflex": {
       "version": "1.5.0",
       "resolved": "https://registry.npmjs.org/@txnlab/deflex/-/deflex-1.5.0.tgz",
@@ -4571,6 +4893,29 @@
         "@types/istanbul-lib-report": "*"
       }
     },
+    "node_modules/@types/jest": {
+      "version": "29.5.14",
+      "resolved": "https://registry.npmjs.org/@types/jest/-/jest-29.5.14.tgz",
+      "integrity": "sha512-ZN+4sdnLUbo8EVvVc2ao0GFW6oVrQRPn4K2lglySj7APvSrgzxHiNNK99us4WDMi57xxA2yggblIAMNhXOotLQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "expect": "^29.0.0",
+        "pretty-format": "^29.0.0"
+      }
+    },
+    "node_modules/@types/jsdom": {
+      "version": "20.0.1",
+      "resolved": "https://registry.npmjs.org/@types/jsdom/-/jsdom-20.0.1.tgz",
+      "integrity": "sha512-d0r18sZPmMQr1eG35u12FZfhIXNrnsPU/g5wvRKCUf/tOGilKKwYMYGqh33BNR6ba+2gkHw1EUiHoN3mn7E5IQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@types/node": "*",
+        "@types/tough-cookie": "*",
+        "parse5": "^7.0.0"
+      }
+    },
     "node_modules/@types/json-schema": {
       "version": "7.0.15",
       "resolved": "https://registry.npmjs.org/@types/json-schema/-/json-schema-7.0.15.tgz",
@@ -4614,6 +4959,13 @@
       "version": "2.0.3",
       "resolved": "https://registry.npmjs.org/@types/stack-utils/-/stack-utils-2.0.3.tgz",
       "integrity": "sha512-9aEbYZ3TbYMznPdcdr3SmIrLXwC/AKZXQeCf9Pgao5CKb8CyHuEX5jzWPTkvregvhRJHcpRO6BFoGW9ycaOkYw==",
+      "license": "MIT"
+    },
+    "node_modules/@types/tough-cookie": {
+      "version": "4.0.5",
+      "resolved": "https://registry.npmjs.org/@types/tough-cookie/-/tough-cookie-4.0.5.tgz",
+      "integrity": "sha512-/Ad8+nIOV7Rl++6f1BdKxFSMgmoqEoYbHRpPcx3JEfv8VRsQe9Z4mCXeJBzxs7mbHY/XOZZuXlRNfhpVPbs6ZA==",
+      "dev": true,
       "license": "MIT"
     },
     "node_modules/@types/ws": {
@@ -5903,6 +6255,14 @@
         "node": ">=10.0.0"
       }
     },
+    "node_modules/abab": {
+      "version": "2.0.6",
+      "resolved": "https://registry.npmjs.org/abab/-/abab-2.0.6.tgz",
+      "integrity": "sha512-j2afSsaIENvHZN2B8GOpF566vZ5WVk5opAiMTvWgaQT8DkbOqsTfvNAvHoRGU2zzP8cPoqys+xHTRDWW8L+/BA==",
+      "deprecated": "Use your platform's native atob() and btoa() methods instead",
+      "dev": true,
+      "license": "BSD-3-Clause"
+    },
     "node_modules/abitype": {
       "version": "1.1.1",
       "resolved": "https://registry.npmjs.org/abitype/-/abitype-1.1.1.tgz",
@@ -5961,6 +6321,17 @@
         "node": ">=0.4.0"
       }
     },
+    "node_modules/acorn-globals": {
+      "version": "7.0.1",
+      "resolved": "https://registry.npmjs.org/acorn-globals/-/acorn-globals-7.0.1.tgz",
+      "integrity": "sha512-umOSDSDrfHbTNPuNpC2NSnnA3LUrqpevPb4T9jRx4MagXNS0rs+gwiTcAvqCRmsD6utzsrzNt+ebm00SNWiC3Q==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "acorn": "^8.1.0",
+        "acorn-walk": "^8.0.2"
+      }
+    },
     "node_modules/acorn-jsx": {
       "version": "5.3.2",
       "resolved": "https://registry.npmjs.org/acorn-jsx/-/acorn-jsx-5.3.2.tgz",
@@ -5969,6 +6340,19 @@
       "license": "MIT",
       "peerDependencies": {
         "acorn": "^6.0.0 || ^7.0.0 || ^8.0.0"
+      }
+    },
+    "node_modules/acorn-walk": {
+      "version": "8.3.5",
+      "resolved": "https://registry.npmjs.org/acorn-walk/-/acorn-walk-8.3.5.tgz",
+      "integrity": "sha512-HEHNfbars9v4pgpW6SO1KSPkfoS0xVOM/9UzkJltjlsHZmJasxg8aXkuZa7SMf8vKGIBhpUsPluQSqhJFCqebw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "acorn": "^8.11.0"
+      },
+      "engines": {
+        "node": ">=0.4.0"
       }
     },
     "node_modules/agent-base": {
@@ -6324,6 +6708,13 @@
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/async-limiter/-/async-limiter-1.0.1.tgz",
       "integrity": "sha512-csOlWGAcRFJaI6m+F2WKdnMKr4HhdhFVBk0H/QbJFMCr+uO2kwohwXQPxw/9OCxp05r5ghVBFSyioixx3gfkNQ==",
+      "license": "MIT"
+    },
+    "node_modules/asynckit": {
+      "version": "0.4.0",
+      "resolved": "https://registry.npmjs.org/asynckit/-/asynckit-0.4.0.tgz",
+      "integrity": "sha512-Oei9OH4tRh0YqU3GxhX79dM/mwVgvbZJaSNaRk+bshkj0S5cfHcgYakreBjrHwatXKbz+IoIdYLxrKim2MjW0Q==",
+      "dev": true,
       "license": "MIT"
     },
     "node_modules/atomic-sleep": {
@@ -6927,6 +7318,16 @@
         "url": "https://github.com/chalk/chalk?sponsor=1"
       }
     },
+    "node_modules/char-regex": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/char-regex/-/char-regex-1.0.2.tgz",
+      "integrity": "sha512-kWWXztvZ5SBQV+eRgKFeh8q5sLuZY2+8WUIzlxWVTg+oGwY14qylx1KbKzHd8P6ZYkAg0xyIDU9JMHhyJMZ1jw==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=10"
+      }
+    },
     "node_modules/chokidar": {
       "version": "4.0.3",
       "resolved": "https://registry.npmjs.org/chokidar/-/chokidar-4.0.3.tgz",
@@ -6997,6 +7398,13 @@
       "engines": {
         "node": ">=8"
       }
+    },
+    "node_modules/cjs-module-lexer": {
+      "version": "1.4.3",
+      "resolved": "https://registry.npmjs.org/cjs-module-lexer/-/cjs-module-lexer-1.4.3.tgz",
+      "integrity": "sha512-9z8TZaGM1pfswYeXrUpzPrkx8UnWYdhJclsiYMm6x/w5+nN+8Tf/LnAgfLGQCm59qAOxU8WwHEq2vNwF6i4j+Q==",
+      "dev": true,
+      "license": "MIT"
     },
     "node_modules/cli-cursor": {
       "version": "2.1.0",
@@ -7077,6 +7485,24 @@
         "node": ">=0.8"
       }
     },
+    "node_modules/co": {
+      "version": "4.6.0",
+      "resolved": "https://registry.npmjs.org/co/-/co-4.6.0.tgz",
+      "integrity": "sha512-QVb0dM5HvG+uaxitm8wONl7jltx8dqhfU33DcqtOZcLSVIKSDDLDi7+0LbAKiyI8hD9u42m2YxXSkMGWThaecQ==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "iojs": ">= 1.0.0",
+        "node": ">= 0.12.0"
+      }
+    },
+    "node_modules/collect-v8-coverage": {
+      "version": "1.0.3",
+      "resolved": "https://registry.npmjs.org/collect-v8-coverage/-/collect-v8-coverage-1.0.3.tgz",
+      "integrity": "sha512-1L5aqIkwPfiodaMgQunkF1zRhNqifHBmtbbbxcr6yVxxBnliw4TDOW6NxpO8DJLgJ16OT+Y4ztZqP6p/FtXnAw==",
+      "dev": true,
+      "license": "MIT"
+    },
     "node_modules/color": {
       "version": "4.2.3",
       "resolved": "https://registry.npmjs.org/color/-/color-4.2.3.tgz",
@@ -7116,6 +7542,19 @@
       "dependencies": {
         "color-name": "^1.0.0",
         "simple-swizzle": "^0.2.2"
+      }
+    },
+    "node_modules/combined-stream": {
+      "version": "1.0.8",
+      "resolved": "https://registry.npmjs.org/combined-stream/-/combined-stream-1.0.8.tgz",
+      "integrity": "sha512-FQN4MRfuJeHf7cBbBMJFXhKSDq+2kAArBlmRBvcvFE5BB1HZKXtSFASDhdlz9zOYwxh8lDdnvmMOe/+5cdoEdg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "delayed-stream": "~1.0.0"
+      },
+      "engines": {
+        "node": ">= 0.8"
       }
     },
     "node_modules/commander": {
@@ -7275,6 +7714,28 @@
         "ieee754": "^1.1.13"
       }
     },
+    "node_modules/create-jest": {
+      "version": "29.7.0",
+      "resolved": "https://registry.npmjs.org/create-jest/-/create-jest-29.7.0.tgz",
+      "integrity": "sha512-Adz2bdH0Vq3F53KEMJOoftQFutWCukm6J24wbPWRO4k1kMY7gS7ds/uoJkNuV8wDCtWWnuwGcJwpWcih+zEW1Q==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@jest/types": "^29.6.3",
+        "chalk": "^4.0.0",
+        "exit": "^0.1.2",
+        "graceful-fs": "^4.2.9",
+        "jest-config": "^29.7.0",
+        "jest-util": "^29.7.0",
+        "prompts": "^2.0.1"
+      },
+      "bin": {
+        "create-jest": "bin/create-jest.js"
+      },
+      "engines": {
+        "node": "^14.15.0 || ^16.10.0 || >=18.0.0"
+      }
+    },
     "node_modules/cross-fetch": {
       "version": "3.2.0",
       "resolved": "https://registry.npmjs.org/cross-fetch/-/cross-fetch-3.2.0.tgz",
@@ -7381,12 +7842,91 @@
         "url": "https://github.com/sponsors/fb55"
       }
     },
+    "node_modules/cssom": {
+      "version": "0.5.0",
+      "resolved": "https://registry.npmjs.org/cssom/-/cssom-0.5.0.tgz",
+      "integrity": "sha512-iKuQcq+NdHqlAcwUY0o/HL69XQrUaQdMjmStJ8JFmUaiiQErlhrmuigkg/CU4E2J0IyUKUrMAgl36TvN67MqTw==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/cssstyle": {
+      "version": "2.3.0",
+      "resolved": "https://registry.npmjs.org/cssstyle/-/cssstyle-2.3.0.tgz",
+      "integrity": "sha512-AZL67abkUzIuvcHqk7c09cezpGNcxUxU4Ioi/05xHk4DQeTkWmGYftIE6ctU6AEt+Gn4n1lDStOtj7FKycP71A==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "cssom": "~0.3.6"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/cssstyle/node_modules/cssom": {
+      "version": "0.3.8",
+      "resolved": "https://registry.npmjs.org/cssom/-/cssom-0.3.8.tgz",
+      "integrity": "sha512-b0tGHbfegbhPJpxpiBPU2sCkigAqtM9O121le6bbOlgyV+NyGyCmVfJ6QW9eRjz8CpNfWEOYBIMIGRYkLwsIYg==",
+      "dev": true,
+      "license": "MIT"
+    },
     "node_modules/csstype": {
       "version": "3.1.3",
       "resolved": "https://registry.npmjs.org/csstype/-/csstype-3.1.3.tgz",
       "integrity": "sha512-M1uQkMl8rQK/szD0LNhtqxIPLpimGm8sOBwU7lLnCpSbTyY3yeU1Vc7l4KT5zT4s/yOxHH5O7tIuuLOCnLADRw==",
       "devOptional": true,
       "license": "MIT"
+    },
+    "node_modules/data-urls": {
+      "version": "3.0.2",
+      "resolved": "https://registry.npmjs.org/data-urls/-/data-urls-3.0.2.tgz",
+      "integrity": "sha512-Jy/tj3ldjZJo63sVAvg6LHt2mHvl4V6AgRAmNDtLdm7faqtsx+aJG42rsyCo9JCoRVKwPFzKlIPx3DIibwSIaQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "abab": "^2.0.6",
+        "whatwg-mimetype": "^3.0.0",
+        "whatwg-url": "^11.0.0"
+      },
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/data-urls/node_modules/tr46": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/tr46/-/tr46-3.0.0.tgz",
+      "integrity": "sha512-l7FvfAHlcmulp8kr+flpQZmVwtu7nfRV7NZujtN0OqES8EL4O4e0qqzL0DC5gAvx/ZC/9lk6rhcUwYvkBnBnYA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "punycode": "^2.1.1"
+      },
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/data-urls/node_modules/webidl-conversions": {
+      "version": "7.0.0",
+      "resolved": "https://registry.npmjs.org/webidl-conversions/-/webidl-conversions-7.0.0.tgz",
+      "integrity": "sha512-VwddBukDzu71offAQR975unBIGqfKZpM+8ZX6ySk8nYhVoo5CYaZyzt3YBvYtRtO+aoGlqxPg/B87NGVZ/fu6g==",
+      "dev": true,
+      "license": "BSD-2-Clause",
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/data-urls/node_modules/whatwg-url": {
+      "version": "11.0.0",
+      "resolved": "https://registry.npmjs.org/whatwg-url/-/whatwg-url-11.0.0.tgz",
+      "integrity": "sha512-RKT8HExMpoYx4igMiVMY83lN6UeITKJlBQ+vR/8ZJ8OCdSiN3RwCq+9gH0+Xzj0+5IrM6i4j/6LuvzbZIQgEcQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "tr46": "^3.0.0",
+        "webidl-conversions": "^7.0.0"
+      },
+      "engines": {
+        "node": ">=12"
+      }
     },
     "node_modules/data-view-buffer": {
       "version": "1.0.2",
@@ -7468,6 +8008,13 @@
         "node": ">=0.10.0"
       }
     },
+    "node_modules/decimal.js": {
+      "version": "10.6.0",
+      "resolved": "https://registry.npmjs.org/decimal.js/-/decimal.js-10.6.0.tgz",
+      "integrity": "sha512-YpgQiITW3JXGntzdUmyUR1V812Hn8T1YVXhCu+wO3OpS4eU9l4YdD3qjyiKdV6mvV29zapkMeD390UVEf2lkUg==",
+      "dev": true,
+      "license": "MIT"
+    },
     "node_modules/decode-uri-component": {
       "version": "0.2.2",
       "resolved": "https://registry.npmjs.org/decode-uri-component/-/decode-uri-component-0.2.2.tgz",
@@ -7475,6 +8022,21 @@
       "license": "MIT",
       "engines": {
         "node": ">=0.10"
+      }
+    },
+    "node_modules/dedent": {
+      "version": "1.7.2",
+      "resolved": "https://registry.npmjs.org/dedent/-/dedent-1.7.2.tgz",
+      "integrity": "sha512-WzMx3mW98SN+zn3hgemf4OzdmyNhhhKz5Ay0pUfQiMQ3e1g+xmTJWp/pKdwKVXhdSkAEGIIzqeuWrL3mV/AXbA==",
+      "dev": true,
+      "license": "MIT",
+      "peerDependencies": {
+        "babel-plugin-macros": "^3.1.0"
+      },
+      "peerDependenciesMeta": {
+        "babel-plugin-macros": {
+          "optional": true
+        }
       }
     },
     "node_modules/deep-extend": {
@@ -7563,6 +8125,16 @@
       "integrity": "sha512-mEQCMmwJu317oSz8CwdIOdwf3xMif1ttiM8LTufzc3g6kR+9Pe236twL8j3IYT1F7GfRgGcW6MWxzZjLIkuHIg==",
       "license": "MIT"
     },
+    "node_modules/delayed-stream": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/delayed-stream/-/delayed-stream-1.0.0.tgz",
+      "integrity": "sha512-ZySD7Nf91aLB0RxL4KGrKHBXl7Eds1DAmEdcoVawXnLD7SDhpNgtuII2aAkg7a7QS41jxPSZ17p4VdGnMHk3MQ==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=0.4.0"
+      }
+    },
     "node_modules/depd": {
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/depd/-/depd-2.0.0.tgz",
@@ -7601,6 +8173,26 @@
       "license": "Apache-2.0",
       "engines": {
         "node": ">=8"
+      }
+    },
+    "node_modules/detect-newline": {
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/detect-newline/-/detect-newline-3.1.0.tgz",
+      "integrity": "sha512-TLz+x/vEXm/Y7P7wn1EJFNLxYpUD4TgMosxY6fAVJUnJMbupHBOncxyWUG9OpTaH9EBD7uFI5LfEgmMOc54DsA==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/diff-sequences": {
+      "version": "29.6.3",
+      "resolved": "https://registry.npmjs.org/diff-sequences/-/diff-sequences-29.6.3.tgz",
+      "integrity": "sha512-EjePK1srD3P08o2j4f0ExnylqRs5B9tJjcp9t1krH2qRi8CCdsYfwe9JgSLurFBWwq4uOlipzfk5fHNvwFKr8Q==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": "^14.15.0 || ^16.10.0 || >=18.0.0"
       }
     },
     "node_modules/dijkstrajs": {
@@ -7647,6 +8239,30 @@
         }
       ],
       "license": "BSD-2-Clause"
+    },
+    "node_modules/domexception": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/domexception/-/domexception-4.0.0.tgz",
+      "integrity": "sha512-A2is4PLG+eeSfoTMA95/s4pvAoSo2mKtiM5jlHkAVewmiO8ISFTFKZjH7UAM1Atli/OT/7JHOrJRJiMKUZKYBw==",
+      "deprecated": "Use your platform's native DOMException instead",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "webidl-conversions": "^7.0.0"
+      },
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/domexception/node_modules/webidl-conversions": {
+      "version": "7.0.0",
+      "resolved": "https://registry.npmjs.org/webidl-conversions/-/webidl-conversions-7.0.0.tgz",
+      "integrity": "sha512-VwddBukDzu71offAQR975unBIGqfKZpM+8ZX6ySk8nYhVoo5CYaZyzt3YBvYtRtO+aoGlqxPg/B87NGVZ/fu6g==",
+      "dev": true,
+      "license": "BSD-2-Clause",
+      "engines": {
+        "node": ">=12"
+      }
     },
     "node_modules/domhandler": {
       "version": "5.0.3",
@@ -7745,6 +8361,19 @@
       "integrity": "sha512-1y5w0Zsq39MSPmEjHjbizvhYoTaulVtivpxkp5q5kaPmQtsK6/2nvAzGRxNMS9DoYySp9PkW0MAQDwU1m764mg==",
       "license": "ISC"
     },
+    "node_modules/emittery": {
+      "version": "0.13.1",
+      "resolved": "https://registry.npmjs.org/emittery/-/emittery-0.13.1.tgz",
+      "integrity": "sha512-DeWwawk6r5yR9jFgnDKYt4sLS0LmHJJi3ZOnb5/JdbYwj3nW+FxQnHIjhBKz8YLC7oRNPVM9NQ47I3CVx34eqQ==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=12"
+      },
+      "funding": {
+        "url": "https://github.com/sindresorhus/emittery?sponsor=1"
+      }
+    },
     "node_modules/emoji-regex": {
       "version": "9.2.2",
       "resolved": "https://registry.npmjs.org/emoji-regex/-/emoji-regex-9.2.2.tgz",
@@ -7780,6 +8409,23 @@
       "engines": {
         "node": ">=8"
       }
+    },
+    "node_modules/error-ex": {
+      "version": "1.3.4",
+      "resolved": "https://registry.npmjs.org/error-ex/-/error-ex-1.3.4.tgz",
+      "integrity": "sha512-sqQamAnR14VgCr1A618A3sGrygcpK+HEbenA/HiEAkkUwcZIIB/tgWqHFxWgOyDh4nB4JCRimh79dR5Ywc9MDQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "is-arrayish": "^0.2.1"
+      }
+    },
+    "node_modules/error-ex/node_modules/is-arrayish": {
+      "version": "0.2.1",
+      "resolved": "https://registry.npmjs.org/is-arrayish/-/is-arrayish-0.2.1.tgz",
+      "integrity": "sha512-zz06S8t0ozoDXMG+ube26zeCTNXcKIPJZJi8hBrF4idCLms4CG9QtK7qBl1boi5ODzFpjswb5JPmHCbMpjaYzg==",
+      "dev": true,
+      "license": "MIT"
     },
     "node_modules/error-stack-parser": {
       "version": "2.1.4",
@@ -8021,6 +8667,39 @@
       },
       "funding": {
         "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/escodegen": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/escodegen/-/escodegen-2.1.0.tgz",
+      "integrity": "sha512-2NlIDTwUWJN0mRPQOdtQBzbUHvdGY2P1VXSyU83Q3xKxM7WHX2Ql8dKq782Q9TgQUNOLEzEYu9bzLNj1q88I5w==",
+      "dev": true,
+      "license": "BSD-2-Clause",
+      "dependencies": {
+        "esprima": "^4.0.1",
+        "estraverse": "^5.2.0",
+        "esutils": "^2.0.2"
+      },
+      "bin": {
+        "escodegen": "bin/escodegen.js",
+        "esgenerate": "bin/esgenerate.js"
+      },
+      "engines": {
+        "node": ">=6.0"
+      },
+      "optionalDependencies": {
+        "source-map": "~0.6.1"
+      }
+    },
+    "node_modules/escodegen/node_modules/source-map": {
+      "version": "0.6.1",
+      "resolved": "https://registry.npmjs.org/source-map/-/source-map-0.6.1.tgz",
+      "integrity": "sha512-UjgapumWlbMhkBgzT7Ykc5YXUT46F0iKu8SGXq0bcwP5dz/h0Plj6enJqjz1Zbq2l5WaqYnrVbwWOWMyF3F47g==",
+      "dev": true,
+      "license": "BSD-3-Clause",
+      "optional": true,
+      "engines": {
+        "node": ">=0.10.0"
       }
     },
     "node_modules/eslint": {
@@ -8682,10 +9361,93 @@
       "integrity": "sha512-87OpwcEiMia/DeiKFzaQNBNFeN3XkkpYIh9FyOqq5mS2oKv3CBE67PXoEKcr6nodWdXNogTiQ0jE2NGuoffXPw==",
       "license": "MIT"
     },
+    "node_modules/execa": {
+      "version": "5.1.1",
+      "resolved": "https://registry.npmjs.org/execa/-/execa-5.1.1.tgz",
+      "integrity": "sha512-8uSpZZocAZRBAPIEINJj3Lo9HyGitllczc27Eh5YYojjMFMn8yHMDMaUHE2Jqfq05D/wucwI4JGURyXt1vchyg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "cross-spawn": "^7.0.3",
+        "get-stream": "^6.0.0",
+        "human-signals": "^2.1.0",
+        "is-stream": "^2.0.0",
+        "merge-stream": "^2.0.0",
+        "npm-run-path": "^4.0.1",
+        "onetime": "^5.1.2",
+        "signal-exit": "^3.0.3",
+        "strip-final-newline": "^2.0.0"
+      },
+      "engines": {
+        "node": ">=10"
+      },
+      "funding": {
+        "url": "https://github.com/sindresorhus/execa?sponsor=1"
+      }
+    },
+    "node_modules/execa/node_modules/mimic-fn": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/mimic-fn/-/mimic-fn-2.1.0.tgz",
+      "integrity": "sha512-OqbOk5oEQeAZ8WXWydlu9HJjz9WVdEIvamMCcXmuqUYjTknH/sqsWvhQ3vgwKFRR1HpjvNBKQ37nbJgYzGqGcg==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=6"
+      }
+    },
+    "node_modules/execa/node_modules/onetime": {
+      "version": "5.1.2",
+      "resolved": "https://registry.npmjs.org/onetime/-/onetime-5.1.2.tgz",
+      "integrity": "sha512-kbpaSSGJTWdAY5KPVeMOKXSrPtr8C8C7wodJbcsd51jRnmD+GZu8Y0VoU6Dm5Z4vWr0Ig/1NKuWRKf7j5aaYSg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "mimic-fn": "^2.1.0"
+      },
+      "engines": {
+        "node": ">=6"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/execa/node_modules/signal-exit": {
+      "version": "3.0.7",
+      "resolved": "https://registry.npmjs.org/signal-exit/-/signal-exit-3.0.7.tgz",
+      "integrity": "sha512-wnD2ZE+l+SPC/uoS0vXeE9L1+0wuaMqKlfz9AMUo38JsyLSBWSFcHR1Rri62LZc12vLr1gb3jl7iwQhgwpAbGQ==",
+      "dev": true,
+      "license": "ISC"
+    },
     "node_modules/exif-parser": {
       "version": "0.1.12",
       "resolved": "https://registry.npmjs.org/exif-parser/-/exif-parser-0.1.12.tgz",
       "integrity": "sha512-c2bQfLNbMzLPmzQuOr8fy0csy84WmwnER81W88DzTp9CYNPJ6yzOj2EZAh9pywYpqHnshVLHQJ8WzldAyfY+Iw=="
+    },
+    "node_modules/exit": {
+      "version": "0.1.2",
+      "resolved": "https://registry.npmjs.org/exit/-/exit-0.1.2.tgz",
+      "integrity": "sha512-Zk/eNKV2zbjpKzrsQ+n1G6poVbErQxJ0LBOJXaKZ1EViLzH+hrLu9cdXI4zw9dBQJslwBEpbQ2P1oS7nDxs6jQ==",
+      "dev": true,
+      "engines": {
+        "node": ">= 0.8.0"
+      }
+    },
+    "node_modules/expect": {
+      "version": "29.7.0",
+      "resolved": "https://registry.npmjs.org/expect/-/expect-29.7.0.tgz",
+      "integrity": "sha512-2Zks0hf1VLFYI1kbh0I5jP3KHHyCHpkfyHBzsSXRFgl/Bg9mWYfMW8oD+PdMPlEwy5HNsR9JutYy6pMeOh61nw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@jest/expect-utils": "^29.7.0",
+        "jest-get-type": "^29.6.3",
+        "jest-matcher-utils": "^29.7.0",
+        "jest-message-util": "^29.7.0",
+        "jest-util": "^29.7.0"
+      },
+      "engines": {
+        "node": "^14.15.0 || ^16.10.0 || >=18.0.0"
+      }
     },
     "node_modules/expo": {
       "version": "54.0.30",
@@ -10117,6 +10879,23 @@
         "url": "https://github.com/sponsors/isaacs"
       }
     },
+    "node_modules/form-data": {
+      "version": "4.0.6",
+      "resolved": "https://registry.npmjs.org/form-data/-/form-data-4.0.6.tgz",
+      "integrity": "sha512-vKatAh4SlVfgbv+YtmhiRjhEMJsYpsG1Y2rMQtR+SVSbytsSD1YGzDIcrAJmdFec88u/+VoGmxnl+80gL1tRCQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "asynckit": "^0.4.0",
+        "combined-stream": "^1.0.8",
+        "es-set-tostringtag": "^2.1.0",
+        "hasown": "^2.0.4",
+        "mime-types": "^2.1.35"
+      },
+      "engines": {
+        "node": ">= 6"
+      }
+    },
     "node_modules/freeport-async": {
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/freeport-async/-/freeport-async-2.0.0.tgz",
@@ -10269,6 +11048,19 @@
       },
       "engines": {
         "node": ">= 0.4"
+      }
+    },
+    "node_modules/get-stream": {
+      "version": "6.0.1",
+      "resolved": "https://registry.npmjs.org/get-stream/-/get-stream-6.0.1.tgz",
+      "integrity": "sha512-ts6Wi+2j3jQjqi70w5AlN8DFnkSwC+MqmxEzdEALB2qXZYV3X/b1CTfgPLGJNMeAWxdPfU8FO1ms3NUfaHCPYg==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=10"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
       }
     },
     "node_modules/get-symbol-description": {
@@ -10574,6 +11366,26 @@
       "integrity": "sha512-JNAzZcXrCt42VGLuYz0zfAzDfAvJWW6AfYlDBQyDV5DClI2m5sAmK+OIO7s59XfsRsWHp02jAJrRadPRGTt6SQ==",
       "license": "ISC"
     },
+    "node_modules/html-encoding-sniffer": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/html-encoding-sniffer/-/html-encoding-sniffer-3.0.0.tgz",
+      "integrity": "sha512-oWv4T4yJ52iKrufjnyZPkrN0CH3QnrUqdB6In1g5Fe1mia8GmF36gnfNySxoZtxD5+NmYw1EElVXiBk93UeskA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "whatwg-encoding": "^2.0.0"
+      },
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/html-escaper": {
+      "version": "2.0.2",
+      "resolved": "https://registry.npmjs.org/html-escaper/-/html-escaper-2.0.2.tgz",
+      "integrity": "sha512-H2iMtd0I4Mt5eYiapRdIDjp+XzelXQ0tFE4JS7YFwFevXXMmOp9myNrUvCg0D6ws8iqkRPBfKHgbwig1SmlLfg==",
+      "dev": true,
+      "license": "MIT"
+    },
     "node_modules/http-errors": {
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/http-errors/-/http-errors-2.0.0.tgz",
@@ -10599,6 +11411,34 @@
         "node": ">= 0.8"
       }
     },
+    "node_modules/http-proxy-agent": {
+      "version": "5.0.0",
+      "resolved": "https://registry.npmjs.org/http-proxy-agent/-/http-proxy-agent-5.0.0.tgz",
+      "integrity": "sha512-n2hY8YdoRE1i7r6M0w9DIw5GgZN0G25P8zLCRQ8rjXtTU3vsNFBI/vWK/UIeE6g5MUUz6avwAPXmL6Fy9D/90w==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@tootallnate/once": "2",
+        "agent-base": "6",
+        "debug": "4"
+      },
+      "engines": {
+        "node": ">= 6"
+      }
+    },
+    "node_modules/http-proxy-agent/node_modules/agent-base": {
+      "version": "6.0.2",
+      "resolved": "https://registry.npmjs.org/agent-base/-/agent-base-6.0.2.tgz",
+      "integrity": "sha512-RZNwNclF7+MS/8bDg70amg32dyeZGZxiDuQmZxKLAlQjr3jGyLx+4Kkk58UO7D2QdgFIQCovuSuZESne6RG6XQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "debug": "4"
+      },
+      "engines": {
+        "node": ">= 6.0.0"
+      }
+    },
     "node_modules/https-proxy-agent": {
       "version": "7.0.6",
       "resolved": "https://registry.npmjs.org/https-proxy-agent/-/https-proxy-agent-7.0.6.tgz",
@@ -10610,6 +11450,16 @@
       },
       "engines": {
         "node": ">= 14"
+      }
+    },
+    "node_modules/human-signals": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/human-signals/-/human-signals-2.1.0.tgz",
+      "integrity": "sha512-B4FFZ6q/T2jhhksgkbEW3HBvWIfDW85snkQgawt07S7J5QXTk6BkNV+0yAeZrM5QpMAdYlocGoljn0sJ/WQkFw==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "engines": {
+        "node": ">=10.17.0"
       }
     },
     "node_modules/hyphenate-style-name": {
@@ -10625,6 +11475,19 @@
       "license": "MIT",
       "engines": {
         "node": ">=20.0.0"
+      }
+    },
+    "node_modules/iconv-lite": {
+      "version": "0.6.3",
+      "resolved": "https://registry.npmjs.org/iconv-lite/-/iconv-lite-0.6.3.tgz",
+      "integrity": "sha512-4fCk79wshMdzMp2rH06qWrJE4iolqLhCUH+OiuIgU++RB0+94NlDL81atO7GX55uUKueo0txHNtvEyI6D7WdMw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "safer-buffer": ">= 2.1.2 < 3.0.0"
+      },
+      "engines": {
+        "node": ">=0.10.0"
       }
     },
     "node_modules/idb-keyval": {
@@ -10718,6 +11581,26 @@
       "license": "MIT",
       "engines": {
         "node": ">=4"
+      }
+    },
+    "node_modules/import-local": {
+      "version": "3.2.0",
+      "resolved": "https://registry.npmjs.org/import-local/-/import-local-3.2.0.tgz",
+      "integrity": "sha512-2SPlun1JUPWoM6t3F0dw0FkCF/jWY8kttcY4f599GLTSjh2OCuuhdTkJQsEcZzBqbXZGKMK2OqW1oZsjtf/gQA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "pkg-dir": "^4.2.0",
+        "resolve-cwd": "^3.0.0"
+      },
+      "bin": {
+        "import-local-fixture": "fixtures/cli.js"
+      },
+      "engines": {
+        "node": ">=8"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
       }
     },
     "node_modules/imurmurhash": {
@@ -11038,6 +11921,16 @@
         "node": ">=8"
       }
     },
+    "node_modules/is-generator-fn": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/is-generator-fn/-/is-generator-fn-2.1.0.tgz",
+      "integrity": "sha512-cTIB4yPYL/Grw0EaSzASzg6bBy9gqCofvWN8okThAYIxKJZC+udlRAmGbM0XLeniEJSs8uEgHPGuHSe1XsOLSQ==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=6"
+      }
+    },
     "node_modules/is-generator-function": {
       "version": "1.1.2",
       "resolved": "https://registry.npmjs.org/is-generator-function/-/is-generator-function-1.1.2.tgz",
@@ -11147,6 +12040,13 @@
         "node": ">=8"
       }
     },
+    "node_modules/is-potential-custom-element-name": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/is-potential-custom-element-name/-/is-potential-custom-element-name-1.0.1.tgz",
+      "integrity": "sha512-bCYeRA2rVibKZd+s2625gGnGF/t7DSqDs4dP7CrLA1m7jKWz6pps0LpYLJN8Q64HtmPKJ1hrN3nzPNKFEKOUiQ==",
+      "dev": true,
+      "license": "MIT"
+    },
     "node_modules/is-regex": {
       "version": "1.2.1",
       "resolved": "https://registry.npmjs.org/is-regex/-/is-regex-1.2.1.tgz",
@@ -11192,6 +12092,19 @@
       },
       "funding": {
         "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/is-stream": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/is-stream/-/is-stream-2.0.1.tgz",
+      "integrity": "sha512-hFoiJiTl63nn+kstHGBtewWSKnQLpyb155KHheA1l39uvtO9nWIop1p3udqPcUd/xbF1VLMO4n7OI6p7RbngDg==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=8"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
       }
     },
     "node_modules/is-string": {
@@ -11349,6 +12262,60 @@
         "node": ">=8"
       }
     },
+    "node_modules/istanbul-lib-report": {
+      "version": "3.0.1",
+      "resolved": "https://registry.npmjs.org/istanbul-lib-report/-/istanbul-lib-report-3.0.1.tgz",
+      "integrity": "sha512-GCfE1mtsHGOELCU8e/Z7YWzpmybrx/+dSTfLrvY8qRmaY6zXTKWn6WQIjaAFw069icm6GVMNkgu0NzI4iPZUNw==",
+      "dev": true,
+      "license": "BSD-3-Clause",
+      "dependencies": {
+        "istanbul-lib-coverage": "^3.0.0",
+        "make-dir": "^4.0.0",
+        "supports-color": "^7.1.0"
+      },
+      "engines": {
+        "node": ">=10"
+      }
+    },
+    "node_modules/istanbul-lib-source-maps": {
+      "version": "4.0.1",
+      "resolved": "https://registry.npmjs.org/istanbul-lib-source-maps/-/istanbul-lib-source-maps-4.0.1.tgz",
+      "integrity": "sha512-n3s8EwkdFIJCG3BPKBYvskgXGoy88ARzvegkitk60NxRdwltLOTaH7CUiMRXvwYorl0Q712iEjcWB+fK/MrWVw==",
+      "dev": true,
+      "license": "BSD-3-Clause",
+      "dependencies": {
+        "debug": "^4.1.1",
+        "istanbul-lib-coverage": "^3.0.0",
+        "source-map": "^0.6.1"
+      },
+      "engines": {
+        "node": ">=10"
+      }
+    },
+    "node_modules/istanbul-lib-source-maps/node_modules/source-map": {
+      "version": "0.6.1",
+      "resolved": "https://registry.npmjs.org/source-map/-/source-map-0.6.1.tgz",
+      "integrity": "sha512-UjgapumWlbMhkBgzT7Ykc5YXUT46F0iKu8SGXq0bcwP5dz/h0Plj6enJqjz1Zbq2l5WaqYnrVbwWOWMyF3F47g==",
+      "dev": true,
+      "license": "BSD-3-Clause",
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "node_modules/istanbul-reports": {
+      "version": "3.2.0",
+      "resolved": "https://registry.npmjs.org/istanbul-reports/-/istanbul-reports-3.2.0.tgz",
+      "integrity": "sha512-HGYWWS/ehqTV3xN10i23tkPkpH46MLCIMFNCaaKNavAXTF1RkqxawEPtnjnGZ6XKSInBKkiOA5BKS+aZiY3AvA==",
+      "dev": true,
+      "license": "BSD-3-Clause",
+      "dependencies": {
+        "html-escaper": "^2.0.0",
+        "istanbul-lib-report": "^3.0.0"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
     "node_modules/iterator.prototype": {
       "version": "1.1.5",
       "resolved": "https://registry.npmjs.org/iterator.prototype/-/iterator.prototype-1.1.5.tgz",
@@ -11382,6 +12349,280 @@
         "@pkgjs/parseargs": "^0.11.0"
       }
     },
+    "node_modules/jest": {
+      "version": "29.7.0",
+      "resolved": "https://registry.npmjs.org/jest/-/jest-29.7.0.tgz",
+      "integrity": "sha512-NIy3oAFp9shda19hy4HK0HRTWKtPJmGdnvywu01nOqNC2vZg+Z+fvJDxpMQA88eb2I9EcafcdjYgsDthnYTvGw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@jest/core": "^29.7.0",
+        "@jest/types": "^29.6.3",
+        "import-local": "^3.0.2",
+        "jest-cli": "^29.7.0"
+      },
+      "bin": {
+        "jest": "bin/jest.js"
+      },
+      "engines": {
+        "node": "^14.15.0 || ^16.10.0 || >=18.0.0"
+      },
+      "peerDependencies": {
+        "node-notifier": "^8.0.1 || ^9.0.0 || ^10.0.0"
+      },
+      "peerDependenciesMeta": {
+        "node-notifier": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/jest-changed-files": {
+      "version": "29.7.0",
+      "resolved": "https://registry.npmjs.org/jest-changed-files/-/jest-changed-files-29.7.0.tgz",
+      "integrity": "sha512-fEArFiwf1BpQ+4bXSprcDc3/x4HSzL4al2tozwVpDFpsxALjLYdyiIK4e5Vz66GQJIbXJ82+35PtysofptNX2w==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "execa": "^5.0.0",
+        "jest-util": "^29.7.0",
+        "p-limit": "^3.1.0"
+      },
+      "engines": {
+        "node": "^14.15.0 || ^16.10.0 || >=18.0.0"
+      }
+    },
+    "node_modules/jest-circus": {
+      "version": "29.7.0",
+      "resolved": "https://registry.npmjs.org/jest-circus/-/jest-circus-29.7.0.tgz",
+      "integrity": "sha512-3E1nCMgipcTkCocFwM90XXQab9bS+GMsjdpmPrlelaxwD93Ad8iVEjX/vvHPdLPnFf+L40u+5+iutRdA1N9myw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@jest/environment": "^29.7.0",
+        "@jest/expect": "^29.7.0",
+        "@jest/test-result": "^29.7.0",
+        "@jest/types": "^29.6.3",
+        "@types/node": "*",
+        "chalk": "^4.0.0",
+        "co": "^4.6.0",
+        "dedent": "^1.0.0",
+        "is-generator-fn": "^2.0.0",
+        "jest-each": "^29.7.0",
+        "jest-matcher-utils": "^29.7.0",
+        "jest-message-util": "^29.7.0",
+        "jest-runtime": "^29.7.0",
+        "jest-snapshot": "^29.7.0",
+        "jest-util": "^29.7.0",
+        "p-limit": "^3.1.0",
+        "pretty-format": "^29.7.0",
+        "pure-rand": "^6.0.0",
+        "slash": "^3.0.0",
+        "stack-utils": "^2.0.3"
+      },
+      "engines": {
+        "node": "^14.15.0 || ^16.10.0 || >=18.0.0"
+      }
+    },
+    "node_modules/jest-cli": {
+      "version": "29.7.0",
+      "resolved": "https://registry.npmjs.org/jest-cli/-/jest-cli-29.7.0.tgz",
+      "integrity": "sha512-OVVobw2IubN/GSYsxETi+gOe7Ka59EFMR/twOU3Jb2GnKKeMGJB5SGUUrEz3SFVmJASUdZUzy83sLNNQ2gZslg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@jest/core": "^29.7.0",
+        "@jest/test-result": "^29.7.0",
+        "@jest/types": "^29.6.3",
+        "chalk": "^4.0.0",
+        "create-jest": "^29.7.0",
+        "exit": "^0.1.2",
+        "import-local": "^3.0.2",
+        "jest-config": "^29.7.0",
+        "jest-util": "^29.7.0",
+        "jest-validate": "^29.7.0",
+        "yargs": "^17.3.1"
+      },
+      "bin": {
+        "jest": "bin/jest.js"
+      },
+      "engines": {
+        "node": "^14.15.0 || ^16.10.0 || >=18.0.0"
+      },
+      "peerDependencies": {
+        "node-notifier": "^8.0.1 || ^9.0.0 || ^10.0.0"
+      },
+      "peerDependenciesMeta": {
+        "node-notifier": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/jest-config": {
+      "version": "29.7.0",
+      "resolved": "https://registry.npmjs.org/jest-config/-/jest-config-29.7.0.tgz",
+      "integrity": "sha512-uXbpfeQ7R6TZBqI3/TxCU4q4ttk3u0PJeC+E0zbfSoSjq6bJ7buBPxzQPL0ifrkY4DNu4JUdk0ImlBUYi840eQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@babel/core": "^7.11.6",
+        "@jest/test-sequencer": "^29.7.0",
+        "@jest/types": "^29.6.3",
+        "babel-jest": "^29.7.0",
+        "chalk": "^4.0.0",
+        "ci-info": "^3.2.0",
+        "deepmerge": "^4.2.2",
+        "glob": "^7.1.3",
+        "graceful-fs": "^4.2.9",
+        "jest-circus": "^29.7.0",
+        "jest-environment-node": "^29.7.0",
+        "jest-get-type": "^29.6.3",
+        "jest-regex-util": "^29.6.3",
+        "jest-resolve": "^29.7.0",
+        "jest-runner": "^29.7.0",
+        "jest-util": "^29.7.0",
+        "jest-validate": "^29.7.0",
+        "micromatch": "^4.0.4",
+        "parse-json": "^5.2.0",
+        "pretty-format": "^29.7.0",
+        "slash": "^3.0.0",
+        "strip-json-comments": "^3.1.1"
+      },
+      "engines": {
+        "node": "^14.15.0 || ^16.10.0 || >=18.0.0"
+      },
+      "peerDependencies": {
+        "@types/node": "*",
+        "ts-node": ">=9.0.0"
+      },
+      "peerDependenciesMeta": {
+        "@types/node": {
+          "optional": true
+        },
+        "ts-node": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/jest-config/node_modules/brace-expansion": {
+      "version": "1.1.16",
+      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.16.tgz",
+      "integrity": "sha512-IDw48K2/2kRkg9LdJxurvq3lV3aBgq0REY89duEqFRthjlPdXHKMj7EnQOXVckxzgisinf3nHfrcE2FufFLXMw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "balanced-match": "^1.0.0",
+        "concat-map": "0.0.1"
+      }
+    },
+    "node_modules/jest-config/node_modules/glob": {
+      "version": "7.2.3",
+      "resolved": "https://registry.npmjs.org/glob/-/glob-7.2.3.tgz",
+      "integrity": "sha512-nFR0zLpU2YCaRxwoCJvL6UvCH2JFyFVIvwTLsIf21AuHlMskA1hhTdk+LlYJtOlYt9v6dvszD2BGRqBL+iQK9Q==",
+      "deprecated": "Old versions of glob are not supported, and contain widely publicized security vulnerabilities, which have been fixed in the current version. Please update. Support for old versions may be purchased (at exorbitant rates) by contacting i@izs.me",
+      "dev": true,
+      "license": "ISC",
+      "dependencies": {
+        "fs.realpath": "^1.0.0",
+        "inflight": "^1.0.4",
+        "inherits": "2",
+        "minimatch": "^3.1.1",
+        "once": "^1.3.0",
+        "path-is-absolute": "^1.0.0"
+      },
+      "engines": {
+        "node": "*"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/isaacs"
+      }
+    },
+    "node_modules/jest-config/node_modules/minimatch": {
+      "version": "3.1.5",
+      "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-3.1.5.tgz",
+      "integrity": "sha512-VgjWUsnnT6n+NUk6eZq77zeFdpW2LWDzP6zFGrCbHXiYNul5Dzqk2HHQ5uFH2DNW5Xbp8+jVzaeNt94ssEEl4w==",
+      "dev": true,
+      "license": "ISC",
+      "dependencies": {
+        "brace-expansion": "^1.1.7"
+      },
+      "engines": {
+        "node": "*"
+      }
+    },
+    "node_modules/jest-diff": {
+      "version": "29.7.0",
+      "resolved": "https://registry.npmjs.org/jest-diff/-/jest-diff-29.7.0.tgz",
+      "integrity": "sha512-LMIgiIrhigmPrs03JHpxUh2yISK3vLFPkAodPeo0+BuF7wA2FoQbkEg1u8gBYBThncu7e1oEDUfIXVuTqLRUjw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "chalk": "^4.0.0",
+        "diff-sequences": "^29.6.3",
+        "jest-get-type": "^29.6.3",
+        "pretty-format": "^29.7.0"
+      },
+      "engines": {
+        "node": "^14.15.0 || ^16.10.0 || >=18.0.0"
+      }
+    },
+    "node_modules/jest-docblock": {
+      "version": "29.7.0",
+      "resolved": "https://registry.npmjs.org/jest-docblock/-/jest-docblock-29.7.0.tgz",
+      "integrity": "sha512-q617Auw3A612guyaFgsbFeYpNP5t2aoUNLwBUbc/0kD1R4t9ixDbyFTHd1nok4epoVFpr7PmeWHrhvuV3XaJ4g==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "detect-newline": "^3.0.0"
+      },
+      "engines": {
+        "node": "^14.15.0 || ^16.10.0 || >=18.0.0"
+      }
+    },
+    "node_modules/jest-each": {
+      "version": "29.7.0",
+      "resolved": "https://registry.npmjs.org/jest-each/-/jest-each-29.7.0.tgz",
+      "integrity": "sha512-gns+Er14+ZrEoC5fhOfYCY1LOHHr0TI+rQUHZS8Ttw2l7gl+80eHc/gFf2Ktkw0+SIACDTeWvpFcv3B04VembQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@jest/types": "^29.6.3",
+        "chalk": "^4.0.0",
+        "jest-get-type": "^29.6.3",
+        "jest-util": "^29.7.0",
+        "pretty-format": "^29.7.0"
+      },
+      "engines": {
+        "node": "^14.15.0 || ^16.10.0 || >=18.0.0"
+      }
+    },
+    "node_modules/jest-environment-jsdom": {
+      "version": "29.7.0",
+      "resolved": "https://registry.npmjs.org/jest-environment-jsdom/-/jest-environment-jsdom-29.7.0.tgz",
+      "integrity": "sha512-k9iQbsf9OyOfdzWH8HDmrRT0gSIcX+FLNW7IQq94tFX0gynPwqDTW0Ho6iMVNjGz/nb+l/vW3dWM2bbLLpkbXA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@jest/environment": "^29.7.0",
+        "@jest/fake-timers": "^29.7.0",
+        "@jest/types": "^29.6.3",
+        "@types/jsdom": "^20.0.0",
+        "@types/node": "*",
+        "jest-mock": "^29.7.0",
+        "jest-util": "^29.7.0",
+        "jsdom": "^20.0.0"
+      },
+      "engines": {
+        "node": "^14.15.0 || ^16.10.0 || >=18.0.0"
+      },
+      "peerDependencies": {
+        "canvas": "^2.5.0"
+      },
+      "peerDependenciesMeta": {
+        "canvas": {
+          "optional": true
+        }
+      }
+    },
     "node_modules/jest-environment-node": {
       "version": "29.7.0",
       "resolved": "https://registry.npmjs.org/jest-environment-node/-/jest-environment-node-29.7.0.tgz",
@@ -11397,6 +12638,42 @@
       },
       "engines": {
         "node": "^14.15.0 || ^16.10.0 || >=18.0.0"
+      }
+    },
+    "node_modules/jest-expo": {
+      "version": "54.0.17",
+      "resolved": "https://registry.npmjs.org/jest-expo/-/jest-expo-54.0.17.tgz",
+      "integrity": "sha512-LyIhrsP4xvHEEcR1R024u/LBj3uPpAgB+UljgV+YXWkEHjprnr0KpE4tROsMNYCVTM1pPlAnPuoBmn5gnAN9KA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@expo/config": "~12.0.13",
+        "@expo/json-file": "^10.0.8",
+        "@jest/create-cache-key-function": "^29.2.1",
+        "@jest/globals": "^29.2.1",
+        "babel-jest": "^29.2.1",
+        "jest-environment-jsdom": "^29.2.1",
+        "jest-snapshot": "^29.2.1",
+        "jest-watch-select-projects": "^2.0.0",
+        "jest-watch-typeahead": "2.2.1",
+        "json5": "^2.2.3",
+        "lodash": "^4.17.19",
+        "react-test-renderer": "19.1.0",
+        "server-only": "^0.0.1",
+        "stacktrace-js": "^2.0.2"
+      },
+      "bin": {
+        "jest": "bin/jest.js"
+      },
+      "peerDependencies": {
+        "expo": "*",
+        "react-native": "*",
+        "react-server-dom-webpack": "~19.0.4 || ~19.1.5 || ~19.2.4"
+      },
+      "peerDependenciesMeta": {
+        "react-server-dom-webpack": {
+          "optional": true
+        }
       }
     },
     "node_modules/jest-get-type": {
@@ -11433,6 +12710,36 @@
         "fsevents": "^2.3.2"
       }
     },
+    "node_modules/jest-leak-detector": {
+      "version": "29.7.0",
+      "resolved": "https://registry.npmjs.org/jest-leak-detector/-/jest-leak-detector-29.7.0.tgz",
+      "integrity": "sha512-kYA8IJcSYtST2BY9I+SMC32nDpBT3J2NvWJx8+JCuCdl/CR1I4EKUJROiP8XtCcxqgTTBGJNdbB1A8XRKbTetw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "jest-get-type": "^29.6.3",
+        "pretty-format": "^29.7.0"
+      },
+      "engines": {
+        "node": "^14.15.0 || ^16.10.0 || >=18.0.0"
+      }
+    },
+    "node_modules/jest-matcher-utils": {
+      "version": "29.7.0",
+      "resolved": "https://registry.npmjs.org/jest-matcher-utils/-/jest-matcher-utils-29.7.0.tgz",
+      "integrity": "sha512-sBkD+Xi9DtcChsI3L3u0+N0opgPYnCRPtGcQYrgXmR+hmt/fYfWAL0xRXYU8eWOdfuLgBe0YCW3AFtnRLagq/g==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "chalk": "^4.0.0",
+        "jest-diff": "^29.7.0",
+        "jest-get-type": "^29.6.3",
+        "pretty-format": "^29.7.0"
+      },
+      "engines": {
+        "node": "^14.15.0 || ^16.10.0 || >=18.0.0"
+      }
+    },
     "node_modules/jest-message-util": {
       "version": "29.7.0",
       "resolved": "https://registry.npmjs.org/jest-message-util/-/jest-message-util-29.7.0.tgz",
@@ -11467,6 +12774,24 @@
         "node": "^14.15.0 || ^16.10.0 || >=18.0.0"
       }
     },
+    "node_modules/jest-pnp-resolver": {
+      "version": "1.2.3",
+      "resolved": "https://registry.npmjs.org/jest-pnp-resolver/-/jest-pnp-resolver-1.2.3.tgz",
+      "integrity": "sha512-+3NpwQEnRoIBtx4fyhblQDPgJI0H1IEIkX7ShLUjPGA7TtUTvI1oiKi3SR4oBR0hQhQR80l4WAe5RrXBwWMA8w==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=6"
+      },
+      "peerDependencies": {
+        "jest-resolve": "*"
+      },
+      "peerDependenciesMeta": {
+        "jest-resolve": {
+          "optional": true
+        }
+      }
+    },
     "node_modules/jest-regex-util": {
       "version": "29.6.3",
       "resolved": "https://registry.npmjs.org/jest-regex-util/-/jest-regex-util-29.6.3.tgz",
@@ -11474,6 +12799,230 @@
       "license": "MIT",
       "engines": {
         "node": "^14.15.0 || ^16.10.0 || >=18.0.0"
+      }
+    },
+    "node_modules/jest-resolve": {
+      "version": "29.7.0",
+      "resolved": "https://registry.npmjs.org/jest-resolve/-/jest-resolve-29.7.0.tgz",
+      "integrity": "sha512-IOVhZSrg+UvVAshDSDtHyFCCBUl/Q3AAJv8iZ6ZjnZ74xzvwuzLXid9IIIPgTnY62SJjfuupMKZsZQRsCvxEgA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "chalk": "^4.0.0",
+        "graceful-fs": "^4.2.9",
+        "jest-haste-map": "^29.7.0",
+        "jest-pnp-resolver": "^1.2.2",
+        "jest-util": "^29.7.0",
+        "jest-validate": "^29.7.0",
+        "resolve": "^1.20.0",
+        "resolve.exports": "^2.0.0",
+        "slash": "^3.0.0"
+      },
+      "engines": {
+        "node": "^14.15.0 || ^16.10.0 || >=18.0.0"
+      }
+    },
+    "node_modules/jest-resolve-dependencies": {
+      "version": "29.7.0",
+      "resolved": "https://registry.npmjs.org/jest-resolve-dependencies/-/jest-resolve-dependencies-29.7.0.tgz",
+      "integrity": "sha512-un0zD/6qxJ+S0et7WxeI3H5XSe9lTBBR7bOHCHXkKR6luG5mwDDlIzVQ0V5cZCuoTgEdcdwzTghYkTWfubi+nA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "jest-regex-util": "^29.6.3",
+        "jest-snapshot": "^29.7.0"
+      },
+      "engines": {
+        "node": "^14.15.0 || ^16.10.0 || >=18.0.0"
+      }
+    },
+    "node_modules/jest-runner": {
+      "version": "29.7.0",
+      "resolved": "https://registry.npmjs.org/jest-runner/-/jest-runner-29.7.0.tgz",
+      "integrity": "sha512-fsc4N6cPCAahybGBfTRcq5wFR6fpLznMg47sY5aDpsoejOcVYFb07AHuSnR0liMcPTgBsA3ZJL6kFOjPdoNipQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@jest/console": "^29.7.0",
+        "@jest/environment": "^29.7.0",
+        "@jest/test-result": "^29.7.0",
+        "@jest/transform": "^29.7.0",
+        "@jest/types": "^29.6.3",
+        "@types/node": "*",
+        "chalk": "^4.0.0",
+        "emittery": "^0.13.1",
+        "graceful-fs": "^4.2.9",
+        "jest-docblock": "^29.7.0",
+        "jest-environment-node": "^29.7.0",
+        "jest-haste-map": "^29.7.0",
+        "jest-leak-detector": "^29.7.0",
+        "jest-message-util": "^29.7.0",
+        "jest-resolve": "^29.7.0",
+        "jest-runtime": "^29.7.0",
+        "jest-util": "^29.7.0",
+        "jest-watcher": "^29.7.0",
+        "jest-worker": "^29.7.0",
+        "p-limit": "^3.1.0",
+        "source-map-support": "0.5.13"
+      },
+      "engines": {
+        "node": "^14.15.0 || ^16.10.0 || >=18.0.0"
+      }
+    },
+    "node_modules/jest-runner/node_modules/source-map": {
+      "version": "0.6.1",
+      "resolved": "https://registry.npmjs.org/source-map/-/source-map-0.6.1.tgz",
+      "integrity": "sha512-UjgapumWlbMhkBgzT7Ykc5YXUT46F0iKu8SGXq0bcwP5dz/h0Plj6enJqjz1Zbq2l5WaqYnrVbwWOWMyF3F47g==",
+      "dev": true,
+      "license": "BSD-3-Clause",
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "node_modules/jest-runner/node_modules/source-map-support": {
+      "version": "0.5.13",
+      "resolved": "https://registry.npmjs.org/source-map-support/-/source-map-support-0.5.13.tgz",
+      "integrity": "sha512-SHSKFHadjVA5oR4PPqhtAVdcBWwRYVd6g6cAXnIbRiIwc2EhPrTuKUBdSLvlEKyIP3GCf89fltvcZiP9MMFA1w==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "buffer-from": "^1.0.0",
+        "source-map": "^0.6.0"
+      }
+    },
+    "node_modules/jest-runtime": {
+      "version": "29.7.0",
+      "resolved": "https://registry.npmjs.org/jest-runtime/-/jest-runtime-29.7.0.tgz",
+      "integrity": "sha512-gUnLjgwdGqW7B4LvOIkbKs9WGbn+QLqRQQ9juC6HndeDiezIwhDP+mhMwHWCEcfQ5RUXa6OPnFF8BJh5xegwwQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@jest/environment": "^29.7.0",
+        "@jest/fake-timers": "^29.7.0",
+        "@jest/globals": "^29.7.0",
+        "@jest/source-map": "^29.6.3",
+        "@jest/test-result": "^29.7.0",
+        "@jest/transform": "^29.7.0",
+        "@jest/types": "^29.6.3",
+        "@types/node": "*",
+        "chalk": "^4.0.0",
+        "cjs-module-lexer": "^1.0.0",
+        "collect-v8-coverage": "^1.0.0",
+        "glob": "^7.1.3",
+        "graceful-fs": "^4.2.9",
+        "jest-haste-map": "^29.7.0",
+        "jest-message-util": "^29.7.0",
+        "jest-mock": "^29.7.0",
+        "jest-regex-util": "^29.6.3",
+        "jest-resolve": "^29.7.0",
+        "jest-snapshot": "^29.7.0",
+        "jest-util": "^29.7.0",
+        "slash": "^3.0.0",
+        "strip-bom": "^4.0.0"
+      },
+      "engines": {
+        "node": "^14.15.0 || ^16.10.0 || >=18.0.0"
+      }
+    },
+    "node_modules/jest-runtime/node_modules/brace-expansion": {
+      "version": "1.1.16",
+      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.16.tgz",
+      "integrity": "sha512-IDw48K2/2kRkg9LdJxurvq3lV3aBgq0REY89duEqFRthjlPdXHKMj7EnQOXVckxzgisinf3nHfrcE2FufFLXMw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "balanced-match": "^1.0.0",
+        "concat-map": "0.0.1"
+      }
+    },
+    "node_modules/jest-runtime/node_modules/glob": {
+      "version": "7.2.3",
+      "resolved": "https://registry.npmjs.org/glob/-/glob-7.2.3.tgz",
+      "integrity": "sha512-nFR0zLpU2YCaRxwoCJvL6UvCH2JFyFVIvwTLsIf21AuHlMskA1hhTdk+LlYJtOlYt9v6dvszD2BGRqBL+iQK9Q==",
+      "deprecated": "Old versions of glob are not supported, and contain widely publicized security vulnerabilities, which have been fixed in the current version. Please update. Support for old versions may be purchased (at exorbitant rates) by contacting i@izs.me",
+      "dev": true,
+      "license": "ISC",
+      "dependencies": {
+        "fs.realpath": "^1.0.0",
+        "inflight": "^1.0.4",
+        "inherits": "2",
+        "minimatch": "^3.1.1",
+        "once": "^1.3.0",
+        "path-is-absolute": "^1.0.0"
+      },
+      "engines": {
+        "node": "*"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/isaacs"
+      }
+    },
+    "node_modules/jest-runtime/node_modules/minimatch": {
+      "version": "3.1.5",
+      "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-3.1.5.tgz",
+      "integrity": "sha512-VgjWUsnnT6n+NUk6eZq77zeFdpW2LWDzP6zFGrCbHXiYNul5Dzqk2HHQ5uFH2DNW5Xbp8+jVzaeNt94ssEEl4w==",
+      "dev": true,
+      "license": "ISC",
+      "dependencies": {
+        "brace-expansion": "^1.1.7"
+      },
+      "engines": {
+        "node": "*"
+      }
+    },
+    "node_modules/jest-runtime/node_modules/strip-bom": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/strip-bom/-/strip-bom-4.0.0.tgz",
+      "integrity": "sha512-3xurFv5tEgii33Zi8Jtp55wEIILR9eh34FAW00PZf+JnSsTmV/ioewSgQl97JHvgjoRGwPShsWm+IdrxB35d0w==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/jest-snapshot": {
+      "version": "29.7.0",
+      "resolved": "https://registry.npmjs.org/jest-snapshot/-/jest-snapshot-29.7.0.tgz",
+      "integrity": "sha512-Rm0BMWtxBcioHr1/OX5YCP8Uov4riHvKPknOGs804Zg9JGZgmIBkbtlxJC/7Z4msKYVbIJtfU+tKb8xlYNfdkw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@babel/core": "^7.11.6",
+        "@babel/generator": "^7.7.2",
+        "@babel/plugin-syntax-jsx": "^7.7.2",
+        "@babel/plugin-syntax-typescript": "^7.7.2",
+        "@babel/types": "^7.3.3",
+        "@jest/expect-utils": "^29.7.0",
+        "@jest/transform": "^29.7.0",
+        "@jest/types": "^29.6.3",
+        "babel-preset-current-node-syntax": "^1.0.0",
+        "chalk": "^4.0.0",
+        "expect": "^29.7.0",
+        "graceful-fs": "^4.2.9",
+        "jest-diff": "^29.7.0",
+        "jest-get-type": "^29.6.3",
+        "jest-matcher-utils": "^29.7.0",
+        "jest-message-util": "^29.7.0",
+        "jest-util": "^29.7.0",
+        "natural-compare": "^1.4.0",
+        "pretty-format": "^29.7.0",
+        "semver": "^7.5.3"
+      },
+      "engines": {
+        "node": "^14.15.0 || ^16.10.0 || >=18.0.0"
+      }
+    },
+    "node_modules/jest-snapshot/node_modules/semver": {
+      "version": "7.8.5",
+      "resolved": "https://registry.npmjs.org/semver/-/semver-7.8.5.tgz",
+      "integrity": "sha512-Y7/KDsb8LjooZpwaqGyulO6DQlksgCncchHGk+sZIY4SBvUocMBEFH5Ur1fI4dV+Jvl0w6cjvucaIi40puRioA==",
+      "dev": true,
+      "license": "ISC",
+      "bin": {
+        "semver": "bin/semver.js"
+      },
+      "engines": {
+        "node": ">=10"
       }
     },
     "node_modules/jest-util": {
@@ -11517,6 +13066,127 @@
         "jest-get-type": "^29.6.3",
         "leven": "^3.1.0",
         "pretty-format": "^29.7.0"
+      },
+      "engines": {
+        "node": "^14.15.0 || ^16.10.0 || >=18.0.0"
+      }
+    },
+    "node_modules/jest-watch-select-projects": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/jest-watch-select-projects/-/jest-watch-select-projects-2.0.0.tgz",
+      "integrity": "sha512-j00nW4dXc2NiCW6znXgFLF9g8PJ0zP25cpQ1xRro/HU2GBfZQFZD0SoXnAlaoKkIY4MlfTMkKGbNXFpvCdjl1w==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "ansi-escapes": "^4.3.0",
+        "chalk": "^3.0.0",
+        "prompts": "^2.2.1"
+      }
+    },
+    "node_modules/jest-watch-select-projects/node_modules/chalk": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/chalk/-/chalk-3.0.0.tgz",
+      "integrity": "sha512-4D3B6Wf41KOYRFdszmDqMCGq5VV/uMAB273JILmO+3jAlh8X4qDtdtgCR3fxtbLEMzSx22QdhnDcJvu2u1fVwg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "ansi-styles": "^4.1.0",
+        "supports-color": "^7.1.0"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/jest-watch-typeahead": {
+      "version": "2.2.1",
+      "resolved": "https://registry.npmjs.org/jest-watch-typeahead/-/jest-watch-typeahead-2.2.1.tgz",
+      "integrity": "sha512-jYpYmUnTzysmVnwq49TAxlmtOAwp8QIqvZyoofQFn8fiWhEDZj33ZXzg3JA4nGnzWFm1hbWf3ADpteUokvXgFA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "ansi-escapes": "^6.0.0",
+        "chalk": "^4.0.0",
+        "jest-regex-util": "^29.0.0",
+        "jest-watcher": "^29.0.0",
+        "slash": "^5.0.0",
+        "string-length": "^5.0.1",
+        "strip-ansi": "^7.0.1"
+      },
+      "engines": {
+        "node": "^14.17.0 || ^16.10.0 || >=18.0.0"
+      },
+      "peerDependencies": {
+        "jest": "^27.0.0 || ^28.0.0 || ^29.0.0"
+      }
+    },
+    "node_modules/jest-watch-typeahead/node_modules/ansi-escapes": {
+      "version": "6.2.1",
+      "resolved": "https://registry.npmjs.org/ansi-escapes/-/ansi-escapes-6.2.1.tgz",
+      "integrity": "sha512-4nJ3yixlEthEJ9Rk4vPcdBRkZvQZlYyu8j4/Mqz5sgIkddmEnH2Yj2ZrnP9S3tQOvSNRUIgVNF/1yPpRAGNRig==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=14.16"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/jest-watch-typeahead/node_modules/char-regex": {
+      "version": "2.0.2",
+      "resolved": "https://registry.npmjs.org/char-regex/-/char-regex-2.0.2.tgz",
+      "integrity": "sha512-cbGOjAptfM2LVmWhwRFHEKTPkLwNddVmuqYZQt895yXwAsWsXObCG+YN4DGQ/JBtT4GP1a1lPPdio2z413LmTg==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=12.20"
+      }
+    },
+    "node_modules/jest-watch-typeahead/node_modules/slash": {
+      "version": "5.1.0",
+      "resolved": "https://registry.npmjs.org/slash/-/slash-5.1.0.tgz",
+      "integrity": "sha512-ZA6oR3T/pEyuqwMgAKT0/hAv8oAXckzbkmR0UkUosQ+Mc4RxGoJkRmwHgHufaenlyAgE1Mxgpdcrf75y6XcnDg==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=14.16"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/jest-watch-typeahead/node_modules/string-length": {
+      "version": "5.0.1",
+      "resolved": "https://registry.npmjs.org/string-length/-/string-length-5.0.1.tgz",
+      "integrity": "sha512-9Ep08KAMUn0OadnVaBuRdE2l615CQ508kr0XMadjClfYpdCyvrbFp6Taebo8yyxokQ4viUd/xPPUA4FGgUa0ow==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "char-regex": "^2.0.0",
+        "strip-ansi": "^7.0.1"
+      },
+      "engines": {
+        "node": ">=12.20"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/jest-watcher": {
+      "version": "29.7.0",
+      "resolved": "https://registry.npmjs.org/jest-watcher/-/jest-watcher-29.7.0.tgz",
+      "integrity": "sha512-49Fg7WXkU3Vl2h6LbLtMQ/HyB6rXSIX7SqvBLQmssRBGN9I0PNvPmAmCWSOY6SOvrjhI/F7/bGAv9RtnsPA03g==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@jest/test-result": "^29.7.0",
+        "@jest/types": "^29.6.3",
+        "@types/node": "*",
+        "ansi-escapes": "^4.2.1",
+        "chalk": "^4.0.0",
+        "emittery": "^0.13.1",
+        "jest-util": "^29.7.0",
+        "string-length": "^4.0.1"
       },
       "engines": {
         "node": "^14.15.0 || ^16.10.0 || >=18.0.0"
@@ -11612,6 +13282,116 @@
       "integrity": "sha512-0wM3YBWtYePOjfyXQH5MWQ8H7sdk5EXSwZvmSLKk2RboVQ2Bu239jycHDz5J/8Blf3K0Qnoy2b6xD+z10MFB+Q==",
       "license": "0BSD"
     },
+    "node_modules/jsdom": {
+      "version": "20.0.3",
+      "resolved": "https://registry.npmjs.org/jsdom/-/jsdom-20.0.3.tgz",
+      "integrity": "sha512-SYhBvTh89tTfCD/CRdSOm13mOBa42iTaTyfyEWBdKcGdPxPtLFBXuHR8XHb33YNYaP+lLbmSvBTsnoesCNJEsQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "abab": "^2.0.6",
+        "acorn": "^8.8.1",
+        "acorn-globals": "^7.0.0",
+        "cssom": "^0.5.0",
+        "cssstyle": "^2.3.0",
+        "data-urls": "^3.0.2",
+        "decimal.js": "^10.4.2",
+        "domexception": "^4.0.0",
+        "escodegen": "^2.0.0",
+        "form-data": "^4.0.0",
+        "html-encoding-sniffer": "^3.0.0",
+        "http-proxy-agent": "^5.0.0",
+        "https-proxy-agent": "^5.0.1",
+        "is-potential-custom-element-name": "^1.0.1",
+        "nwsapi": "^2.2.2",
+        "parse5": "^7.1.1",
+        "saxes": "^6.0.0",
+        "symbol-tree": "^3.2.4",
+        "tough-cookie": "^4.1.2",
+        "w3c-xmlserializer": "^4.0.0",
+        "webidl-conversions": "^7.0.0",
+        "whatwg-encoding": "^2.0.0",
+        "whatwg-mimetype": "^3.0.0",
+        "whatwg-url": "^11.0.0",
+        "ws": "^8.11.0",
+        "xml-name-validator": "^4.0.0"
+      },
+      "engines": {
+        "node": ">=14"
+      },
+      "peerDependencies": {
+        "canvas": "^2.5.0"
+      },
+      "peerDependenciesMeta": {
+        "canvas": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/jsdom/node_modules/agent-base": {
+      "version": "6.0.2",
+      "resolved": "https://registry.npmjs.org/agent-base/-/agent-base-6.0.2.tgz",
+      "integrity": "sha512-RZNwNclF7+MS/8bDg70amg32dyeZGZxiDuQmZxKLAlQjr3jGyLx+4Kkk58UO7D2QdgFIQCovuSuZESne6RG6XQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "debug": "4"
+      },
+      "engines": {
+        "node": ">= 6.0.0"
+      }
+    },
+    "node_modules/jsdom/node_modules/https-proxy-agent": {
+      "version": "5.0.1",
+      "resolved": "https://registry.npmjs.org/https-proxy-agent/-/https-proxy-agent-5.0.1.tgz",
+      "integrity": "sha512-dFcAjpTQFgoLMzC2VwU+C/CbS7uRL0lWmxDITmqm7C+7F0Odmj6s9l6alZc6AELXhrnggM2CeWSXHGOdX2YtwA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "agent-base": "6",
+        "debug": "4"
+      },
+      "engines": {
+        "node": ">= 6"
+      }
+    },
+    "node_modules/jsdom/node_modules/tr46": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/tr46/-/tr46-3.0.0.tgz",
+      "integrity": "sha512-l7FvfAHlcmulp8kr+flpQZmVwtu7nfRV7NZujtN0OqES8EL4O4e0qqzL0DC5gAvx/ZC/9lk6rhcUwYvkBnBnYA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "punycode": "^2.1.1"
+      },
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/jsdom/node_modules/webidl-conversions": {
+      "version": "7.0.0",
+      "resolved": "https://registry.npmjs.org/webidl-conversions/-/webidl-conversions-7.0.0.tgz",
+      "integrity": "sha512-VwddBukDzu71offAQR975unBIGqfKZpM+8ZX6ySk8nYhVoo5CYaZyzt3YBvYtRtO+aoGlqxPg/B87NGVZ/fu6g==",
+      "dev": true,
+      "license": "BSD-2-Clause",
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/jsdom/node_modules/whatwg-url": {
+      "version": "11.0.0",
+      "resolved": "https://registry.npmjs.org/whatwg-url/-/whatwg-url-11.0.0.tgz",
+      "integrity": "sha512-RKT8HExMpoYx4igMiVMY83lN6UeITKJlBQ+vR/8ZJ8OCdSiN3RwCq+9gH0+Xzj0+5IrM6i4j/6LuvzbZIQgEcQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "tr46": "^3.0.0",
+        "webidl-conversions": "^7.0.0"
+      },
+      "engines": {
+        "node": ">=12"
+      }
+    },
     "node_modules/jsesc": {
       "version": "3.1.0",
       "resolved": "https://registry.npmjs.org/jsesc/-/jsesc-3.1.0.tgz",
@@ -11637,6 +13417,13 @@
       "version": "3.0.1",
       "resolved": "https://registry.npmjs.org/json-buffer/-/json-buffer-3.0.1.tgz",
       "integrity": "sha512-4bV5BfR2mqfQTJm+V5tPPdf+ZpuhiIvTuAB5g8kcrXOZpTT/QwwVRWBywX1ozr6lEuPdbHxwaJlm9G6mI2sfSQ==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/json-parse-even-better-errors": {
+      "version": "2.3.1",
+      "resolved": "https://registry.npmjs.org/json-parse-even-better-errors/-/json-parse-even-better-errors-2.3.1.tgz",
+      "integrity": "sha512-xyFwyhro/JEof6Ghe2iz2NcXoj2sloNsWr/XsERDK/oiPCfaNhl5ONfp+jQdAZRQQ0IJWNzH9zIZF7li91kh2w==",
       "dev": true,
       "license": "MIT"
     },
@@ -12167,6 +13954,35 @@
       "license": "ISC",
       "dependencies": {
         "yallist": "^3.0.2"
+      }
+    },
+    "node_modules/make-dir": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/make-dir/-/make-dir-4.0.0.tgz",
+      "integrity": "sha512-hXdUTZYIVOt1Ex//jAQi+wTZZpUpwBj/0QsOzqegb3rGMMeJiSEu5xLHnYfBrRV4RH2+OCSOO95Is/7x1WJ4bw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "semver": "^7.5.3"
+      },
+      "engines": {
+        "node": ">=10"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/make-dir/node_modules/semver": {
+      "version": "7.8.5",
+      "resolved": "https://registry.npmjs.org/semver/-/semver-7.8.5.tgz",
+      "integrity": "sha512-Y7/KDsb8LjooZpwaqGyulO6DQlksgCncchHGk+sZIY4SBvUocMBEFH5Ur1fI4dV+Jvl0w6cjvucaIi40puRioA==",
+      "dev": true,
+      "license": "ISC",
+      "bin": {
+        "semver": "bin/semver.js"
+      },
+      "engines": {
+        "node": ">=10"
       }
     },
     "node_modules/makeerror": {
@@ -12914,6 +14730,19 @@
         "node": ">=10"
       }
     },
+    "node_modules/npm-run-path": {
+      "version": "4.0.1",
+      "resolved": "https://registry.npmjs.org/npm-run-path/-/npm-run-path-4.0.1.tgz",
+      "integrity": "sha512-S48WzZW777zhNIrn7gxOlISNAqi9ZC/uQFnRdbeIHhZhCA6UqpkOT8T1G7BvfdgP4Er8gF4sUbaS0i7QvIfCWw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "path-key": "^3.0.0"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
     "node_modules/nth-check": {
       "version": "2.1.1",
       "resolved": "https://registry.npmjs.org/nth-check/-/nth-check-2.1.1.tgz",
@@ -12930,6 +14759,13 @@
       "version": "1.1.1",
       "resolved": "https://registry.npmjs.org/nullthrows/-/nullthrows-1.1.1.tgz",
       "integrity": "sha512-2vPPEi+Z7WqML2jZYddDIfy5Dqb0r2fze2zTxNNknZaFpVHU3mFB3R+DWeJWGVx0ecvttSGlJTI+WG+8Z4cDWw==",
+      "license": "MIT"
+    },
+    "node_modules/nwsapi": {
+      "version": "2.2.24",
+      "resolved": "https://registry.npmjs.org/nwsapi/-/nwsapi-2.2.24.tgz",
+      "integrity": "sha512-7YRhZ3jS45LwmSCT4b2sVFHt/WuovaktDU07QrtOBY2PXskss5a9jfmR9jptyumwXST+rFjrmppMY1KT/yn35A==",
+      "dev": true,
       "license": "MIT"
     },
     "node_modules/ob1": {
@@ -13440,6 +15276,25 @@
         "node": ">=6"
       }
     },
+    "node_modules/parse-json": {
+      "version": "5.2.0",
+      "resolved": "https://registry.npmjs.org/parse-json/-/parse-json-5.2.0.tgz",
+      "integrity": "sha512-ayCKvm/phCGxOkYRSCM82iDwct8/EonSEgCSxWxD7ve6jHggsFl4fZVQBPRNgQoKiuV/odhFrGzQXZwbifC8Rg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@babel/code-frame": "^7.0.0",
+        "error-ex": "^1.3.1",
+        "json-parse-even-better-errors": "^2.3.0",
+        "lines-and-columns": "^1.1.6"
+      },
+      "engines": {
+        "node": ">=8"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
     "node_modules/parse-png": {
       "version": "2.1.0",
       "resolved": "https://registry.npmjs.org/parse-png/-/parse-png-2.1.0.tgz",
@@ -13450,6 +15305,32 @@
       },
       "engines": {
         "node": ">=10"
+      }
+    },
+    "node_modules/parse5": {
+      "version": "7.3.0",
+      "resolved": "https://registry.npmjs.org/parse5/-/parse5-7.3.0.tgz",
+      "integrity": "sha512-IInvU7fabl34qmi9gY8XOVxhYyMyuH2xUNpb2q8/Y+7552KlejkRvqvD19nMoUW/uQGGbqNpA6Tufu5FL5BZgw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "entities": "^6.0.0"
+      },
+      "funding": {
+        "url": "https://github.com/inikulin/parse5?sponsor=1"
+      }
+    },
+    "node_modules/parse5/node_modules/entities": {
+      "version": "6.0.1",
+      "resolved": "https://registry.npmjs.org/entities/-/entities-6.0.1.tgz",
+      "integrity": "sha512-aN97NXWF6AWBTahfVOIrB/NShkzi5H7F9r1s9mD3cDj4Ko5f2qhhVoYMibXF7GlLveb/D2ioWay8lxI97Ven3g==",
+      "dev": true,
+      "license": "BSD-2-Clause",
+      "engines": {
+        "node": ">=0.12"
+      },
+      "funding": {
+        "url": "https://github.com/fb55/entities?sponsor=1"
       }
     },
     "node_modules/parseurl": {
@@ -13612,6 +15493,75 @@
       },
       "bin": {
         "pixelmatch": "bin/pixelmatch"
+      }
+    },
+    "node_modules/pkg-dir": {
+      "version": "4.2.0",
+      "resolved": "https://registry.npmjs.org/pkg-dir/-/pkg-dir-4.2.0.tgz",
+      "integrity": "sha512-HRDzbaKjC+AOWVXxAU/x54COGeIv9eb+6CkDSQoNTt4XyWoIJvuPsXizxu/Fr23EiekbtZwmh1IcIG/l/a10GQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "find-up": "^4.0.0"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/pkg-dir/node_modules/find-up": {
+      "version": "4.1.0",
+      "resolved": "https://registry.npmjs.org/find-up/-/find-up-4.1.0.tgz",
+      "integrity": "sha512-PpOwAdQ/YlXQ2vj8a3h8IipDuYRi3wceVQQGYWxNINccq40Anw7BlsEXCMbt1Zt+OLA6Fq9suIpIWD0OsnISlw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "locate-path": "^5.0.0",
+        "path-exists": "^4.0.0"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/pkg-dir/node_modules/locate-path": {
+      "version": "5.0.0",
+      "resolved": "https://registry.npmjs.org/locate-path/-/locate-path-5.0.0.tgz",
+      "integrity": "sha512-t7hw9pI+WvuwNJXwk5zVHpyhIqzg2qTlklJOf0mVxGSbe3Fp2VieZcduNYjaLDoy6p9uGpQEGWG87WpMKlNq8g==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "p-locate": "^4.1.0"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/pkg-dir/node_modules/p-limit": {
+      "version": "2.3.0",
+      "resolved": "https://registry.npmjs.org/p-limit/-/p-limit-2.3.0.tgz",
+      "integrity": "sha512-//88mFWSJx8lxCzwdAABTJL2MyWB12+eIY7MDL2SqLmAkeKU9qxRvWuSyTjm3FUmpBEMuFfckAIqEaVGUDxb6w==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "p-try": "^2.0.0"
+      },
+      "engines": {
+        "node": ">=6"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/pkg-dir/node_modules/p-locate": {
+      "version": "4.1.0",
+      "resolved": "https://registry.npmjs.org/p-locate/-/p-locate-4.1.0.tgz",
+      "integrity": "sha512-R79ZZ/0wAxKGu3oYMlz8jy/kbhsNrS7SKZ7PxEHBgJ5+F2mtFW2fK2cOtBh1cHYkQsbzFV7I+EoRKe6Yt0oK7A==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "p-limit": "^2.2.0"
+      },
+      "engines": {
+        "node": ">=8"
       }
     },
     "node_modules/plist": {
@@ -13851,6 +15801,19 @@
       "integrity": "sha512-24e6ynE2H+OKt4kqsOvNd8kBpV65zoxbA4BVsEOB3ARVWQki/DHzaUoC5KuON/BiccDaCCTZBuOcfZs70kR8bQ==",
       "license": "MIT"
     },
+    "node_modules/psl": {
+      "version": "1.15.0",
+      "resolved": "https://registry.npmjs.org/psl/-/psl-1.15.0.tgz",
+      "integrity": "sha512-JZd3gMVBAVQkSs6HdNZo9Sdo0LNcQeMNP3CozBJb3JYC/QUYZTnKxP+f8oWRX4rHP5EurWxqAHTSwUCjlNKa1w==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "punycode": "^2.3.1"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/lupomontero"
+      }
+    },
     "node_modules/punycode": {
       "version": "2.3.1",
       "resolved": "https://registry.npmjs.org/punycode/-/punycode-2.3.1.tgz",
@@ -13859,6 +15822,23 @@
       "engines": {
         "node": ">=6"
       }
+    },
+    "node_modules/pure-rand": {
+      "version": "6.1.0",
+      "resolved": "https://registry.npmjs.org/pure-rand/-/pure-rand-6.1.0.tgz",
+      "integrity": "sha512-bVWawvoZoBYpp6yIoQtQXHZjmz35RSVHnUOTefl8Vcjr8snTPY1wnpSPMWekcFwbxI6gtmT7rSYPFvz71ldiOA==",
+      "dev": true,
+      "funding": [
+        {
+          "type": "individual",
+          "url": "https://github.com/sponsors/dubzzz"
+        },
+        {
+          "type": "opencollective",
+          "url": "https://opencollective.com/fast-check"
+        }
+      ],
+      "license": "MIT"
     },
     "node_modules/qrcode": {
       "version": "1.5.4",
@@ -14070,6 +16050,13 @@
       "funding": {
         "url": "https://github.com/sponsors/sindresorhus"
       }
+    },
+    "node_modules/querystringify": {
+      "version": "2.2.0",
+      "resolved": "https://registry.npmjs.org/querystringify/-/querystringify-2.2.0.tgz",
+      "integrity": "sha512-FIqgj2EUvTa7R50u0rGsyTftzjYmv/a3hO345bZNrqabNqjtgiDMgmo4mkUjd+nzU5oF3dClKqFIPUKybUyqoQ==",
+      "dev": true,
+      "license": "MIT"
     },
     "node_modules/queue": {
       "version": "6.0.2",
@@ -14682,6 +16669,20 @@
         "node": ">=0.10.0"
       }
     },
+    "node_modules/react-test-renderer": {
+      "version": "19.1.0",
+      "resolved": "https://registry.npmjs.org/react-test-renderer/-/react-test-renderer-19.1.0.tgz",
+      "integrity": "sha512-jXkSl3CpvPYEF+p/eGDLB4sPoDX8pKkYvRl9+rR8HxLY0X04vW7hCm1/0zHoUSjPZ3bDa+wXWNTDVIw/R8aDVw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "react-is": "^19.1.0",
+        "scheduler": "^0.26.0"
+      },
+      "peerDependencies": {
+        "react": "^19.1.0"
+      }
+    },
     "node_modules/readable-stream": {
       "version": "4.7.0",
       "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-4.7.0.tgz",
@@ -14885,6 +16886,13 @@
         "path-parse": "^1.0.5"
       }
     },
+    "node_modules/requires-port": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/requires-port/-/requires-port-1.0.0.tgz",
+      "integrity": "sha512-KigOCHcocU3XODJxsu8i/j8T9tzT4adHiecwORRQ0ZZFcp7ahwXuRU1m+yuO90C5ZUyGeGfocHDI14M3L3yDAQ==",
+      "dev": true,
+      "license": "MIT"
+    },
     "node_modules/resolve": {
       "version": "1.22.11",
       "resolved": "https://registry.npmjs.org/resolve/-/resolve-1.22.11.tgz",
@@ -14903,6 +16911,19 @@
       },
       "funding": {
         "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/resolve-cwd": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/resolve-cwd/-/resolve-cwd-3.0.0.tgz",
+      "integrity": "sha512-OrZaX2Mb+rJCpH/6CpSqt9xFVpN++x01XnN2ie9g6P5/3xelLAkXWVADpdz1IHD/KFfEXyE6V0U01OQ3UO2rEg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "resolve-from": "^5.0.0"
+      },
+      "engines": {
+        "node": ">=8"
       }
     },
     "node_modules/resolve-from": {
@@ -15127,11 +17148,31 @@
         "node": ">=10"
       }
     },
+    "node_modules/safer-buffer": {
+      "version": "2.1.2",
+      "resolved": "https://registry.npmjs.org/safer-buffer/-/safer-buffer-2.1.2.tgz",
+      "integrity": "sha512-YZo3K82SD7Riyi0E1EQPojLz7kpepnSQI9IyPbHHg1XXXevb5dJI7tpyN2ADxGcQbHG7vcyRHk0cbwqcQriUtg==",
+      "dev": true,
+      "license": "MIT"
+    },
     "node_modules/sax": {
       "version": "1.4.1",
       "resolved": "https://registry.npmjs.org/sax/-/sax-1.4.1.tgz",
       "integrity": "sha512-+aWOz7yVScEGoKNd4PA10LZ8sk0A/z5+nXQG5giUO5rprX9jgYsTdov9qCchZiPIZezbZH+jRut8nPodFAX4Jg==",
       "license": "ISC"
+    },
+    "node_modules/saxes": {
+      "version": "6.0.0",
+      "resolved": "https://registry.npmjs.org/saxes/-/saxes-6.0.0.tgz",
+      "integrity": "sha512-xAg7SOnEhrm5zI3puOOKyy1OMcMlIJZYNJY7xLBwSze0UjhPLnWfj2GF2EpT0jmzaJKIWKHLsaSSajf35bcYnA==",
+      "dev": true,
+      "license": "ISC",
+      "dependencies": {
+        "xmlchars": "^2.2.0"
+      },
+      "engines": {
+        "node": ">=v12.22.7"
+      }
     },
     "node_modules/scheduler": {
       "version": "0.26.0",
@@ -15318,6 +17359,13 @@
       "engines": {
         "node": ">= 0.8"
       }
+    },
+    "node_modules/server-only": {
+      "version": "0.0.1",
+      "resolved": "https://registry.npmjs.org/server-only/-/server-only-0.0.1.tgz",
+      "integrity": "sha512-qepMx2JxAa5jjfzxG79yPPq+8BuFToHd1hm7kI+Z4zAq1ftQiP7HcxMhDDItrbtwVeLg/cY2JnKnrcFkmiswNA==",
+      "dev": true,
+      "license": "MIT"
     },
     "node_modules/set-blocking": {
       "version": "2.0.0",
@@ -15674,6 +17722,16 @@
       "dev": true,
       "license": "MIT"
     },
+    "node_modules/stack-generator": {
+      "version": "2.0.10",
+      "resolved": "https://registry.npmjs.org/stack-generator/-/stack-generator-2.0.10.tgz",
+      "integrity": "sha512-mwnua/hkqM6pF4k8SnmZ2zfETsRUpWXREfA/goT8SLCV4iOFa4bzOX2nDipWAZFPTjLvQB82f5yaodMVhK0yJQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "stackframe": "^1.3.4"
+      }
+    },
     "node_modules/stack-utils": {
       "version": "2.0.6",
       "resolved": "https://registry.npmjs.org/stack-utils/-/stack-utils-2.0.6.tgz",
@@ -15700,6 +17758,39 @@
       "resolved": "https://registry.npmjs.org/stackframe/-/stackframe-1.3.4.tgz",
       "integrity": "sha512-oeVtt7eWQS+Na6F//S4kJ2K2VbRlS9D43mAlMyVpVWovy9o+jfgH8O9agzANzaiLjclA0oYzUXEM4PurhSUChw==",
       "license": "MIT"
+    },
+    "node_modules/stacktrace-gps": {
+      "version": "3.1.2",
+      "resolved": "https://registry.npmjs.org/stacktrace-gps/-/stacktrace-gps-3.1.2.tgz",
+      "integrity": "sha512-GcUgbO4Jsqqg6RxfyTHFiPxdPqF+3LFmQhm7MgCuYQOYuWyqxo5pwRPz5d/u6/WYJdEnWfK4r+jGbyD8TSggXQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "source-map": "0.5.6",
+        "stackframe": "^1.3.4"
+      }
+    },
+    "node_modules/stacktrace-gps/node_modules/source-map": {
+      "version": "0.5.6",
+      "resolved": "https://registry.npmjs.org/source-map/-/source-map-0.5.6.tgz",
+      "integrity": "sha512-MjZkVp0NHr5+TPihLcadqnlVoGIoWo4IBHptutGh9wI3ttUYvCG26HkSuDi+K6lsZ25syXJXcctwgyVCt//xqA==",
+      "dev": true,
+      "license": "BSD-3-Clause",
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "node_modules/stacktrace-js": {
+      "version": "2.0.2",
+      "resolved": "https://registry.npmjs.org/stacktrace-js/-/stacktrace-js-2.0.2.tgz",
+      "integrity": "sha512-Je5vBeY4S1r/RnLydLl0TBTi3F2qdfWmYsGvtfZgEI+SCprPppaIhQf5nGcal4gI4cGpCV/duLcAzT1np6sQqg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "error-stack-parser": "^2.0.6",
+        "stack-generator": "^2.0.5",
+        "stacktrace-gps": "^3.0.4"
+      }
     },
     "node_modules/stacktrace-parser": {
       "version": "0.1.11",
@@ -15761,6 +17852,33 @@
       "license": "MIT",
       "dependencies": {
         "safe-buffer": "~5.2.0"
+      }
+    },
+    "node_modules/string-length": {
+      "version": "4.0.2",
+      "resolved": "https://registry.npmjs.org/string-length/-/string-length-4.0.2.tgz",
+      "integrity": "sha512-+l6rNN5fYHNhZZy41RXsYptCjA2Igmq4EG7kZAYFQI1E1VTXarr6ZPXBg6eq7Y6eK4FEhY6AJlyuFIb/v/S0VQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "char-regex": "^1.0.2",
+        "strip-ansi": "^6.0.0"
+      },
+      "engines": {
+        "node": ">=10"
+      }
+    },
+    "node_modules/string-length/node_modules/strip-ansi": {
+      "version": "6.0.1",
+      "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-6.0.1.tgz",
+      "integrity": "sha512-Y38VPSHcqkFrCpFnQ9vuSXmquuv5oXOKpGeT6aGrr3o3Gc9AlVa6JBfUSOCnbxGGZF+/0ooI7KrPuUSztUdU5A==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "ansi-regex": "^5.0.1"
+      },
+      "engines": {
+        "node": ">=8"
       }
     },
     "node_modules/string-width": {
@@ -15962,6 +18080,16 @@
         "node": ">=4"
       }
     },
+    "node_modules/strip-final-newline": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/strip-final-newline/-/strip-final-newline-2.0.0.tgz",
+      "integrity": "sha512-BrpvfNAE3dcvq7ll3xVumzjKjZQ5tI1sEUIKr3Uoks0XUl45St3FlatVqef9prk4jRDzhW6WZg+3bk93y6pLjA==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=6"
+      }
+    },
     "node_modules/strip-json-comments": {
       "version": "3.1.1",
       "resolved": "https://registry.npmjs.org/strip-json-comments/-/strip-json-comments-3.1.1.tgz",
@@ -16071,6 +18199,13 @@
       "funding": {
         "url": "https://github.com/sponsors/ljharb"
       }
+    },
+    "node_modules/symbol-tree": {
+      "version": "3.2.4",
+      "resolved": "https://registry.npmjs.org/symbol-tree/-/symbol-tree-3.2.4.tgz",
+      "integrity": "sha512-9QNk5KwDF+Bvz+PyObkmSYjI5ksVUYtjW7AU22r2NKcfLJcXp96hkDWU3+XndOsUb+AQ9QhfzfCT2O+CNWT5Tw==",
+      "dev": true,
+      "license": "MIT"
     },
     "node_modules/synckit": {
       "version": "0.11.11",
@@ -16364,6 +18499,22 @@
       "funding": {
         "type": "github",
         "url": "https://github.com/sponsors/Borewit"
+      }
+    },
+    "node_modules/tough-cookie": {
+      "version": "4.1.4",
+      "resolved": "https://registry.npmjs.org/tough-cookie/-/tough-cookie-4.1.4.tgz",
+      "integrity": "sha512-Loo5UUvLD9ScZ6jh8beX1T6sO1w2/MpCRpEP7V280GKMVUQ0Jzar2U3UJPsrdbziLEMMhu3Ujnq//rhiFuIeag==",
+      "dev": true,
+      "license": "BSD-3-Clause",
+      "dependencies": {
+        "psl": "^1.1.33",
+        "punycode": "^2.1.1",
+        "universalify": "^0.2.0",
+        "url-parse": "^1.5.3"
+      },
+      "engines": {
+        "node": ">=6"
       }
     },
     "node_modules/tr46": {
@@ -16690,6 +18841,16 @@
         "node": ">=8"
       }
     },
+    "node_modules/universalify": {
+      "version": "0.2.0",
+      "resolved": "https://registry.npmjs.org/universalify/-/universalify-0.2.0.tgz",
+      "integrity": "sha512-CJ1QgKmNg3CwvAv/kOFmtnEN05f0D/cn9QntgNOQlQF9dgvVTHj3t+8JPdjqawCHk7V/KA+fbUqzZ9XWhcqPUg==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">= 4.0.0"
+      }
+    },
     "node_modules/unpipe": {
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/unpipe/-/unpipe-1.0.0.tgz",
@@ -16879,6 +19040,17 @@
         "punycode": "^2.1.0"
       }
     },
+    "node_modules/url-parse": {
+      "version": "1.5.10",
+      "resolved": "https://registry.npmjs.org/url-parse/-/url-parse-1.5.10.tgz",
+      "integrity": "sha512-WypcfiRhfeUP9vvF0j6rw0J3hrWrw6iZv3+22h6iRMJ/8z1Tj6XfLP4DsUix5MhMPnXpiHDoKyoZ/bdCkwBCiQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "querystringify": "^2.1.1",
+        "requires-port": "^1.0.0"
+      }
+    },
     "node_modules/use-latest-callback": {
       "version": "0.2.6",
       "resolved": "https://registry.npmjs.org/use-latest-callback/-/use-latest-callback-0.2.6.tgz",
@@ -16941,6 +19113,21 @@
         "uuid": "dist/bin/uuid"
       }
     },
+    "node_modules/v8-to-istanbul": {
+      "version": "9.3.0",
+      "resolved": "https://registry.npmjs.org/v8-to-istanbul/-/v8-to-istanbul-9.3.0.tgz",
+      "integrity": "sha512-kiGUalWN+rgBJ/1OHZsBtU4rXZOfj/7rKQxULKlIzwzQSvMJUUNgPwJEEh7gU6xEVxC0ahoOBvN2YI8GH6FNgA==",
+      "dev": true,
+      "license": "ISC",
+      "dependencies": {
+        "@jridgewell/trace-mapping": "^0.3.12",
+        "@types/istanbul-lib-coverage": "^2.0.1",
+        "convert-source-map": "^2.0.0"
+      },
+      "engines": {
+        "node": ">=10.12.0"
+      }
+    },
     "node_modules/validate-npm-package-name": {
       "version": "5.0.1",
       "resolved": "https://registry.npmjs.org/validate-npm-package-name/-/validate-npm-package-name-5.0.1.tgz",
@@ -16964,6 +19151,19 @@
       "resolved": "https://registry.npmjs.org/vlq/-/vlq-2.0.4.tgz",
       "integrity": "sha512-aodjPa2wPQFkra1G8CzJBTHXhgk3EVSwxSWXNPr1fgdFLUb8kvLV1iEb6rFgasIsjP82HWI6dsb5Io26DDnasA==",
       "license": "MIT"
+    },
+    "node_modules/w3c-xmlserializer": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/w3c-xmlserializer/-/w3c-xmlserializer-4.0.0.tgz",
+      "integrity": "sha512-d+BFHzbiCx6zGfz0HyQ6Rg69w9k19nviJspaj4yNscGjrHu94sVP+aRm75yEbCh+r2/yR+7q6hux9LVtbuTGBw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "xml-name-validator": "^4.0.0"
+      },
+      "engines": {
+        "node": ">=14"
+      }
     },
     "node_modules/walker": {
       "version": "1.0.8",
@@ -17010,11 +19210,35 @@
       "integrity": "sha512-2JAn3z8AR6rjK8Sm8orRC0h/bcl/DqL7tRPdGZ4I1CjdF+EaMLmYxBHyXuKL849eucPFhvBoxMsflfOb8kxaeQ==",
       "license": "BSD-2-Clause"
     },
+    "node_modules/whatwg-encoding": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/whatwg-encoding/-/whatwg-encoding-2.0.0.tgz",
+      "integrity": "sha512-p41ogyeMUrw3jWclHWTQg1k05DSVXPLcVxRTYsXUk+ZooOCZLcoYgPZ/HL/D/N+uQPOtcp1me1WhBEaX02mhWg==",
+      "deprecated": "Use @exodus/bytes instead for a more spec-conformant and faster implementation",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "iconv-lite": "0.6.3"
+      },
+      "engines": {
+        "node": ">=12"
+      }
+    },
     "node_modules/whatwg-fetch": {
       "version": "3.6.20",
       "resolved": "https://registry.npmjs.org/whatwg-fetch/-/whatwg-fetch-3.6.20.tgz",
       "integrity": "sha512-EqhiFU6daOA8kpjOWTL0olhVOF3i7OrFzSYiGsEMB8GcXS+RrzauAERX65xMeNWVqxA6HXH2m69Z9LaKKdisfg==",
       "license": "MIT"
+    },
+    "node_modules/whatwg-mimetype": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/whatwg-mimetype/-/whatwg-mimetype-3.0.0.tgz",
+      "integrity": "sha512-nt+N2dzIutVRxARx1nghPKGv1xHikU7HKdfafKkLNLindmPU/ch3U31NOCGGA/dmPcmb1VlofO0vnKAcsm0o/Q==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=12"
+      }
     },
     "node_modules/whatwg-url": {
       "version": "5.0.0",
@@ -17365,6 +19589,16 @@
         "uuid": "dist/bin/uuid"
       }
     },
+    "node_modules/xml-name-validator": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/xml-name-validator/-/xml-name-validator-4.0.0.tgz",
+      "integrity": "sha512-ICP2e+jsHvAj2E2lIHxa5tjXRlKDJo4IdvPvCXbXQGdzSfmSpNVyIKMvoZHjDY9DP0zV17iI85o90vRFXNccRw==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "engines": {
+        "node": ">=12"
+      }
+    },
     "node_modules/xml2js": {
       "version": "0.6.0",
       "resolved": "https://registry.npmjs.org/xml2js/-/xml2js-0.6.0.tgz",
@@ -17395,6 +19629,13 @@
       "engines": {
         "node": ">=8.0"
       }
+    },
+    "node_modules/xmlchars": {
+      "version": "2.2.0",
+      "resolved": "https://registry.npmjs.org/xmlchars/-/xmlchars-2.2.0.tgz",
+      "integrity": "sha512-JZnDKK8B0RCDw84FNdDAIpZK+JuJw+s7Lz8nksI7SIuU3UXJJslUthsi+uWBUYOwPFwW7W7PRLRfUKpxjtjFCw==",
+      "dev": true,
+      "license": "MIT"
     },
     "node_modules/y18n": {
       "version": "5.0.8",

--- a/package.json
+++ b/package.json
@@ -14,7 +14,9 @@
     "eas-build-pre-install": "node scripts/eas-build-pre-install.js",
     "build:android:dev": "GOOGLE_SERVICES_DEV_JSON_BASE64=$(base64 -i ./google-services-dev.json) eas build --platform android --profile development --local",
     "build:android:preview": "GOOGLE_SERVICES_JSON_BASE64=$(base64 -i ./google-services.json) eas build --platform android --profile preview --local",
-    "build:android:production": "GOOGLE_SERVICES_JSON_BASE64=$(base64 -i ./google-services.json) eas build --platform android --profile production --local"
+    "build:android:production": "GOOGLE_SERVICES_JSON_BASE64=$(base64 -i ./google-services.json) eas build --platform android --profile production --local",
+    "test": "jest",
+    "test:watch": "jest --watch"
   },
   "dependencies": {
     "@expo/cli": "^54.0.8",
@@ -88,6 +90,7 @@
   "devDependencies": {
     "@eslint/js": "^9.35.0",
     "@types/crypto-js": "^4.2.2",
+    "@types/jest": "29.5.14",
     "@types/react": "~19.1.0",
     "@typescript-eslint/eslint-plugin": "^8.43.0",
     "@typescript-eslint/parser": "^8.43.0",
@@ -98,6 +101,8 @@
     "eslint-plugin-prettier": "^5.5.4",
     "expo-build-properties": "~1.0.10",
     "globals": "17.7.0",
+    "jest": "~29.7.0",
+    "jest-expo": "~54.0.17",
     "prettier": "^3.6.2",
     "typescript": "~5.9.2"
   },

--- a/src/utils/__tests__/address.test.ts
+++ b/src/utils/__tests__/address.test.ts
@@ -1,0 +1,326 @@
+import algosdk from 'algosdk';
+
+// --- Mock BOTH services so ONLY the pure address logic runs. ---------------
+// No live Envoi resolution, no live network calls. isFeatureAvailable /
+// isValidNameFormat are pure synchronous gates we can steer per-test; the
+// getName/getAddress resolvers exist but we never exercise real resolution.
+jest.mock('@/services/network', () => ({
+  __esModule: true,
+  default: { isFeatureAvailable: jest.fn(() => false) },
+}));
+
+jest.mock('@/services/envoi', () => {
+  const instance = { getName: jest.fn(), getAddress: jest.fn() };
+  return {
+    __esModule: true,
+    default: {
+      getInstance: jest.fn(() => instance),
+      isValidNameFormat: jest.fn(() => false),
+    },
+  };
+});
+
+import {
+  formatAddress,
+  formatAddressSync,
+  formatAddressWithName,
+  resolveAddressOrName,
+  isLikelyEnvoiName,
+  clearFormatCache,
+} from '../address';
+import VoiNetworkService from '@/services/network';
+import EnvoiService from '@/services/envoi';
+
+const mockNetwork = VoiNetworkService as unknown as {
+  isFeatureAvailable: jest.Mock;
+};
+const mockEnvoi = EnvoiService as unknown as {
+  getInstance: jest.Mock;
+  isValidNameFormat: jest.Mock;
+};
+const envoiInstance = mockEnvoi.getInstance() as unknown as {
+  getName: jest.Mock;
+  getAddress: jest.Mock;
+};
+
+// A fixed, known-valid 58-char Algorand address. Truncations below are
+// hand-computed from the base32 string, NOT read back from the function.
+const KNOWN = '7ZUECA7HFLZTXENRV24SHLU4AVPUTMTTDUFUBNBD64C73F3UHRTHAIOF6Q';
+const KNOWN_TRUNC_6_4 = '7ZUECA...OF6Q'; // slice(0,6) + '...' + slice(-4)
+const KNOWN_TRUNC_4_6 = '7ZUE...AIOF6Q'; // slice(0,4) + '...' + slice(-6)
+// Tampered: flip the final base32 char -> checksum breaks -> invalid address.
+const TAMPERED = KNOWN.slice(0, 57) + 'A';
+
+// A fresh, real, cryptographically-valid address for each call.
+const genAddr = (): string => algosdk.generateAccount().addr.toString();
+
+beforeEach(() => {
+  // clearMocks (jest config) wipes call data but NOT implementations, so we
+  // re-pin the default gates every test to avoid leakage between tests.
+  clearFormatCache();
+  mockNetwork.isFeatureAvailable.mockReset().mockReturnValue(false);
+  mockEnvoi.isValidNameFormat.mockReset().mockReturnValue(false);
+  envoiInstance.getName.mockReset();
+  envoiInstance.getAddress.mockReset();
+});
+
+describe('address utils — fixtures sanity', () => {
+  it('KNOWN is a valid 58-char address and TAMPERED is not', () => {
+    expect(KNOWN).toHaveLength(58);
+    expect(algosdk.isValidAddress(KNOWN)).toBe(true);
+    expect(TAMPERED).toHaveLength(58);
+    expect(algosdk.isValidAddress(TAMPERED)).toBe(false);
+  });
+});
+
+describe('formatAddress', () => {
+  it('truncates a known valid address to <first6>...<last4>', () => {
+    expect(formatAddress(KNOWN)).toBe(KNOWN_TRUNC_6_4);
+  });
+
+  it('honours custom prefix/suffix lengths', () => {
+    expect(formatAddress(KNOWN, 4, 6)).toBe(KNOWN_TRUNC_4_6);
+  });
+
+  it('truncates any generated valid address consistently', () => {
+    const addr = genAddr();
+    const out = formatAddress(addr);
+    // Spec: keep the first 6 and last 4 base32 chars, joined by an ellipsis.
+    expect(out).toBe(`${addr.slice(0, 6)}...${addr.slice(-4)}`);
+    expect(out).toHaveLength(6 + 3 + 4); // 13
+    expect(out.startsWith(addr.slice(0, 6))).toBe(true);
+    expect(out.endsWith(addr.slice(-4))).toBe(true);
+  });
+
+  it('returns "Invalid Address" for empty / nullish input', () => {
+    expect(formatAddress('')).toBe('Invalid Address');
+    expect(formatAddress(undefined as unknown as string)).toBe(
+      'Invalid Address'
+    );
+    expect(formatAddress(null as unknown as string)).toBe('Invalid Address');
+  });
+
+  it('echoes a non-empty but invalid string verbatim', () => {
+    // Guard is `address || "Invalid Address"`, so a present-but-invalid value
+    // is returned as typed (used to echo user input in the UI).
+    expect(formatAddress('not-an-address')).toBe('not-an-address');
+  });
+
+  it('does NOT truncate a tampered (checksum-broken) address', () => {
+    // Crypto negative case: an address whose checksum was flipped is invalid,
+    // so it must NOT be treated/truncated as a real address.
+    expect(formatAddress(TAMPERED)).toBe(TAMPERED);
+    expect(formatAddress(TAMPERED)).not.toBe(KNOWN_TRUNC_6_4);
+  });
+});
+
+describe('formatAddressSync', () => {
+  it('shortens a valid address when there is no name', () => {
+    const addr = genAddr();
+    const res = formatAddressSync(addr);
+    expect(res.displayText).toBe(`${addr.slice(0, 6)}...${addr.slice(-4)}`);
+    expect(res.fullAddress).toBe(addr);
+    expect(res.hasName).toBe(false);
+    expect(res.envoiName).toBeUndefined();
+  });
+
+  it('honours custom prefix/suffix', () => {
+    expect(
+      formatAddressSync(KNOWN, null, { prefixLength: 4, suffixLength: 6 })
+    ).toMatchObject({ displayText: KNOWN_TRUNC_4_6, fullAddress: KNOWN });
+  });
+
+  it('shows the full address when showFullAddress is set', () => {
+    const res = formatAddressSync(KNOWN, null, { showFullAddress: true });
+    expect(res.displayText).toBe(KNOWN);
+    expect(res.hasName).toBe(false);
+  });
+
+  it('prefers the Envoi name over truncation when a name is supplied', () => {
+    const addr = genAddr();
+    const res = formatAddressSync(addr, { name: 'alice.voi' } as never);
+    expect(res.displayText).toBe('alice.voi');
+    expect(res.envoiName).toBe('alice.voi');
+    expect(res.hasName).toBe(true);
+    expect(res.fullAddress).toBe(addr);
+  });
+
+  it('name wins even over showFullAddress', () => {
+    const res = formatAddressSync(KNOWN, { name: 'bob.voi' } as never, {
+      showFullAddress: true,
+    });
+    expect(res.displayText).toBe('bob.voi');
+    expect(res.hasName).toBe(true);
+  });
+
+  it('treats an empty name as "no name" and falls back to truncation', () => {
+    const res = formatAddressSync(KNOWN, { name: '' } as never);
+    expect(res.displayText).toBe(KNOWN_TRUNC_6_4);
+    expect(res.hasName).toBe(false);
+  });
+
+  it('reports invalid input without a name', () => {
+    const empty = formatAddressSync('');
+    expect(empty).toEqual({
+      displayText: 'Invalid Address',
+      fullAddress: '',
+      hasName: false,
+    });
+
+    const bad = formatAddressSync('not-an-address');
+    expect(bad.displayText).toBe('not-an-address');
+    expect(bad.fullAddress).toBe('not-an-address');
+    expect(bad.hasName).toBe(false);
+  });
+
+  it('does not shorten a tampered address (crypto negative case)', () => {
+    const res = formatAddressSync(TAMPERED);
+    expect(res.displayText).toBe(TAMPERED);
+    expect(res.hasName).toBe(false);
+  });
+});
+
+describe('formatAddressWithName (Envoi feature OFF => pure formatting)', () => {
+  it('shortens a valid address and never touches Envoi when the feature is off', async () => {
+    const addr = genAddr();
+    const res = await formatAddressWithName(addr);
+    expect(res).toMatchObject({
+      displayText: `${addr.slice(0, 6)}...${addr.slice(-4)}`,
+      fullAddress: addr,
+      hasName: false,
+    });
+    expect(res.envoiName).toBeUndefined();
+    expect(envoiInstance.getName).not.toHaveBeenCalled();
+  });
+
+  it('returns a frozen result object', async () => {
+    const res = await formatAddressWithName(genAddr());
+    expect(Object.isFrozen(res)).toBe(true);
+  });
+
+  it('returns a STABLE reference for identical inputs (cache hit)', async () => {
+    const addr = genAddr();
+    const a = await formatAddressWithName(addr);
+    const b = await formatAddressWithName(addr);
+    expect(b).toBe(a); // same object reference, not just equal
+  });
+
+  it('caches per-options: different options => different object, correct text', async () => {
+    const a = await formatAddressWithName(KNOWN);
+    const b = await formatAddressWithName(KNOWN, {
+      prefixLength: 4,
+      suffixLength: 6,
+    });
+    expect(b).not.toBe(a);
+    expect(a.displayText).toBe(KNOWN_TRUNC_6_4);
+    expect(b.displayText).toBe(KNOWN_TRUNC_4_6);
+  });
+
+  it('short-circuits invalid input before any feature/service check', async () => {
+    mockNetwork.isFeatureAvailable.mockReturnValue(true); // even if enabled...
+    const res = await formatAddressWithName('not-an-address');
+    expect(res).toMatchObject({
+      displayText: 'not-an-address',
+      fullAddress: 'not-an-address',
+      hasName: false,
+    });
+    // ...validation returns first, so the resolver is never consulted.
+    expect(envoiInstance.getName).not.toHaveBeenCalled();
+  });
+});
+
+describe('formatAddressWithName (Envoi feature ON, resolver mocked)', () => {
+  it('uses the resolved Envoi name as the display text', async () => {
+    const addr = genAddr();
+    mockNetwork.isFeatureAvailable.mockReturnValue(true);
+    envoiInstance.getName.mockResolvedValue({
+      name: 'carol.voi',
+      address: addr,
+    });
+
+    const res = await formatAddressWithName(addr);
+
+    expect(envoiInstance.getName).toHaveBeenCalledWith(addr);
+    expect(res.displayText).toBe('carol.voi');
+    expect(res.envoiName).toBe('carol.voi');
+    expect(res.hasName).toBe(true);
+    expect(res.fullAddress).toBe(addr);
+  });
+
+  it('falls back to truncation when the resolver returns no name', async () => {
+    const addr = genAddr();
+    mockNetwork.isFeatureAvailable.mockReturnValue(true);
+    envoiInstance.getName.mockResolvedValue(null);
+
+    const res = await formatAddressWithName(addr);
+    expect(res.displayText).toBe(`${addr.slice(0, 6)}...${addr.slice(-4)}`);
+    expect(res.hasName).toBe(false);
+  });
+});
+
+describe('clearFormatCache', () => {
+  it('drops cached references so the next call rebuilds the object', async () => {
+    const addr = genAddr();
+    const first = await formatAddressWithName(addr);
+    clearFormatCache();
+    const second = await formatAddressWithName(addr);
+    expect(second).not.toBe(first); // new object after clear
+    expect(second).toEqual(first); // but identical content
+  });
+});
+
+describe('resolveAddressOrName (pure / short-circuit branches only)', () => {
+  it('returns a valid address as-is without hitting the resolver', async () => {
+    const addr = genAddr();
+    await expect(resolveAddressOrName(addr)).resolves.toBe(addr);
+    expect(envoiInstance.getAddress).not.toHaveBeenCalled();
+  });
+
+  it('trims surrounding whitespace before returning a valid address', async () => {
+    const addr = genAddr();
+    await expect(resolveAddressOrName(`  ${addr}\n`)).resolves.toBe(addr);
+  });
+
+  it('returns null for empty / whitespace / nullish input', async () => {
+    await expect(resolveAddressOrName('')).resolves.toBeNull();
+    await expect(resolveAddressOrName('   ')).resolves.toBeNull();
+    await expect(
+      resolveAddressOrName(undefined as unknown as string)
+    ).resolves.toBeNull();
+  });
+
+  it('returns null for a non-address when Envoi is disabled', async () => {
+    mockNetwork.isFeatureAvailable.mockReturnValue(false);
+    await expect(resolveAddressOrName('nope')).resolves.toBeNull();
+    expect(envoiInstance.getAddress).not.toHaveBeenCalled();
+  });
+});
+
+describe('isLikelyEnvoiName (branch logic only)', () => {
+  it('is false for empty / nullish input', () => {
+    expect(isLikelyEnvoiName('')).toBe(false);
+    expect(isLikelyEnvoiName('   ')).toBe(false);
+    expect(isLikelyEnvoiName(undefined as unknown as string)).toBe(false);
+  });
+
+  it('is false whenever the Envoi feature is disabled', () => {
+    mockNetwork.isFeatureAvailable.mockReturnValue(false);
+    mockEnvoi.isValidNameFormat.mockReturnValue(true); // would-be name...
+    expect(isLikelyEnvoiName('alice.voi')).toBe(false); // ...still false
+  });
+
+  it('is false for a valid address even when the feature is enabled', () => {
+    mockNetwork.isFeatureAvailable.mockReturnValue(true);
+    expect(isLikelyEnvoiName(KNOWN)).toBe(false);
+  });
+
+  it('defers to Envoi name-format check when the feature is enabled', () => {
+    mockNetwork.isFeatureAvailable.mockReturnValue(true);
+
+    mockEnvoi.isValidNameFormat.mockReturnValue(true);
+    expect(isLikelyEnvoiName('alice.voi')).toBe(true);
+
+    mockEnvoi.isValidNameFormat.mockReturnValue(false);
+    expect(isLikelyEnvoiName('alice.voi')).toBe(false);
+  });
+});

--- a/src/utils/__tests__/algorandUri.test.ts
+++ b/src/utils/__tests__/algorandUri.test.ts
@@ -1,0 +1,390 @@
+import algosdk from 'algosdk';
+import {
+  isAlgorandPaymentUri,
+  parseAlgorandUri,
+  convertAmountToDisplay,
+  createPaymentSummary,
+  type AlgorandUriParams,
+  type ParsedAlgorandUri,
+} from '../algorandUri';
+
+// A real, checksum-valid Algorand/Voi address generated at load time. algosdk
+// 3.x returns `addr` as an Address object, so `.toString()` yields the 58-char
+// base32 string the URI format expects.
+const VALID_ADDRESS = algosdk.generateAccount().addr.toString();
+// Tamper a character *inside* the payload so the checksum genuinely breaks.
+// (Flipping the last base32 char can only alter padding bits and may still
+// validate.) This is the "tampered input" negative for address crypto.
+function makeInvalidAddress(addr: string): string {
+  const base32 = 'ABCDEFGHIJKLMNOPQRSTUVWXYZ234567';
+  const i = 10; // well inside the 32-byte public key
+  for (const c of base32) {
+    if (c === addr[i]) continue;
+    const candidate = addr.slice(0, i) + c + addr.slice(i + 1);
+    if (!algosdk.isValidAddress(candidate)) return candidate;
+  }
+  return addr.slice(1); // practically unreachable fallback
+}
+const TAMPERED_ADDRESS = makeInvalidAddress(VALID_ADDRESS);
+
+/**
+ * Builds a URI string from parts using standard form-urlencoding (single
+ * encode) so we can round-trip it through the parser. There is no build()
+ * export in the module under test, so the "round-trip" is: assemble a
+ * spec-correct URI here, parse it, and assert the parsed parts match.
+ */
+function buildUri(
+  scheme: 'algorand' | 'voi' | 'perawallet',
+  address: string,
+  params: AlgorandUriParams = {}
+): string {
+  const qs = new URLSearchParams();
+  if (params.amount !== undefined) qs.set('amount', params.amount);
+  if (params.asset !== undefined) qs.set('asset', params.asset);
+  if (params.label !== undefined) qs.set('label', params.label);
+  if (params.note !== undefined) qs.set('note', params.note);
+  if (params.xnote !== undefined) qs.set('xnote', params.xnote);
+  if (params.address !== undefined) qs.set('address', params.address);
+  const query = qs.toString();
+  return `${scheme}://${address}${query ? `?${query}` : ''}`;
+}
+
+describe('algorandUri', () => {
+  describe('isAlgorandPaymentUri', () => {
+    it('accepts each supported scheme', () => {
+      expect(isAlgorandPaymentUri(`algorand://${VALID_ADDRESS}`)).toBe(true);
+      expect(isAlgorandPaymentUri(`voi://${VALID_ADDRESS}`)).toBe(true);
+      expect(isAlgorandPaymentUri(`perawallet://${VALID_ADDRESS}`)).toBe(true);
+    });
+
+    it('is case-insensitive on the scheme', () => {
+      expect(isAlgorandPaymentUri(`VOI://${VALID_ADDRESS}`)).toBe(true);
+      expect(isAlgorandPaymentUri(`Algorand://${VALID_ADDRESS}`)).toBe(true);
+      expect(isAlgorandPaymentUri(`PERAWALLET://${VALID_ADDRESS}`)).toBe(true);
+    });
+
+    it('rejects unrelated / malformed schemes', () => {
+      expect(isAlgorandPaymentUri('https://example.com')).toBe(false);
+      expect(isAlgorandPaymentUri('bitcoin:1abc')).toBe(false);
+      expect(isAlgorandPaymentUri('algorand:no-slashes')).toBe(false);
+      expect(isAlgorandPaymentUri('')).toBe(false);
+      // "voi" appearing mid-string must not match a prefix check
+      expect(isAlgorandPaymentUri('https://voi://x')).toBe(false);
+    });
+  });
+
+  describe('parseAlgorandUri - scheme + address handling', () => {
+    it('parses the address from the path for each scheme', () => {
+      for (const scheme of ['algorand', 'voi', 'perawallet'] as const) {
+        const parsed = parseAlgorandUri(`${scheme}://${VALID_ADDRESS}`);
+        expect(parsed).not.toBeNull();
+        expect(parsed!.scheme).toBe(scheme);
+        expect(parsed!.address).toBe(VALID_ADDRESS);
+        expect(parsed!.isValid).toBe(true);
+        expect(parsed!.params).toEqual({});
+      }
+    });
+
+    it('preserves address casing even when the scheme is uppercased', () => {
+      const parsed = parseAlgorandUri(`VOI://${VALID_ADDRESS}`);
+      expect(parsed).not.toBeNull();
+      expect(parsed!.scheme).toBe('voi');
+      // base32 addresses are case-sensitive; the slice must come off the
+      // original (not lowercased) URI, otherwise the checksum breaks.
+      expect(parsed!.address).toBe(VALID_ADDRESS);
+      expect(parsed!.isValid).toBe(true);
+    });
+
+    it('returns null for unsupported schemes', () => {
+      expect(parseAlgorandUri('https://example.com')).toBeNull();
+      expect(parseAlgorandUri('bitcoin:1abc')).toBeNull();
+      expect(parseAlgorandUri('')).toBeNull();
+      expect(parseAlgorandUri('just some text')).toBeNull();
+    });
+
+    it('marks a checksum-invalid address as isValid:false but still returns an object', () => {
+      const parsed = parseAlgorandUri(`voi://${TAMPERED_ADDRESS}`);
+      expect(parsed).not.toBeNull();
+      expect(parsed!.address).toBe(TAMPERED_ADDRESS);
+      expect(parsed!.isValid).toBe(false);
+      expect(parsed!.scheme).toBe('voi');
+    });
+
+    it('marks obvious garbage in the address slot as invalid', () => {
+      const parsed = parseAlgorandUri('algorand://NOTAVALIDADDRESS');
+      expect(parsed).not.toBeNull();
+      expect(parsed!.isValid).toBe(false);
+    });
+
+    it('treats an empty address (asset opt-in style) as valid', () => {
+      const parsed = parseAlgorandUri('voi://?amount=1000000');
+      expect(parsed).not.toBeNull();
+      expect(parsed!.address).toBe('');
+      // No address to validate -> defaults to valid.
+      expect(parsed!.isValid).toBe(true);
+      expect(parsed!.params.amount).toBe('1000000');
+    });
+
+    it('falls back to the ?address= query param when the path is empty', () => {
+      const uri = buildUri('voi', '', {
+        address: VALID_ADDRESS,
+        amount: '500000',
+      });
+      const parsed = parseAlgorandUri(uri);
+      expect(parsed).not.toBeNull();
+      expect(parsed!.address).toBe(VALID_ADDRESS);
+      expect(parsed!.params.address).toBe(VALID_ADDRESS);
+      expect(parsed!.isValid).toBe(true);
+    });
+  });
+
+  describe('parseAlgorandUri - round-trips', () => {
+    it('round-trips a full native-token payment request', () => {
+      const params: AlgorandUriParams = {
+        amount: '1500000',
+        label: 'Alice Smith',
+        note: 'coffee money',
+        xnote: 'immutable receipt',
+      };
+      const uri = buildUri('voi', VALID_ADDRESS, params);
+      const parsed = parseAlgorandUri(uri);
+
+      expect(parsed).not.toBeNull();
+      expect(parsed!.address).toBe(VALID_ADDRESS);
+      expect(parsed!.scheme).toBe('voi');
+      expect(parsed!.isValid).toBe(true);
+      expect(parsed!.params.amount).toBe('1500000');
+      expect(parsed!.params.label).toBe('Alice Smith');
+      expect(parsed!.params.note).toBe('coffee money');
+      expect(parsed!.params.xnote).toBe('immutable receipt');
+      // asset omitted -> undefined (native token)
+      expect(parsed!.params.asset).toBeUndefined();
+    });
+
+    it('round-trips an ASA (asset) payment request', () => {
+      const params: AlgorandUriParams = { amount: '250', asset: '12345' };
+      const uri = buildUri('algorand', VALID_ADDRESS, params);
+      const parsed = parseAlgorandUri(uri);
+
+      expect(parsed).not.toBeNull();
+      expect(parsed!.params.amount).toBe('250');
+      expect(parsed!.params.asset).toBe('12345');
+      expect(parsed!.scheme).toBe('algorand');
+    });
+
+    it('round-trips unicode and reserved characters in the label', () => {
+      const params: AlgorandUriParams = { label: 'Café & Bar' };
+      const uri = buildUri('voi', VALID_ADDRESS, params);
+      const parsed = parseAlgorandUri(uri);
+
+      expect(parsed).not.toBeNull();
+      // These survive because after a single decode no '%' remains.
+      expect(parsed!.params.label).toBe('Café & Bar');
+    });
+  });
+
+  describe('parseAlgorandUri - amount validation', () => {
+    it('accepts a valid non-negative integer amount', () => {
+      expect(
+        parseAlgorandUri(buildUri('voi', VALID_ADDRESS, { amount: '0' }))!
+          .params.amount
+      ).toBe('0');
+      expect(
+        parseAlgorandUri(buildUri('voi', VALID_ADDRESS, { amount: '1000000' }))!
+          .params.amount
+      ).toBe('1000000');
+    });
+
+    it('accepts the exact upper bound (1e16)', () => {
+      const parsed = parseAlgorandUri(
+        buildUri('voi', VALID_ADDRESS, { amount: '10000000000000000' })
+      );
+      expect(parsed!.params.amount).toBe('10000000000000000');
+    });
+
+    it('drops an amount over the deliberate upper bound (native total supply)', () => {
+      // The parser caps amount at 1e16 base units — VOI/ALGO total supply
+      // (10B * 1e6 microunits) — as a documented sanity bound (not a URI-spec
+      // requirement). NOTE: this native bound can be below a high-supply ASA's
+      // max valid amount; whether the cap should be asset-aware (or uint64-max)
+      // is tracked separately.
+      const parsed = parseAlgorandUri(
+        buildUri('voi', VALID_ADDRESS, { amount: '10000000000000001' })
+      );
+      expect(parsed!.params.amount).toBeUndefined();
+    });
+
+    it('drops non-integer / negative / non-numeric amounts', () => {
+      for (const bad of ['-100', '1.5', '1e6', 'abc', '0x10', '  5  ']) {
+        const parsed = parseAlgorandUri(
+          buildUri('voi', VALID_ADDRESS, { amount: bad })
+        );
+        expect(parsed!.params.amount).toBeUndefined();
+      }
+    });
+  });
+
+  describe('parseAlgorandUri - asset validation', () => {
+    it('accepts a positive integer asset id', () => {
+      const parsed = parseAlgorandUri(
+        buildUri('voi', VALID_ADDRESS, { asset: '31566704' })
+      );
+      expect(parsed!.params.asset).toBe('31566704');
+    });
+
+    it('drops asset id 0 (native token is represented by omission)', () => {
+      const parsed = parseAlgorandUri(
+        buildUri('voi', VALID_ADDRESS, { asset: '0' })
+      );
+      expect(parsed!.params.asset).toBeUndefined();
+    });
+
+    it('drops negative / non-numeric asset ids', () => {
+      for (const bad of ['-1', 'abc', '1.5', '']) {
+        const parsed = parseAlgorandUri(
+          buildUri('voi', VALID_ADDRESS, { asset: bad })
+        );
+        expect(parsed!.params.asset).toBeUndefined();
+      }
+    });
+  });
+
+  describe('parseAlgorandUri - note/label decoding (double-decode bug)', () => {
+    // KNOWN BUG (tracked): parseAlgorandUri decodes twice — URLSearchParams
+    // already percent-decodes, then decodeURIComponent runs again. For a note
+    // with a literal '%', the second decode throws URIError on the leftover '%'
+    // and the whole parse returns null, rejecting a valid payment URI.
+    // it.failing asserts the CORRECT behavior (passes while buggy; flips when fixed).
+    it.failing('preserves a note containing a literal percent sign', () => {
+      const uri = buildUri('voi', VALID_ADDRESS, { note: '100%' });
+      expect(uri).toContain('note=100%25'); // encoded exactly once
+      const parsed = parseAlgorandUri(uri);
+      expect(parsed).not.toBeNull();
+      expect(parsed!.params.note).toBe('100%');
+    });
+
+    // KNOWN BUG (tracked, same double-decode): a label whose literal text is the
+    // 3 chars "%41" is correctly encoded "%2541"; one decode restores "%41", but
+    // the second decode corrupts it to "A".
+    it.failing(
+      'does not corrupt a label that is literally a percent escape',
+      () => {
+        const uri = buildUri('voi', VALID_ADDRESS, { label: '%41' });
+        expect(uri).toContain('label=%2541');
+        const parsed = parseAlgorandUri(uri);
+        expect(parsed!.params.label).toBe('%41');
+      }
+    );
+  });
+
+  describe('convertAmountToDisplay', () => {
+    it('converts whole microVOI/microAlgos amounts (default 6 decimals)', () => {
+      expect(convertAmountToDisplay('1000000')).toBe('1');
+      expect(convertAmountToDisplay('10000000000000000')).toBe('10000000000');
+      expect(convertAmountToDisplay('0')).toBe('0');
+    });
+
+    it('formats fractional amounts and trims trailing zeros', () => {
+      expect(convertAmountToDisplay('1500000')).toBe('1.5');
+      expect(convertAmountToDisplay('1234567')).toBe('1.234567');
+      expect(convertAmountToDisplay('500000')).toBe('0.5');
+      expect(convertAmountToDisplay('1200000')).toBe('1.2');
+    });
+
+    it('pads leading fractional zeros correctly (no trailing zeros to trim)', () => {
+      expect(convertAmountToDisplay('1')).toBe('0.000001');
+      expect(convertAmountToDisplay('1000001')).toBe('1.000001');
+      expect(convertAmountToDisplay('1000010')).toBe('1.00001');
+    });
+
+    it('honours a custom decimals argument', () => {
+      expect(convertAmountToDisplay('100', 0)).toBe('100');
+      expect(convertAmountToDisplay('123', 2)).toBe('1.23');
+      expect(convertAmountToDisplay('120', 2)).toBe('1.2');
+      expect(convertAmountToDisplay('1', 2)).toBe('0.01');
+    });
+
+    it('returns "0" for un-parseable input instead of throwing', () => {
+      expect(convertAmountToDisplay('not-a-number')).toBe('0');
+      expect(convertAmountToDisplay('1.5')).toBe('0');
+    });
+  });
+
+  describe('createPaymentSummary', () => {
+    const base = (over: Partial<ParsedAlgorandUri>): ParsedAlgorandUri => ({
+      address: VALID_ADDRESS,
+      params: {},
+      isValid: true,
+      scheme: 'voi',
+      ...over,
+    });
+
+    it('prefers the label over the truncated address', () => {
+      const summary = createPaymentSummary(
+        base({ params: { label: 'Alice', amount: '1000000' } })
+      );
+      expect(summary).toBe('Send to Alice 1 VOI');
+    });
+
+    it('truncates the address to first-8...last-8 when there is no label', () => {
+      const summary = createPaymentSummary(
+        base({ params: { amount: '2500000' } })
+      );
+      const short = `${VALID_ADDRESS.slice(0, 8)}...${VALID_ADDRESS.slice(-8)}`;
+      expect(summary).toBe(`Send to ${short} 2.5 VOI`);
+    });
+
+    it('labels the native token "Algos" for the algorand scheme', () => {
+      const summary = createPaymentSummary(
+        base({
+          scheme: 'algorand',
+          params: { amount: '1000000', label: 'Bob' },
+        })
+      );
+      expect(summary).toBe('Send to Bob 1 Algos');
+    });
+
+    it('labels the native token "VOI" for the perawallet scheme', () => {
+      const summary = createPaymentSummary(
+        base({
+          scheme: 'perawallet',
+          params: { amount: '3000000', label: 'Bo' },
+        })
+      );
+      expect(summary).toBe('Send to Bo 3 VOI');
+    });
+
+    it('describes an ASA amount with 0 decimals and the asset id', () => {
+      const summary = createPaymentSummary(
+        base({ params: { amount: '250', asset: '12345', label: 'Eve' } })
+      );
+      expect(summary).toBe('Send to Eve 250 units of asset 12345');
+    });
+
+    it('prefers xnote over note in the summary', () => {
+      const summary = createPaymentSummary(
+        base({ params: { label: 'Al', note: 'mutable', xnote: 'locked' } })
+      );
+      expect(summary).toBe('Send to Al with note: "locked"');
+    });
+
+    it('uses note when xnote is absent', () => {
+      const summary = createPaymentSummary(
+        base({ params: { label: 'Al', note: 'thanks' } })
+      );
+      expect(summary).toBe('Send to Al with note: "thanks"');
+    });
+
+    it('falls back to a generic message when there is nothing to summarise', () => {
+      const summary = createPaymentSummary(base({ address: '', params: {} }));
+      expect(summary).toBe('Process payment request');
+    });
+
+    it('combines label, amount and note into one sentence', () => {
+      const summary = createPaymentSummary(
+        base({ params: { label: 'Alice', amount: '1500000', note: 'hi' } })
+      );
+      expect(summary).toBe('Send to Alice 1.5 VOI with note: "hi"');
+    });
+  });
+});

--- a/src/utils/__tests__/arc0300.test.ts
+++ b/src/utils/__tests__/arc0300.test.ts
@@ -1,0 +1,387 @@
+import { Buffer } from 'buffer';
+import nacl from 'tweetnacl';
+
+import {
+  parseArc0300AccountImportUri,
+  normalizeBase64ToHex,
+  collectArc0300Entries,
+  isArc0300AccountImportUri,
+  generateArc0300AccountExportUri,
+} from '../arc0300';
+
+// --- Independent spec helpers -------------------------------------------------
+// RFC 4648 §5 "URL-safe" base64 (no padding). This is the canonical definition
+// of the transform ARC-0300 requires — computing expectations this way is
+// spec-based, not a copy of "whatever the code returns".
+const toB64Url = (bytes: Uint8Array): string =>
+  Buffer.from(bytes)
+    .toString('base64')
+    .replace(/\+/g, '-')
+    .replace(/\//g, '_')
+    .replace(/=+$/, '');
+
+// Deterministic Ed25519 material: seed(32) -> secretKey(64) = seed || pubkey.
+const makeSeed = (fill: number): Uint8Array => new Uint8Array(32).fill(fill);
+const makeSecretKey = (fill: number): Uint8Array =>
+  nacl.sign.keyPair.fromSeed(makeSeed(fill)).secretKey; // 64 bytes
+const hexOf = (bytes: Uint8Array): string => Buffer.from(bytes).toString('hex');
+
+describe('arc0300', () => {
+  describe('generateArc0300AccountExportUri', () => {
+    it('builds a canonical avm://account/import URI with URL-safe base64', () => {
+      const sk = makeSecretKey(7);
+      const uri = generateArc0300AccountExportUri({ privateKeyBytes: sk });
+      expect(uri).toBe(`avm://account/import?privatekey=${toB64Url(sk)}`);
+    });
+
+    it('strips base64 padding and uses URL-safe alphabet (no + / =)', () => {
+      // 0xFB bytes force both '+' and '/' in standard base64.
+      const sk = new Uint8Array(64).fill(0xfb);
+      const uri = generateArc0300AccountExportUri({ privateKeyBytes: sk });
+      const payload = uri.split('privatekey=')[1];
+      expect(payload).not.toMatch(/[+/=]/);
+      expect(payload).toMatch(/[-_]/);
+      expect(payload).toBe(toB64Url(sk));
+    });
+
+    it('appends a percent-encoded name when provided', () => {
+      const sk = makeSecretKey(3);
+      const uri = generateArc0300AccountExportUri({
+        privateKeyBytes: sk,
+        name: 'My Wallet',
+      });
+      expect(uri).toBe(
+        `avm://account/import?privatekey=${toB64Url(sk)}&name=My%20Wallet`
+      );
+    });
+
+    it('encodes reserved characters in the name so they do not break the query', () => {
+      const sk = makeSecretKey(4);
+      const uri = generateArc0300AccountExportUri({
+        privateKeyBytes: sk,
+        name: 'A & B',
+      });
+      // encodeURIComponent('A & B') === 'A%20%26%20B'
+      expect(uri.endsWith('&name=A%20%26%20B')).toBe(true);
+    });
+
+    it('omits the name segment for an empty name', () => {
+      const sk = makeSecretKey(5);
+      const uri = generateArc0300AccountExportUri({
+        privateKeyBytes: sk,
+        name: '',
+      });
+      expect(uri).toBe(`avm://account/import?privatekey=${toB64Url(sk)}`);
+    });
+
+    it('throws for a private key that is not 64 bytes', () => {
+      expect(() =>
+        generateArc0300AccountExportUri({ privateKeyBytes: new Uint8Array(32) })
+      ).toThrow('Invalid private key length: expected 64 bytes, got 32');
+      expect(() =>
+        generateArc0300AccountExportUri({ privateKeyBytes: new Uint8Array(0) })
+      ).toThrow('Invalid private key length: expected 64 bytes, got 0');
+    });
+  });
+
+  describe('parseArc0300AccountImportUri', () => {
+    it('parses a standard (private-key) import', () => {
+      const parsed = parseArc0300AccountImportUri(
+        'avm://account/import?privatekey=K1&name=Alice'
+      );
+      expect(parsed).not.toBeNull();
+      expect(parsed!.kind).toBe('standard');
+      expect(parsed!.scheme).toBe('avm');
+      expect(parsed!.entries).toEqual([
+        { privateKeyBase64: 'K1', name: 'Alice' },
+      ]);
+    });
+
+    it('accepts the "algorand" scheme too', () => {
+      const parsed = parseArc0300AccountImportUri(
+        'algorand://account/import?privatekey=K1'
+      );
+      expect(parsed).not.toBeNull();
+      expect(parsed!.scheme).toBe('algorand');
+      expect(parsed!.kind).toBe('standard');
+    });
+
+    it('lowercases the scheme (case-insensitive)', () => {
+      const parsed = parseArc0300AccountImportUri(
+        'AVM://account/import?privatekey=K1'
+      );
+      expect(parsed).not.toBeNull();
+      expect(parsed!.scheme).toBe('avm');
+    });
+
+    it('trims surrounding whitespace on the whole URI', () => {
+      const parsed = parseArc0300AccountImportUri(
+        '   avm://account/import?address=ADDR   '
+      );
+      expect(parsed).not.toBeNull();
+      expect(parsed!.kind).toBe('watch');
+      expect(parsed!.entries).toEqual([{ address: 'ADDR' }]);
+    });
+
+    it('trims whitespace inside a private-key value', () => {
+      const parsed = parseArc0300AccountImportUri(
+        'avm://account/import?privatekey=%20AAAA%20'
+      );
+      expect(parsed!.entries[0].privateKeyBase64).toBe('AAAA');
+    });
+
+    it('parses multiple key/name pairs, matching names by index', () => {
+      const parsed = parseArc0300AccountImportUri(
+        'avm://account/import?privatekey=K1&name=One&privatekey=K2&name=Two'
+      );
+      expect(parsed!.entries).toEqual([
+        { privateKeyBase64: 'K1', name: 'One' },
+        { privateKeyBase64: 'K2', name: 'Two' },
+      ]);
+    });
+
+    it('leaves name undefined when fewer names than keys are supplied', () => {
+      const parsed = parseArc0300AccountImportUri(
+        'avm://account/import?privatekey=K1&privatekey=K2&name=Only'
+      );
+      expect(parsed!.entries).toEqual([
+        { privateKeyBase64: 'K1', name: 'Only' },
+        { privateKeyBase64: 'K2', name: undefined },
+      ]);
+    });
+
+    it('prefers a private-key import over an address when both are present', () => {
+      const parsed = parseArc0300AccountImportUri(
+        'avm://account/import?privatekey=K1&address=ADDR'
+      );
+      expect(parsed!.kind).toBe('standard');
+      expect(parsed!.entries[0].privateKeyBase64).toBe('K1');
+      // address is ignored when a private key is present
+      expect(parsed!.entries[0].address).toBeUndefined();
+    });
+
+    it('parses a watch (address-only) import', () => {
+      const parsed = parseArc0300AccountImportUri(
+        'avm://account/import?address=ABCDEF'
+      );
+      expect(parsed!.kind).toBe('watch');
+      expect(parsed!.entries).toEqual([{ address: 'ABCDEF' }]);
+    });
+
+    it('captures the checksum query parameter', () => {
+      const parsed = parseArc0300AccountImportUri(
+        'avm://account/import?privatekey=K1&checksum=deadbeef'
+      );
+      expect(parsed!.checksum).toBe('deadbeef');
+    });
+
+    it('parses valid "index:total" pagination', () => {
+      const parsed = parseArc0300AccountImportUri(
+        'avm://account/import?privatekey=K1&page=1:4'
+      );
+      expect(parsed!.pagination).toEqual({ index: 1, total: 4 });
+    });
+
+    it('accepts a zero page index', () => {
+      const parsed = parseArc0300AccountImportUri(
+        'avm://account/import?privatekey=K1&page=0:2'
+      );
+      expect(parsed!.pagination).toEqual({ index: 0, total: 2 });
+    });
+
+    it('rejects pagination when total is not positive', () => {
+      const parsed = parseArc0300AccountImportUri(
+        'avm://account/import?privatekey=K1&page=1:0'
+      );
+      expect(parsed!.pagination).toBeUndefined();
+    });
+
+    it('rejects non-numeric pagination', () => {
+      const parsed = parseArc0300AccountImportUri(
+        'avm://account/import?privatekey=K1&page=abc'
+      );
+      expect(parsed!.pagination).toBeUndefined();
+    });
+
+    describe('returns null for malformed / non-matching URIs', () => {
+      const invalid: [string, string][] = [
+        ['empty string', ''],
+        ['whitespace only', '   '],
+        ['missing scheme', 'account/import?privatekey=K1'],
+        ['unsupported scheme', 'https://account/import?privatekey=K1'],
+        ['unsupported scheme (ftp)', 'ftp://account/import?privatekey=K1'],
+        ['wrong authority', 'avm://wallet/import?privatekey=K1'],
+        ['wrong path', 'avm://account/export?privatekey=K1'],
+        ['too few path segments', 'avm://account'],
+        ['no key and no address', 'avm://account/import'],
+        ['only checksum, no key/address', 'avm://account/import?checksum=x'],
+        ['only address is empty-ish absent', 'avm://account/import?name=NoKey'],
+      ];
+
+      it.each(invalid)('%s -> null', (_label, uri) => {
+        expect(parseArc0300AccountImportUri(uri)).toBeNull();
+      });
+    });
+
+    // KNOWN BUG (tracked): `privatekey=` carries no key material, so the URI is
+    // malformed and the correct result is null. The parser only checks
+    // privateKeys.length > 0, so an empty string yields a 'standard' entry with
+    // an empty key. it.failing asserts the CORRECT behavior — it passes while
+    // the bug exists and flips to failing (remove `.failing`) once it's fixed.
+    it.failing('rejects an empty private-key value', () => {
+      expect(
+        parseArc0300AccountImportUri('avm://account/import?privatekey=')
+      ).toBeNull();
+    });
+  });
+
+  describe('isArc0300AccountImportUri', () => {
+    it('is true for a valid import URI', () => {
+      expect(
+        isArc0300AccountImportUri('avm://account/import?privatekey=K1')
+      ).toBe(true);
+    });
+
+    it('is true for a generated export URI (round-trip recognition)', () => {
+      const uri = generateArc0300AccountExportUri({
+        privateKeyBytes: makeSecretKey(11),
+        name: 'Acct',
+      });
+      expect(isArc0300AccountImportUri(uri)).toBe(true);
+    });
+
+    it('is false for unrelated / malformed URIs', () => {
+      expect(isArc0300AccountImportUri('https://example.com')).toBe(false);
+      expect(isArc0300AccountImportUri('avm://account/import')).toBe(false);
+      expect(isArc0300AccountImportUri('')).toBe(false);
+    });
+  });
+
+  describe('normalizeBase64ToHex', () => {
+    it('hex-encodes a 64-byte secret key unchanged', () => {
+      const sk = makeSecretKey(9);
+      expect(normalizeBase64ToHex(toB64Url(sk))).toBe(hexOf(sk));
+    });
+
+    it('derives the full 64-byte secret key from a 32-byte seed', () => {
+      const seed = makeSeed(7);
+      const kp = nacl.sign.keyPair.fromSeed(seed);
+      const hex = normalizeBase64ToHex(toB64Url(seed));
+
+      expect(hex).toBe(hexOf(kp.secretKey));
+      // Ed25519 secret key layout: first 32 bytes = seed, last 32 = public key.
+      expect(hex.slice(0, 64)).toBe(hexOf(seed));
+      expect(hex.slice(64)).toBe(hexOf(kp.publicKey));
+    });
+
+    it('decodes URL-safe base64 (handles - and _)', () => {
+      const bytes = new Uint8Array(64).fill(0xfb); // std base64 has + and /
+      const urlB64 = toB64Url(bytes);
+      expect(urlB64).toMatch(/[-_]/);
+      expect(urlB64).not.toMatch(/[+/]/);
+      expect(normalizeBase64ToHex(urlB64)).toBe(hexOf(bytes));
+    });
+
+    it('adds the padding it needs to decode an unpadded 32-byte seed', () => {
+      const seed = makeSeed(2);
+      const unpadded = toB64Url(seed);
+      expect(unpadded).not.toContain('=');
+      expect(unpadded.length % 4).not.toBe(0); // proves padding is required
+      expect(() => normalizeBase64ToHex(unpadded)).not.toThrow();
+    });
+
+    it('throws for an unsupported key length', () => {
+      const sixteen = toB64Url(new Uint8Array(16));
+      expect(() => normalizeBase64ToHex(sixteen)).toThrow(
+        'Unsupported ARC-0300 private key length: 16 bytes'
+      );
+    });
+
+    it('throws for an empty (0-byte) input', () => {
+      expect(() => normalizeBase64ToHex('')).toThrow(
+        'Unsupported ARC-0300 private key length: 0 bytes'
+      );
+    });
+  });
+
+  describe('collectArc0300Entries', () => {
+    it('flattens entries across results while preserving kind', () => {
+      const std = parseArc0300AccountImportUri(
+        'avm://account/import?privatekey=K1&name=A&privatekey=K2&name=B'
+      )!;
+      const watch = parseArc0300AccountImportUri(
+        'avm://account/import?address=ADDR'
+      )!;
+
+      const collected = collectArc0300Entries([std, watch]);
+
+      expect(collected).toHaveLength(3);
+      expect(collected[0]).toEqual({
+        kind: 'standard',
+        name: 'A',
+        privateKeyBase64: 'K1',
+        address: undefined,
+      });
+      expect(collected[1]).toEqual({
+        kind: 'standard',
+        name: 'B',
+        privateKeyBase64: 'K2',
+        address: undefined,
+      });
+      expect(collected[2]).toEqual({
+        kind: 'watch',
+        name: undefined,
+        privateKeyBase64: undefined,
+        address: 'ADDR',
+      });
+    });
+
+    it('returns an empty array for no results', () => {
+      expect(collectArc0300Entries([])).toEqual([]);
+    });
+  });
+
+  describe('round-trip: generate -> parse -> normalizeBase64ToHex', () => {
+    it('recovers the exact 64-byte secret key and name', () => {
+      const sk = makeSecretKey(13);
+      const uri = generateArc0300AccountExportUri({
+        privateKeyBytes: sk,
+        name: 'Air-Gapped Wallet',
+      });
+
+      const parsed = parseArc0300AccountImportUri(uri)!;
+      expect(parsed.kind).toBe('standard');
+      expect(parsed.scheme).toBe('avm');
+      expect(parsed.entries).toHaveLength(1);
+      expect(parsed.entries[0].name).toBe('Air-Gapped Wallet');
+
+      const hex = normalizeBase64ToHex(parsed.entries[0].privateKeyBase64!);
+      expect(hex).toBe(hexOf(sk));
+    });
+
+    it('tampered base64 payload decodes to a DIFFERENT key (negative test)', () => {
+      const sk = makeSecretKey(21);
+      const uri = generateArc0300AccountExportUri({ privateKeyBytes: sk });
+
+      const start = uri.indexOf('privatekey=') + 'privatekey='.length;
+      const ch = uri[start];
+      const swapped = ch === 'A' ? 'B' : 'A'; // stays valid base64, same length
+      const tampered = uri.slice(0, start) + swapped + uri.slice(start + 1);
+
+      const parsed = parseArc0300AccountImportUri(tampered)!;
+      const hex = normalizeBase64ToHex(parsed.entries[0].privateKeyBase64!);
+
+      // Structurally still a valid import, but the recovered key must differ.
+      expect(parsed.kind).toBe('standard');
+      expect(hex).not.toBe(hexOf(sk));
+    });
+
+    it('seed derivation is sensitive to a single-byte change (crypto tamper)', () => {
+      const hexA = normalizeBase64ToHex(toB64Url(makeSeed(1)));
+      const hexB = normalizeBase64ToHex(toB64Url(makeSeed(2)));
+      expect(hexA).not.toBe(hexB);
+      // The derived public-key halves must also diverge.
+      expect(hexA.slice(64)).not.toBe(hexB.slice(64));
+    });
+  });
+});

--- a/src/utils/__tests__/bigint.test.ts
+++ b/src/utils/__tests__/bigint.test.ts
@@ -1,0 +1,157 @@
+// The money-math core. Assertions are spec-based (hand-computed from the
+// documented behavior), so a regression that changes a signed/parsed amount
+// fails the test rather than being silently codified.
+
+// bigint.ts -> formatting.ts -> @/store/walletStore. The pure money-math
+// functions under test don't touch the store; mock it so the import resolves
+// without pulling in the real zustand store / services.
+jest.mock('@/store/walletStore', () => ({
+  useWalletStore: Object.assign(() => ({}), { getState: () => ({}) }),
+}));
+
+import {
+  parseAmountToBaseUnits,
+  formatBaseUnitsToAmount,
+  sanitizeAmountInput,
+  compareBigInt,
+  compareBigIntSafe,
+  addBigIntSafe,
+  subtractBigIntSafe,
+  toBigIntSafeNumber,
+} from '../bigint';
+
+describe('parseAmountToBaseUnits (user amount string -> integer base units)', () => {
+  it('parses whole and fractional amounts exactly', () => {
+    expect(parseAmountToBaseUnits('1', 6)).toBe(1000000n);
+    expect(parseAmountToBaseUnits('1.5', 6)).toBe(1500000n);
+    // the documented example — the float pattern would lose precision here
+    expect(parseAmountToBaseUnits('1.005', 6)).toBe(1005000n);
+    expect(parseAmountToBaseUnits('0.000001', 6)).toBe(1n);
+  });
+
+  it('treats empty / bare dot / zero as 0n', () => {
+    expect(parseAmountToBaseUnits('', 6)).toBe(0n);
+    expect(parseAmountToBaseUnits('.', 6)).toBe(0n);
+    expect(parseAmountToBaseUnits('0', 6)).toBe(0n);
+    expect(parseAmountToBaseUnits('   ', 6)).toBe(0n);
+  });
+
+  it('allows trailing zeros beyond precision but rejects significant excess', () => {
+    expect(parseAmountToBaseUnits('1.0000000', 6)).toBe(1000000n); // trailing zeros ok
+    expect(() => parseAmountToBaseUnits('1.0000001', 6)).toThrow(
+      /more decimal places/
+    );
+  });
+
+  it('handles 0-decimal assets (reject any significant fraction)', () => {
+    expect(parseAmountToBaseUnits('5', 0)).toBe(5n);
+    expect(parseAmountToBaseUnits('5.0', 0)).toBe(5n);
+    expect(() => parseAmountToBaseUnits('5.1', 0)).toThrow(
+      /more decimal places/
+    );
+  });
+
+  it('is exact for high-decimal ARC-200 amounts (no Number overflow)', () => {
+    expect(parseAmountToBaseUnits('1.123456789012345678', 18)).toBe(
+      1123456789012345678n
+    );
+  });
+
+  it('tolerates leading zeros', () => {
+    expect(parseAmountToBaseUnits('007', 6)).toBe(7000000n);
+  });
+
+  it('throws on malformed / negative / exponent / multi-dot input', () => {
+    for (const bad of ['-5', '1.2.3', 'abc', '1e6', '1,000']) {
+      expect(() => parseAmountToBaseUnits(bad, 6)).toThrow('Invalid amount');
+    }
+  });
+});
+
+describe('formatBaseUnitsToAmount (inverse of parseAmountToBaseUnits)', () => {
+  it('formats and trims trailing zeros', () => {
+    expect(formatBaseUnitsToAmount(1000000n, 6)).toBe('1');
+    expect(formatBaseUnitsToAmount(1500000n, 6)).toBe('1.5');
+    expect(formatBaseUnitsToAmount(1005000n, 6)).toBe('1.005');
+    expect(formatBaseUnitsToAmount(1n, 6)).toBe('0.000001');
+    expect(formatBaseUnitsToAmount(0n, 6)).toBe('0');
+  });
+
+  it('handles 0-decimals and negatives', () => {
+    expect(formatBaseUnitsToAmount(5n, 0)).toBe('5');
+    expect(formatBaseUnitsToAmount(-1500000n, 6)).toBe('-1.5');
+  });
+
+  it('round-trips with parseAmountToBaseUnits', () => {
+    // All inputs are in canonical form (no trailing zeros), so the round-trip
+    // returns the exact same string.
+    for (const [amt, dec] of [
+      ['1.005', 6],
+      ['0.000001', 6],
+      ['1234.56', 8],
+      ['1.123456789012345678', 18],
+    ] as const) {
+      expect(
+        formatBaseUnitsToAmount(parseAmountToBaseUnits(amt, dec), dec)
+      ).toBe(amt);
+    }
+  });
+});
+
+describe('sanitizeAmountInput (raw field text -> normalized decimal string | null)', () => {
+  it('normalizes comma to dot', () => {
+    expect(sanitizeAmountInput('1,5')).toBe('1.5');
+    expect(sanitizeAmountInput('1.5')).toBe('1.5');
+    expect(sanitizeAmountInput('0,000001')).toBe('0.000001');
+  });
+
+  it('allows a lone dot as a typing intermediate', () => {
+    expect(sanitizeAmountInput('.')).toBe('.');
+    expect(sanitizeAmountInput('.5')).toBe('.5');
+  });
+
+  it('returns null for ambiguous multi-separator input', () => {
+    expect(sanitizeAmountInput('1,234.56')).toBeNull(); // two separators
+    expect(sanitizeAmountInput('1..2')).toBeNull();
+    expect(sanitizeAmountInput('1,,2')).toBeNull();
+  });
+
+  it('returns null for non-numeric characters', () => {
+    expect(sanitizeAmountInput('-1')).toBeNull();
+    expect(sanitizeAmountInput('1e3')).toBeNull();
+    expect(sanitizeAmountInput('$1')).toBeNull();
+  });
+
+  it('passes empty through', () => {
+    expect(sanitizeAmountInput('')).toBe('');
+  });
+});
+
+describe('compareBigInt (true bigint compare, no Number downcast)', () => {
+  it('orders values correctly', () => {
+    expect(compareBigInt(1n, 2n)).toBe(-1);
+    expect(compareBigInt(2n, 1n)).toBe(1);
+    expect(compareBigInt(5n, 5n)).toBe(0);
+    expect(compareBigInt(3, 5)).toBe(-1);
+  });
+
+  it('stays exact above Number.MAX_SAFE_INTEGER (where downcast would fail)', () => {
+    const a = 9007199254740993n; // MAX_SAFE_INTEGER + 2
+    const b = 9007199254740992n; // MAX_SAFE_INTEGER + 1
+    expect(compareBigInt(a, b)).toBe(1);
+    // sanity: the lossy comparator cannot distinguish these
+    expect(compareBigIntSafe(a, b)).toBe(0);
+  });
+});
+
+describe('safe number helpers', () => {
+  it('toBigIntSafeNumber downcasts bigint', () => {
+    expect(toBigIntSafeNumber(5n)).toBe(5);
+    expect(toBigIntSafeNumber(5)).toBe(5);
+  });
+
+  it('add/subtract operate on numbers', () => {
+    expect(addBigIntSafe(2n, 3)).toBe(5);
+    expect(subtractBigIntSafe(10n, 4n)).toBe(6);
+  });
+});

--- a/src/utils/__tests__/bip39.test.ts
+++ b/src/utils/__tests__/bip39.test.ts
@@ -1,0 +1,122 @@
+import { BIP39Utils } from '../bip39';
+
+describe('BIP39Utils', () => {
+  describe('isValidWord', () => {
+    it('accepts real wordlist words', () => {
+      expect(BIP39Utils.isValidWord('abandon')).toBe(true);
+      expect(BIP39Utils.isValidWord('zoo')).toBe(true);
+    });
+
+    it('is case-insensitive and trims whitespace', () => {
+      expect(BIP39Utils.isValidWord('  ABANDON  ')).toBe(true);
+      expect(BIP39Utils.isValidWord('Zoo')).toBe(true);
+    });
+
+    it('rejects non-wordlist words', () => {
+      expect(BIP39Utils.isValidWord('notaword')).toBe(false);
+      expect(BIP39Utils.isValidWord('')).toBe(false);
+      // "abandonx" is a prefix-superset, must still be rejected
+      expect(BIP39Utils.isValidWord('abandonx')).toBe(false);
+    });
+  });
+
+  describe('getWordlistLength', () => {
+    it('is the standard BIP-39 length of 2048', () => {
+      expect(BIP39Utils.getWordlistLength()).toBe(2048);
+    });
+  });
+
+  describe('getWordIndex / getWordAtIndex', () => {
+    it('maps the first and last words to their indices', () => {
+      expect(BIP39Utils.getWordIndex('abandon')).toBe(0);
+      expect(BIP39Utils.getWordAtIndex(0)).toBe('abandon');
+      expect(BIP39Utils.getWordAtIndex(2047)).toBe('zoo');
+    });
+
+    it('round-trips index -> word -> index', () => {
+      for (const i of [0, 1, 1000, 2047]) {
+        const word = BIP39Utils.getWordAtIndex(i);
+        expect(BIP39Utils.getWordIndex(word)).toBe(i);
+      }
+    });
+
+    it('returns -1 / empty string for invalid input', () => {
+      expect(BIP39Utils.getWordIndex('notaword')).toBe(-1);
+      expect(BIP39Utils.getWordAtIndex(-1)).toBe('');
+      expect(BIP39Utils.getWordAtIndex(9999)).toBe('');
+    });
+  });
+
+  describe('getWordSuggestions', () => {
+    it('returns words matching the prefix, capped at the limit', () => {
+      const suggestions = BIP39Utils.getWordSuggestions('aban', 5);
+      expect(suggestions.length).toBeGreaterThan(0);
+      expect(suggestions.length).toBeLessThanOrEqual(5);
+      expect(suggestions.every((s) => s.word.startsWith('aban'))).toBe(true);
+      expect(suggestions.map((s) => s.word)).toContain('abandon');
+    });
+
+    it('respects a custom limit', () => {
+      expect(BIP39Utils.getWordSuggestions('a', 3)).toHaveLength(3);
+    });
+
+    it('returns [] for empty input', () => {
+      expect(BIP39Utils.getWordSuggestions('')).toEqual([]);
+    });
+  });
+
+  describe('validateMnemonicWords (Algorand 25-word)', () => {
+    const valid25 = Array(25).fill('abandon');
+
+    it('accepts exactly 25 valid words', () => {
+      expect(BIP39Utils.validateMnemonicWords(valid25)).toBe(true);
+    });
+
+    it('rejects the wrong word count', () => {
+      expect(BIP39Utils.validateMnemonicWords(Array(24).fill('abandon'))).toBe(
+        false
+      );
+      expect(BIP39Utils.validateMnemonicWords(Array(26).fill('abandon'))).toBe(
+        false
+      );
+    });
+
+    it('rejects when any word is invalid or blank', () => {
+      const withBad = [...valid25];
+      withBad[12] = 'notaword';
+      expect(BIP39Utils.validateMnemonicWords(withBad)).toBe(false);
+
+      const withBlank = [...valid25];
+      withBlank[3] = '   ';
+      expect(BIP39Utils.validateMnemonicWords(withBlank)).toBe(false);
+    });
+  });
+
+  describe('normalizeWord / getMnemonicFromWords', () => {
+    it('normalizes case and whitespace', () => {
+      expect(BIP39Utils.normalizeWord('  AbAnDoN ')).toBe('abandon');
+    });
+
+    it('joins normalized words, dropping empties', () => {
+      expect(
+        BIP39Utils.getMnemonicFromWords(['Abandon', '', '  Zoo  ', ''])
+      ).toBe('abandon zoo');
+    });
+  });
+
+  describe('parsePastedMnemonic', () => {
+    it('splits on any whitespace and pads to 25 slots', () => {
+      const result = BIP39Utils.parsePastedMnemonic('abandon   zoo\nvote');
+      expect(result).toHaveLength(25);
+      expect(result.slice(0, 3)).toEqual(['abandon', 'zoo', 'vote']);
+      expect(result.slice(3).every((w) => w === '')).toBe(true);
+    });
+
+    it('truncates to the first 25 words when more are pasted', () => {
+      const result = BIP39Utils.parsePastedMnemonic(
+        Array(30).fill('abandon').join(' ')
+      );
+      expect(result).toHaveLength(25);
+    });
+  });
+});

--- a/src/utils/__tests__/formatting.test.ts
+++ b/src/utils/__tests__/formatting.test.ts
@@ -1,0 +1,313 @@
+// Money-display formatting. Assertions are SPECIFICATION-based: every expected
+// value is hand-computed from the documented behavior of each function (decimal
+// rules, locale separators, rounding, min/max-decimals), not read back from the
+// implementation — so a regression fails the test instead of being codified.
+//
+// formatting.ts imports @/store/walletStore only to read an optional locale
+// override. Mock it so the import resolves without the real zustand store, and
+// keep a mutable state object we can point at a fixed locale for determinism.
+let mockStoreState: unknown = {};
+jest.mock('@/store/walletStore', () => ({
+  useWalletStore: Object.assign(() => ({}), {
+    getState: () => mockStoreState,
+  }),
+}));
+
+import {
+  getSignificantDecimals,
+  formatNumber,
+  formatTokenBalance,
+  formatCurrency,
+  formatAssetListBalance,
+  formatAssetDetailBalance,
+  resolveLocale,
+  getUserLocale,
+} from '../formatting';
+
+// Every non-locale-specific test pins locale: 'en-US' so grouping/decimal
+// separators are deterministic regardless of the runner's system locale.
+const EN = { locale: 'en-US' } as const;
+
+afterEach(() => {
+  // Reset the store back to the neutral {} default the task specifies.
+  mockStoreState = {};
+});
+
+describe('getSignificantDecimals (magnitude -> decimal-place count)', () => {
+  it('returns minDecimals for exactly zero', () => {
+    expect(getSignificantDecimals(0)).toBe(2); // default minDecimals
+    expect(getSignificantDecimals(0, 8, 4)).toBe(4);
+  });
+
+  it('large values (>= 1000) collapse to 2 decimals', () => {
+    expect(getSignificantDecimals(5000)).toBe(2);
+    expect(getSignificantDecimals(1000)).toBe(2);
+    expect(getSignificantDecimals(1_234_567.89)).toBe(2);
+    // magnitude is taken on the absolute value
+    expect(getSignificantDecimals(-1500)).toBe(2);
+  });
+
+  it('values in [1, 1000) use 4 decimals', () => {
+    expect(getSignificantDecimals(1)).toBe(4);
+    expect(getSignificantDecimals(5)).toBe(4);
+    expect(getSignificantDecimals(999.99)).toBe(4);
+  });
+
+  it('medium values in [0.01, 1) use 6 decimals', () => {
+    expect(getSignificantDecimals(0.5)).toBe(6);
+    expect(getSignificantDecimals(0.01)).toBe(6);
+  });
+
+  it('small values (< 0.01) preserve significant digits: floor(-log10)+4, capped by maxDecimals', () => {
+    // 0.001 -> leadingZeros = floor(-log10(0.001)) = 3, +4 = 7
+    expect(getSignificantDecimals(0.001)).toBe(7);
+    // 0.0001 -> 4 + 4 = 8
+    expect(getSignificantDecimals(0.0001)).toBe(8);
+    // 0.00001 -> floor is 5, 5 + 4 = 9, clamped to maxDecimals (8)
+    expect(getSignificantDecimals(0.00001)).toBe(8);
+    // magnitude uses abs value
+    expect(getSignificantDecimals(-0.001)).toBe(7);
+  });
+
+  it('honors minDecimals as a floor', () => {
+    // large branch would give 2, but minDecimals 5 raises it
+    expect(getSignificantDecimals(5000, 8, 5)).toBe(5);
+    // [1,1000) branch gives 4, minDecimals 6 raises it
+    expect(getSignificantDecimals(5, 8, 6)).toBe(6);
+  });
+
+  it('honors maxDecimals in the small-value (<0.01) branch', () => {
+    // Without the clamp this would be leadingZeros(5)+4 = 9.
+    expect(getSignificantDecimals(0.0000012345, 6, 2)).toBe(6);
+  });
+
+  // KNOWN BUG (tracked): maxDecimals is documented "Maximum decimals to show",
+  // but the fixed magnitude bands (>=1000 -> 2, [1,1000) -> 4, [0.01,1) -> 6)
+  // never clamp to it — only the small-value branch does. So a maxDecimals below
+  // a band default is ignored. Not triggered in-app today (callers pass
+  // maxDecimals >= the band defaults). it.failing asserts the correct clamp.
+  it.failing('clamps the fixed magnitude bands to maxDecimals', () => {
+    expect(getSignificantDecimals(0.123456789, 4, 2)).toBe(4); // min(4, band 6)
+    expect(getSignificantDecimals(5, 3, 2)).toBe(3); // min(3, band 4)
+  });
+});
+
+describe('formatNumber (locale-aware, intelligent truncation)', () => {
+  it('applies magnitude-based decimals and pads up to minDecimals', () => {
+    // >=1000 => 2 decimals; "1,234.5" then padded to min 2 => "1,234.50"
+    expect(formatNumber(1234.5, EN)).toBe('1,234.50');
+    // rounds to the 2 allowed decimals
+    expect(formatNumber(1234.567, EN)).toBe('1,234.57');
+    // [1,1000) => 4 decimals; "5.5" padded to 2 => "5.50"
+    expect(formatNumber(5.5, EN)).toBe('5.50');
+  });
+
+  it('leaves whole numbers without a decimal part', () => {
+    expect(formatNumber(5, EN)).toBe('5');
+    expect(formatNumber(0, EN)).toBe('0');
+    expect(formatNumber(-5, EN)).toBe('-5');
+  });
+
+  it('truncates fractional digits to the significant count', () => {
+    // medium value => 6 decimals, rounds 0.123456789 -> 0.123457
+    expect(formatNumber(0.123456789, EN)).toBe('0.123457');
+    // small value keeps significant digits (8 decimals here)
+    expect(formatNumber(0.00001234, EN)).toBe('0.00001234');
+  });
+
+  it('formats negatives with grouping and min-decimal padding', () => {
+    expect(formatNumber(-1234.5, EN)).toBe('-1,234.50');
+  });
+
+  it('honors an explicit locale separator (de-DE)', () => {
+    // German: "." grouping, "," decimal
+    expect(formatNumber(1234.5, { locale: 'de-DE' })).toBe('1.234,50');
+  });
+
+  it('reads a stored locale override when no explicit locale is passed', () => {
+    mockStoreState = { wallet: { settings: { numberLocale: 'de-DE' } } };
+    expect(formatNumber(1234.5)).toBe('1.234,50');
+  });
+
+  it('showTrailingZeros keeps the full computed decimal count', () => {
+    // 5 -> 4 decimals, all zeros retained
+    expect(formatNumber(5, { ...EN, showTrailingZeros: true })).toBe('5.0000');
+    // 1234.5 -> 2 decimals retained
+    expect(formatNumber(1234.5, { ...EN, showTrailingZeros: true })).toBe(
+      '1,234.50'
+    );
+  });
+
+  it('respects an explicit decimals override', () => {
+    expect(formatNumber(1.23456, { ...EN, decimals: 3 })).toBe('1.235');
+    // decimals:0 rounds to integer, but minDecimals(2) still forces ".00"
+    // on a fractional input (min-decimals rule wins over the override).
+    expect(formatNumber(1.2, { ...EN, decimals: 0 })).toBe('1.00');
+    // dropping minDecimals to 0 yields a clean integer
+    expect(formatNumber(1.2, { ...EN, decimals: 0, minDecimals: 0 })).toBe('1');
+  });
+
+  it('supports compact notation', () => {
+    expect(formatNumber(1_000_000, { ...EN, compact: true })).toBe('1M');
+    expect(formatNumber(1_500_000, { ...EN, compact: true })).toBe('1.5M');
+  });
+
+  it('falls back to Number.toFixed(computedDecimals) when the locale is invalid', () => {
+    // Intl.NumberFormat throws RangeError on a malformed locale -> catch path.
+    // 1.5 is in [1,1000) => 4 decimals => toFixed(4).
+    expect(formatNumber(1.5, { locale: 'bad!!locale' })).toBe('1.5000');
+  });
+
+  it('degrades predictably on non-finite input', () => {
+    // getSignificantDecimals(NaN) -> NaN, Intl throws, toFixed coerces -> "NaN"
+    expect(formatNumber(NaN, EN)).toBe('NaN');
+    // Infinity hits the >=1000 branch (2 decimals); Intl renders the glyph
+    expect(formatNumber(Infinity, EN)).toBe('∞');
+  });
+
+  // KNOWN BUG (same maxDecimals gap, tracked): downstream, formatNumber does not
+  // cap a medium value to maxDecimals=4. Correct output is "0.1235".
+  it.failing(
+    'caps formatNumber output to maxDecimals for medium magnitudes',
+    () => {
+      expect(formatNumber(0.123456789, { ...EN, maxDecimals: 4 })).toBe(
+        '0.1235'
+      );
+    }
+  );
+});
+
+describe('formatTokenBalance (base units -> display units)', () => {
+  it('converts by 10^decimals and formats the result', () => {
+    // 1500000 / 1e6 = 1.5 -> "1.50"
+    expect(formatTokenBalance(1_500_000, 6, EN)).toBe('1.50');
+    // 1234567890 / 1e6 = 1234.56789 -> 2 decimals -> "1,234.57"
+    expect(formatTokenBalance(1_234_567_890, 6, EN)).toBe('1,234.57');
+  });
+
+  it('accepts bigint amounts', () => {
+    // 1000000n / 1e6 = 1 -> whole -> "1"
+    expect(formatTokenBalance(1_000_000n, 6, EN)).toBe('1');
+  });
+
+  it('preserves precision for sub-unit balances', () => {
+    // 123456 / 1e6 = 0.123456 -> medium value, exact to 6 decimals
+    expect(formatTokenBalance(123_456, 6, EN)).toBe('0.123456');
+    // 1 / 1e6 = 0.000001 -> small value, 8-decimal cap keeps it
+    expect(formatTokenBalance(1, 6, EN)).toBe('0.000001');
+  });
+
+  it('handles 0-decimal assets and zero balances', () => {
+    expect(formatTokenBalance(5, 0, EN)).toBe('5');
+    expect(formatTokenBalance(0, 6, EN)).toBe('0');
+  });
+
+  it('converts large bigints via Number (display precision, not exact)', () => {
+    // 123456789012345678n / 1e18 -> ~0.12345678901234568 (Number-domain).
+    // formatTokenBalance is a *display* helper that downcasts to Number, so a
+    // medium value renders to 6 decimals: "0.123457".
+    expect(formatTokenBalance(123_456_789_012_345_678n, 18, EN)).toBe(
+      '0.123457'
+    );
+  });
+});
+
+describe('formatAssetListBalance / formatAssetDetailBalance (maxDecimals presets)', () => {
+  it('list view caps precision more aggressively than detail view', () => {
+    // 123 / 1e8 = 0.00000123 (a small value; rule wants 9 decimals).
+    // List preset maxDecimals=6 -> "0.000001"; detail preset maxDecimals=8 ->
+    // "0.00000123". This is where the small-value clamp *does* apply.
+    expect(formatAssetListBalance(123, 8, EN)).toBe('0.000001');
+    expect(formatAssetDetailBalance(123, 8, EN)).toBe('0.00000123');
+  });
+
+  it('both share the standard formatting for ordinary balances', () => {
+    expect(formatAssetListBalance(1_500_000, 6, EN)).toBe('1.50');
+    expect(formatAssetDetailBalance(1_500_000, 6, EN)).toBe('1.50');
+  });
+});
+
+describe('formatCurrency (USD-style money display)', () => {
+  it('formats standard USD amounts with symbol and 2 decimals', () => {
+    expect(formatCurrency(1234.5, EN)).toBe('$1,234.50');
+    // rounds to cents
+    expect(formatCurrency(1234.567, EN)).toBe('$1,234.57');
+    expect(formatCurrency(0, EN)).toBe('$0.00');
+  });
+
+  it('collapses tiny positive amounts to a "< $0.01" sentinel', () => {
+    expect(formatCurrency(0.005, EN)).toBe('<$0.01');
+    expect(formatCurrency(0.001, EN)).toBe('<$0.01');
+    // exactly 0.01 is not "less than", so it renders normally
+    expect(formatCurrency(0.01, EN)).toBe('$0.01');
+  });
+
+  it('formats negative amounts', () => {
+    expect(formatCurrency(-5, EN)).toBe('-$5.00');
+  });
+
+  it('omits the currency symbol when requested (decimal style)', () => {
+    expect(formatCurrency(1234.5, { ...EN, showCurrencySymbol: false })).toBe(
+      '1,234.50'
+    );
+    // the tiny-value sentinel still prefixes "<" but no symbol
+    expect(formatCurrency(0.005, { ...EN, showCurrencySymbol: false })).toBe(
+      '<0.01'
+    );
+  });
+
+  it('supports alternate currencies and locales', () => {
+    expect(formatCurrency(1234.5, { ...EN, currency: 'EUR' })).toBe(
+      '€1,234.50'
+    );
+    // de-DE places the USD symbol after the amount with a comma decimal
+    expect(formatCurrency(5, { locale: 'de-DE' })).toBe('5,00 $');
+  });
+
+  it('supports compact notation', () => {
+    // compact currency keeps 2 fraction digits: "$1.00M"
+    expect(formatCurrency(1_000_000, { ...EN, compact: true })).toBe('$1.00M');
+  });
+
+  it('falls back to a plain $x.xx string on an invalid locale', () => {
+    // Intl throws -> catch -> value.toFixed(2) with a "$" prefix.
+    expect(formatCurrency(1.5, { locale: 'bad!!locale' })).toBe('$1.50');
+    expect(
+      formatCurrency(1.5, { locale: 'bad!!locale', showCurrencySymbol: false })
+    ).toBe('1.50');
+  });
+});
+
+describe('resolveLocale / getUserLocale (locale resolution precedence)', () => {
+  it('prefers an explicitly requested locale over everything', () => {
+    mockStoreState = { wallet: { settings: { numberLocale: 'de-DE' } } };
+    expect(resolveLocale('en-GB')).toBe('en-GB');
+  });
+
+  it('uses the stored override when no locale is requested', () => {
+    mockStoreState = { wallet: { settings: { numberLocale: 'fr-FR' } } };
+    expect(resolveLocale()).toBe('fr-FR');
+  });
+
+  it('treats the "system" sentinel as "no override" and falls back to device locale', () => {
+    mockStoreState = { wallet: { settings: { numberLocale: 'system' } } };
+    expect(resolveLocale()).toBe(getUserLocale());
+  });
+
+  it('falls back to the device locale when no override is present', () => {
+    mockStoreState = {};
+    expect(resolveLocale()).toBe(getUserLocale());
+  });
+
+  it('swallows store-access failures and falls back to the device locale', () => {
+    // getState().wallet on null throws -> getLocaleOverride catches -> null.
+    mockStoreState = null;
+    expect(resolveLocale()).toBe(getUserLocale());
+  });
+
+  it('getUserLocale returns a non-empty BCP-47-ish string', () => {
+    const loc = getUserLocale();
+    expect(typeof loc).toBe('string');
+    expect(loc.length).toBeGreaterThan(0);
+  });
+});

--- a/src/utils/__tests__/signatureVerification.test.ts
+++ b/src/utils/__tests__/signatureVerification.test.ts
@@ -1,0 +1,417 @@
+/**
+ * Unit tests for src/utils/signatureVerification.ts
+ *
+ * These tests generate REAL cryptographic vectors in-process:
+ *   - create an algosdk account,
+ *   - build + sign an Algorand transaction,
+ *   - assert the verify* helpers return the SPECIFICATION-correct result,
+ *   - then tamper the signature / bytes and assert rejection.
+ *
+ * Expected values are computed independently (via tweetnacl / algosdk) from the
+ * INTENDED behaviour rather than read back from the function under test, so a
+ * regression in the signing surface fails the suite instead of being codified.
+ */
+
+import algosdk from 'algosdk';
+import nacl from 'tweetnacl';
+
+import {
+  verifySignedTransaction,
+  extractTransactionComponents,
+  verifyEd25519Signature,
+  verifySignedTransactionBytes,
+} from '../signatureVerification';
+
+// Deterministic-enough suggested params. genesisHash is 32 zero bytes; we never
+// submit these transactions so the network identity is irrelevant to signing.
+const SUGGESTED_PARAMS = {
+  fee: 1000,
+  firstValid: 1,
+  lastValid: 1001,
+  genesisID: 'voi-test-v1',
+  genesisHash: new Uint8Array(32),
+  flatFee: true,
+  minFee: 1000,
+};
+
+type Account = ReturnType<typeof algosdk.generateAccount>;
+
+const addrOf = (acct: Account): string => acct.addr.toString();
+
+function makePayment(
+  sender: string,
+  overrides: Record<string, unknown> = {}
+): algosdk.Transaction {
+  return algosdk.makePaymentTxnWithSuggestedParamsFromObject({
+    sender,
+    receiver: sender,
+    amount: 0,
+    suggestedParams: SUGGESTED_PARAMS as algosdk.SuggestedParams,
+    ...overrides,
+  } as Parameters<
+    typeof algosdk.makePaymentTxnWithSuggestedParamsFromObject
+  >[0]);
+}
+
+/** Build a real, self-signed self-payment and its encodings. */
+function signSelfPayment(overrides: Record<string, unknown> = {}) {
+  const acct = algosdk.generateAccount();
+  const address = addrOf(acct);
+  const txn = makePayment(address, overrides);
+  const signedBytes = txn.signTxn(acct.sk); // Uint8Array
+  const signedBase64 = Buffer.from(signedBytes).toString('base64');
+  return { acct, address, txn, signedBytes, signedBase64 };
+}
+
+/** Locate a msgpack marker (hex) and return the byte offset of the byte AFTER it. */
+function offsetAfterMarker(bytes: Uint8Array, markerHex: string): number {
+  const hex = Buffer.from(bytes).toString('hex');
+  const idx = hex.indexOf(markerHex);
+  if (idx === -1) throw new Error(`marker ${markerHex} not found`);
+  return idx / 2 + markerHex.length / 2;
+}
+
+// msgpack keys: "sig" -> a3 73 69 67, value bin8(64) -> c4 40
+const SIG_MARKER = 'a3736967c440';
+// msgpack key "note" -> a4 6e6f7465, value bin8(4) -> c4 04
+const NOTE_MARKER = 'a46e6f7465c404';
+
+describe('verifySignedTransaction', () => {
+  it('accepts a genuinely self-signed self-payment (happy path)', () => {
+    const { address, signedBytes, signedBase64 } = signSelfPayment();
+
+    // Independently prove the vector really is valid before trusting the assert.
+    const decoded = algosdk.decodeSignedTransaction(signedBytes);
+    const pk = algosdk.decodeAddress(address).publicKey;
+    expect(
+      nacl.sign.detached.verify(decoded.txn.bytesToSign(), decoded.sig!, pk)
+    ).toBe(true);
+
+    const result = verifySignedTransaction(signedBase64, address);
+    expect(result).toEqual({ valid: true });
+    expect(result.error).toBeUndefined();
+  });
+
+  it('rejects when the expected signer is a DIFFERENT valid address', () => {
+    const { signedBase64 } = signSelfPayment();
+    const other = addrOf(algosdk.generateAccount());
+
+    const result = verifySignedTransaction(signedBase64, other);
+
+    expect(result.valid).toBe(false);
+    // Sender-mismatch is detected before the crypto step.
+    expect(result.error).toMatch(/does not match expected signer/i);
+  });
+
+  it('rejects a signature produced by the wrong key (sender still matches)', () => {
+    // sender = A, but the blob carries a signature made with B's secret key.
+    const a = algosdk.generateAccount();
+    const b = algosdk.generateAccount();
+    const address = addrOf(a);
+    const txn = makePayment(address);
+    const foreignSigned = txn.signTxn(b.sk);
+
+    // Sanity: sender is A, but the Ed25519 sig does NOT verify under A's key.
+    const decoded = algosdk.decodeSignedTransaction(foreignSigned);
+    expect(decoded.txn.sender.toString()).toBe(address);
+    const pkA = algosdk.decodeAddress(address).publicKey;
+    expect(
+      nacl.sign.detached.verify(decoded.txn.bytesToSign(), decoded.sig!, pkA)
+    ).toBe(false);
+
+    const result = verifySignedTransaction(
+      Buffer.from(foreignSigned).toString('base64'),
+      address
+    );
+    expect(result.valid).toBe(false);
+    expect(result.error).toMatch(/Signature verification failed/i);
+  });
+
+  it('rejects a bit-flipped signature (corrupted sig bytes)', () => {
+    const { address, signedBytes } = signSelfPayment();
+    const tampered = new Uint8Array(signedBytes);
+    const sigOffset = offsetAfterMarker(tampered, SIG_MARKER);
+    tampered[sigOffset] ^= 0xff; // corrupt the first signature byte
+
+    // Still decodes with the same sender, but the sig no longer verifies.
+    const decoded = algosdk.decodeSignedTransaction(tampered);
+    expect(decoded.txn.sender.toString()).toBe(address);
+    const pk = algosdk.decodeAddress(address).publicKey;
+    expect(
+      nacl.sign.detached.verify(decoded.txn.bytesToSign(), decoded.sig!, pk)
+    ).toBe(false);
+
+    const result = verifySignedTransaction(
+      Buffer.from(tampered).toString('base64'),
+      address
+    );
+    expect(result.valid).toBe(false);
+    expect(result.error).toMatch(/Signature verification failed/i);
+  });
+
+  it('rejects a tampered transaction body (note mutated after signing)', () => {
+    // Note is arbitrary data, so flipping a byte keeps the blob decodable while
+    // changing bytesToSign -> the original signature no longer matches.
+    const { address, signedBytes } = signSelfPayment({
+      note: new Uint8Array([9, 9, 9, 9]),
+    });
+    const tampered = new Uint8Array(signedBytes);
+    const noteOffset = offsetAfterMarker(tampered, NOTE_MARKER);
+    tampered[noteOffset] ^= 0xff;
+
+    const result = verifySignedTransaction(
+      Buffer.from(tampered).toString('base64'),
+      address
+    );
+    expect(result.valid).toBe(false);
+    expect(result.error).toMatch(/Signature verification failed/i);
+  });
+
+  it('rejects a transaction that contains a rekey field (security guard)', () => {
+    // Even a correctly self-signed txn must be rejected if it rekeys the account.
+    const acct = algosdk.generateAccount();
+    const address = addrOf(acct);
+    const rekeyTarget = addrOf(algosdk.generateAccount());
+    const txn = makePayment(address, { rekeyTo: rekeyTarget });
+    const signedBytes = txn.signTxn(acct.sk);
+
+    // The signature itself is perfectly valid — rejection is policy, not crypto.
+    const decoded = algosdk.decodeSignedTransaction(signedBytes);
+    const pk = algosdk.decodeAddress(address).publicKey;
+    expect(
+      nacl.sign.detached.verify(decoded.txn.bytesToSign(), decoded.sig!, pk)
+    ).toBe(true);
+
+    const result = verifySignedTransaction(
+      Buffer.from(signedBytes).toString('base64'),
+      address
+    );
+    expect(result.valid).toBe(false);
+    expect(result.error).toMatch(/rekey/i);
+  });
+
+  it('rejects a multisig-signed transaction (no standard sig present)', () => {
+    const a1 = algosdk.generateAccount();
+    const a2 = algosdk.generateAccount();
+    const mparams = {
+      version: 1,
+      threshold: 1,
+      addrs: [addrOf(a1), addrOf(a2)],
+    };
+    const msigAddress = algosdk.multisigAddress(mparams).toString();
+    const txn = makePayment(msigAddress);
+    const { blob } = algosdk.signMultisigTransaction(txn, mparams, a1.sk);
+
+    // Confirm the blob carries msig, not a plain sig.
+    const decoded = algosdk.decodeSignedTransaction(blob);
+    expect(decoded.sig).toBeUndefined();
+
+    const result = verifySignedTransaction(
+      Buffer.from(blob).toString('base64'),
+      msigAddress
+    );
+    expect(result.valid).toBe(false);
+    expect(result.error).toMatch(/does not contain a standard signature/i);
+  });
+
+  it('rejects malformed / non-decodable base64 input', () => {
+    const address = addrOf(algosdk.generateAccount());
+    const result = verifySignedTransaction('AAAA', address);
+    expect(result.valid).toBe(false);
+    expect(result.error).toMatch(/Failed to verify signature/i);
+  });
+
+  it('rejects an empty string input', () => {
+    const address = addrOf(algosdk.generateAccount());
+    const result = verifySignedTransaction('', address);
+    expect(result.valid).toBe(false);
+    expect(result.error).toMatch(/Failed to verify signature/i);
+  });
+
+  it('rejects a non-canonical (lowercased) expected address', () => {
+    // The sender comparison is case-insensitive, but decodeAddress requires the
+    // canonical uppercase base32, so a lowercased address is ultimately rejected.
+    const { address, signedBase64 } = signSelfPayment();
+    const result = verifySignedTransaction(signedBase64, address.toLowerCase());
+    expect(result.valid).toBe(false);
+    expect(result.error).toBeDefined();
+  });
+
+  // KNOWN GAP (flagged for human security review — signing path): the function's
+  // inline docs say this verification flow expects a SELF-payment (sender ===
+  // receiver === expectedSignerAddress) to prove the airgap device controls the
+  // address, but the code only checks the sender. A payment A->B signed by A
+  // (expected signer A) is currently ACCEPTED. it.failing asserts the CORRECT
+  // per-doc behavior (reject non-self-payments) — it passes while the gap exists
+  // and flips red once a receiver===sender check is added. Whether to enforce
+  // the stricter invariant is a human security decision.
+  it.failing('rejects a non-self-payment (self-payment invariant)', () => {
+    const a = algosdk.generateAccount();
+    const b = algosdk.generateAccount();
+    const senderAddr = addrOf(a);
+    const txn = makePayment(senderAddr, { receiver: addrOf(b), amount: 1000 });
+    const signedBytes = txn.signTxn(a.sk);
+
+    const result = verifySignedTransaction(
+      Buffer.from(signedBytes).toString('base64'),
+      senderAddr
+    );
+    expect(result.valid).toBe(false);
+  });
+});
+
+describe('extractTransactionComponents', () => {
+  it('extracts self-consistent components from a valid signed txn', () => {
+    const { address, signedBytes } = signSelfPayment();
+
+    const components = extractTransactionComponents(signedBytes);
+    expect(components).not.toBeNull();
+
+    // Compute the expected values independently from the decoded transaction.
+    const decoded = algosdk.decodeSignedTransaction(signedBytes);
+    const expectedTxnBytes = decoded.txn.bytesToSign();
+    const expectedPublicKey = algosdk.decodeAddress(address).publicKey;
+
+    expect(components!.signerAddress).toBe(address);
+    expect(Array.from(components!.signerPublicKey)).toEqual(
+      Array.from(expectedPublicKey)
+    );
+    expect(Array.from(components!.signature)).toEqual(Array.from(decoded.sig!));
+    expect(Array.from(components!.txnBytes)).toEqual(
+      Array.from(expectedTxnBytes)
+    );
+
+    // The signed bytes carry the "TX" domain-separation prefix.
+    expect(components!.txnBytes[0]).toBe(0x54); // 'T'
+    expect(components!.txnBytes[1]).toBe(0x58); // 'X'
+
+    // The extracted components must verify against each other.
+    expect(
+      nacl.sign.detached.verify(
+        components!.txnBytes,
+        components!.signature,
+        components!.signerPublicKey
+      )
+    ).toBe(true);
+  });
+
+  it('returns null for a multisig transaction (no standard sig)', () => {
+    const a1 = algosdk.generateAccount();
+    const a2 = algosdk.generateAccount();
+    const mparams = {
+      version: 1,
+      threshold: 1,
+      addrs: [addrOf(a1), addrOf(a2)],
+    };
+    const msigAddress = algosdk.multisigAddress(mparams).toString();
+    const txn = makePayment(msigAddress);
+    const { blob } = algosdk.signMultisigTransaction(txn, mparams, a1.sk);
+
+    expect(extractTransactionComponents(blob)).toBeNull();
+  });
+
+  it('returns null for garbage bytes', () => {
+    expect(
+      extractTransactionComponents(new Uint8Array([1, 2, 3, 4]))
+    ).toBeNull();
+    expect(extractTransactionComponents(new Uint8Array(0))).toBeNull();
+  });
+});
+
+describe('verifyEd25519Signature', () => {
+  it('returns true for a real signature over the signed message', () => {
+    const kp = nacl.sign.keyPair();
+    const message = new Uint8Array(Buffer.from('voi verification message'));
+    const signature = nacl.sign.detached(message, kp.secretKey);
+
+    expect(verifyEd25519Signature(message, signature, kp.publicKey)).toBe(true);
+  });
+
+  it('returns false when the message is tampered', () => {
+    const kp = nacl.sign.keyPair();
+    const message = new Uint8Array(Buffer.from('original'));
+    const signature = nacl.sign.detached(message, kp.secretKey);
+    const tampered = new Uint8Array(message);
+    tampered[0] ^= 0xff;
+
+    expect(verifyEd25519Signature(tampered, signature, kp.publicKey)).toBe(
+      false
+    );
+  });
+
+  it('returns false when verified against the wrong public key', () => {
+    const kp = nacl.sign.keyPair();
+    const other = nacl.sign.keyPair();
+    const message = new Uint8Array(Buffer.from('hello'));
+    const signature = nacl.sign.detached(message, kp.secretKey);
+
+    expect(verifyEd25519Signature(message, signature, other.publicKey)).toBe(
+      false
+    );
+  });
+
+  it('returns false when the signature is corrupted', () => {
+    const kp = nacl.sign.keyPair();
+    const message = new Uint8Array(Buffer.from('hello'));
+    const signature = nacl.sign.detached(message, kp.secretKey);
+    const corrupted = new Uint8Array(signature);
+    corrupted[0] ^= 0xff;
+
+    expect(verifyEd25519Signature(message, corrupted, kp.publicKey)).toBe(
+      false
+    );
+  });
+
+  it('returns false (does not throw) for malformed key/signature lengths', () => {
+    const kp = nacl.sign.keyPair();
+    const message = new Uint8Array(Buffer.from('hello'));
+    const signature = nacl.sign.detached(message, kp.secretKey);
+
+    // Wrong signature length.
+    expect(
+      verifyEd25519Signature(message, signature.slice(0, 32), kp.publicKey)
+    ).toBe(false);
+    // Wrong public key length.
+    expect(
+      verifyEd25519Signature(message, signature, kp.publicKey.slice(0, 16))
+    ).toBe(false);
+    // Empty inputs.
+    expect(
+      verifyEd25519Signature(
+        new Uint8Array(0),
+        new Uint8Array(0),
+        new Uint8Array(0)
+      )
+    ).toBe(false);
+  });
+});
+
+describe('verifySignedTransactionBytes', () => {
+  it('accepts valid signed bytes and matches the base64 entrypoint', () => {
+    const { address, signedBytes, signedBase64 } = signSelfPayment();
+
+    const fromBytes = verifySignedTransactionBytes(signedBytes, address);
+    expect(fromBytes).toEqual({ valid: true });
+
+    // Must be exactly equivalent to feeding the base64 form to the other fn.
+    expect(fromBytes).toEqual(verifySignedTransaction(signedBase64, address));
+  });
+
+  it('rejects tampered signed bytes', () => {
+    const { address, signedBytes } = signSelfPayment();
+    const tampered = new Uint8Array(signedBytes);
+    const sigOffset = offsetAfterMarker(tampered, SIG_MARKER);
+    tampered[sigOffset] ^= 0xff;
+
+    const result = verifySignedTransactionBytes(tampered, address);
+    expect(result.valid).toBe(false);
+    expect(result.error).toMatch(/Signature verification failed/i);
+  });
+
+  it('rejects empty bytes', () => {
+    const address = addrOf(algosdk.generateAccount());
+    const result = verifySignedTransactionBytes(new Uint8Array(0), address);
+    expect(result.valid).toBe(false);
+    expect(result.error).toMatch(/Failed to verify signature/i);
+  });
+});


### PR DESCRIPTION
## What
Bootstraps the project's **first automated test suite** (there was none) and wires **CI**, targeting the highest-consequence pure-logic layer — money math, crypto, mnemonic, URI parsing. No app source changed.

## Infra
- `jest-expo@54` preset (SDK-matched); `jest.setup.js` (Buffer polyfill mirroring `index.ts`); `@/` `moduleNameMapper`; ESM crypto-lib transpile in `transformIgnorePatterns`; `npm test` / `test:watch`. Test deps in **devDependencies**, lockfile synced (so `npm ci` works).
- eslint override for test files (jest globals; allow `jest.mock` above imports).
- `.github/workflows/ci.yml` runs **lint + unit tests** on push/PR. `typecheck` is intentionally NOT gated yet (pre-existing tsc backlog — TASK-93).

## Tests — 211, spec-based
Expected values are **hand-computed from documented behavior**, not read back from the implementation — so a regression *fails* rather than being silently codified.
- `bip39` (25-word mnemonic), `bigint` (money math: `parseAmountToBaseUnits`, `formatBaseUnitsToAmount`, `sanitizeAmountInput`, `compareBigInt` incl. > MAX_SAFE_INTEGER), `formatting` (locale-aware display), `signatureVerification` (**real algosdk vectors** + tampered-input negatives), `algorandUri` + `arc0300` (URI parse/encode), `address`.

## It found real bugs on day one
Each captured as an `it.failing` test (green while buggy, flips red when fixed → prompts cleanup):
- **arc0300** accepts an empty private key (`privatekey=`) → security-adjacent — **TASK-100**
- **algorandUri** double-decodes note/label (a valid `100%` note is rejected) → **TASK-100**
- **formatting** `maxDecimals` not clamped for magnitude bands (latent) → **TASK-100**
- **signatureVerification** self-payment invariant not enforced → **HT-101** (signing security decision — human)

## Merge / risk
No app runtime code changed (only tests, jest/CI config, devDeps, eslint test-override). CI on this PR self-validates lint + tests. Safe to merge once CI is green.

Refs PLAN-99. Next: Expo 54→57 upgrade (this suite is its regression net).