### PR TITLE
fix(signature-verification): enforce self-payment invariant (receiver===sender)

### DIFF
--- a/src/utils/__tests__/signatureVerification.test.ts
+++ b/src/utils/__tests__/signatureVerification.test.ts
@@ -237,15 +237,12 @@ describe('verifySignedTransaction', () => {
     expect(result.error).toBeDefined();
   });
 
-  // KNOWN GAP (flagged for human security review — signing path): the function's
-  // inline docs say this verification flow expects a SELF-payment (sender ===
-  // receiver === expectedSignerAddress) to prove the airgap device controls the
-  // address, but the code only checks the sender. A payment A->B signed by A
-  // (expected signer A) is currently ACCEPTED. it.failing asserts the CORRECT
-  // per-doc behavior (reject non-self-payments) — it passes while the gap exists
-  // and flips red once a receiver===sender check is added. Whether to enforce
-  // the stricter invariant is a human security decision.
-  it.failing('rejects a non-self-payment (self-payment invariant)', () => {
+  // ENFORCED (HT-101 Option A): the verification flow expects a SELF-payment
+  // (sender === receiver === expectedSignerAddress) to prove the airgap device
+  // controls the address. A payment A->B signed by A (expected signer A) must be
+  // rejected because it is not the self-payment we asked for. This asserts the
+  // per-doc behavior now that verifySignedTransaction enforces receiver===sender.
+  it('rejects a non-self-payment (self-payment invariant)', () => {
     const a = algosdk.generateAccount();
     const b = algosdk.generateAccount();
     const senderAddr = addrOf(a);

--- a/src/utils/signatureVerification.ts
+++ b/src/utils/signatureVerification.ts
@@ -80,6 +80,29 @@ export function verifySignedTransaction(
       };
     }
 
+    // SECURITY: Enforce the self-payment invariant (receiver === sender).
+    // The verification flow proves the airgap device controls the expected
+    // address by round-tripping a zero-amount SELF-payment. A missing receiver
+    // (i.e. a non-payment transaction) or any receiver other than the sender
+    // means the signed blob is NOT the self-payment we asked for, so we must
+    // reject it even though the sender and signature already checked out.
+    const receiverField = txnAny.to || txnAny.rcv || txnAny.payment?.receiver;
+    const receiverAddress = receiverField?.publicKey
+      ? algosdk.encodeAddress(receiverField.publicKey)
+      : String(receiverField || '');
+
+    if (
+      !receiverAddress ||
+      receiverAddress.toUpperCase() !== senderAddress.toUpperCase()
+    ) {
+      return {
+        valid: false,
+        error: `Transaction is not a self-payment: receiver ${
+          receiverAddress || '(missing)'
+        } does not match sender ${senderAddress}`,
+      };
+    }
+
     // Get the bytes that were signed (TX prefix + encoded transaction)
     const txnBytesToSign = txn.bytesToSign();
 


### PR DESCRIPTION
## Summary

`verifySignedTransaction` (in `src/utils/signatureVerification.ts`) is the local crypto verifier for the airgap device-control flow. Its doc comment says it expects a **self-payment** (`sender === receiver === expectedSignerAddress`) to prove the airgap device controls the expected address — but the code only checked the **sender**. An A→B payment signed by A (expected signer A) was therefore wrongly **accepted**.

Per the human decision **HT-101 → Option A**, this PR **enforces** the self-payment invariant.

## Change

- After the existing `sender === expectedSigner` check, read the receiver the same robust way the sender is read (`txn.to || txn.rcv || txn.payment?.receiver`), normalize it identically (encode from `publicKey` when present), and **reject** when `receiver !== sender`.
- A **missing receiver** (non-payment txn, e.g. keyreg/asset/app calls have no `payment` field) is also rejected, since these flows are always self-payments.
- Signature-verification and rekey-rejection logic are unchanged.

## Safety

Both production call sites — `TransferToAirgapFlow.tsx:168` and `AirgapVerificationFlow.tsx:220` — feed zero-amount self-payments by construction, so enforcing `receiver === sender` is safe for all production flows. The general entry point `verifySignedTransactionBytes` has no non-test caller in `src/`.

## Tests

Flips the pinning test `it.failing('rejects a non-self-payment')` → `it(...)` (now passes with the fix). The existing happy-path test that a legitimate zero-amount self-payment IS accepted still passes. All 22 tests in the suite are green; full suite 211/211.

## Gates

- `npm run typecheck`: no new errors in edited files (baseline TASK-93 red is pre-existing/unrelated)
- `npm run lint`: clean
- `npm test`: green (211/211)
- Codex signing-security review: CLEAN

https://claude.ai/code/session_012WoHuh1utAZRBTDiDZ2sEk