### PR TITLE
fix(navigation): P2 — React Navigation v7 typing + airgap route fixes (TASK-116)

### DIFF
--- a/src/navigation/AppNavigator.tsx
+++ b/src/navigation/AppNavigator.tsx
@@ -4,6 +4,7 @@ import {
   StackActions,
   useFocusEffect,
   useNavigation,
+  NavigatorScreenParams,
 } from '@react-navigation/native';
 import { createBottomTabNavigator } from '@react-navigation/bottom-tabs';
 import { createNativeStackNavigator } from '@react-navigation/native-stack';
@@ -96,7 +97,7 @@ import { realtimeService } from '@/services/realtime';
 import { NetworkId } from '@/types/network';
 import { TransactionInfo, WalletAccount } from '@/types/wallet';
 import { ScannedAccount } from '@/utils/accountQRParser';
-import { NFTToken } from '@/types/nft';
+import { NFTToken, ARC72Collection } from '@/types/nft';
 import { SerializableClaimableItem } from '@/types/claimable';
 import { NFTBackground } from '@/components/common/NFTBackground';
 import { TransactionRequestQueue } from '@/services/walletconnect/TransactionRequestQueue';
@@ -117,7 +118,7 @@ import NewMessageScreen from '@/screens/social/NewMessageScreen';
 import ChatScreen from '@/screens/social/ChatScreen';
 
 export type RootStackParamList = {
-  Main: undefined;
+  Main: NavigatorScreenParams<MainTabParamList> | undefined;
   Onboarding: undefined;
   CreateWallet: undefined;
   SecuritySetup: {
@@ -126,11 +127,15 @@ export type RootStackParamList = {
     source?: 'create' | 'qr' | 'watch' | 'mnemonic' | 'ledger';
     accountLabel?: string;
   };
-  MnemonicImport: { isOnboarding?: boolean };
+  MnemonicImport: { isOnboarding?: boolean } | undefined;
   AddWatchAccount: { isOnboarding?: boolean };
-  WalletConnectSessionProposal: { proposal: any };
+  WalletConnectSessionProposal: {
+    proposal: any;
+    version?: number;
+    sessionRequest?: any;
+  };
   WalletConnectSessions: undefined;
-  WalletConnectTransactionRequest: { requestEvent: any };
+  WalletConnectTransactionRequest: { requestEvent: any; version?: number };
   WalletConnectPairing: { uri: string };
   WalletConnectError: { error: string; uri?: string };
   UniversalTransactionSigning: {
@@ -167,7 +172,7 @@ export type RootStackParamList = {
   SignatureDisplay: {
     request: RemoteSignerRequest;
   };
-  RestoreWallet: { isOnboarding?: boolean };
+  RestoreWallet: { isOnboarding?: boolean } | undefined;
   // ARC-0090 deep link screens
   KeyregConfirm: {
     address: string;
@@ -209,11 +214,17 @@ export type RootStackParamList = {
 };
 
 export type MainTabParamList = {
-  Home: undefined;
-  Friends: undefined;
-  NFTs: undefined;
+  // In normal mode Home mounts the WalletStack; in signer/airgap mode it
+  // mounts the AirgapStack (see MainTabNavigator). Accept both param shapes
+  // (plus undefined so `navigate('Main', { screen: 'Home' })` stays valid).
+  Home:
+    | NavigatorScreenParams<WalletStackParamList>
+    | NavigatorScreenParams<AirgapStackParamList>
+    | undefined;
+  Friends: NavigatorScreenParams<FriendsStackParamList> | undefined;
+  NFTs: NavigatorScreenParams<NFTStackParamList> | undefined;
   Discover: { reload?: number } | undefined;
-  Settings: undefined;
+  Settings: NavigatorScreenParams<SettingsStackParamList> | undefined;
 };
 
 export type WalletStackParamList = {
@@ -242,20 +253,22 @@ export type WalletStackParamList = {
     url: string;
     title: string;
   };
-  Send: {
-    assetName?: string;
-    assetId?: number;
-    accountId?: string;
-    networkId?: NetworkId;
-    // Payment request parameters from ARC-0090 URIs
-    recipient?: string;
-    amount?: string;
-    note?: string;
-    label?: string;
-    asset?: string;
-    fee?: string; // Transaction fee in microunits
-    isXnote?: boolean; // Whether the note is non-modifiable
-  };
+  Send:
+    | {
+        assetName?: string;
+        assetId?: number;
+        accountId?: string;
+        networkId?: NetworkId;
+        // Payment request parameters from ARC-0090 URIs
+        recipient?: string;
+        amount?: string;
+        note?: string;
+        label?: string;
+        asset?: string;
+        fee?: string; // Transaction fee in microunits
+        isXnote?: boolean; // Whether the note is non-modifiable
+      }
+    | undefined;
   Swap: {
     assetName?: string;
     assetId?: number;
@@ -285,6 +298,8 @@ export type WalletStackParamList = {
     outputTokenId?: number;
     outputTokenSymbol?: string;
     swapProvider?: 'deflex' | 'snowball';
+    /** ID to retrieve callbacks from registry (avoids serialization warnings) */
+    callbackId?: string;
   };
   TransactionResult: {
     transactionId?: string;
@@ -299,11 +314,13 @@ export type WalletStackParamList = {
     errorMessage?: string;
     networkId?: NetworkId;
   };
-  Receive: {
-    assetName?: string;
-    assetId?: number;
-    accountId?: string;
-  };
+  Receive:
+    | {
+        assetName?: string;
+        assetId?: number;
+        accountId?: string;
+      }
+    | undefined;
   AccountInfo: { address?: string } | undefined;
   AccountSearch: undefined;
   ClaimableTokens:
@@ -320,6 +337,9 @@ export type WalletStackParamList = {
 
 export type NFTStackParamList = {
   NFTMain: undefined;
+  CollectionDetail: {
+    collection: ARC72Collection;
+  };
   NFTDetail: {
     nft: NFTToken;
   };
@@ -382,7 +402,7 @@ export type SettingsStackParamList = {
   WalletConnectSessions: undefined;
   AddWatchAccount: undefined;
   CreateAccount: undefined;
-  MnemonicImport: undefined;
+  MnemonicImport: { isOnboarding?: boolean } | undefined;
   RekeyAccount: {
     accountId: string;
   };
@@ -390,7 +410,7 @@ export type SettingsStackParamList = {
   NotificationSettings: undefined;
   ExperimentalFeatures: undefined;
   BackupWallet: undefined;
-  RestoreWallet: { isOnboarding?: boolean };
+  RestoreWallet: { isOnboarding?: boolean } | undefined;
   WebView: {
     url: string;
     title: string;
@@ -427,7 +447,7 @@ export type AirgapStackParamList = {
   // Account management screens (accessible in airgap mode)
   // These use RootStackParamList types internally
   CreateAccount: undefined;
-  MnemonicImport: { isOnboarding?: boolean };
+  MnemonicImport: { isOnboarding?: boolean } | undefined;
   QRAccountImport: undefined;
   AccountImportPreview: { accounts: ScannedAccount[]; source: 'qr' };
   LedgerAccountImport:
@@ -963,7 +983,8 @@ function MainTabNavigator() {
 }
 
 function AppStack() {
-  const [initialRoute, setInitialRoute] = useState<string>('Onboarding');
+  const [initialRoute, setInitialRoute] =
+    useState<keyof RootStackParamList>('Onboarding');
   const [isLoading, setIsLoading] = useState(true);
 
   useEffect(() => {

--- a/src/screens/account/AddWatchAccountScreen.tsx
+++ b/src/screens/account/AddWatchAccountScreen.tsx
@@ -15,6 +15,7 @@ import {
   useRoute,
   useNavigation,
   useFocusEffect,
+  CommonActions,
 } from '@react-navigation/native';
 import { Ionicons } from '@expo/vector-icons';
 import * as algosdk from 'algosdk';
@@ -90,13 +91,20 @@ export default function AddWatchAccountScreen() {
       ) {
         const currentParams = state.routes[0]?.params;
 
-        navigation.reset({
-          index: 1,
-          routes: [
-            { name: 'SettingsMain' as never },
-            { name: 'AddWatchAccount' as never, params: currentParams },
-          ],
-        });
+        // Cross-navigator reset (SettingsMain lives in the parent Settings
+        // stack); CommonActions.reset accepts dynamic route names without casts.
+        navigation.dispatch(
+          CommonActions.reset({
+            index: 1,
+            routes: [
+              { name: 'SettingsMain' },
+              {
+                name: 'AddWatchAccount',
+                params: currentParams as { isOnboarding?: boolean } | undefined,
+              },
+            ],
+          })
+        );
       }
 
       return undefined;

--- a/src/screens/account/MnemonicImportScreen.tsx
+++ b/src/screens/account/MnemonicImportScreen.tsx
@@ -80,13 +80,20 @@ export default function MnemonicImportScreen({ navigation, route }: Props) {
       ) {
         const currentParams = state.routes[0]?.params;
 
-        navigation.reset({
-          index: 1,
-          routes: [
-            { name: 'SettingsMain' as never },
-            { name: 'MnemonicImport' as never, params: currentParams },
-          ],
-        });
+        // Cross-navigator reset (SettingsMain lives in the parent Settings
+        // stack); CommonActions.reset accepts dynamic route names without casts.
+        navigation.dispatch(
+          CommonActions.reset({
+            index: 1,
+            routes: [
+              { name: 'SettingsMain' },
+              {
+                name: 'MnemonicImport',
+                params: currentParams as { isOnboarding?: boolean } | undefined,
+              },
+            ],
+          })
+        );
       }
 
       return undefined;

--- a/src/screens/remoteSigner/AirgapHomeScreen.tsx
+++ b/src/screens/remoteSigner/AirgapHomeScreen.tsx
@@ -15,8 +15,16 @@ import {
 } from 'react-native';
 import { SafeAreaView } from 'react-native-safe-area-context';
 import { Ionicons } from '@expo/vector-icons';
-import { useNavigation } from '@react-navigation/native';
+import {
+  useNavigation,
+  CompositeNavigationProp,
+} from '@react-navigation/native';
 import { NativeStackNavigationProp } from '@react-navigation/native-stack';
+import { BottomTabNavigationProp } from '@react-navigation/bottom-tabs';
+import type {
+  AirgapStackParamList,
+  MainTabParamList,
+} from '@/navigation/AppNavigator';
 import Animated, {
   FadeIn,
   FadeInDown,
@@ -42,14 +50,12 @@ import {
 } from '@/store/walletStore';
 import { AccountMetadata, AccountType } from '@/types/wallet';
 
-type AirgapStackParamList = {
-  AirgapHome: undefined;
-  ExportAccounts: undefined;
-  SignRequestScanner: undefined;
-  SettingsMain: undefined;
-};
-
-type NavigationProp = NativeStackNavigationProp<AirgapStackParamList>;
+// AirgapHomeScreen is the AirgapHome route of the Airgap stack, and can also
+// navigate up to the parent tab navigator (e.g. the Settings tab).
+type NavigationProp = CompositeNavigationProp<
+  NativeStackNavigationProp<AirgapStackParamList>,
+  BottomTabNavigationProp<MainTabParamList>
+>;
 
 export default function AirgapHomeScreen() {
   const navigation = useNavigation<NavigationProp>();
@@ -103,11 +109,11 @@ export default function AirgapHomeScreen() {
 
   const handleOpenSettings = useCallback(() => {
     // Navigate to settings tab
-    (navigation as any).navigate('Settings', { screen: 'SettingsMain' });
+    navigation.navigate('Settings', { screen: 'SettingsMain' });
   }, [navigation]);
 
   const handleImportFromWallet = useCallback(() => {
-    navigation.navigate('ImportFromOnlineWallet' as any);
+    navigation.navigate('ImportFromOnlineWallet');
   }, [navigation]);
 
   const handleEditAccount = useCallback((accountId: string) => {
@@ -121,16 +127,16 @@ export default function AirgapHomeScreen() {
       // Navigate to appropriate screen based on type
       switch (type) {
         case 'create':
-          (navigation as any).navigate('CreateAccount');
+          navigation.navigate('CreateAccount');
           break;
         case 'import':
-          (navigation as any).navigate('ImportAccount');
+          navigation.navigate('MnemonicImport');
           break;
         case 'ledger':
-          (navigation as any).navigate('LedgerAccountImport');
+          navigation.navigate('LedgerAccountImport');
           break;
         case 'qr':
-          (navigation as any).navigate('QRImportScanner');
+          navigation.navigate('QRAccountImport');
           break;
       }
     },

--- a/src/screens/wallet/AccountInfoScreen.tsx
+++ b/src/screens/wallet/AccountInfoScreen.tsx
@@ -12,6 +12,7 @@ import {
   Linking,
 } from 'react-native';
 import { useNavigation, RouteProp, useRoute } from '@react-navigation/native';
+import { NativeStackNavigationProp } from '@react-navigation/native-stack';
 import { Ionicons } from '@expo/vector-icons';
 import { SafeAreaView } from 'react-native-safe-area-context';
 import * as Clipboard from 'expo-clipboard';
@@ -71,7 +72,8 @@ export default function AccountInfoScreen() {
   const [isLoadingAccountInfo, setIsLoadingAccountInfo] = useState(true);
   const [accountAge, setAccountAge] = useState<string>('Loading...');
   const route = useRoute<AccountInfoScreenRouteProp>();
-  const navigation = useNavigation();
+  const navigation =
+    useNavigation<NativeStackNavigationProp<WalletStackParamList>>();
   const styles = useThemedStyles(createStyles);
   const { theme } = useTheme();
 
@@ -452,7 +454,7 @@ export default function AccountInfoScreen() {
   };
 
   const navigateToMyAccount = () => {
-    navigation.navigate('AccountInfo' as any, {});
+    navigation.navigate('AccountInfo', {});
   };
 
   const getConsensusStatus = (accountInfo: any) => {

--- a/src/screens/wallet/AccountSearchScreen.tsx
+++ b/src/screens/wallet/AccountSearchScreen.tsx
@@ -15,7 +15,9 @@ import {
 import { SafeAreaView } from 'react-native-safe-area-context';
 import { Ionicons } from '@expo/vector-icons';
 import { useNavigation } from '@react-navigation/native';
+import { NativeStackNavigationProp } from '@react-navigation/native-stack';
 import algosdk from 'algosdk';
+import { WalletStackParamList } from '@/navigation/AppNavigator';
 import { useThemedStyles } from '@/hooks/useThemedStyles';
 import { Theme } from '@/constants/themes';
 import { EnvoiService, EnvoiNameInfo } from '@/services/envoi';
@@ -32,7 +34,8 @@ interface SearchResult {
 
 export default function AccountSearchScreen() {
   const styles = useThemedStyles(createStyles);
-  const navigation = useNavigation();
+  const navigation =
+    useNavigation<NativeStackNavigationProp<WalletStackParamList>>();
   const [searchQuery, setSearchQuery] = useState('');
   const [searchResults, setSearchResults] = useState<SearchResult[]>([]);
   const [isLoading, setIsLoading] = useState(false);
@@ -153,7 +156,7 @@ export default function AccountSearchScreen() {
   const handleResultPress = useCallback(
     (result: SearchResult) => {
       // Navigate to the account profile with the selected address
-      navigation.navigate('AccountInfo' as any, { address: result.address });
+      navigation.navigate('AccountInfo', { address: result.address });
     },
     [navigation]
   );

--- a/src/screens/wallet/HomeScreen.tsx
+++ b/src/screens/wallet/HomeScreen.tsx
@@ -12,8 +12,16 @@ import {
 } from 'react-native';
 import { SafeAreaView } from 'react-native-safe-area-context';
 import { Ionicons } from '@expo/vector-icons';
-import { useNavigation, CommonActions } from '@react-navigation/native';
-import type { StackNavigationProp } from '@react-navigation/stack';
+import {
+  useNavigation,
+  CommonActions,
+  CompositeNavigationProp,
+} from '@react-navigation/native';
+import type { NativeStackNavigationProp } from '@react-navigation/native-stack';
+import type {
+  WalletStackParamList,
+  RootStackParamList,
+} from '@/navigation/AppNavigator';
 import Animated, {
   useSharedValue,
   useAnimatedStyle,
@@ -93,7 +101,13 @@ export default function HomeScreen() {
   const [isOnboardingModalVisible, setIsOnboardingModalVisible] =
     useState(false);
 
-  const navigation = useNavigation<StackNavigationProp<any>>();
+  const navigation =
+    useNavigation<
+      CompositeNavigationProp<
+        NativeStackNavigationProp<WalletStackParamList>,
+        NativeStackNavigationProp<RootStackParamList>
+      >
+    >();
   const { updateActivity } = useAuth();
   const activeAccount = useActiveAccount();
   const currentNetworkConfig = useCurrentNetworkConfig();
@@ -907,7 +921,7 @@ export default function HomeScreen() {
 
   // Navigate to sign request scanner (signer mode)
   const handleScanSigningRequest = useCallback(() => {
-    navigation.navigate('SignRequestScanner' as never);
+    navigation.navigate('SignRequestScanner');
   }, [navigation]);
 
   const handleAccountSelectorPress = () => {
@@ -924,19 +938,19 @@ export default function HomeScreen() {
   };
 
   const handleQRScan = () => {
-    navigation.navigate('QRScanner' as never);
+    navigation.navigate('QRScanner');
   };
 
   const handleSend = () => {
-    navigation.navigate('Send' as never);
+    navigation.navigate('Send');
   };
 
   const handleReceive = () => {
-    navigation.navigate('Receive' as never);
+    navigation.navigate('Receive');
   };
 
   const handleHistory = () => {
-    navigation.navigate('TransactionHistory' as never);
+    navigation.navigate('TransactionHistory');
   };
 
   const handleAddAsset = () => {
@@ -949,7 +963,7 @@ export default function HomeScreen() {
   };
 
   const handleAccountInfo = () => {
-    navigation.navigate('AccountInfo' as never);
+    navigation.navigate('AccountInfo');
   };
 
   const handleOpenAssetFilter = () => {
@@ -1590,11 +1604,11 @@ export default function HomeScreen() {
           }}
           onImportQRAccount={() => {
             setIsAddAccountModalVisible(false);
-            navigation.navigate('QRAccountImport' as never);
+            navigation.navigate('QRAccountImport');
           }}
           onImportLedgerAccount={() => {
             setIsAddAccountModalVisible(false);
-            navigation.navigate('LedgerAccountImport' as never);
+            navigation.navigate('LedgerAccountImport');
           }}
           onAddWatchAccount={() => {
             setIsAddAccountModalVisible(false);
@@ -1630,18 +1644,18 @@ export default function HomeScreen() {
           isVisible={isOnboardingModalVisible}
           onClose={() => setIsOnboardingModalVisible(false)}
           onCreateAccount={() => {
-            navigation.navigate('CreateWallet' as never);
+            navigation.navigate('CreateWallet');
           }}
           onImportAccount={() => {
-            navigation.navigate('MnemonicImport' as never, {
+            navigation.navigate('MnemonicImport', {
               isOnboarding: true,
             });
           }}
           onImportQRAccount={() => {
-            navigation.navigate('QRAccountImport' as never);
+            navigation.navigate('QRAccountImport');
           }}
           onAddWatchAccount={() => {
-            navigation.navigate('AddWatchAccount' as never, {
+            navigation.navigate('AddWatchAccount', {
               isOnboarding: true,
             });
           }}

--- a/src/screens/wallet/NFTDetailScreen.tsx
+++ b/src/screens/wallet/NFTDetailScreen.tsx
@@ -14,9 +14,11 @@ import {
 import { SafeAreaView } from 'react-native-safe-area-context';
 import { Ionicons } from '@expo/vector-icons';
 import { useRoute, useNavigation } from '@react-navigation/native';
-import type { StackNavigationProp } from '@react-navigation/stack';
+import type { NativeStackNavigationProp } from '@react-navigation/native-stack';
 import * as Clipboard from 'expo-clipboard';
 import { NFTToken } from '@/types/nft';
+import { NetworkId } from '@/types/network';
+import { NFTStackParamList } from '@/navigation/AppNavigator';
 import { NFTService } from '@/services/nft';
 import { useTheme } from '@/contexts/ThemeContext';
 
@@ -31,7 +33,8 @@ export default function NFTDetailScreen() {
   const [imageError, setImageError] = useState(false);
   const [isSettingTheme, setIsSettingTheme] = useState(false);
   const route = useRoute();
-  const navigation = useNavigation<StackNavigationProp<any>>();
+  const navigation =
+    useNavigation<NativeStackNavigationProp<NFTStackParamList>>();
   const { nft } = route.params as NFTDetailRouteParams;
   const { theme, setNFTTheme } = useTheme();
 
@@ -72,13 +75,11 @@ export default function NFTDetailScreen() {
   };
 
   const handleSend = () => {
-    navigation.navigate(
-      'Send' as never,
-      {
-        nftToken: nft,
-        networkId: nft.networkId, // Pass the network ID from the NFT
-      } as never
-    );
+    navigation.navigate('Send', {
+      nftToken: nft,
+      // NFTToken.networkId is a plain string id; the route expects NetworkId.
+      networkId: nft.networkId as NetworkId | undefined,
+    });
   };
 
   const handleSetAsTheme = async () => {

--- a/src/screens/wallet/NFTScreen.tsx
+++ b/src/screens/wallet/NFTScreen.tsx
@@ -9,8 +9,18 @@ import {
 } from 'react-native';
 import { SafeAreaView } from 'react-native-safe-area-context';
 import { Ionicons } from '@expo/vector-icons';
-import { useNavigation, CommonActions } from '@react-navigation/native';
-import type { StackNavigationProp } from '@react-navigation/stack';
+import {
+  useNavigation,
+  CommonActions,
+  CompositeNavigationProp,
+} from '@react-navigation/native';
+import type { NativeStackNavigationProp } from '@react-navigation/native-stack';
+import type { BottomTabNavigationProp } from '@react-navigation/bottom-tabs';
+import type {
+  NFTStackParamList,
+  MainTabParamList,
+  RootStackParamList,
+} from '@/navigation/AppNavigator';
 import Animated, {
   useAnimatedStyle,
   useSharedValue,
@@ -38,8 +48,18 @@ const AnimatedPressable = Animated.createAnimatedComponent(Pressable);
 type TabType = 'my-nfts' | 'browse-collections';
 type ViewMode = 'my-nfts' | 'browse-collections' | 'collection-tokens';
 
+// NFTScreen lives in the NFT stack but can also navigate up to the Settings
+// tab (account management) and to root-level import screens.
+type NFTScreenNavigationProp = CompositeNavigationProp<
+  NativeStackNavigationProp<NFTStackParamList>,
+  CompositeNavigationProp<
+    BottomTabNavigationProp<MainTabParamList>,
+    NativeStackNavigationProp<RootStackParamList>
+  >
+>;
+
 export default function NFTScreen() {
-  const navigation = useNavigation<StackNavigationProp<any>>();
+  const navigation = useNavigation<NFTScreenNavigationProp>();
   const activeAccount = useActiveAccount();
   const { theme, setNFTTheme } = useTheme();
 
@@ -517,18 +537,15 @@ export default function NFTScreen() {
           }}
           onImportLedgerAccount={() => {
             setIsAddAccountModalVisible(false);
-            navigation.navigate('LedgerAccountImport' as never);
+            navigation.navigate('LedgerAccountImport');
           }}
           onImportQRAccount={() => {
             setIsAddAccountModalVisible(false);
-            navigation.navigate('QRAccountImport' as never);
+            navigation.navigate('QRAccountImport');
           }}
           onAddWatchAccount={() => {
             setIsAddAccountModalVisible(false);
-            navigation.navigate(
-              'Settings' as never,
-              { screen: 'AddWatchAccount' } as never
-            );
+            navigation.navigate('Settings', { screen: 'AddWatchAccount' });
           }}
         />
       </SafeAreaView>

--- a/src/screens/wallet/ReceiveScreen.tsx
+++ b/src/screens/wallet/ReceiveScreen.tsx
@@ -15,7 +15,15 @@ import {
   useRoute,
   useNavigation,
   CommonActions,
+  CompositeNavigationProp,
 } from '@react-navigation/native';
+import type { NativeStackNavigationProp } from '@react-navigation/native-stack';
+import type { BottomTabNavigationProp } from '@react-navigation/bottom-tabs';
+import type {
+  WalletStackParamList,
+  MainTabParamList,
+  RootStackParamList,
+} from '@/navigation/AppNavigator';
 import QRCode from 'react-native-qrcode-svg';
 import { Ionicons } from '@expo/vector-icons';
 import { useThemedStyles, useThemeColors } from '@/hooks/useThemedStyles';
@@ -37,10 +45,20 @@ interface ReceiveScreenRouteParams {
   accountId?: string;
 }
 
+// ReceiveScreen lives in the wallet stack but can also navigate up to the
+// Settings tab (account management) and to root-level import screens.
+type ReceiveScreenNavigationProp = CompositeNavigationProp<
+  NativeStackNavigationProp<WalletStackParamList>,
+  CompositeNavigationProp<
+    BottomTabNavigationProp<MainTabParamList>,
+    NativeStackNavigationProp<RootStackParamList>
+  >
+>;
+
 export default function ReceiveScreen() {
   const styles = useThemedStyles(createStyles);
   const themeColors = useThemeColors();
-  const navigation = useNavigation();
+  const navigation = useNavigation<ReceiveScreenNavigationProp>();
   const [isAccountModalVisible, setIsAccountModalVisible] = useState(false);
   const [isAddAccountModalVisible, setIsAddAccountModalVisible] =
     useState(false);
@@ -249,18 +267,15 @@ export default function ReceiveScreen() {
           }}
           onImportLedgerAccount={() => {
             setIsAddAccountModalVisible(false);
-            navigation.navigate('LedgerAccountImport' as never);
+            navigation.navigate('LedgerAccountImport');
           }}
           onImportQRAccount={() => {
             setIsAddAccountModalVisible(false);
-            navigation.navigate('QRAccountImport' as never);
+            navigation.navigate('QRAccountImport');
           }}
           onAddWatchAccount={() => {
             setIsAddAccountModalVisible(false);
-            navigation.navigate(
-              'Settings' as never,
-              { screen: 'AddWatchAccount' } as never
-            );
+            navigation.navigate('Settings', { screen: 'AddWatchAccount' });
           }}
         />
       </SafeAreaView>

--- a/src/screens/wallet/SwapScreen.tsx
+++ b/src/screens/wallet/SwapScreen.tsx
@@ -26,10 +26,12 @@ import {
   useNavigation,
   CommonActions,
 } from '@react-navigation/native';
+import { NativeStackNavigationProp } from '@react-navigation/native-stack';
+import { WalletStackParamList } from '@/navigation/AppNavigator';
 import { useThemedStyles, useThemeColors } from '@/hooks/useThemedStyles';
 import { Theme } from '@/constants/themes';
 import { useActiveAccount, useWalletStore } from '@/store/walletStore';
-import { AccountBalance } from '@/types/wallet';
+import { AccountBalance, WalletAccount } from '@/types/wallet';
 import UniversalHeader from '@/components/common/UniversalHeader';
 import KeyboardAwareScrollView from '@/components/common/KeyboardAwareScrollView';
 import { TokenSelector } from '@/components/swap/TokenSelector';
@@ -71,7 +73,8 @@ const NATIVE_TOKEN_ID = 0; // Native token ID for both VOI and ALGO
 export default function SwapScreen() {
   const styles = useThemedStyles(createStyles);
   const themeColors = useThemeColors();
-  const navigation = useNavigation();
+  const navigation =
+    useNavigation<NativeStackNavigationProp<WalletStackParamList, 'Swap'>>();
   const route = useRoute();
   const routeParams = route.params as SwapScreenRouteParams | undefined;
   const delayedRefreshTimeout = useRef<ReturnType<typeof setTimeout> | null>(
@@ -685,7 +688,9 @@ export default function SwapScreen() {
     // Navigate to UniversalTransactionSigning screen with swap transactions
     navigation.navigate('UniversalTransactionSigning', {
       transactions: quote.unsignedTransactions,
-      account: activeAccount,
+      // AccountMetadata → WalletAccount bridge (matches SendScreen /
+      // KeyregConfirmScreen convention); full reconciliation is a later phase.
+      account: activeAccount as unknown as WalletAccount,
       title: 'Confirm Swap',
       networkId: selectedNetwork,
       callbackId,


### PR DESCRIPTION
## Summary

TASK-116 **P2** of the TypeScript typecheck burndown (PLAN-110): React Navigation v7 typed-navigation drift. Clears **31** tsc errors (**192 → 161**) with **only-removals** — no new error locations.

## Central typing (AppNavigator ParamLists)
- Import `NavigatorScreenParams`; retype nested-navigator routes previously typed `undefined`:
  - `Main` → `NavigatorScreenParams<MainTabParamList> | undefined`
  - `MainTabParamList` `Home`/`Friends`/`NFTs`/`Settings` → `NavigatorScreenParams<…>`. `Home` is a **union** of `WalletStackParamList` and `AirgapStackParamList` params because it mounts a **different** navigator in signer/airgap mode (`AirgapStackNavigator`) vs normal mode (`WalletStackNavigator`).
  - `| undefined` is retained on these so existing no-arg `navigate('Main')` / `navigate('Main', { screen: 'Home' })` calls stay valid (params stay optional).
- Completed incomplete param lists: `WalletConnectSessionProposal` (`version`, `sessionRequest`), `WalletConnectTransactionRequest` (`version`), `NFTStack` `CollectionDetail`, SettingsStack/Root/Airgap `MnemonicImport` optional, `RestoreWallet` optional, WalletStack `Send`/`Receive` optional, WalletStack `UniversalTransactionSigning` `callbackId`. Typed `AppStack` `initialRoute` as `keyof RootStackParamList`.

## Real nav-route bug fixes (latent, surfaced by typing)
- `AirgapHomeScreen` navigated to **unregistered** routes `ImportAccount` and `QRImportScanner`; corrected to the registered `MnemonicImport` and `QRAccountImport` (both registered in `AirgapStackNavigator`). Also replaced its incomplete shadow param list + `as any` navigation with the exported `AirgapStackParamList` + parent-tab composite.

## Per-site
- Replaced untyped/`<any>` `useNavigation()` with correctly-typed generics (`NativeStackNavigationProp` / `CompositeNavigationProp`) and deleted `as never`/`as any` navigate casts: AccountInfo, AccountSearch, HomeScreen, NFTDetail, NFTScreen, ReceiveScreen, SwapScreen.
- Converted the two cross-navigator `navigation.reset(...)` calls (Add-Watch / Mnemonic import) to the runtime-equivalent `navigation.dispatch(CommonActions.reset(...))`, removing the `as never` name casts.
- SwapScreen account arg bridged with `as unknown as WalletAccount`, matching the existing SendScreen/KeyregConfirmScreen convention (full `AccountMetadata`↔`WalletAccount` reconciliation is a later phase).

## Out of scope (left for P3/P4/P5)
`AppNavigator` custom `tabBarButton` TouchableOpacityProps; `ImportAccountRequest` store call; SwapScreen `asset-id`; `UniversalTransactionSigningScreen` NetworkId/WalletAccount.

## Gates
- `npm run typecheck`: 192 → 161, verified only-removals (signature diff shows zero genuinely-new error signatures).
- `npm run lint`: 0 errors in touched files.
- Codex: reviewed; airgap route targets confirmed to exist, Airgap/Home nested typing sound, no behavioral change beyond the two intentional route-name corrections.

https://claude.ai/code/session_012WoHuh1utAZRBTDiDZ2sEk