### PR TITLE
fix(auth): P5e — React 19 refs + secure-storage error narrowing (TASK-123)

### DIFF
--- a/src/components/wallet/MnemonicBackupFlow.tsx
+++ b/src/components/wallet/MnemonicBackupFlow.tsx
@@ -65,7 +65,7 @@ export default function MnemonicBackupFlow({
 
   const startVerification = () => {
     // Select 3 random word positions for verification
-    const positions = [];
+    const positions: number[] = [];
     while (positions.length < 3) {
       const randomPos = Math.floor(Math.random() * mnemonicWords.length);
       if (!positions.includes(randomPos)) {

--- a/src/contexts/AuthContext.tsx
+++ b/src/contexts/AuthContext.tsx
@@ -5,7 +5,7 @@ import React, {
   useEffect,
   useRef,
 } from 'react';
-import { AppState, Platform } from 'react-native';
+import { AppState, Platform, AppStateStatus } from 'react-native';
 import { MultiAccountWalletService } from '@/services/wallet';
 import { AccountSecureStorage } from '@/services/secure';
 import { SecurityUtils } from '@/utils/security';
@@ -90,9 +90,9 @@ export function AuthProvider({ children }: { children: React.ReactNode }) {
     hasPin: false,
   });
 
-  const activityTimer = useRef<NodeJS.Timeout>();
-  const sessionTimer = useRef<NodeJS.Timeout>();
-  const backgroundTimer = useRef<NodeJS.Timeout>();
+  const activityTimer = useRef<NodeJS.Timeout | undefined>(undefined);
+  const sessionTimer = useRef<NodeJS.Timeout | undefined>(undefined);
+  const backgroundTimer = useRef<NodeJS.Timeout | undefined>(undefined);
 
   useEffect(() => {
     checkInitialAuthState();
@@ -215,7 +215,7 @@ export function AuthProvider({ children }: { children: React.ReactNode }) {
 
     let previousAppState = AppState.currentState;
 
-    const handleAppStateChange = (nextAppState: string) => {
+    const handleAppStateChange = (nextAppState: AppStateStatus) => {
       const now = Date.now();
 
       if (nextAppState === 'background') {

--- a/src/platform/extension/secureStorage.ts
+++ b/src/platform/extension/secureStorage.ts
@@ -81,7 +81,7 @@ export class ExtensionSecureStorageAdapter implements SecureStorageAdapter {
     const iv = await extensionCrypto.getRandomBytes(12);
 
     const ciphertext = await crypto.subtle.encrypt(
-      { name: 'AES-GCM', iv },
+      { name: 'AES-GCM', iv: iv as BufferSource },
       key,
       data
     );

--- a/src/screens/settings/ShowRecoveryPhraseScreen.tsx
+++ b/src/screens/settings/ShowRecoveryPhraseScreen.tsx
@@ -39,7 +39,7 @@ export default function ShowRecoveryPhraseScreen() {
   const [isLoading, setIsLoading] = useState(false);
   const [isBlurred, setIsBlurred] = useState(true);
   const [hasCopied, setHasCopied] = useState(false);
-  const timeoutRef = useRef<NodeJS.Timeout>();
+  const timeoutRef = useRef<NodeJS.Timeout | undefined>(undefined);
 
   const loadMnemonic = useCallback(async () => {
     if (!targetAddress) {

--- a/src/screens/wallet/NFTScreen.tsx
+++ b/src/screens/wallet/NFTScreen.tsx
@@ -258,7 +258,10 @@ export default function NFTScreen() {
       if (newSet.size > NFT_CONSTANTS.MAX_IMAGE_CACHE_SIZE) {
         const iterator = newSet.values();
         iterator.next();
-        newSet.delete(iterator.next().value);
+        const oldestKey = iterator.next().value;
+        if (oldestKey !== undefined) {
+          newSet.delete(oldestKey);
+        }
       }
       return newSet;
     });

--- a/src/services/secure/AccountSecureStorage.ts
+++ b/src/services/secure/AccountSecureStorage.ts
@@ -261,7 +261,7 @@ export class AccountSecureStorage {
       await this.storeAccountMetadata(metadata);
     } catch (error) {
       throw new AccountStorageError(
-        `Failed to store account: ${error.message}`
+        `Failed to store account: ${error instanceof Error ? error.message : 'Unknown error'}`
       );
     }
   }
@@ -327,7 +327,7 @@ export class AccountSecureStorage {
         throw error;
       }
       throw new AccountRetrievalError(
-        `Failed to retrieve account: ${error.message}`
+        `Failed to retrieve account: ${error instanceof Error ? error.message : 'Unknown error'}`
       );
     }
   }
@@ -477,7 +477,7 @@ export class AccountSecureStorage {
           throw error;
         }
         throw new AccountRetrievalError(
-          `Failed to retrieve private key: ${error.message}`
+          `Failed to retrieve private key: ${error instanceof Error ? error.message : 'Unknown error'}`
         );
       }
     })();
@@ -810,7 +810,7 @@ export class AccountSecureStorage {
       await this.addToAccountList(metadata.accountId);
     } catch (error) {
       throw new AccountStorageError(
-        `Failed to store account metadata: ${error.message}`
+        `Failed to store account metadata: ${error instanceof Error ? error.message : 'Unknown error'}`
       );
     }
   }
@@ -859,7 +859,9 @@ export class AccountSecureStorage {
       await this.saveMetadata(accountId, updated);
     } catch (error) {
       // Don't throw error for last accessed update failure - it's not critical
-      console.warn(`Failed to update last accessed time: ${error.message}`);
+      console.warn(
+        `Failed to update last accessed time: ${error instanceof Error ? error.message : 'Unknown error'}`
+      );
     }
   }
 
@@ -923,7 +925,9 @@ export class AccountSecureStorage {
       await this.persistPinHash(hashedPin, salt);
       this.legacyCheckRequired = false;
     } catch (error) {
-      throw new AccountStorageError(`Failed to store PIN: ${error.message}`);
+      throw new AccountStorageError(
+        `Failed to store PIN: ${error instanceof Error ? error.message : 'Unknown error'}`
+      );
     }
   }
 
@@ -1028,7 +1032,9 @@ export class AccountSecureStorage {
       await this.persistPinHash(hashedNewPin, salt);
       this.legacyCheckRequired = false;
     } catch (error) {
-      throw new AccountStorageError(`Failed to change PIN: ${error.message}`);
+      throw new AccountStorageError(
+        `Failed to change PIN: ${error instanceof Error ? error.message : 'Unknown error'}`
+      );
     }
   }
 


### PR DESCRIPTION
## Summary (PLAN-110 / TASK-123, P5e)

Type-only TypeScript burndown across secure/auth files. **No behavior change** in normal operation. Clears **20** tsc errors (**99 → 79**), zero new error signatures.

### Changes (type-only)
- **AuthContext.tsx / ShowRecoveryPhraseScreen.tsx** — `useRef<NodeJS.Timeout>()` → `useRef<NodeJS.Timeout | undefined>(undefined)` (React 19 dropped the zero-arg `useRef` overload). This also clears the dependent `= undefined` timer-clear assignments (AuthContext 144/148/247/376).
- **AuthContext.tsx** — typed the AppState change handler param as `AppStateStatus` (imported from `react-native`); clears the `previousAppState` assignment error.
- **AccountSecureStorage.ts** — narrowed 7 `catch (error: unknown)` sites to `error instanceof Error ? error.message : 'Unknown error'`. Each interpolates **only** an error message — no private key / mnemonic / PIN / secret material. (Per security review, the non-`Error` fallback is a fixed `'Unknown error'` string, not `String(error)`, so a non-`Error` rejected value can never be serialized into a thrown/logged string.)
- **MnemonicBackupFlow.tsx** — `const positions: number[] = []` (grid indices for verification, not mnemonic words; no mnemonic logic touched).
- **extension/secureStorage.ts** — WebCrypto IV cast `iv as BufferSource` (lib.dom `ArrayBufferLike` drift; web/extension target only).
- **NFTScreen.tsx** — guarded the Set-iterator value (`string | undefined`) before `delete` in the image-cache eviction.

### Verification
- `npm run typecheck`: 99 → 79, **0 new** error signatures (diffed vs baseline).
- `npm run lint`: 0 errors in touched files (pre-existing warnings only).
- Codex security review: **no secret/key/mnemonic/PIN exposure**; timer, mnemonic-position, IV-cast, and NFT-guard changes confirmed type-only / no-op in normal operation.

### Light device flows to verify
- App boot / auth init
- Lock / unlock (inactivity + background grace-period timers)
- View recovery phrase (ShowRecoveryPhrase auto-hide timer)
- Mnemonic backup verification grid

**DO NOT MERGE** — burndown PR; no auto-merge.

https://claude.ai/code/session_012WoHuh1utAZRBTDiDZ2sEk