### PR TITLE
fix(algorand-uri): drop redundant decodeURIComponent that corrupted note/label

### DIFF
--- a/src/utils/__tests__/algorandUri.test.ts
+++ b/src/utils/__tests__/algorandUri.test.ts
@@ -255,7 +255,7 @@ describe('algorandUri', () => {
     // with a literal '%', the second decode throws URIError on the leftover '%'
     // and the whole parse returns null, rejecting a valid payment URI.
     // it.failing asserts the CORRECT behavior (passes while buggy; flips when fixed).
-    it.failing('preserves a note containing a literal percent sign', () => {
+    it('preserves a note containing a literal percent sign', () => {
       const uri = buildUri('voi', VALID_ADDRESS, { note: '100%' });
       expect(uri).toContain('note=100%25'); // encoded exactly once
       const parsed = parseAlgorandUri(uri);
@@ -266,15 +266,12 @@ describe('algorandUri', () => {
     // KNOWN BUG (tracked, same double-decode): a label whose literal text is the
     // 3 chars "%41" is correctly encoded "%2541"; one decode restores "%41", but
     // the second decode corrupts it to "A".
-    it.failing(
-      'does not corrupt a label that is literally a percent escape',
-      () => {
-        const uri = buildUri('voi', VALID_ADDRESS, { label: '%41' });
-        expect(uri).toContain('label=%2541');
-        const parsed = parseAlgorandUri(uri);
-        expect(parsed!.params.label).toBe('%41');
-      }
-    );
+    it('does not corrupt a label that is literally a percent escape', () => {
+      const uri = buildUri('voi', VALID_ADDRESS, { label: '%41' });
+      expect(uri).toContain('label=%2541');
+      const parsed = parseAlgorandUri(uri);
+      expect(parsed!.params.label).toBe('%41');
+    });
   });
 
   describe('convertAmountToDisplay', () => {

--- a/src/utils/algorandUri.ts
+++ b/src/utils/algorandUri.ts
@@ -92,15 +92,15 @@ export function parseAlgorandUri(uri: string): ParsedAlgorandUri | null {
       }
 
       if (searchParams.has('label')) {
-        params.label = decodeURIComponent(searchParams.get('label')!);
+        params.label = searchParams.get('label')!;
       }
 
       if (searchParams.has('note')) {
-        params.note = decodeURIComponent(searchParams.get('note')!);
+        params.note = searchParams.get('note')!;
       }
 
       if (searchParams.has('xnote')) {
-        params.xnote = decodeURIComponent(searchParams.get('xnote')!);
+        params.xnote = searchParams.get('xnote')!;
       }
     }
 


### PR DESCRIPTION
## Summary

`parseAlgorandUri` in `src/utils/algorandUri.ts` double-decoded the `label`, `note`, and `xnote` query parameters. `URLSearchParams` already percent-decodes query values, and the code then called `decodeURIComponent(...)` again on the already-decoded string.

Effects fixed:
- A note like `100%` caused `decodeURIComponent` to throw `URIError` on the leftover `%`, so the **entire parse returned `null`** — a valid payment URI was rejected.
- A label whose literal text is `%41` (correctly encoded once as `%2541`) was **corrupted to `A`** by the second decode.

## Fix

Read the already-decoded `searchParams.get(...)` values directly for `label`/`note`/`xnote`, matching the existing (correct) handling of `amount`/`asset`. Non-null assertions and null handling are preserved unchanged.

## Tests

Flipped the two `it.failing` pins in `src/utils/__tests__/algorandUri.test.ts` that tracked this bug (`preserves a note containing a literal percent sign`, `does not corrupt a label that is literally a percent escape`) to passing `it(...)`. Full jest suite green (211 tests). My changed files are eslint + prettier clean.

https://claude.ai/code/session_012WoHuh1utAZRBTDiDZ2sEk