### PR TITLE
fix(platform): P4 — expo SDK54/lib drift + WC plumbing + avatarCache fix (TASK-118)

### DIFF
--- a/src/components/account/AccountAvatar.tsx
+++ b/src/components/account/AccountAvatar.tsx
@@ -1,5 +1,12 @@
 import React, { useState, useEffect } from 'react';
-import { View, StyleSheet, Text, Image } from 'react-native';
+import {
+  View,
+  StyleSheet,
+  Text,
+  Image,
+  StyleProp,
+  ViewStyle,
+} from 'react-native';
 import Svg, { Circle, Rect, Polygon } from 'react-native-svg';
 import { Ionicons } from '@expo/vector-icons';
 import EnvoiService from '@/services/envoi';
@@ -26,6 +33,7 @@ interface AccountAvatarProps {
   fallbackToGenerated?: boolean;
   account?: AccountMetadata; // Optional account metadata for rekey indicators
   showRekeyIndicator?: boolean;
+  style?: StyleProp<ViewStyle>; // Optional style applied to the root container
 }
 
 // Generate deterministic colors from address
@@ -139,6 +147,7 @@ export default function AccountAvatar({
   fallbackToGenerated = true,
   account,
   showRekeyIndicator = true,
+  style,
 }: AccountAvatarProps) {
   const styles = useThemedStyles(createStyles);
   const [envoiAvatarUrl, setEnvoiAvatarUrl] = useState<string | null>(null);
@@ -313,7 +322,7 @@ export default function AccountAvatar({
   const rekeyIndicator = getRekeyIndicator();
 
   return (
-    <View style={[styles.container, { width: size, height: size }]}>
+    <View style={[styles.container, { width: size, height: size }, style]}>
       <View
         style={[
           styles.avatar,

--- a/src/components/account/AccountListModal.tsx
+++ b/src/components/account/AccountListModal.tsx
@@ -257,7 +257,7 @@ export default function AccountListModal({
     >
       <BottomSheetFlatList
         data={filteredAccounts}
-        keyExtractor={(item) => item.id}
+        keyExtractor={(item: AccountMetadata) => item.id}
         renderItem={renderAccountItem}
         showsVerticalScrollIndicator={false}
         ItemSeparatorComponent={() => <View style={styles.separator} />}

--- a/src/components/account/AccountRecipientModal.tsx
+++ b/src/components/account/AccountRecipientModal.tsx
@@ -255,7 +255,7 @@ export default function AccountRecipientModal({
       <BottomSheetFlatList<AccountMetadata | Friend>
         data={listData}
         renderItem={renderListItem}
-        keyExtractor={(item) => item.id}
+        keyExtractor={(item: AccountMetadata | Friend) => item.id}
         contentContainerStyle={listContentStyle}
         keyboardShouldPersistTaps="handled"
         keyboardDismissMode="on-drag"

--- a/src/components/common/ThemedWebView.tsx
+++ b/src/components/common/ThemedWebView.tsx
@@ -57,8 +57,18 @@ interface ThemedWebViewProps {
     bottom?: number;
   };
   contentInsetAdjustmentBehavior?: string;
-  // Additional props passed to native WebView
-  [key: string]: any;
+  // Additional props passed through to the native WebView.
+  // Declared explicitly (rather than via a `[key: string]: any` index
+  // signature) so that the typed callback props above — notably
+  // `onLoadError` — keep their parameter types at call sites. A string
+  // index signature would widen every attribute's contextual type to
+  // `any`, silently dropping `errorDescription`'s `string` type.
+  setSupportMultipleWindows?: boolean;
+  refreshControl?: React.ReactElement;
+  javaScriptEnabled?: boolean;
+  domStorageEnabled?: boolean;
+  allowsInlineMediaPlayback?: boolean;
+  mediaPlaybackRequiresUserAction?: boolean;
 }
 
 const ThemedWebView = forwardRef<ThemedWebViewRef, ThemedWebViewProps>(
@@ -177,7 +187,7 @@ const ThemedWebView = forwardRef<ThemedWebViewRef, ThemedWebViewProps>(
       injectJavaScript: (script: string) => {
         if (Platform.OS === 'web') {
           try {
-            iframeRef.current?.contentWindow?.eval(script);
+            (iframeRef.current?.contentWindow as any)?.eval(script);
           } catch (e) {
             // Cross-origin restrictions may prevent this
             console.warn(

--- a/src/components/ledger/UnifiedLedgerSigningModal.tsx
+++ b/src/components/ledger/UnifiedLedgerSigningModal.tsx
@@ -336,7 +336,7 @@ const UnifiedLedgerSigningModal: React.FC<UnifiedLedgerSigningModalProps> = ({
   };
 
   const renderActionButtons = () => {
-    const buttons: JSX.Element[] = [];
+    const buttons: React.JSX.Element[] = [];
 
     // Always show cancel button
     buttons.push(

--- a/src/components/navigation/FABRadialMenu.tsx
+++ b/src/components/navigation/FABRadialMenu.tsx
@@ -26,6 +26,7 @@ import Animated, {
   withDelay,
   interpolate,
   runOnJS,
+  type SharedValue,
 } from 'react-native-reanimated';
 import { Ionicons } from '@expo/vector-icons';
 import { useNavigation } from '@react-navigation/native';
@@ -98,7 +99,7 @@ interface FABMenuItemProps {
   item: MenuItem;
   index: number;
   totalItems: number;
-  menuProgress: Animated.SharedValue<number>;
+  menuProgress: SharedValue<number>;
   onPress: () => void;
 }
 

--- a/src/navigation/AppNavigator.tsx
+++ b/src/navigation/AppNavigator.tsx
@@ -10,7 +10,13 @@ import { createBottomTabNavigator } from '@react-navigation/bottom-tabs';
 import { createNativeStackNavigator } from '@react-navigation/native-stack';
 import { Ionicons } from '@expo/vector-icons';
 import { GestureHandlerRootView } from 'react-native-gesture-handler';
-import { View, TouchableOpacity, StyleSheet, Platform } from 'react-native';
+import {
+  View,
+  TouchableOpacity,
+  TouchableOpacityProps,
+  StyleSheet,
+  Platform,
+} from 'react-native';
 import { detectPlatform } from '@/platform/detection';
 import { BottomSheetModalProvider } from '@gorhom/bottom-sheet';
 import { useTheme } from '@/contexts/ThemeContext';
@@ -795,7 +801,12 @@ function MainTabNavigator() {
                     props.onPress(e);
                   }
                 };
-                return <TouchableOpacity {...props} onPress={handlePress} />;
+                return (
+                  <TouchableOpacity
+                    {...(props as TouchableOpacityProps)}
+                    onPress={handlePress}
+                  />
+                );
               },
               tabBarActiveTintColor: tabIconActive,
               tabBarInactiveTintColor: tabIconInactive,
@@ -899,7 +910,12 @@ function MainTabNavigator() {
                 // Invisible placeholder to reserve space for FABRadialMenu
                 return <View style={styles.centerButtonPlaceholder} />;
               }
-              return <TouchableOpacity {...props} onPress={handlePress} />;
+              return (
+                <TouchableOpacity
+                  {...(props as TouchableOpacityProps)}
+                  onPress={handlePress}
+                />
+              );
             },
             tabBarActiveTintColor: tabIconActive,
             tabBarInactiveTintColor: tabIconInactive,

--- a/src/screens/settings/AboutScreen.tsx
+++ b/src/screens/settings/AboutScreen.tsx
@@ -97,10 +97,7 @@ export default function AboutScreen() {
         <View style={styles.appInfoSection}>
           <Text style={styles.appName}>Voi Wallet</Text>
           <Text style={styles.version}>
-            Version{' '}
-            {Constants.expoConfig?.version ||
-              Constants.manifest?.version ||
-              '1.0.0'}
+            Version {Constants.expoConfig?.version || '1.0.0'}
           </Text>
           <Text style={styles.buildInfo}>
             {updateInfo.type === 'ota'

--- a/src/services/avatarCache.ts
+++ b/src/services/avatarCache.ts
@@ -1,6 +1,6 @@
 import AsyncStorage from '@react-native-async-storage/async-storage';
 import { Platform } from 'react-native';
-import { Directory, File } from 'expo-file-system';
+import { Directory, File, Paths } from 'expo-file-system';
 import * as Crypto from 'expo-crypto';
 
 interface CachedAvatar {
@@ -32,8 +32,12 @@ class AvatarCacheService {
 
     try {
       // Create cache directory
-      this.cacheDirectory = new Directory(Directory.cacheDirectory, 'avatars');
-      await this.cacheDirectory.create();
+      this.cacheDirectory = new Directory(Paths.cache, 'avatars');
+      // SDK 54's Directory.create() throws if the directory already exists
+      // unless `idempotent` is set. Without this, every relaunch after the
+      // first (when the avatars dir already exists) would throw here, skip
+      // loading the persisted cache index, and lose all prior cache hits.
+      this.cacheDirectory.create({ idempotent: true });
 
       // Load cache index from storage
       await this.loadCacheIndex();
@@ -88,7 +92,7 @@ class AvatarCacheService {
           const filename = entry.localUri.split('/').pop();
           if (filename) {
             const file = new File(this.cacheDirectory, filename);
-            if (await file.exists()) {
+            if (file.exists) {
               await file.delete();
             }
           }
@@ -113,7 +117,7 @@ class AvatarCacheService {
     }
   }
 
-  private generateCacheKey(url: string): string {
+  private generateCacheKey(url: string): Promise<string> {
     // Create a hash of the URL for the cache key
     return Crypto.digestStringAsync(Crypto.CryptoDigestAlgorithm.MD5, url);
   }
@@ -143,7 +147,7 @@ class AvatarCacheService {
       const filename = cached.localUri.split('/').pop();
       if (filename) {
         const file = new File(this.cacheDirectory, filename);
-        if (!(await file.exists())) {
+        if (!file.exists) {
           await this.removeCachedAvatar(url);
           return null;
         }
@@ -194,7 +198,7 @@ class AvatarCacheService {
       }
 
       const arrayBuffer = await response.arrayBuffer();
-      await file.write(arrayBuffer);
+      await file.write(new Uint8Array(arrayBuffer));
 
       // Store in cache
       const now = Date.now();
@@ -232,7 +236,7 @@ class AvatarCacheService {
           const filename = cached.localUri.split('/').pop();
           if (filename) {
             const file = new File(this.cacheDirectory, filename);
-            if (await file.exists()) {
+            if (file.exists) {
               await file.delete();
             }
           }
@@ -256,7 +260,7 @@ class AvatarCacheService {
   async clearCache(): Promise<void> {
     try {
       // Delete all cached files
-      if (this.cacheDirectory && (await this.cacheDirectory.exists())) {
+      if (this.cacheDirectory && this.cacheDirectory.exists) {
         await this.cacheDirectory.delete();
         await this.cacheDirectory.create();
       }

--- a/src/services/ledger/index.ts
+++ b/src/services/ledger/index.ts
@@ -26,7 +26,6 @@ export { SimpleLedgerAuthController } from '../auth/simpleLedgerAuthController';
 // UI Components
 export { default as UnifiedLedgerSigningModal } from '../../components/ledger/UnifiedLedgerSigningModal';
 export { default as SimpleLedgerTransactionModal } from '../../components/ledger/SimpleLedgerTransactionModal';
-export { default as LedgerTestComponent } from '../../components/ledger/LedgerTestComponent';
 
 // Key Management
 export { SimplifiedKeyManager } from '../secure/simplifiedKeyManager';

--- a/src/services/notifications/index.ts
+++ b/src/services/notifications/index.ts
@@ -116,7 +116,7 @@ class NotificationService {
       // Only process if we haven't already handled this notification
       if (notificationId !== lastHandledId) {
         const data = lastResponse.notification.request.content
-          .data as NotificationData;
+          .data as unknown as NotificationData;
         if (data && data.type) {
           console.log(
             '[Notifications] Cold start from notification:',
@@ -616,7 +616,7 @@ class NotificationService {
               // Trigger the same navigation as tapping the system notification
               Toast.hide();
               if (this.onNotificationTap && data) {
-                this.onNotificationTap(data as NotificationData);
+                this.onNotificationTap(data as unknown as NotificationData);
               }
             },
           });
@@ -628,7 +628,7 @@ class NotificationService {
     this.responseListener =
       Notifications.addNotificationResponseReceivedListener((response) => {
         const data = response.notification.request.content
-          .data as NotificationData;
+          .data as unknown as NotificationData;
         console.log('Notification tapped:', data);
 
         if (this.onNotificationTap) {

--- a/src/services/realtime/index.ts
+++ b/src/services/realtime/index.ts
@@ -325,6 +325,3 @@ class RealtimeService {
 
 // Export singleton getter
 export const realtimeService = RealtimeService.getInstance();
-
-// Export types
-export type { RealtimeEventHandlers };

--- a/src/services/walletconnect/TransactionRequestQueue.ts
+++ b/src/services/walletconnect/TransactionRequestQueue.ts
@@ -334,7 +334,7 @@ class TransactionRequestQueueService {
     try {
       const state = await AsyncStorage.getItem(PROCESSING_STATE_KEY);
       this.processingStateCache = state ? JSON.parse(state) : false;
-      return this.processingStateCache;
+      return this.processingStateCache ?? false;
     } catch (error) {
       console.error(
         '[TransactionRequestQueue] Failed to get processing state:',

--- a/src/services/walletconnect/config.ts
+++ b/src/services/walletconnect/config.ts
@@ -11,7 +11,6 @@ const resolveWalletConnectProjectId = (): string => {
 
   const extra = (Constants?.expoConfig?.extra ??
     (Constants as any)?.manifest2?.extra ??
-    Constants?.manifest?.extra ??
     {}) as Record<string, unknown>;
 
   const fromExtra = extra['walletConnectProjectId'];

--- a/src/services/walletconnect/index.ts
+++ b/src/services/walletconnect/index.ts
@@ -395,10 +395,11 @@ export class WalletConnectService extends EventEmitter {
 
       // Otherwise, disconnect v2 session
       const provider = this.client.getProvider();
-      await provider.disconnect({
-        topic,
-        reason: getSdkError('USER_DISCONNECTED'),
-      });
+      // UniversalProvider.disconnect() takes no arguments in this SDK version;
+      // the topic/reason were already ignored at runtime. Disconnecting closes
+      // the provider's active session, and we still remove `topic` from our
+      // local bookkeeping below.
+      await provider.disconnect();
 
       this.activeSessions.delete(topic);
       this.emit('session_disconnected', topic);
@@ -440,7 +441,7 @@ export class WalletConnectService extends EventEmitter {
         namespaces: {
           algorand: {
             accounts: v1SessionData.accounts.map(
-              (addr) => `algorand:${v1SessionData.chainId}:${addr}`
+              (addr: string) => `algorand:${v1SessionData.chainId}:${addr}`
             ),
             methods: ['algo_signTxn'],
             events: [],
@@ -605,8 +606,10 @@ export class WalletConnectService extends EventEmitter {
       const sessions = signClient.session.getAll();
 
       for (const session of sessions) {
-        if (!isSessionExpired(session as WalletConnectSession)) {
-          this.sanitizeAndCacheSession(session as WalletConnectSession);
+        if (!isSessionExpired(session as unknown as WalletConnectSession)) {
+          this.sanitizeAndCacheSession(
+            session as unknown as WalletConnectSession
+          );
         } else {
           // Clean up expired session
           await this.disconnectSession(session.topic).catch(() => {

--- a/src/services/walletconnect/types.ts
+++ b/src/services/walletconnect/types.ts
@@ -86,7 +86,7 @@ export interface SessionProposal {
     metadata: WalletConnectMetadata;
   };
   requiredNamespaces: Record<string, ProposalTypes.RequiredNamespace>;
-  optionalNamespaces?: Record<string, ProposalTypes.OptionalNamespace>;
+  optionalNamespaces?: Record<string, ProposalTypes.RequiredNamespace>;
   sessionProperties?: Record<string, string>;
   expiryTimestamp: number;
 }

--- a/src/services/walletconnect/v1/protocol.ts
+++ b/src/services/walletconnect/v1/protocol.ts
@@ -231,7 +231,10 @@ export function parseSessionRequest(request: WalletConnectV1SessionRequest): {
 export function validateAlgoSignTxnRequest(
   request: AlgoSignTxnRequest
 ): boolean {
-  if (!Array.isArray(request.params) || request.params.length === 0) {
+  if (
+    !Array.isArray(request.params) ||
+    (request.params as unknown[]).length === 0
+  ) {
     return false;
   }
 

--- a/src/utils/animations.ts
+++ b/src/utils/animations.ts
@@ -165,7 +165,7 @@ export function useEntranceAnimation(
   const enter = useCallback(() => {
     opacity.value = withTiming(1, {
       ...timingConfigs.normal,
-      duration: timingConfigs.normal.duration + delay,
+      duration: (timingConfigs.normal.duration ?? 0) + delay,
     });
     translateYValue.value = withSpring(0, springConfigs.smooth);
   }, [opacity, translateYValue, delay]);


### PR DESCRIPTION
## Summary

TASK-118 (P4) TypeScript typecheck burndown — Expo SDK54 / library type drift plus WalletConnect plumbing and misc non-crypto fixes. Part of PLAN-110.

Clears **33** tsc errors (161 -> 128 measured independently on this branch), **zero** new error locations, no runtime behavior change beyond **restoring avatar disk caching**.

## Changes

- **avatarCache** (real bug fix): migrate to expo-file-system SDK54 `File`/`Directory` API — `Paths.cache`, boolean `exists` property, `Uint8Array` write, async `generateCacheKey` return type. Disk caching was a silent no-op under the old (broken) API surface; this restores it. Also `Directory.create({ idempotent: true })` so the persisted cache index survives app relaunch (SDK54 `create()` throws on an existing dir by default).
- **Expo manifest**: use `Constants.expoConfig` accessors (drop dead `.manifest?.version` / `.manifest?.extra` fallbacks).
- **Library / type drift**: reanimated `SharedValue` named import; React 19 `React.JSX.Element`; reanimated timing `duration` guard; ThemedWebView web-branch `eval` cast; remove duplicate `RealtimeEventHandlers` export and dead `LedgerTestComponent` re-export.
- **ThemedWebView**: replace `[key: string]: any` index signature (which poisoned callback contextual typing) with explicit passthrough props, restoring typed `onLoadError` at call sites — BuyScreen / DiscoverScreen / WebViewScreen compile untouched.
- **AccountAvatar**: accept optional `style` prop (fixes the AccountImportItem call site; disabled-avatar dimming now applies).
- **Implicit-any annotations**: FlatList `keyExtractor` item params, WalletConnect v1 accounts `map`, AppNavigator custom `tabBarButton` props.
- **Notifications**: `content.data as unknown as NotificationData` casts.
- **WalletConnect plumbing (type-only, no session/signing behavior change)**: `UniversalProvider.disconnect()` 0-arg (topic/reason were already ignored at runtime), `Struct` -> `WalletConnectSession` double cast, `ProposalTypes` optional-namespace type, v1 params `length` guard, `TransactionRequestQueue.isProcessing` null-coalesce.

## Verification

- `npm run typecheck`: 161 -> 128, all scoped files clean, zero new error signatures (line-shift-aware diff), no new erroring files.
- `npm run lint`: 0 new errors in touched files (only pre-existing warnings remain).
- Codex read-only review: **CLEAN** (P1 non-idempotent `create()` finding from round 1 was fixed; WC changes confirmed type-only; notifications cast erases at runtime).

https://claude.ai/code/session_012WoHuh1utAZRBTDiDZ2sEk