### PR TITLE
fix(formatting): honor maxDecimals in getSignificantDecimals magnitude bands

### DIFF
--- a/src/utils/__tests__/formatting.test.ts
+++ b/src/utils/__tests__/formatting.test.ts
@@ -81,12 +81,11 @@ describe('getSignificantDecimals (magnitude -> decimal-place count)', () => {
     expect(getSignificantDecimals(0.0000012345, 6, 2)).toBe(6);
   });
 
-  // KNOWN BUG (tracked): maxDecimals is documented "Maximum decimals to show",
-  // but the fixed magnitude bands (>=1000 -> 2, [1,1000) -> 4, [0.01,1) -> 6)
-  // never clamp to it — only the small-value branch does. So a maxDecimals below
-  // a band default is ignored. Not triggered in-app today (callers pass
-  // maxDecimals >= the band defaults). it.failing asserts the correct clamp.
-  it.failing('clamps the fixed magnitude bands to maxDecimals', () => {
+  // Regression guard (TASK-106): maxDecimals is documented "Maximum decimals to
+  // show", and every fixed magnitude band (>=1000 -> 2, [1,1000) -> 4,
+  // [0.01,1) -> 6) now clamps to it via min(max, max(min, band)), matching the
+  // small-value branch. A maxDecimals below a band default is honored.
+  it('clamps the fixed magnitude bands to maxDecimals', () => {
     expect(getSignificantDecimals(0.123456789, 4, 2)).toBe(4); // min(4, band 6)
     expect(getSignificantDecimals(5, 3, 2)).toBe(3); // min(3, band 4)
   });
@@ -165,16 +164,12 @@ describe('formatNumber (locale-aware, intelligent truncation)', () => {
     expect(formatNumber(Infinity, EN)).toBe('∞');
   });
 
-  // KNOWN BUG (same maxDecimals gap, tracked): downstream, formatNumber does not
-  // cap a medium value to maxDecimals=4. Correct output is "0.1235".
-  it.failing(
-    'caps formatNumber output to maxDecimals for medium magnitudes',
-    () => {
-      expect(formatNumber(0.123456789, { ...EN, maxDecimals: 4 })).toBe(
-        '0.1235'
-      );
-    }
-  );
+  // Regression guard (TASK-106): downstream, formatNumber passes maxDecimals
+  // through to getSignificantDecimals, so a medium value caps to maxDecimals=4.
+  // Correct output is "0.1235".
+  it('caps formatNumber output to maxDecimals for medium magnitudes', () => {
+    expect(formatNumber(0.123456789, { ...EN, maxDecimals: 4 })).toBe('0.1235');
+  });
 });
 
 describe('formatTokenBalance (base units -> display units)', () => {

--- a/src/utils/formatting.ts
+++ b/src/utils/formatting.ts
@@ -93,16 +93,16 @@ export const getSignificantDecimals = (
 
   // Large values: use fewer decimals
   if (absValue >= 1000) {
-    return Math.max(minDecimals, 2);
+    return Math.min(maxDecimals, Math.max(minDecimals, 2));
   }
 
   if (absValue >= 1) {
-    return Math.max(minDecimals, 4);
+    return Math.min(maxDecimals, Math.max(minDecimals, 4));
   }
 
   // Medium values: moderate decimals
   if (absValue >= 0.01) {
-    return Math.max(minDecimals, 6);
+    return Math.min(maxDecimals, Math.max(minDecimals, 6));
   }
 
   // Small values: preserve significant digits


### PR DESCRIPTION
## TASK-106 — getSignificantDecimals ignores maxDecimals for larger magnitude bands

### Problem
`getSignificantDecimals` (src/utils/formatting.ts) ignored its `maxDecimals` parameter for the fixed magnitude bands:
- `>=1000` -> `Math.max(minDecimals, 2)`
- `[1, 1000)` -> `Math.max(minDecimals, 4)`
- `[0.01, 1)` -> `Math.max(minDecimals, 6)` (concrete defect: returned 6 even when `maxDecimals < 6`)

Only the `<0.01` branch clamped to `maxDecimals`. A `maxDecimals` below a band default was silently ignored, and this also affected `formatNumber`, which passes `maxDecimals` through.

### Fix
Apply the same `Math.min(maxDecimals, Math.max(minDecimals, band))` clamp used by the `<0.01` branch to all three fixed bands. This honors `maxDecimals` while preserving the `minDecimals` floor (behavior identical to the existing small-value branch pattern).

### Tests
Flips two `it.failing` pins in `formatting.test.ts` (both covered by this single fix) to passing regression guards, and refreshes their now-stale "KNOWN BUG" comments.

### Gates
- `npm test`: green (7 suites, 211 tests)
- `npm run lint`: 0 errors (693 pre-existing warnings, unchanged from main)
- `npm run typecheck`: no errors in touched files. The repo has ~272 pre-existing tsc errors on `main` (tracked as TASK-93); this change introduces none.
- Codex review: CLEAN

https://claude.ai/code/session_012WoHuh1utAZRBTDiDZ2sEk