### PR TITLE
fix(account-qr-parser): best-effort secret scrub via reference-drop + document immutability limit

### DIFF
--- a/src/utils/__tests__/accountQRParser.test.ts
+++ b/src/utils/__tests__/accountQRParser.test.ts
@@ -1,0 +1,111 @@
+// Unit tests for the in-memory account-secret store in accountQRParser.
+//
+// SECURITY NOTE: these tests use OBVIOUSLY-FAKE placeholder secrets only — never
+// a real mnemonic or private key. They pin the observable lifecycle contract of
+// the secret store (store -> read -> clear) and the best-effort reference-drop
+// that clearAccountSecret performs before deleting the entry.
+//
+// LIMITATION being documented (this is a real limitation, not a test bug):
+// JavaScript strings are immutable, so their backing memory CANNOT be zeroed in
+// place. clearAccountSecret can only DROP references so the GC can reclaim the
+// strings. These tests therefore assert reference-dropping + entry-removal —
+// NOT an in-memory wipe, which is impossible in JS.
+
+// Mock the heavy wallet/ARC-0300 dependency graph so importing accountQRParser
+// stays lightweight and deterministic. The mocked validator/importer let a
+// fake 25-"word" phrase flow through the public parse path and store a secret,
+// with no real crypto and no real key material involved.
+jest.mock('@/services/wallet', () => ({
+  MultiAccountWalletService: {
+    validateMnemonic: jest.fn(() => true),
+    importFromMnemonic: jest.fn(() => ({ address: 'FAKEADDRESSNOTREAL' })),
+    validateAddress: jest.fn(() => false),
+    importFromPrivateKey: jest.fn(),
+  },
+}));
+
+jest.mock('@/utils/arc0300', () => ({
+  isArc0300AccountImportUri: jest.fn(() => false),
+  parseArc0300AccountImportUri: jest.fn(() => null),
+  normalizeBase64ToHex: jest.fn((v: string) => v),
+}));
+
+import {
+  AccountQRParser,
+  getAccountSecret,
+  clearAccountSecret,
+  clearAllAccountSecrets,
+  type AccountSecret,
+} from '../accountQRParser';
+
+// Obviously-fake 25-"word" phrase — never a real mnemonic.
+const FAKE_MNEMONIC = Array(25).fill('fake-word-not-real').join(' ');
+
+/** Stores a fake secret via the public parse flow and returns its secret id. */
+const storeFakeSecret = async (): Promise<string> => {
+  const result = await AccountQRParser.parseQRContent(FAKE_MNEMONIC, []);
+  const secretId = result.accounts[0]?.secretId;
+  if (!secretId) {
+    throw new Error(
+      'expected the parse flow to store a secret and return an id'
+    );
+  }
+  return secretId;
+};
+
+describe('accountQRParser secret store', () => {
+  afterEach(() => {
+    // Ensure no fake secret leaks between tests.
+    clearAllAccountSecrets();
+  });
+
+  it('stores a secret that can be read back before clearing', async () => {
+    const id = await storeFakeSecret();
+    expect(getAccountSecret(id)).toEqual({ mnemonic: FAKE_MNEMONIC });
+  });
+
+  it('getAccountSecret returns an independent COPY, not the stored reference', async () => {
+    const id = await storeFakeSecret();
+    const a = getAccountSecret(id);
+    const b = getAccountSecret(id);
+    expect(a).toEqual(b);
+    expect(a).not.toBe(b); // distinct copies — copy semantics intentionally unchanged
+  });
+
+  it('clearAccountSecret drops secret references on the stored object and removes the entry', async () => {
+    // Capture the exact object the store places in its Map. getAccountSecret
+    // intentionally returns a COPY (contract unchanged), so the stored object's
+    // field state is otherwise unobservable; spy on Map.set to grab the ref.
+    const setSpy = jest.spyOn(Map.prototype, 'set');
+    const id = await storeFakeSecret();
+    const storeCall = setSpy.mock.calls.find(
+      ([, value]) =>
+        value != null &&
+        typeof value === 'object' &&
+        'mnemonic' in (value as object)
+    );
+    setSpy.mockRestore();
+
+    const storedObject = storeCall?.[1] as AccountSecret | undefined;
+    expect(storedObject).toBeDefined();
+    // Sanity: the stored object holds the fake secret before clearing.
+    expect(storedObject?.mnemonic).toBe(FAKE_MNEMONIC);
+
+    clearAccountSecret(id);
+
+    // Best-effort: references dropped so the GC can reclaim the secret strings.
+    // NOTE: this pins REFERENCE-DROPPING, not a memory wipe — JS strings are
+    // immutable and their backing bytes cannot be zeroed in place.
+    expect(storedObject?.mnemonic).toBeUndefined();
+    expect(storedObject?.privateKey).toBeUndefined();
+
+    // Observable contract: the entry is gone.
+    expect(getAccountSecret(id)).toBeUndefined();
+  });
+
+  it('clearAccountSecret is a safe no-op for undefined or unknown ids', () => {
+    expect(() => clearAccountSecret(undefined)).not.toThrow();
+    expect(() => clearAccountSecret('does-not-exist')).not.toThrow();
+    expect(getAccountSecret('does-not-exist')).toBeUndefined();
+  });
+});

