### PR TITLE
fix(components): P1c — StyleSheet string extraction + style-array/KeyboardAware typing (TASK-115)

### DIFF
--- a/src/components/NetworkBadge.tsx
+++ b/src/components/NetworkBadge.tsx
@@ -1,5 +1,5 @@
 import React from 'react';
-import { StyleSheet, Text, View } from 'react-native';
+import { StyleSheet, StyleProp, Text, TextStyle, View } from 'react-native';
 import { NetworkId } from '@/types/network';
 import { getNetworkConfig } from '@/services/network/config';
 import { Theme } from '@/constants/themes';
@@ -31,7 +31,7 @@ const NetworkBadge: React.FC<NetworkBadgeProps> = ({
     minimal: styles.variantMinimal,
   };
 
-  const textStyles = {
+  const textStyles: Record<string, StyleProp<TextStyle>> = {
     filled: styles.textFilled,
     outlined: { color: networkConfig.color, fontWeight: '600' },
     minimal: { color: networkConfig.color, fontWeight: '600' },

--- a/src/components/account/AccountImportItem.tsx
+++ b/src/components/account/AccountImportItem.tsx
@@ -29,6 +29,7 @@ export default function AccountImportItem({
 }: AccountImportItemProps) {
   const styles = useThemedStyles(createStyles);
   const { theme } = useTheme();
+  const colors = createColors(theme);
   const [name, setName] = useState(account.name || '');
 
   const handleNameChange = (newName: string) => {
@@ -42,10 +43,10 @@ export default function AccountImportItem({
   };
 
   const getStatusColor = () => {
-    if (!account.isValid) return styles.errorColor;
-    if (account.isDuplicate) return styles.warningColor;
-    if (account.isUpgrade) return styles.infoColor;
-    return styles.successColor;
+    if (!account.isValid) return colors.errorColor;
+    if (account.isDuplicate) return colors.warningColor;
+    if (account.isUpgrade) return colors.infoColor;
+    return colors.successColor;
   };
 
   const getStatusIcon = () => {
@@ -163,7 +164,7 @@ export default function AccountImportItem({
             value={name}
             onChangeText={handleNameChange}
             placeholder="Enter account name"
-            placeholderTextColor={styles.placeholderColor}
+            placeholderTextColor={colors.placeholderColor}
             maxLength={50}
           />
         </View>
@@ -262,9 +263,14 @@ const createStyles = (theme: Theme) =>
       color: theme.colors.text,
       backgroundColor: theme.colors.inputBackground,
     },
-    placeholderColor: theme.colors.placeholder,
-    errorColor: theme.colors.error,
-    warningColor: theme.colors.warning,
-    successColor: theme.colors.success,
-    infoColor: theme.colors.info,
   });
+
+// Raw color strings kept out of StyleSheet.create (RN NamedStyles rejects
+// string values); referenced directly as color props by consumers.
+const createColors = (theme: Theme) => ({
+  placeholderColor: theme.colors.placeholder,
+  errorColor: theme.colors.error,
+  warningColor: theme.colors.warning,
+  successColor: theme.colors.success,
+  infoColor: theme.colors.info,
+});

--- a/src/components/account/AccountSelector.tsx
+++ b/src/components/account/AccountSelector.tsx
@@ -14,6 +14,7 @@ import {
   getCurrencySymbol,
 } from '@/utils/bigint';
 import { useThemedStyles } from '@/hooks/useThemedStyles';
+import { useTheme } from '@/contexts/ThemeContext';
 import { Theme } from '@/constants/themes';
 
 // Constants for address formatting
@@ -34,6 +35,8 @@ export default function AccountSelector({
   compact = false,
 }: AccountSelectorProps) {
   const styles = useThemedStyles(createStyles);
+  const { theme } = useTheme();
+  const colors = createColors(theme);
   const activeAccount = useActiveAccount();
   const allAccounts = useAccounts();
   const { balance: centralizedBalance, isLoading: isBalanceLoading } =
@@ -53,7 +56,7 @@ export default function AccountSelector({
       <TouchableOpacity style={styles.container} onPress={onPress}>
         <View style={styles.content}>
           <Text style={styles.noAccountText}>No Account</Text>
-          <Ionicons name="chevron-down" size={20} color={styles.chevronColor} />
+          <Ionicons name="chevron-down" size={20} color={colors.chevronColor} />
         </View>
       </TouchableOpacity>
     );
@@ -124,7 +127,7 @@ export default function AccountSelector({
         <Ionicons
           name="chevron-down"
           size={compact ? 14 : 16}
-          color={styles.chevronColor}
+          color={colors.chevronColor}
         />
       </View>
     </TouchableOpacity>
@@ -187,5 +190,10 @@ const createStyles = (theme: Theme) =>
     compactAccountAddress: {
       fontSize: 11,
     },
-    chevronColor: theme.colors.textSecondary,
   });
+
+// Raw color string kept out of StyleSheet.create (RN NamedStyles rejects
+// string values); referenced directly as a color prop.
+const createColors = (theme: Theme) => ({
+  chevronColor: theme.colors.textSecondary,
+});

--- a/src/components/account/RenameAccountModal.tsx
+++ b/src/components/account/RenameAccountModal.tsx
@@ -9,6 +9,7 @@ import {
   ActivityIndicator,
 } from 'react-native';
 import { useThemedStyles } from '@/hooks/useThemedStyles';
+import { useTheme } from '@/contexts/ThemeContext';
 import { Theme } from '@/constants/themes';
 import KeyboardAwareScrollView from '@/components/common/KeyboardAwareScrollView';
 
@@ -30,6 +31,8 @@ export default function RenameAccountModal({
   accountDisplayName,
 }: RenameAccountModalProps) {
   const styles = useThemedStyles(createStyles);
+  const { theme } = useTheme();
+  const colors = createColors(theme);
   const [name, setName] = useState(initialName);
   const [hasEdited, setHasEdited] = useState(false);
 
@@ -91,7 +94,7 @@ export default function RenameAccountModal({
                 }
               }}
               placeholder="Account name"
-              placeholderTextColor={styles.placeholderColor}
+              placeholderTextColor={colors.placeholderColor}
               autoFocus
               editable={!isSubmitting}
               maxLength={40}
@@ -229,5 +232,10 @@ const createStyles = (theme: Theme) =>
     buttonDisabled: {
       opacity: 0.6,
     },
-    placeholderColor: theme.colors.placeholder,
   });
+
+// Raw color string kept out of StyleSheet.create (RN NamedStyles rejects
+// string values); referenced directly as a color prop.
+const createColors = (theme: Theme) => ({
+  placeholderColor: theme.colors.placeholder,
+});

--- a/src/components/common/GlassButton.tsx
+++ b/src/components/common/GlassButton.tsx
@@ -254,7 +254,7 @@ export const GlassButton: React.FC<GlassButtonProps> = ({
 
   // Container styles
   const containerStyles = useMemo(
-    (): ViewStyle[] =>
+    (): StyleProp<ViewStyle> =>
       [
         styles.container,
         {
@@ -273,13 +273,13 @@ export const GlassButton: React.FC<GlassButtonProps> = ({
 
   // Text styles
   const textStyles = useMemo(
-    (): TextStyle[] =>
+    (): StyleProp<TextStyle> =>
       [
         styles.label,
         {
           fontSize: sizeConfig.fontSize,
           color: variantConfig.textColor,
-          fontWeight: '600',
+          fontWeight: '600' as const,
           letterSpacing: 0.3,
         },
         labelStyle as TextStyle,

--- a/src/components/common/GlassInput.tsx
+++ b/src/components/common/GlassInput.tsx
@@ -433,7 +433,10 @@ const styles = StyleSheet.create({
     margin: 0,
     ...Platform.select({
       web: {
-        outlineStyle: 'none',
+        // `outlineStyle` is a valid react-native-web property, but it is absent
+        // from React Native core's TextStyle type. Cast the value so the style
+        // object stays assignable to TextStyle at consumer style-arrays.
+        outlineStyle: 'none' as any,
       },
     }),
   },

--- a/src/components/common/KeyboardAwareScrollView.tsx
+++ b/src/components/common/KeyboardAwareScrollView.tsx
@@ -1,38 +1,39 @@
-import React from 'react';
+import React, { forwardRef } from 'react';
 import { KeyboardAwareScrollView as KeyboardAwareScrollViewLib } from 'react-native-keyboard-aware-scroll-view';
 import { useThemeColors } from '@/hooks/useThemedStyles';
 import { Platform } from 'react-native';
 
-interface KeyboardAwareScrollViewProps {
-  children: React.ReactNode;
-  style?: any;
-  contentContainerStyle?: any;
-  extraScrollHeight?: number;
-  extraHeight?: number;
-  keyboardShouldPersistTaps?: 'always' | 'never' | 'handled';
-  showsVerticalScrollIndicator?: boolean;
-  enableOnAndroid?: boolean;
-  scrollEnabled?: boolean;
-  enableAutomaticScroll?: boolean;
-}
+// Widen the wrapper's props to the underlying component's full prop surface so
+// callers can pass ScrollView props (onScroll, scrollEventThrottle,
+// refreshControl, etc.) and a ref in addition to the keyboard-aware options.
+type KeyboardAwareScrollViewProps = React.ComponentProps<
+  typeof KeyboardAwareScrollViewLib
+>;
 
-export default function KeyboardAwareScrollView({
-  children,
-  style,
-  contentContainerStyle,
-  extraScrollHeight = 20,
-  extraHeight,
-  keyboardShouldPersistTaps = 'handled',
-  showsVerticalScrollIndicator = false,
-  enableOnAndroid = true,
-  scrollEnabled = true,
-  enableAutomaticScroll = true,
-  ...props
-}: KeyboardAwareScrollViewProps) {
-  const themeColors = useThemeColors();
+const KeyboardAwareScrollView = forwardRef<
+  KeyboardAwareScrollViewLib,
+  KeyboardAwareScrollViewProps
+>(function KeyboardAwareScrollView(
+  {
+    children,
+    style,
+    contentContainerStyle,
+    extraScrollHeight = 20,
+    extraHeight,
+    keyboardShouldPersistTaps = 'handled',
+    showsVerticalScrollIndicator = false,
+    enableOnAndroid = true,
+    scrollEnabled = true,
+    enableAutomaticScroll = true,
+    ...props
+  },
+  ref
+) {
+  useThemeColors();
 
   return (
     <KeyboardAwareScrollViewLib
+      ref={ref}
       style={style}
       contentContainerStyle={contentContainerStyle}
       extraScrollHeight={extraScrollHeight}
@@ -55,4 +56,6 @@ export default function KeyboardAwareScrollView({
       {children}
     </KeyboardAwareScrollViewLib>
   );
-}
+});
+
+export default KeyboardAwareScrollView;

--- a/src/components/common/SafeBlurView.tsx
+++ b/src/components/common/SafeBlurView.tsx
@@ -27,7 +27,9 @@ export const SafeBlurView = forwardRef<View, SafeBlurViewProps>(
   ({ intensity = 10, tint = 'light', children, style, ...viewProps }, ref) => {
     return (
       <BlurView
-        ref={ref}
+        // forwardRef exposes a View ref for callers, but the underlying element
+        // is a BlurView instance; bridge the two ref types here.
+        ref={ref as React.Ref<BlurView>}
         intensity={intensity}
         tint={tint}
         experimentalBlurMethod={

--- a/src/components/common/WaitingForConfirmationModal.tsx
+++ b/src/components/common/WaitingForConfirmationModal.tsx
@@ -2,6 +2,7 @@ import React from 'react';
 import { ActivityIndicator, Modal, StyleSheet, Text, View } from 'react-native';
 import { Ionicons } from '@expo/vector-icons';
 import { useThemedStyles } from '@/hooks/useThemedStyles';
+import { useTheme } from '@/contexts/ThemeContext';
 import { Theme } from '@/constants/themes';
 
 interface WaitingForConfirmationModalProps {
@@ -22,6 +23,8 @@ export default function WaitingForConfirmationModal({
   subMessage = 'This may take a few seconds.',
 }: WaitingForConfirmationModalProps) {
   const styles = useThemedStyles(createStyles);
+  const { theme } = useTheme();
+  const colors = createColors(theme);
 
   return (
     <Modal
@@ -35,7 +38,7 @@ export default function WaitingForConfirmationModal({
           <Ionicons
             name="time-outline"
             size={48}
-            color={styles.iconColor}
+            color={colors.iconColor}
             style={styles.icon}
           />
           <Text style={styles.title}>{title}</Text>
@@ -43,7 +46,7 @@ export default function WaitingForConfirmationModal({
           <Text style={styles.subMessage}>{subMessage}</Text>
           <ActivityIndicator
             size="large"
-            color={styles.spinnerColor as any}
+            color={colors.spinnerColor}
             style={styles.spinner}
           />
         </View>
@@ -71,7 +74,6 @@ const createStyles = (theme: Theme) =>
     icon: {
       marginBottom: theme.spacing.md,
     },
-    iconColor: theme.colors.primary,
     title: {
       fontSize: 20,
       fontWeight: '700',
@@ -94,5 +96,11 @@ const createStyles = (theme: Theme) =>
     spinner: {
       marginTop: theme.spacing.lg,
     },
-    spinnerColor: theme.colors.primary,
   });
+
+// Raw color strings kept out of StyleSheet.create (RN NamedStyles rejects
+// string values); referenced directly as color props.
+const createColors = (theme: Theme) => ({
+  iconColor: theme.colors.primary,
+  spinnerColor: theme.colors.primary,
+});

--- a/src/screens/account/MnemonicImportScreen.tsx
+++ b/src/screens/account/MnemonicImportScreen.tsx
@@ -366,7 +366,9 @@ export default function MnemonicImportScreen({ navigation, route }: Props) {
             {index + 1}
           </Text>
           <TextInput
-            ref={(ref) => (inputRefs.current[index] = ref)}
+            ref={(ref) => {
+              inputRefs.current[index] = ref;
+            }}
             style={[
               styles.wordInput,
               {


### PR DESCRIPTION
## Summary

P1c of the TypeScript typecheck burndown (PLAN-110 / TASK-115). Clears **21** `tsc` errors: **272 → 251**, with zero new error locations.

### Changes
1. **Extract raw color-STRING members out of `StyleSheet.create`** into sibling `createColors(theme)` factories. RN `NamedStyles` rejects string values (TS2322) and the string members polluted the style-union, cascading into TS2769 at later `style={[...]}` sites. Colors are applied identically via `color`/`placeholderTextColor` props — no visual change.
   - `AccountImportItem`, `RenameAccountModal`, `WaitingForConfirmationModal`, `AccountSelector`.
2. **Relax over-narrow style-array types.**
   - `GlassButton`: container/text memo returns `StyleProp<ViewStyle|TextStyle>` (was `ViewStyle[]`/`TextStyle[]`); `fontWeight: '600' as const`.
   - `NetworkBadge`: `textStyles` typed `Record<string, StyleProp<TextStyle>>` so the `fontWeight` literals get contextual typing.
   - `GlassInput`: cast the web-only `outlineStyle: 'none'` (a react-native-web property absent from RN core's `TextStyle`) so `styles.input` stays assignable at the consumer style-array.
   - `SafeBlurView`: bridge the `forwardRef` View ref to the underlying `BlurView` instance ref.
3. **Widen the `KeyboardAwareScrollView` wrapper** to `React.ComponentProps<typeof lib>` via `forwardRef`, so callers can pass `onScroll`/`scrollEventThrottle`/`refreshControl`/`ref` (clears `AssetOptInModal`, `MnemonicImportScreen`, `FriendProfileScreen` usages).
4. `MnemonicImportScreen` word-input ref callback now returns `void` (block body) instead of the assignment value.

### Verification
- `npm run typecheck`: 272 → 251 (−21). Diff against baseline shows only removals; the 3 shifted line numbers (AccountImportItem 87→88, MnemonicImport 519→521, 613→615) are pre-existing **out-of-scope** errors renumbered by added lines — no new file+error-code signatures.
- `npm run lint`: 0 errors on touched files (pre-existing react-hooks warnings only; one unused-var warning removed).
- Codex review: **CLEAN**. No visual/behavior change; extracted color constants still applied.

https://claude.ai/code/session_012WoHuh1utAZRBTDiDZ2sEk