### PR TITLE
fix(assets): P3 — asset/network/store model typing + 3 latent bug fixes (TASK-117)

### DIFF
--- a/src/components/assets/AssetOptInModal.tsx
+++ b/src/components/assets/AssetOptInModal.tsx
@@ -65,8 +65,9 @@ export default function AssetOptInModal({
   const themeColors = useThemeColors();
   const insets = useSafeAreaInsets();
   const activeAccount = useActiveAccount();
-  const [selectedNetworkId, setSelectedNetworkId] =
-    useState<NetworkId>('voi-mainnet');
+  const [selectedNetworkId, setSelectedNetworkId] = useState<NetworkId>(
+    NetworkId.VOI_MAINNET
+  );
   const [searchQuery, setSearchQuery] = useState('');
   const [searching, setSearching] = useState(false);
   const [searchResults, setSearchResults] = useState<SearchResult[]>([]);
@@ -149,7 +150,9 @@ export default function AssetOptInModal({
         loadMore,
       });
     } catch (err) {
-      setError(`Error searching for assets: ${err.message}`);
+      setError(
+        `Error searching for assets: ${err instanceof Error ? err.message : String(err)}`
+      );
     } finally {
       if (loadMore) {
         setLoadingMore(false);
@@ -210,7 +213,9 @@ export default function AssetOptInModal({
         setMbrCost(validation.mbrCost || 100000);
       }
     } catch (err) {
-      setError(`Error validating asset: ${err.message}`);
+      setError(
+        `Error validating asset: ${err instanceof Error ? err.message : String(err)}`
+      );
     }
   };
 
@@ -255,7 +260,9 @@ export default function AssetOptInModal({
         },
       ]);
     } catch (err) {
-      setError(`Failed to opt-in: ${err.message}`);
+      setError(
+        `Failed to opt-in: ${err instanceof Error ? err.message : String(err)}`
+      );
       setShowAuthModal(false);
     } finally {
       setIsProcessing(false);
@@ -365,7 +372,7 @@ export default function AssetOptInModal({
                 returnKeyType="search"
               />
               <TouchableOpacity
-                onPress={searchAssets}
+                onPress={() => searchAssets()}
                 disabled={searching || isProcessing}
                 style={styles.searchButton}
               >

--- a/src/components/common/NFTThemeSelector.tsx
+++ b/src/components/common/NFTThemeSelector.tsx
@@ -54,7 +54,7 @@ export default function NFTThemeSelector({
     useState(false);
   const [ownershipMap, setOwnershipMap] = useState<Set<string>>(new Set());
   const [loadingMore, setLoadingMore] = useState(false);
-  const [nextToken, setNextToken] = useState<number | undefined>();
+  const [nextToken, setNextToken] = useState<string | undefined>();
   const [hasMore, setHasMore] = useState(false);
 
   // Load my NFTs when visible and active account changes

--- a/src/screens/wallet/AssetDetailScreen.tsx
+++ b/src/screens/wallet/AssetDetailScreen.tsx
@@ -16,7 +16,8 @@ import { useRoute, useNavigation } from '@react-navigation/native';
 import type { StackNavigationProp } from '@react-navigation/stack';
 import { useThemedStyles, useThemeColors } from '@/hooks/useThemedStyles';
 import { Theme } from '@/constants/themes';
-import { TransactionInfo, AccountBalance } from '@/types/wallet';
+import { TransactionInfo, AccountBalance, AssetBalance } from '@/types/wallet';
+import { MappedAsset } from '@/services/token-mapping/types';
 import { useAuth } from '@/contexts/AuthContext';
 import {
   useWalletStore,
@@ -39,7 +40,7 @@ import {
   validateAsaOptOut,
 } from '@/services/transactions/asa';
 import { MultiAccountWalletService } from '@/services/wallet';
-import NetworkServiceInstance, { NetworkService } from '@/services/network';
+import { NetworkService } from '@/services/network';
 import UnifiedAuthModal from '@/components/UnifiedAuthModal';
 import { BlurredContainer } from '@/components/common/BlurredContainer';
 import { GlassCard } from '@/components/common/GlassCard';
@@ -570,7 +571,7 @@ export default function AssetDetailScreen() {
     return formatNativeBalance(amount, specificNetworkConfig.nativeToken);
   };
 
-  const getAsset = () => {
+  const getAsset = (): AssetBalance | MappedAsset | null => {
     if (assetId === 0) {
       return null; // VOI doesn't have enhanced asset data
     }
@@ -618,10 +619,15 @@ export default function AssetDetailScreen() {
     if (!asset?.amount) return formatCurrency(0);
 
     // For mapped assets, calculate USD value across all source networks
-    if (asset.isMapped && asset.sourceBalances && multiNetworkBalance) {
+    const mappedAsset = asset as MappedAsset;
+    if (
+      mappedAsset.isMapped &&
+      mappedAsset.sourceBalances &&
+      multiNetworkBalance
+    ) {
       let totalValue = 0;
 
-      for (const source of asset.sourceBalances) {
+      for (const source of mappedAsset.sourceBalances) {
         const sourceAsset = source.balance;
 
         // Check if this is a native asset on this network
@@ -700,7 +706,11 @@ export default function AssetDetailScreen() {
       return;
     }
 
-    const validation = await validateAsaOptOut(currentAccount.address, assetId);
+    const validation = await validateAsaOptOut(
+      currentAccount.address,
+      assetId,
+      specificNetworkConfig.id
+    );
     if (!validation.valid) {
       Alert.alert(
         'Cannot Opt Out',
@@ -740,14 +750,29 @@ export default function AssetDetailScreen() {
         throw new Error('No active account');
       }
 
-      const txId = await submitAsaOptOut(assetId, currentAccount.address, pin);
+      const txId = await submitAsaOptOut(
+        assetId,
+        currentAccount.address,
+        specificNetworkConfig.id,
+        pin
+      );
 
-      // Wait for confirmation
-      await NetworkServiceInstance.waitForConfirmation(txId, 4);
+      // Wait for confirmation on the same network the opt-out was submitted to
+      // (not the globally active network) so we don't poll the wrong chain.
+      await NetworkService.getInstance(
+        specificNetworkConfig.id
+      ).waitForConfirmation(txId, 4);
 
-      // Refresh balances
+      // Refresh balances. refreshAllBalances only refreshes the globally active
+      // network, so also reload the context balance for the opted-out network
+      // (which may differ from the active one) — mirrors onRefresh.
       const { refreshAllBalances } = useWalletStore.getState();
-      await refreshAllBalances();
+      await Promise.all([
+        refreshAllBalances(),
+        networkId
+          ? loadMultiNetworkBalance(accountId, true)
+          : accountBalance.reload(),
+      ]);
 
       Alert.alert(
         'Success',

--- a/src/screens/wallet/MultiNetworkAssetScreen.tsx
+++ b/src/screens/wallet/MultiNetworkAssetScreen.tsx
@@ -66,8 +66,7 @@ export default function MultiNetworkAssetScreen() {
     route.params as MultiNetworkAssetRouteParams;
 
   const { updateActivity } = useAuth();
-  const { balance: multiNetworkBalance, reload: reloadMultiNetworkBalance } =
-    useMultiNetworkBalance(accountId);
+  const { balance: multiNetworkBalance } = useMultiNetworkBalance(accountId);
   const loadMultiNetworkBalance = useWalletStore(
     (state) => state.loadMultiNetworkBalance
   );

--- a/src/screens/wallet/NFTScreen.tsx
+++ b/src/screens/wallet/NFTScreen.tsx
@@ -82,7 +82,7 @@ export default function NFTScreen() {
     useState(false);
   const [ownershipMap, setOwnershipMap] = useState<Set<string>>(new Set());
   const [loadingMoreTokens, setLoadingMoreTokens] = useState(false);
-  const [nextTokensToken, setNextTokensToken] = useState<number | undefined>();
+  const [nextTokensToken, setNextTokensToken] = useState<string | undefined>();
   const [hasMoreTokens, setHasMoreTokens] = useState(false);
 
   // Modals

--- a/src/screens/wallet/SendScreen.tsx
+++ b/src/screens/wallet/SendScreen.tsx
@@ -41,7 +41,11 @@ import {
   formatBaseUnitsToAmount,
   sanitizeAmountInput,
 } from '@/utils/bigint';
-import { AccountType, type WalletAccount } from '@/types/wallet';
+import {
+  AccountType,
+  type WalletAccount,
+  type AssetBalance,
+} from '@/types/wallet';
 import {
   useCurrentNetwork,
   useCurrentNetworkConfig,
@@ -374,7 +378,7 @@ export default function SendScreen() {
                 options.push({
                   networkId: source.networkId,
                   assetId: source.balance.assetId,
-                  balance: source.balance.amount,
+                  balance: BigInt(source.balance.amount),
                   decimals: source.balance.decimals,
                   symbol: source.balance.symbol || '',
                   name: source.balance.name || '',
@@ -408,7 +412,7 @@ export default function SendScreen() {
                 options.push({
                   networkId: source.networkId,
                   assetId: source.balance.assetId,
-                  balance: source.balance.amount,
+                  balance: BigInt(source.balance.amount),
                   decimals: source.balance.decimals,
                   symbol: source.balance.symbol || contextAssetName || '',
                   name: source.balance.name || contextAssetName || '',
@@ -484,10 +488,10 @@ export default function SendScreen() {
               options.push({
                 networkId,
                 assetId:
-                  asset.assetType === 'arc200'
+                  (asset.assetType === 'arc200'
                     ? asset.contractId
-                    : asset.assetId,
-                balance: asset.amount,
+                    : asset.assetId) ?? 0,
+                balance: BigInt(asset.amount),
                 decimals: asset.decimals,
                 symbol: asset.symbol || contextAssetName || '',
                 name: asset.name || contextAssetName || '',
@@ -502,7 +506,7 @@ export default function SendScreen() {
               options.push({
                 networkId,
                 assetId: 0,
-                balance: balance.amount,
+                balance: BigInt(balance.amount),
                 decimals: 6,
                 symbol: networkConfig.nativeToken,
                 name: networkConfig.nativeToken,
@@ -709,7 +713,7 @@ export default function SendScreen() {
       return null; // Native token doesn't have enhanced asset data
     }
     return accountBalance?.assets?.find(
-      (a) =>
+      (a: AssetBalance) =>
         a.assetId === effectiveAssetId ||
         (a.assetType === 'arc200' && a.contractId === effectiveAssetId)
     );
@@ -1336,13 +1340,20 @@ export default function SendScreen() {
         return;
       }
 
-      // Get mapping ID if this asset is part of a multi-network mapping
+      // Get mapping ID if this asset is part of a multi-network mapping.
+      // Match against the mapped asset's source balances (the aggregate's
+      // top-level assetId/primaryNetwork only describe the first source, so a
+      // non-primary selected version would otherwise never match).
       const mappingId =
         contextMappingId ||
         multiNetworkBalance?.assets.find(
           (a) =>
-            a.assetId === assetOption.assetId &&
-            a.networkId === selectedAsset.networkId
+            a.isMapped &&
+            a.sourceBalances.some(
+              (s) =>
+                s.networkId === selectedAsset.networkId &&
+                s.balance.assetId === assetOption.assetId
+            )
         )?.mappingId;
 
       // Navigate to transaction confirmation screen
@@ -1426,7 +1437,7 @@ export default function SendScreen() {
         selectedNetworkConfig.nativeToken
       ),
     };
-    const otherAssets = accountBalance.assets.map((asset) => ({
+    const otherAssets = accountBalance.assets.map((asset: AssetBalance) => ({
       id: asset.assetType === 'arc200' ? asset.contractId : asset.assetId,
       name: asset.name || asset.symbol || `Asset ${asset.assetId}`,
       symbol: asset.symbol || 'TOKEN',

--- a/src/screens/wallet/SwapScreen.tsx
+++ b/src/screens/wallet/SwapScreen.tsx
@@ -471,7 +471,7 @@ export default function SwapScreen() {
       if (!newNetworkBalance) return BigInt(0);
       if (assetId === 0) return BigInt(newNetworkBalance.amount || 0);
       const asset = newNetworkBalance.assets?.find((a) => {
-        const id = a.assetId ?? a['asset-id'] ?? a.contractId;
+        const id = a.assetId ?? a.contractId;
         return id === assetId;
       });
       return BigInt(asset?.amount || 0);
@@ -844,7 +844,7 @@ export default function SwapScreen() {
 
       // Find asset by ID - check multiple possible field names
       const asset = accountBalance.assets?.find((a) => {
-        const assetId = a.assetId ?? a['asset-id'] ?? a.contractId;
+        const assetId = a.assetId ?? a.contractId;
         return assetId === tokenId;
       });
 

--- a/src/screens/wallet/TransactionResultScreen.tsx
+++ b/src/screens/wallet/TransactionResultScreen.tsx
@@ -17,6 +17,7 @@ import UniversalHeader from '@/components/common/UniversalHeader';
 import { WalletStackParamList } from '@/navigation/AppNavigator';
 import { copyToClipboard } from '@/utils/clipboard';
 import { getTransactionUrl } from '@/utils/blockExplorer';
+import { NetworkId } from '@/types/network';
 import { useThemedStyles } from '@/hooks/useThemedStyles';
 import { Theme } from '@/constants/themes';
 import { useTheme } from '@/contexts/ThemeContext';
@@ -61,7 +62,10 @@ export default function TransactionResultScreen() {
   const handleViewInExplorer = async () => {
     if (!params.transactionId) return;
 
-    const url = getTransactionUrl(params.transactionId, params.networkId);
+    const url = getTransactionUrl(
+      params.transactionId,
+      params.networkId as NetworkId | undefined
+    );
     const supported = await Linking.canOpenURL(url);
 
     if (supported) {

--- a/src/services/network/multi-network.ts
+++ b/src/services/network/multi-network.ts
@@ -221,7 +221,8 @@ export class MultiNetworkBalanceService {
               mappingId: mapping.mappingId,
               sourceBalances: [{ networkId, balance: asset }],
               isMapped: true,
-              verified: mapping.verified,
+              // AssetBalance.verified is a number (1 = verified); coerce the boolean mapping flag.
+              verified: mapping.verified ? 1 : 0,
               primaryNetwork: networkId, // First network encountered is primary
             };
             mappedAssets.set(mappingId, mappedAsset);

--- a/src/services/token-mapping/types.ts
+++ b/src/services/token-mapping/types.ts
@@ -53,9 +53,7 @@ export interface MappedAsset extends AssetBalance {
   sourceBalances: NetworkBalanceSource[];
   /** Whether this asset is part of a multi-network mapping */
   isMapped: boolean;
-  /** Whether the mapping is verified */
-  verified?: boolean;
-  /** Primary network for this asset (for UI display) */
+  /** Primary network for this asset (for UI display); `verified` is inherited from AssetBalance as a number (1 = verified). */
   primaryNetwork: NetworkId;
 }
 

--- a/src/store/walletStore.ts
+++ b/src/store/walletStore.ts
@@ -1341,6 +1341,10 @@ export const useWalletStore = create<WalletState>()(
                   ...accountStates[accountId]?.assetTransactionsPagination?.[
                     assetKey
                   ],
+                  hasMore:
+                    accountStates[accountId]?.assetTransactionsPagination?.[
+                      assetKey
+                    ]?.hasMore ?? false,
                   isLoadingMore: false,
                 },
               },
@@ -1550,7 +1554,7 @@ export const useWalletStore = create<WalletState>()(
         ...accountStates,
       };
       const rekeyUpdates: { account: AccountMetadata; balance: any }[] = [];
-      let updatedWallet = get().wallet;
+      let updatedWallet: Wallet | null = get().wallet;
 
       // Process all results
       for (const result of results) {
@@ -1634,9 +1638,11 @@ export const useWalletStore = create<WalletState>()(
             }
           }
 
-          // Update wallet with rekey metadata
-          const updatedAccounts = updatedWallet.accounts.map((acc) =>
-            acc.id === account.id ? updatedAccount : acc
+          // Update wallet with rekey metadata. Annotate explicitly: the
+          // in-loop reassignment of `updatedWallet` below would otherwise make
+          // this initializer self-referential (TS7022).
+          const updatedAccounts: AccountMetadata[] = updatedWallet.accounts.map(
+            (acc) => (acc.id === account.id ? updatedAccount : acc)
           );
           updatedWallet = { ...updatedWallet, accounts: updatedAccounts };
         }

--- a/src/types/nft.ts
+++ b/src/types/nft.ts
@@ -35,13 +35,13 @@ export interface NFTToken {
 export interface NFTIndexerResponse {
   currentRound: number;
   tokens: ARC72Token[];
-  'next-token'?: number;
+  'next-token'?: string;
 }
 
 export interface NFTCollectionResponse {
   currentRound: number;
   tokens: NFTToken[];
-  nextToken?: number;
+  nextToken?: string;
 }
 
 export interface ARC72Collection {


### PR DESCRIPTION
## Summary

P3 slice of the TypeScript typecheck burndown (TASK-117, PLAN-110): the non-crypto **asset / network / store model**. Clears **~29 tsc errors (161 → 132)** with **zero new error locations** and no new lint errors. Also fixes 3 latent runtime bugs surfaced while typing.

## Central fixes (cascade)

- **`MappedAsset.verified` boolean → number.** `MappedAsset extends AssetBalance`, but it overrode `verified` as `boolean` while `AssetBalance.verified` is `number` ("incorrectly extends"). Removed the override so it inherits `number`; `multi-network.ts` now coerces the boolean `TokenMapping.verified` to `1/0`. **Latent bug fixed:** the verified badge (gated on `=== 1`) never rendered for mapped assets because `verified` held a boolean.
- **NFT cursor number → string.** `NFTIndexerResponse['next-token']` / `NFTCollectionResponse.nextToken` are opaque Mimir cursors; typed them as `string` (matching the raw API) and updated the screen state that holds them.

## Latent bug fixes

1. **Verified badge** — see above; mapped-asset verified badge now works.
2. **SendScreen mapping auto-detect** — matched a non-existent `.networkId` on the aggregate `MappedAsset`, so the `.find(...)` was always false and `mappingId` was never detected. Now matches the mapped asset's `sourceBalances` by selected network + source asset id.
3. **AssetOptInModal search** — `onPress={searchAssets}` passed the `GestureResponderEvent` as the `loadMore` flag (truthy → wrong path); now `onPress={() => searchAssets()}` restores fresh-search behavior.

## Other typing

- NetworkId enum boundaries (`AssetOptInModal`, `TransactionResultScreen`).
- `AssetDetailScreen`: widened `getAsset()` to `AssetBalance | MappedAsset | null`; **fixed a broken ASA opt-out call** that passed `pin` in the `networkId` slot and omitted the network — validate/submit/confirm/refresh now all use `specificNetworkConfig.id` (consistent network throughout).
- `SendScreen`: coerce `balance`→`bigint` and `assetId`→`number` at push time; annotate implicit-any params.
- `walletStore`: `hasMore` default in the catch path; `Wallet | null` + `AccountMetadata[]` annotations to break a self-referential implicit-any.
- `SwapScreen`: dropped the dead `?? a['asset-id']` relic on typed `AssetBalance`.
- `MultiNetworkAssetScreen`: removed a dead `reload` destructure the hook doesn't return.

## Verification

- `npm run typecheck`: 161 → 132, zero new error signatures (line-shift-aware diff), untouched files identical.
- `npm run lint`: 0 errors in touched files.
- Codex review: **CLEAN** (4 rounds — it also flagged, and I fixed, network-consistency across the opt-out validate/confirm/refresh path).

Does NOT touch crypto/wallet/transactions/auth/secure/messaging files or P5-owned screens.

https://claude.ai/code/session_012WoHuh1utAZRBTDiDZ2sEk