### PR TITLE
fix(wallet): P5a — address persistence + heal-on-read + clearAllWallets (TASK-119)

### DIFF
--- a/src/services/wallet/index.ts
+++ b/src/services/wallet/index.ts
@@ -13,6 +13,7 @@ import {
   RemoteSignerAccountMetadata,
   CreateAccountRequest,
   ImportAccountRequest,
+  ImportAuthAccountRequest,
   ImportLedgerAccountRequest,
   DetectLedgerAccountsRequest,
   LedgerAccountDiscoveryResult,
@@ -50,7 +51,9 @@ export class MultiAccountWalletService {
 
       const accountMetadata: StandardAccountMetadata = {
         id: this.generateAccountId(),
-        address: account.addr,
+        // algosdk 3 returns an `Address` object; persist the 58-char base32
+        // string so the stored value stays Pera/Algorand-wallet compatible.
+        address: account.addr.toString(),
         publicKey: Buffer.from(account.sk.slice(32)).toString('hex'),
         type: AccountType.STANDARD,
         label: request.label || `Account ${(await this.getAccountCount()) + 1}`,
@@ -83,7 +86,14 @@ export class MultiAccountWalletService {
     request: ImportAccountRequest
   ): Promise<StandardAccountMetadata> {
     try {
-      let account: algosdk.Account;
+      // The mnemonic path yields an algosdk 3 `Account` (addr is an `Address`
+      // object); the private-key path builds an object whose addr is already a
+      // base32 string. Allow both so `account.addr.toString()` normalizes them.
+      let account: {
+        sk: Uint8Array;
+        addr: algosdk.Address | string;
+        publicKey?: Uint8Array;
+      };
 
       if (request.mnemonic) {
         const cleanMnemonic = this.cleanMnemonic(request.mnemonic);
@@ -104,7 +114,9 @@ export class MultiAccountWalletService {
       }
 
       // Check if account already exists
-      const existingAccount = await this.findAccountByAddress(account.addr);
+      const existingAccount = await this.findAccountByAddress(
+        account.addr.toString()
+      );
       if (existingAccount) {
         throw new AccountExistsError('Account already exists in wallet');
       }
@@ -115,7 +127,8 @@ export class MultiAccountWalletService {
 
       const accountMetadata: StandardAccountMetadata = {
         id: this.generateAccountId(),
-        address: account.addr,
+        // Persist the 58-char base32 string, never the algosdk `Address` object.
+        address: account.addr.toString(),
         publicKey: Buffer.from(
           (account as any).publicKey ?? account.sk.slice(32)
         ).toString('hex'),
@@ -503,7 +516,7 @@ export class MultiAccountWalletService {
       const authAccount = await this.findAccountByAddress(request.authAddress);
       const canSign =
         request.canSign ??
-        (authAccount && authAccount.type === AccountType.STANDARD);
+        (!!authAccount && authAccount.type === AccountType.STANDARD);
 
       const publicKey = algosdk.decodeAddress(
         request.originalAddress
@@ -704,18 +717,31 @@ export class MultiAccountWalletService {
             : defaultSettings.numberLocale,
       };
 
-      // Repair invalid or missing addresses from public keys if needed
+      // Heal-on-read: repair invalid, missing, or non-base32 (e.g. a persisted
+      // algosdk `Address` object serialized to `{"publicKey":{...}}`) addresses
+      // by re-deriving them from the stored hex public key. This only ever
+      // rewrites to a freshly derived, checksum-valid base32 address obtained
+      // from an exactly-32-byte public key; it never weakens validation.
       let modified = false;
       wallet.accounts = wallet.accounts.map((acc) => {
-        if (!acc.address || !algosdk.isValidAddress(acc.address)) {
+        const rawAddress = acc.address as unknown;
+        const currentAddress = typeof rawAddress === 'string' ? rawAddress : '';
+        if (!currentAddress || !algosdk.isValidAddress(currentAddress)) {
           try {
-            if (acc.publicKey && /^[0-9a-fA-F]+$/.test(acc.publicKey)) {
+            const rawPublicKey = acc.publicKey as unknown;
+            const hexPublicKey =
+              typeof rawPublicKey === 'string' ? rawPublicKey : '';
+            if (hexPublicKey && /^[0-9a-fA-F]+$/.test(hexPublicKey)) {
               const pubBytes = new Uint8Array(
-                acc.publicKey.match(/.{1,2}/g)!.map((b) => parseInt(b, 16))
+                hexPublicKey.match(/.{1,2}/g)!.map((b) => parseInt(b, 16))
               );
-              const address = algosdk.encodeAddress(pubBytes);
-              modified = true;
-              return { ...acc, address } as AccountMetadata;
+              if (pubBytes.length === 32) {
+                const derived = algosdk.encodeAddress(pubBytes);
+                if (algosdk.isValidAddress(derived)) {
+                  modified = true;
+                  return { ...acc, address: derived } as AccountMetadata;
+                }
+              }
             }
           } catch {}
         }
@@ -885,12 +911,14 @@ export class MultiAccountWalletService {
 
   static async clearAllWallets(): Promise<void> {
     try {
-      // Delete wallet metadata
-      await AsyncStorage.removeItem(this.WALLET_KEY);
+      // Clears wallet METADATA only (the account list / active-account record).
+      // Private keys in secure storage are NOT touched here; callers that need a
+      // full reset must also call AccountSecureStorage.clearAll() — as
+      // LockScreen.performReset() does immediately before invoking this method.
+      await storage.removeItem(this.WALLET_KEY);
       await this.clearLegacyValue(this.WALLET_KEY);
 
-      // The secure storage will be cleared by AccountSecureStorage.clearAll()
-      console.log('All wallet data cleared');
+      console.log('All wallet metadata cleared');
     } catch (error) {
       console.error('Failed to clear wallet data:', error);
       throw new Error(
@@ -1159,7 +1187,8 @@ export class MultiAccountWalletService {
     );
   }
 
-  private static async findAccountByAddress(
+  // Public so auth-account-discovery can reuse the same lookup/dedup logic.
+  static async findAccountByAddress(
     address: string
   ): Promise<AccountMetadata | null> {
     const wallet = await this.getCurrentWallet();
@@ -1295,7 +1324,7 @@ export class MultiAccountWalletService {
         await this.createWallet(accountMetadata as StandardAccountMetadata);
       } else if (
         accountMetadata.type === AccountType.REMOTE_SIGNER ||
-        accountMetadata.type === AccountType.WATCH_ONLY
+        accountMetadata.type === AccountType.WATCH
       ) {
         // Create wallet with non-standard account (no mnemonic required)
         await this.createWalletWithAccount(accountMetadata);

--- a/src/services/wallet/rekeyManager.ts
+++ b/src/services/wallet/rekeyManager.ts
@@ -214,6 +214,12 @@ export class RekeyManager {
               importedAt: account.importedAt,
               lastUsed: account.lastUsed,
               type: AccountType.STANDARD,
+              // Sanitized-storage convention: the real mnemonic lives only in
+              // secure storage and is stripped on persist, so keep it empty here.
+              mnemonic: '',
+              // Backup is unverified; the private key is confirmed present in
+              // secure storage (checked above) but that is not a mnemonic backup.
+              hasBackup: false,
             };
             return standardAccount;
           } else {


### PR DESCRIPTION
## Summary — TASK-119 (P5a), CRYPTO / KEY-HANDLING

TypeScript burndown in the wallet service. Clears **12** tsc errors (**99 → 87**), including 2 auth-account-discovery cascade errors. All changes are behavior-preserving except the intended bug fixes. No key/mnemonic material added to any log or store.

### Fixes
- **Stored-address corruption (real bug):** algosdk 3 returns an `Address` **object**; it was being persisted into a `string` field. Now persists `account.addr.toString()` (58-char base32) in `createStandardAccount` and the mnemonic import path, and passes a string to `findAccountByAddress` for duplicate detection. Restores Pera/Algorand-wallet compatibility and dup-detect.
- **Heal-on-read (`getCurrentWallet`) hardened:** only rewrites a stored address when a checksum-valid base32 address can be re-derived from an **exactly 32-byte** hex public key (`isValidAddress(derived)` gate). Handles a previously-persisted `Address`-object / non-base32 value. Never weakens address validation.
- **`clearAllWallets`:** `AsyncStorage` was undefined (method threw on every call) → `storage.removeItem`. Clarified it clears wallet **metadata only**; private keys in secure storage are cleared by the caller via `AccountSecureStorage.clearAll()` (as `LockScreen.performReset()` does immediately before).
- **Watch-as-first-account:** `AccountType.WATCH_ONLY` → `AccountType.WATCH` (enum has `WATCH`; importing a watch account as the first account threw).
- `importAuthAccount`: import the `ImportAuthAccountRequest` type.
- `detectRekeyedAccount`: coerce `canSign` to a pure `boolean` (`!!authAccount`).
- `findAccountByAddress` made `public static` so auth-account-discovery reuses it (clears the cascade).
- **rekeyManager:** `StandardAccountMetadata` literal gains `mnemonic: ''` (sanitized-storage convention; persistence strips it) and `hasBackup: false` (private key confirmed in secure storage, but not a verified mnemonic backup).

### Gate
- Typecheck: **99 → 87**, zero new error signatures (untouched-file errors byte-identical before/after).
- Lint: no new errors/warnings in the two touched files (1 prettier issue introduced then auto-fixed; remaining 2 warnings are pre-existing on untouched lines).

### Codex crypto review — intended fixes CLEAN
Verified: `account.addr.toString()` correct; heal-on-read only rewrites a validly-derived checksummed address from a 32-byte pubkey; no mnemonic/private-key logging or general-storage persistence added; `clearAllWallets` targets the right store; `WATCH_ONLY → WATCH` correct.

**One pre-existing, OUT-OF-SCOPE finding (not fixed here):** `parsePrivateKey` accepts a 64-byte Ed25519 key validated only as 128 hex chars, without verifying the appended 32-byte public half matches the seed. This code is unchanged by this PR (present on `main`). Fixing it is a crypto **behavior change** that per CLAUDE.md requires human sign-off — recommended as a **follow-up**, not folded into this behavior-preserving burndown.

### DR-2 heal-on-read / PLAN-110

## ⚠️ DO NOT MERGE — NEEDS DEVICE VERIFICATION
In-app flows a human must verify first:
- Create standard account → stored address is 58-char base32.
- Mnemonic import + **duplicate detection** (re-import same account rejected).
- Private-key import path (address/dup unchanged).
- Clear-all-wallets / reset (LockScreen `performReset`): secure keys + metadata both gone.
- Import **watch account as the FIRST account** (previously threw).
- Rekey detect/convert (rekeyManager standard/watch reconstruction).
- Heal-on-read: a wallet with a legacy corrupted (Address-object) stored address loads and self-heals to a valid base32 address.

https://claude.ai/code/session_012WoHuh1utAZRBTDiDZ2sEk