### PR TITLE
fix(arc0300): reject empty/whitespace private-key value on account import

### DIFF
--- a/src/utils/__tests__/arc0300.test.ts
+++ b/src/utils/__tests__/arc0300.test.ts
@@ -223,15 +223,43 @@ describe('arc0300', () => {
       });
     });
 
-    // KNOWN BUG (tracked): `privatekey=` carries no key material, so the URI is
-    // malformed and the correct result is null. The parser only checks
-    // privateKeys.length > 0, so an empty string yields a 'standard' entry with
-    // an empty key. it.failing asserts the CORRECT behavior — it passes while
-    // the bug exists and flips to failing (remove `.failing`) once it's fixed.
-    it.failing('rejects an empty private-key value', () => {
+    // FIXED (TASK-104): `privatekey=` carries no key material, so the URI is
+    // malformed and the correct result is null. The parser now filters out
+    // empty/whitespace private-key values before the length check, so an empty
+    // string no longer yields a bogus 'standard' entry — it falls through to
+    // the watch/null path.
+    it('rejects an empty private-key value', () => {
       expect(
         parseArc0300AccountImportUri('avm://account/import?privatekey=')
       ).toBeNull();
+    });
+
+    it('rejects a whitespace-only private-key value', () => {
+      expect(
+        parseArc0300AccountImportUri('avm://account/import?privatekey=%20')
+      ).toBeNull();
+    });
+
+    it('drops a blank key without misaligning the remaining key/name pairs', () => {
+      // A blank first key must not shift the valid second key onto the wrong
+      // label: it should be dropped, and the valid key keeps its own name.
+      const parsed = parseArc0300AccountImportUri(
+        'avm://account/import?privatekey=%20&name=Decoy&privatekey=K2&name=Actual'
+      );
+      expect(parsed).not.toBeNull();
+      expect(parsed!.kind).toBe('standard');
+      expect(parsed!.entries).toEqual([
+        { privateKeyBase64: 'K2', name: 'Actual' },
+      ]);
+    });
+
+    it('falls through to a watch import when the only key is blank but an address is present', () => {
+      const parsed = parseArc0300AccountImportUri(
+        'avm://account/import?privatekey=%20&address=ADDR'
+      );
+      expect(parsed).not.toBeNull();
+      expect(parsed!.kind).toBe('watch');
+      expect(parsed!.entries).toEqual([{ address: 'ADDR' }]);
     });
   });
 

--- a/src/utils/arc0300.ts
+++ b/src/utils/arc0300.ts
@@ -79,13 +79,22 @@ export function parseArc0300AccountImportUri(
     }
   }
 
-  if (privateKeys.length > 0) {
+  // Match names to keys by their original query index, then drop entries whose
+  // private key is empty/whitespace-only. Filtering after the index mapping (not
+  // before) preserves key/name alignment for multi-account URIs, so a blank key
+  // cannot shift a later key onto the wrong label. A URI with no usable key
+  // material falls through to the watch/null path below.
+  const standardEntries = privateKeys
+    .map((value, idx) => ({
+      privateKeyBase64: value.trim(),
+      name: names[idx],
+    }))
+    .filter((entry) => entry.privateKeyBase64.length > 0);
+
+  if (standardEntries.length > 0) {
     return {
       kind: 'standard',
-      entries: privateKeys.map((value, idx) => ({
-        privateKeyBase64: value.trim(),
-        name: names[idx],
-      })),
+      entries: standardEntries,
       pagination,
       checksum,
       scheme,


### PR DESCRIPTION
parseArc0300AccountImportUri only checked privateKeys.length > 0, so a URI
like `avm://account/import?privatekey=` (yielding ['']) or `?privatekey=%20`
(yielding [' ']) produced a bogus 'standard' import with an empty key before
downstream normalizeBase64ToHex('') threw.

Map names to keys by their original query index first, then drop entries
whose trimmed private key is empty. This makes an empty/whitespace key fall
through to the watch/null path (per the function's contract) while preserving
key/name alignment for multi-account URIs — a blank key can no longer shift a
later key onto the wrong label.

Flips the it.failing pin to it and adds regression tests for whitespace-only
keys, name-alignment after dropping a blank key, and fall-through to a watch
import.

Claude-Session: https://claude.ai/code/session_012WoHuh1utAZRBTDiDZ2sEk