--- a/src/utils/accountQRParser.ts
+++ b/src/utils/accountQRParser.ts
@@ -16,29 +16,64 @@ const accountSecretStore = new Map<string, AccountSecret>();
 const generateSecretId = (): string =>
   `account_secret_${Date.now()}_${Math.random().toString(36).slice(2, 10)}`;
 
+/**
+ * Stores an account secret in the in-memory map and returns an opaque id.
+ *
+ * Intentionally stores a shallow COPY (`{ ...secret }`) so the caller's object
+ * and the stored object are independent references. These copy semantics are
+ * part of the module contract and are deliberately left unchanged.
+ */
 const storeAccountSecret = (secret: AccountSecret): string => {
   const id = generateSecretId();
   accountSecretStore.set(id, { ...secret });
   return id;
 };
 
-const scrubString = (value?: string): string | undefined => {
-  if (!value) return undefined;
-  return ''.padEnd(value.length, '0');
-};
-
+/**
+ * Returns a stored account secret by id, or `undefined` if none exists.
+ *
+ * IMPORTANT: this returns a shallow COPY (`{ ...secret }`), so mutating or
+ * clearing the returned object does NOT affect the stored entry. Callers MUST
+ * NOT retain the returned object longer than necessary — it holds live secret
+ * strings that {@link clearAccountSecret} cannot reach (it can only drop the
+ * store's own references; see the JS-string-immutability note there). Read it,
+ * use the secret, then drop the reference and call {@link clearAccountSecret}.
+ */
 export const getAccountSecret = (id: string): AccountSecret | undefined => {
   const secret = accountSecretStore.get(id);
   if (!secret) return undefined;
   return { ...secret };
 };
 
+/**
+ * Removes a stored account secret and best-effort releases its in-memory secret
+ * strings so they become garbage-collector-eligible, then deletes the entry.
+ *
+ * SECURITY LIMITATION — READ BEFORE CHANGING: JavaScript strings are IMMUTABLE.
+ * Their backing memory CANNOT be overwritten or zeroed in place, so there is no
+ * portable way to actually wipe a secret's bytes from RAM. (A previous version
+ * assigned an all-'0' string of equal length via a `scrubString` helper; that
+ * only allocated a NEW string and never touched the original secret's memory —
+ * pure theater, so it was removed.) The best achievable mitigation is to DROP
+ * our references (assign `undefined`) so the strings become unreachable and
+ * eligible for garbage collection; the runtime then reclaims them on its own
+ * schedule. This is a GC hint, NOT a guaranteed in-memory wipe.
+ *
+ * Note we operate on the LIVE stored object via `Map.get` (which returns the
+ * stored reference), unlike {@link getAccountSecret} which hands out a COPY.
+ * This can therefore only drop references the store itself holds — any copy a
+ * caller obtained from {@link getAccountSecret} is beyond our reach, so callers
+ * MUST NOT retain that copy and SHOULD call this as soon as the secret has been
+ * consumed. Minimizing secret lifetime is the real defense.
+ */
 export const clearAccountSecret = (id: string | undefined): void => {
   if (!id) return;
   const secret = accountSecretStore.get(id);
   if (secret) {
-    secret.mnemonic = scrubString(secret.mnemonic);
-    secret.privateKey = scrubString(secret.privateKey);
+    // Drop references so the secret strings become GC-eligible. This cannot
+    // zero their memory (JS strings are immutable) — it only releases our hold.
+    secret.mnemonic = undefined;
+    secret.privateKey = undefined;
   }
   accountSecretStore.delete(id);
 };


### PR DESCRIPTION
## Summary
Hardens the in-memory account-secret store in `src/utils/accountQRParser.ts` (holds mnemonic/private-key material during QR import) and documents an inherent limitation honestly.

- `clearAccountSecret` now **drops the references** (`secret.mnemonic = undefined; secret.privateKey = undefined`) on the live stored object before deleting the map entry, so the secret strings become garbage-collector-eligible.
- Removed the previous `scrubString` `''.padEnd(len, '0')` step: JS strings are **immutable**, so it only allocated a new string and never touched the original secret's backing memory — misleading theater.
- Thorough doc comments on `getAccountSecret` / `clearAccountSecret` stating plainly that **no in-memory wipe is possible in JS**; the real mitigation is minimizing secret lifetime and dropping references. Callers must not retain the copy returned by `getAccountSecret` and should clear as soon as the secret is consumed.
- **Copy semantics of `getAccountSecret` / `storeAccountSecret` are intentionally unchanged** (a contract change is out of scope).

## Tests
New `src/utils/__tests__/accountQRParser.test.ts` using **obviously-fake placeholder secrets only** (never a real mnemonic/key). Pins the observable contract (store -> read -> clear removes the entry) and the best-effort reference-drop on the stored object, with a comment noting this pins reference-dropping, not a memory wipe (impossible for immutable JS strings).

## Gates
- `npm test`: 225 passed (9 suites)
- `npm run lint`: clean (0 errors on changed files; 2 pre-existing warnings unrelated)
- `npm run typecheck`: no new errors in changed files (baseline is pre-existing red — TASK-93)
- Codex security review: CLEAN

Refs TASK-109.

https://claude.ai/code/session_012WoHuh1utAZRBTDiDZ2sEk