### PR TITLE
fix(messaging): P5d — E2E messaging typing + ed2curve decl (TASK-122)

### DIFF
--- a/src/screens/social/MessagesInboxScreen.tsx
+++ b/src/screens/social/MessagesInboxScreen.tsx
@@ -106,26 +106,17 @@ export default function MessagesInboxScreen() {
     if (!activeAccount) return false;
 
     // Direct Ledger account
-    if (
-      activeAccount.type === AccountType.LEDGER ||
-      activeAccount.type === 'ledger'
-    ) {
+    if (activeAccount.type === AccountType.LEDGER) {
       return true;
     }
 
     // Rekeyed account - check if auth address belongs to a Ledger account
-    if (
-      activeAccount.type === AccountType.REKEYED ||
-      activeAccount.type === 'rekeyed'
-    ) {
+    if (activeAccount.type === AccountType.REKEYED) {
       const rekeyedAccount = activeAccount as RekeyedAccountMetadata;
       const authAccount = allAccounts.find(
         (acc) => acc.address === rekeyedAccount.authAddress
       );
-      if (
-        authAccount?.type === AccountType.LEDGER ||
-        authAccount?.type === 'ledger'
-      ) {
+      if (authAccount?.type === AccountType.LEDGER) {
         return true;
       }
     }
@@ -485,26 +476,17 @@ export default function MessagesInboxScreen() {
     if (!activeAccount) return false;
 
     // Direct Ledger account
-    if (
-      activeAccount.type === AccountType.LEDGER ||
-      activeAccount.type === 'ledger'
-    ) {
+    if (activeAccount.type === AccountType.LEDGER) {
       return true;
     }
 
     // Rekeyed account - check if auth address belongs to a Ledger account
-    if (
-      activeAccount.type === AccountType.REKEYED ||
-      activeAccount.type === 'rekeyed'
-    ) {
+    if (activeAccount.type === AccountType.REKEYED) {
       const rekeyedAccount = activeAccount as RekeyedAccountMetadata;
       const authAccount = allAccounts.find(
         (acc) => acc.address === rekeyedAccount.authAddress
       );
-      if (
-        authAccount?.type === AccountType.LEDGER ||
-        authAccount?.type === 'ledger'
-      ) {
+      if (authAccount?.type === AccountType.LEDGER) {
         return true;
       }
     }

--- a/src/screens/social/NewMessageScreen.tsx
+++ b/src/screens/social/NewMessageScreen.tsx
@@ -72,26 +72,17 @@ export default function NewMessageScreen() {
     if (!activeAccount) return false;
 
     // Direct Ledger account
-    if (
-      activeAccount.type === AccountType.LEDGER ||
-      activeAccount.type === 'ledger'
-    ) {
+    if (activeAccount.type === AccountType.LEDGER) {
       return true;
     }
 
     // Rekeyed account - check if auth address belongs to a Ledger account
-    if (
-      activeAccount.type === AccountType.REKEYED ||
-      activeAccount.type === 'rekeyed'
-    ) {
+    if (activeAccount.type === AccountType.REKEYED) {
       const rekeyedAccount = activeAccount as RekeyedAccountMetadata;
       const authAccount = allAccounts.find(
         (acc) => acc.address === rekeyedAccount.authAddress
       );
-      if (
-        authAccount?.type === AccountType.LEDGER ||
-        authAccount?.type === 'ledger'
-      ) {
+      if (authAccount?.type === AccountType.LEDGER) {
         return true;
       }
     }
@@ -254,7 +245,7 @@ export default function NewMessageScreen() {
           }));
 
           // Deduplicate
-          const allResults = [...friendResults];
+          const allResults: RecipientOption[] = [...friendResults];
           for (const result of envoiResults) {
             if (!allResults.some((r) => r.address === result.address)) {
               allResults.push(result);

--- a/src/services/messaging/index.ts
+++ b/src/services/messaging/index.ts
@@ -167,7 +167,7 @@ export class MessagingService {
       // unconfirmed message shows as pending instead of a premature "confirmed".
       const { txId, confirmed } = await TransactionService.sendTransaction(
         params,
-        account as WalletAccount,
+        account as unknown as WalletAccount,
         pin
       );
 
@@ -384,22 +384,19 @@ export class MessagingService {
     const response = await query.do();
 
     // Filter for transactions between user and friend
-    const allTxns = (response.transactions || []).filter(
-      (txn: Record<string, unknown>) => {
-        const receiver =
-          (txn['payment-transaction'] as Record<string, unknown>)?.receiver ||
-          (txn.paymentTransaction as Record<string, unknown>)?.receiver;
-        return (
-          (txn.sender === userAddress && receiver === friendAddress) ||
-          (txn.sender === friendAddress && receiver === userAddress)
-        );
-      }
-    );
+    const allTxns = (response.transactions || []).filter((txn) => {
+      const receiver = txn.paymentTransaction?.receiver;
+      return (
+        (txn.sender === userAddress && receiver === friendAddress) ||
+        (txn.sender === friendAddress && receiver === userAddress)
+      );
+    });
 
     const messages: Message[] = [];
 
     for (const txn of allTxns) {
       if (!txn.note) continue;
+      if (!txn.id) continue;
 
       const noteBase64 =
         typeof txn.note === 'string'
@@ -628,6 +625,7 @@ export class MessagingService {
 
     for (const txn of response.transactions || []) {
       if (!txn.note) continue;
+      if (!txn.id) continue;
 
       const noteBase64 =
         typeof txn.note === 'string'
@@ -641,12 +639,9 @@ export class MessagingService {
       const direction: MessageDirection =
         txn.sender === userAddress ? 'sent' : 'received';
 
-      let friendAddress: string;
+      let friendAddress: string | undefined;
       if (direction === 'sent') {
-        friendAddress =
-          txn['payment-transaction']?.receiver ||
-          txn.paymentTransaction?.receiver ||
-          txn.receiver;
+        friendAddress = txn.paymentTransaction?.receiver;
       } else {
         friendAddress = txn.sender;
       }
@@ -792,7 +787,7 @@ export class MessagingService {
     // Register on-chain
     return registerMessagingKey(
       messagingKeyPair.publicKey,
-      account as WalletAccount,
+      account as unknown as WalletAccount,
       pin
     );
   }

--- a/src/services/messaging/keyRegistry.ts
+++ b/src/services/messaging/keyRegistry.ts
@@ -226,13 +226,12 @@ async function lookupMessagingKeyViaIndexer(
       if (txn.sender !== address) continue;
 
       // Get receiver from payment transaction
-      const receiver =
-        txn['payment-transaction']?.receiver ||
-        txn.paymentTransaction?.receiver;
+      const receiver = txn.paymentTransaction?.receiver;
       if (receiver !== address) continue;
 
       // Skip transactions without notes
       if (!txn.note) continue;
+      if (!txn.id) continue;
 
       // Get note as base64 string
       const noteBase64 =

--- a/src/types/ed2curve.d.ts
+++ b/src/types/ed2curve.d.ts
@@ -1,0 +1,8 @@
+declare module 'ed2curve' {
+  export function convertPublicKey(pk: Uint8Array): Uint8Array | null;
+  export function convertSecretKey(sk: Uint8Array): Uint8Array;
+  export function convertKeyPair(kp: {
+    publicKey: Uint8Array;
+    secretKey: Uint8Array;
+  }): { publicKey: Uint8Array; secretKey: Uint8Array } | null;
+}


### PR DESCRIPTION
## Summary

P5d of the TypeScript burndown (TASK-122, PLAN-110). Behavior-preserving typing fixes for the **E2E-encrypted messaging** service and social screens. Crypto-adjacent — no change to any encrypt/decrypt behavior.

Typecheck: **99 → 79** (clears 20; target was ~18). Zero new error signatures; `eslint` shows 0 new errors in touched files (only pre-existing warnings).

## Changes

- **New `src/types/ed2curve.d.ts`** — ambient module declaration for `ed2curve` (fixes `crypto.ts:15` implicit-any). Purely additive; `crypto.ts` untouched, so the Ed25519→Curve25519 conversion path is unchanged.
- **`messaging/index.ts` + `keyRegistry.ts`** — use algosdk-3 indexer camelCase `Transaction.paymentTransaction?.receiver`. Dropped the dead kebab-case (`payment-transaction`) and top-level (`txn.receiver`) operands that always resolved to `undefined` under algosdk-3; the resolved value is identical.
- **`messaging/index.ts`** — fixed the `.filter` predicate typing (infer indexer `Transaction` instead of `Record<string, unknown>`); changed `AccountMetadata` casts to `as unknown as WalletAccount`; narrowed `txn.id` / `friendAddress` with `if (!…) continue` guards rather than force-casting away real `undefined`.
- **`MessagesInboxScreen.tsx` / `NewMessageScreen.tsx`** — removed the runtime-redundant `|| x.type === 'ledger' / 'rekeyed'` string-literal clauses (`AccountType` is a string enum; the `=== AccountType.LEDGER/REKEYED` operand already matches). Typed `NewMessage` `allResults` as `RecipientOption[]`.

## Review

Codex crypto review (read-only): **CLEAN** — ed2curve decl additive, no encrypt/decrypt output change, receiver access resolves same value, deleted enum clauses truly redundant, no key/secret leakage.

## NEEDS DEVICE VERIFICATION

- Send a message + receive/decrypt a message (thread load from chain)
- Decrypt a legacy V1 message and a V2 message
- Messaging key registration + lookup (self-transfer note path)
- Ledger / rekeyed-to-Ledger account gating in both social screens

**DO NOT MERGE.**

https://claude.ai/code/session_012WoHuh1utAZRBTDiDZ2sEk