### PR TITLE
fix(transactions): P5b — algosdk-3 transaction field renames (TASK-120)

### DIFF
--- a/src/services/network/index.ts
+++ b/src/services/network/index.ts
@@ -38,8 +38,8 @@ export class NetworkService {
   private static instances: Map<NetworkId, NetworkService> = new Map();
   private static activeNetworkId: NetworkId = DEFAULT_NETWORK_ID;
   private currentNetworkId: NetworkId;
-  private algodClient: algosdk.Algodv2;
-  private indexerClient: algosdk.Indexer;
+  private algodClient!: algosdk.Algodv2;
+  private indexerClient!: algosdk.Indexer;
   private config: NetworkConfiguration;
   private networkStatus: NetworkStatus;
   private mimirService?: MimirApiService;
@@ -575,7 +575,7 @@ export class NetworkService {
             amount = txn.assetTransferTransaction.amount ?? 0;
             recipient = txn.assetTransferTransaction.receiver ?? sender;
           } else if (txn.txType === 'appl' && txn.applicationTransaction) {
-            applicationId = txn.applicationTransaction.applicationId;
+            applicationId = Number(txn.applicationTransaction.applicationId);
             recipient = applicationId ? `App ${applicationId}` : 'App Call';
           }
 
@@ -1423,7 +1423,7 @@ export class NetworkService {
       const txId =
         (response as { txId?: string }).txId ??
         (response as { txid?: string }).txid ??
-        (response as Record<string, unknown>).txID;
+        (response as unknown as Record<string, unknown>).txID;
 
       if (!txId || typeof txId !== 'string') {
         throw new Error(
@@ -1464,13 +1464,12 @@ export class NetworkService {
           .pendingTransactionInformation(txId)
           .do();
 
-        const confirmedRound =
-          pendingInfo['confirmed-round'] ?? pendingInfo['confirmedRound'];
+        const confirmedRound = pendingInfo.confirmedRound;
         if (confirmedRound && Number(confirmedRound) > 0) {
           return pendingInfo;
         }
 
-        const poolError = pendingInfo['pool-error'] ?? pendingInfo['poolError'];
+        const poolError = pendingInfo.poolError;
         if (typeof poolError === 'string' && poolError.length > 0) {
           throw new Error(`Transaction rejected: ${poolError}`);
         }

--- a/src/services/transactions/arc200.ts
+++ b/src/services/transactions/arc200.ts
@@ -131,7 +131,7 @@ export class Arc200TransactionService {
       );
 
       // If asset exists and has balance > 0, recipient is already opted in
-      return hasBalance;
+      return !!hasBalance;
     } catch (error) {
       // Silently assume MBR payment is needed if we can't check
       console.log('[ARC200] checkRecipientBalance error:', error);
@@ -271,8 +271,6 @@ export class Arc200TransactionService {
       const simulationParams = {
         ...suggestedParams,
         fee: Number(suggestedParams.fee),
-        firstRound: Number(suggestedParams.firstRound),
-        lastRound: Number(suggestedParams.lastRound),
         minFee: Number(suggestedParams.minFee),
       };
 
@@ -530,8 +528,6 @@ export class Arc200TransactionService {
       const simulationParams = {
         ...suggestedParams,
         fee: Number(suggestedParams.fee),
-        firstRound: Number(suggestedParams.firstRound),
-        lastRound: Number(suggestedParams.lastRound),
         minFee: Number(suggestedParams.minFee),
       };
 

--- a/src/services/transactions/arc72.ts
+++ b/src/services/transactions/arc72.ts
@@ -71,10 +71,15 @@ export class Arc72TransactionService {
       const assets =
         await MimirApiService.getAllAccountAssets(recipientAddress);
 
-      // Find any ARC-72 token for this contract
+      // Find any ARC-72 token for this contract.
+      // Note: MimirAsset.assetType is statically typed as 'arc200' | 'asa',
+      // but this legacy backwards-compat fallback also handles older Mimir
+      // responses that tagged ARC-72 holdings; widen the compare so the
+      // intended 'arc72' branch is reachable without altering runtime behavior.
       const arc72Asset = assets.find(
         (asset) =>
-          asset.assetType === 'arc72' && asset.contractId === contractId
+          (asset.assetType as string) === 'arc72' &&
+          asset.contractId === contractId
       );
 
       // If any ARC-72 token exists for this contract, recipient is already opted in
@@ -215,8 +220,6 @@ export class Arc72TransactionService {
       const simulationParams = {
         ...suggestedParams,
         fee: Number(suggestedParams.fee),
-        firstRound: Number(suggestedParams.firstRound),
-        lastRound: Number(suggestedParams.lastRound),
         minFee: Number(suggestedParams.minFee),
       };
 

--- a/src/services/transactions/asa.ts
+++ b/src/services/transactions/asa.ts
@@ -29,7 +29,7 @@ export async function buildAsaOptInTransaction(
 
   const networkService = networkId
     ? NetworkService.getInstance(networkId)
-    : NetworkService.getInstance('voi-mainnet');
+    : NetworkService.getInstance(NetworkId.VOI_MAINNET);
 
   const suggestedParams =
     params.suggestedParams || (await networkService.getSuggestedParams());
@@ -56,7 +56,7 @@ export async function buildAsaOptOutTransaction(
 
   const networkService = networkId
     ? NetworkService.getInstance(networkId)
-    : NetworkService.getInstance('voi-mainnet');
+    : NetworkService.getInstance(NetworkId.VOI_MAINNET);
 
   const suggestedParams =
     params.suggestedParams || (await networkService.getSuggestedParams());
@@ -80,7 +80,7 @@ export async function buildAsaOptOutTransaction(
     .accountInformation(from)
     .do();
   const assetHolding = accountInfo.assets?.find((asset) => {
-    const holdingId = Number((asset as any).assetId ?? asset['asset-id']);
+    const holdingId = Number(asset.assetId);
     return holdingId === assetId;
   });
 
@@ -114,7 +114,7 @@ export async function validateAsaOptIn(
   try {
     const networkService = networkId
       ? NetworkService.getInstance(networkId)
-      : NetworkService.getInstance('voi-mainnet');
+      : NetworkService.getInstance(NetworkId.VOI_MAINNET);
 
     // Check if already opted in
     const accountInfo = await networkService
@@ -130,7 +130,7 @@ export async function validateAsaOptIn(
     }
 
     const alreadyOptedIn = accountInfo.assets?.some((asset) => {
-      const holdingId = Number((asset as any).assetId ?? asset['asset-id']);
+      const holdingId = Number(asset.assetId);
       return holdingId === assetId;
     });
 
@@ -163,9 +163,7 @@ export async function validateAsaOptIn(
     };
 
     const currentBalance = normalizeBalanceValue(accountInfo.amount);
-    const minBalance = normalizeBalanceValue(
-      accountInfo['min-balance'] ?? accountInfo.minBalance
-    );
+    const minBalance = normalizeBalanceValue(accountInfo.minBalance);
 
     if (currentBalance === null || minBalance === null) {
       return {
@@ -191,7 +189,7 @@ export async function validateAsaOptIn(
   } catch (error) {
     return {
       valid: false,
-      error: `Failed to validate opt-in: ${error.message}`,
+      error: `Failed to validate opt-in: ${error instanceof Error ? error.message : String(error)}`,
     };
   }
 }
@@ -208,14 +206,14 @@ export async function validateAsaOptOut(
   try {
     const networkService = networkId
       ? NetworkService.getInstance(networkId)
-      : NetworkService.getInstance('voi-mainnet');
+      : NetworkService.getInstance(NetworkId.VOI_MAINNET);
 
     const accountInfo = await networkService
       .getAlgodClient()
       .accountInformation(address)
       .do();
     const assetHolding = accountInfo.assets?.find((asset) => {
-      const holdingId = Number((asset as any).assetId ?? asset['asset-id']);
+      const holdingId = Number(asset.assetId);
       return holdingId === assetId;
     });
 
@@ -239,7 +237,7 @@ export async function validateAsaOptOut(
   } catch (error) {
     return {
       valid: false,
-      error: `Failed to validate opt-out: ${error.message}`,
+      error: `Failed to validate opt-out: ${error instanceof Error ? error.message : String(error)}`,
     };
   }
 }


### PR DESCRIPTION
## P5b — algosdk-3 transaction field access (TASK-120)

**CRYPTO / transaction-building code.** Part of PLAN-110 TypeScript burndown. Behavior-preserving fixes only — no runtime semantics change.

### Scope
Edits four files: `transactions/arc200.ts`, `transactions/arc72.ts`, `transactions/asa.ts`, `network/index.ts`.

### Changes
- **arc200.ts / arc72.ts** — Delete dead `firstRound`/`lastRound` keys from the simulation-params objects. Under algosdk-3 these evaluated to `Number(undefined) = NaN` and were never read; algosdk-3 reads `firstValid`/`lastValid`, which the `...suggestedParams` spread already carries. Coerce `checkRecipientBalance` to `boolean`.
- **arc72.ts** — Widen the legacy Mimir-fallback `assetType` compare so the intended `'arc72'` branch is type-reachable (Mimir's static type is `'arc200' | 'asa'`). Runtime behavior unchanged; the `contractId` guard is preserved, so no MBR false-positive risk.
- **asa.ts** — Pass `NetworkId.VOI_MAINNET` (enum member, value-equal to the raw `'voi-mainnet'` — no wrong-chain); read `AssetHolding.assetId` and `Account.minBalance` directly (drop dead kebab fallbacks + unneeded `as any`); narrow `unknown` catch errors.
- **network/index.ts** — Definite-assignment `!` on `algod`/`indexer` clients (assigned in init, not ctor); wrap bigint `applicationId` in `Number()` for a display string; cast `PostTransactionsResponse` via `unknown`; on the post-`waitForConfirmation` recovery path read `confirmedRound`/`poolError` directly (drop dead kebab fallbacks) — confirmation/pool-error detection preserved.

### Gate
- Typecheck: **99 → 75** (clears 24 errors); zero new error signatures.
- Lint: no new errors in touched files.
- **Codex crypto review: CLEAN** — verified firstValid/lastValid still flow via the spread (no NaN/undefined in built txns, confirmed with a runtime probe), asset holding/minBalance reads are correct, confirmation-recovery detects confirmedRound/poolError, NetworkId enum members value-equal, no key/signing regression, Algorand-compatibility preserved.

### NEEDS DEVICE VERIFICATION
Physical-device smoke test of: send ASA, ARC-200 transfer, ARC-72 transfer, asset opt-in, and transaction confirmation (incl. the post-timeout recovery path).

**DO NOT MERGE** — no auto-merge.

https://claude.ai/code/session_012WoHuh1utAZRBTDiDZ2sEk