### PR TITLE
fix(signing): P5c — account-model retype + Ledger signing types (TASK-121)

### DIFF
--- a/src/screens/account/MnemonicImportScreen.tsx
+++ b/src/screens/account/MnemonicImportScreen.tsx
@@ -22,6 +22,7 @@ import {
 } from '@react-navigation/native';
 import { Ionicons } from '@expo/vector-icons';
 import { RootStackParamList } from '@/navigation/AppNavigator';
+import { AccountType } from '@/types/wallet';
 import { useWalletStore } from '@/store/walletStore';
 import { BIP39Utils, WordSuggestion } from '@/utils/bip39';
 import KeyboardAwareScrollView from '@/components/common/KeyboardAwareScrollView';
@@ -270,6 +271,7 @@ export default function MnemonicImportScreen({ navigation, route }: Props) {
       } else {
         // For adding additional accounts, import directly
         await importAccount({
+          type: AccountType.STANDARD,
           mnemonic,
           label:
             normalizedLabel ||

--- a/src/screens/wallet/RekeyAccountScreen.tsx
+++ b/src/screens/wallet/RekeyAccountScreen.tsx
@@ -67,8 +67,9 @@ export default function RekeyAccountScreen() {
   const loadAccountBalance = useWalletStore(
     (state) => state.loadAccountBalance
   );
-  const [selectedNetworkId, setSelectedNetworkId] =
-    useState<NetworkId>('voi-mainnet');
+  const [selectedNetworkId, setSelectedNetworkId] = useState<NetworkId>(
+    NetworkId.VOI_MAINNET
+  );
   const [rekeyFlow, setRekeyFlow] = useState<RekeyFlow>('standard');
   const [selectedStandardAccount, setSelectedStandardAccount] =
     useState<StandardAccountMetadata | null>(null);

--- a/src/screens/wallet/TransactionConfirmationScreen.tsx
+++ b/src/screens/wallet/TransactionConfirmationScreen.tsx
@@ -25,7 +25,7 @@ import {
 } from '@/services/transactions/unifiedSigner';
 import UniversalHeader from '@/components/common/UniversalHeader';
 import { WalletStackParamList } from '@/navigation/AppNavigator';
-import { WalletAccount } from '@/types/wallet';
+import { AccountMetadata } from '@/types/wallet';
 import { NFTToken } from '@/types/nft';
 import { NetworkId } from '@/types/network';
 import { getNetworkConfig } from '@/services/network/config';
@@ -60,7 +60,7 @@ interface TransactionConfirmationParams {
   assetDecimals?: number;
   note?: string;
   estimatedFee: number;
-  fromAccount: WalletAccount;
+  fromAccount: AccountMetadata;
   nftToken?: NFTToken;
   networkId?: string;
   assetImageUrl?: string;
@@ -71,7 +71,10 @@ export default function TransactionConfirmationScreen() {
   const route = useRoute<TransactionConfirmationScreenRouteProp>();
   const navigation =
     useNavigation<TransactionConfirmationScreenNavigationProp>();
-  const params = route.params as TransactionConfirmationParams;
+  // The local param shape intentionally diverges from the registered route type
+  // (extra display fields, and `fromAccount` typed as the real `AccountMetadata`
+  // rather than the legacy `WalletAccount`), so assert through `unknown`.
+  const params = route.params as unknown as TransactionConfirmationParams;
   const styles = useThemedStyles(createStyles);
   const currentNetwork = useCurrentNetwork();
 
@@ -176,7 +179,7 @@ export default function TransactionConfirmationScreen() {
           // Check if this asset is in the same mapping
           if (asset.mappingId === params.mappingId && asset.imageUrl) {
             console.log(
-              `[TransactionConfirmation] Using fallback image from ${asset.symbol} on ${asset.networkId}`
+              `[TransactionConfirmation] Using fallback image from ${asset.symbol} on ${asset.primaryNetwork}`
             );
             setFallbackImageUrl(asset.imageUrl);
             return;
@@ -283,8 +286,12 @@ export default function TransactionConfirmationScreen() {
     setCurrentRequest(null);
 
     if (success && result?.transactionId) {
-      // Replace this screen with result to keep stack cleaner
-      navigation.replace('TransactionResult', {
+      // Replace this screen with result to keep stack cleaner.
+      // Built as an intermediate object so the extra display fields carried for
+      // the result screen (assetType/contractId/tokenId/homeRoute, which the
+      // registered route type omits) are structurally assignable rather than
+      // tripping the fresh-literal excess-property check.
+      const successParams = {
         transactionId: result.transactionId,
         recipient: params.recipient,
         recipientName: getDisplayName(),
@@ -301,14 +308,15 @@ export default function TransactionConfirmationScreen() {
         // result screen treats as confirmed success (backward-compatible).
         confirmed: result?.confirmed,
         homeRoute: params.assetType === 'arc72' ? 'NFTMain' : 'HomeMain',
-        networkId: params.networkId,
-      });
+        networkId: params.networkId as NetworkId | undefined,
+      };
+      navigation.replace('TransactionResult', successParams);
     } else {
       // Replace this screen with error result
       const errorMessage =
         result instanceof Error ? result.message : 'Transaction failed';
 
-      navigation.replace('TransactionResult', {
+      const errorParams = {
         recipient: params.recipient,
         recipientName: getDisplayName(),
         amount: params.amount,
@@ -321,8 +329,9 @@ export default function TransactionConfirmationScreen() {
         isSuccess: false,
         errorMessage,
         homeRoute: params.assetType === 'arc72' ? 'NFTMain' : 'HomeMain',
-        networkId: params.networkId,
-      });
+        networkId: params.networkId as NetworkId | undefined,
+      };
+      navigation.replace('TransactionResult', errorParams);
     }
   };
 

--- a/src/screens/wallet/UniversalTransactionSigningScreen.tsx
+++ b/src/screens/wallet/UniversalTransactionSigningScreen.tsx
@@ -71,7 +71,6 @@ export default function UniversalTransactionSigningScreen({
 }: Props) {
   const {
     transactions,
-    account,
     onSuccess: directOnSuccess,
     onReject: directOnReject,
     callbackId,
@@ -79,6 +78,12 @@ export default function UniversalTransactionSigningScreen({
     networkId,
     chainId,
   } = route.params;
+  // The route param is typed `WalletAccount` (legacy), but callers always pass a
+  // full `AccountMetadata` at runtime (see SwapScreen/Claim screens which cast the
+  // other direction). Coerce to the real shape so display fields (color/label) and
+  // the unified request account (which needs `type`/`authAddress` for signer
+  // selection) are correctly typed. Behavior-preserving: same runtime object.
+  const account = route.params.account as unknown as AccountMetadata;
 
   // Get callbacks from registry if callbackId provided, otherwise use direct callbacks
   const registryCallbacks = getNavigationCallbacks(callbackId);
@@ -119,10 +124,14 @@ export default function UniversalTransactionSigningScreen({
         networkCurrency: getNetworkCurrencyByChainId(chainId),
       };
     }
-    if (networkId === 'algorand-mainnet' || networkId === 'algorand-testnet') {
+    // Compare against the raw network id string. NetworkId currently only defines
+    // the *-mainnet members, so the testnet arms are inert today; the string
+    // widening keeps them without a "no overlap" type error and is future-proof.
+    const netId = networkId as string | undefined;
+    if (netId === 'algorand-mainnet' || netId === 'algorand-testnet') {
       return { networkName: 'Algorand', networkCurrency: 'ALGO' };
     }
-    if (networkId === 'voi-mainnet' || networkId === 'voi-testnet') {
+    if (netId === 'voi-mainnet' || netId === 'voi-testnet') {
       return { networkName: 'Voi Network', networkCurrency: 'VOI' };
     }
     return { networkName: 'Unknown Network', networkCurrency: 'VOI' };

--- a/src/screens/walletconnect/TransactionRequestScreen.tsx
+++ b/src/screens/walletconnect/TransactionRequestScreen.tsx
@@ -26,6 +26,7 @@ import {
   AccountMetadata,
   AccountType,
   LedgerAccountMetadata,
+  WalletAccount,
 } from '@/types/wallet';
 import UniversalHeader from '@/components/common/UniversalHeader';
 import UnifiedTransactionAuthModal from '@/components/UnifiedTransactionAuthModal';
@@ -271,7 +272,10 @@ export default function TransactionRequestScreen({ navigation, route }: Props) {
 
           navigation.replace('UniversalTransactionSigning', {
             transactions: txns.map((wtxn) => wtxn.txn),
-            account: signingAccount,
+            // Nav param is typed WalletAccount (legacy); the screen coerces it back
+            // to AccountMetadata at runtime. Matches the existing cast pattern used
+            // by the other callers of this route (e.g. SwapScreen).
+            account: signingAccount as unknown as WalletAccount,
             chainId: effectiveChainId,
             title: 'WalletConnect Request',
             callbackId,

--- a/src/services/auth/simpleLedgerAuthController.ts
+++ b/src/services/auth/simpleLedgerAuthController.ts
@@ -5,6 +5,7 @@ import {
 } from '@/services/transactions/unifiedSigner';
 import {
   simpleLedgerSigner,
+  SimpleLedgerSigner,
   SimpleLedgerSigningCallbacks,
 } from '@/services/ledger/simpleLedgerSigner';
 import {
@@ -235,7 +236,7 @@ export class SimpleLedgerAuthController {
           );
 
           requests.push(
-            simpleLedgerSigner.constructor.createSigningRequest(
+            SimpleLedgerSigner.createSigningRequest(
               txn,
               this.ledgerSigningInfo.derivationIndex,
               this.ledgerSigningInfo.signerAddress
@@ -253,7 +254,7 @@ export class SimpleLedgerAuthController {
           );
 
           requests.push(
-            simpleLedgerSigner.constructor.createSigningRequest(
+            SimpleLedgerSigner.createSigningRequest(
               rekeyTxn,
               this.ledgerSigningInfo.derivationIndex,
               this.ledgerSigningInfo.signerAddress
@@ -270,7 +271,7 @@ export class SimpleLedgerAuthController {
             const txnBytes = Buffer.from(wtxn.txn, 'base64');
 
             requests.push(
-              simpleLedgerSigner.constructor.createSigningRequest(
+              SimpleLedgerSigner.createSigningRequest(
                 txnBytes,
                 this.ledgerSigningInfo.derivationIndex,
                 this.ledgerSigningInfo.signerAddress

--- a/src/services/auth/transactionAuthController.ts
+++ b/src/services/auth/transactionAuthController.ts
@@ -119,6 +119,9 @@ export class TransactionAuthController {
   private currentState: TransactionAuthState_Interface;
   private currentRequest: UnifiedTransactionRequest | null = null;
   private ledgerSigningInfo: LedgerSigningInfo | null = null;
+  // Tracks the device currently being connected during a Ledger flow; cleared on
+  // reset(). Declared so the reset assignment type-checks.
+  private connectingDeviceId: string | null = null;
   private connectionTimeout: NodeJS.Timeout | null = null;
   private ledgerCancelRequested: boolean = false;
   private cancelledFlowGeneration: number = 0;
@@ -530,7 +533,7 @@ export class TransactionAuthController {
    * Determine what type of authentication is required
    */
   private async determineAuthRequirements(
-    account: WalletAccount
+    account: Pick<WalletAccount, 'address' | 'type'>
   ): Promise<void> {
     try {
       // Check if biometric authentication is available and enabled

--- a/src/services/transactions/index.ts
+++ b/src/services/transactions/index.ts
@@ -677,7 +677,7 @@ export class TransactionService {
 
   static async sendTransaction(
     params: TransactionParams,
-    account: WalletAccount,
+    account: Pick<WalletAccount, 'address' | 'type'>,
     pin?: string,
     callbacks?: SignProgressCallbacks
   ): Promise<{ txId: string; confirmed: boolean }> {
@@ -750,7 +750,7 @@ export class TransactionService {
 
   static async validateTransaction(
     params: TransactionParams,
-    account: WalletAccount
+    account: Pick<WalletAccount, 'address' | 'type'>
   ): Promise<string[]> {
     const errors: string[] = [];
 
@@ -1065,7 +1065,7 @@ export class TransactionService {
 
   private static async appendSigningValidation(
     errors: string[],
-    account: WalletAccount,
+    account: Pick<WalletAccount, 'address' | 'type'>,
     networkId?: NetworkId
   ): Promise<void> {
     try {

--- a/src/services/transactions/unifiedSigner.ts
+++ b/src/services/transactions/unifiedSigner.ts
@@ -11,6 +11,7 @@ import {
 } from '@/services/walletconnect';
 import {
   WalletAccount,
+  AccountMetadata,
   AccountType,
   LedgerAccountError,
   LedgerDeviceNotConnectedError,
@@ -96,7 +97,14 @@ export type UnifiedTransactionType =
  */
 export interface UnifiedTransactionRequest {
   type: UnifiedTransactionType;
-  account: WalletAccount;
+  /**
+   * Signing account. Accepts the full `AccountMetadata` (the real runtime shape
+   * passed by the in-app confirmation screens, which carries `type`/`authAddress`
+   * for correct signer selection) as well as the legacy `WalletAccount` still
+   * supplied by a couple of callers (AppCall/Keyreg confirm screens). The union
+   * is behavior-preserving and keeps every existing caller type-safe.
+   */
+  account: AccountMetadata | WalletAccount;
   pin?: string;
 
   // For standard transfers (VOI/ASA/ARC200)

--- a/src/types/wallet.ts
+++ b/src/types/wallet.ts
@@ -241,6 +241,13 @@ export interface LedgerSigningInfo {
   requiresConnection: boolean;
   transportType?: LedgerTransportMedium;
   lastDeviceConnection?: string;
+  /**
+   * Address whose signature is attached to the on-device signing request. Equals
+   * the Ledger account's own address; only affects the post-device `sgnr`
+   * attachment used for rekeyed accounts. Optional because not every
+   * `getLedgerSigningInfo` producer populates it (behavior-preserving default).
+   */
+  signerAddress?: string;
 }
 
 export interface AddWatchAccountRequest {


### PR DESCRIPTION
## P5c — account-model retype + Ledger signing types (TASK-121)

**SIGNING-CRITICAL. Type-only, behavior-preserving. DO NOT MERGE without device verification.**

Part of the TypeScript burndown (PLAN-110). Clears ~22 type errors on the transaction-signing path.

### Typecheck
- **99 → 77** (22 cleared), **zero new type errors**, **zero new lint errors** (0 eslint errors on all touched files).

### What changed (and why it's behavior-preserving)
- `UnifiedTransactionRequest.account`: `WalletAccount` → **`AccountMetadata | WalletAccount`** (union).
  - Not a *pure* `AccountMetadata` retype: two out-of-scope callers (`AppCallConfirmScreen`, `KeyregConfirmScreen`) build the request with `account as unknown as WalletAccount`; a pure retype would create new errors in files outside this task's scope. The union keeps every existing caller type-safe and leaves the REKEYED `authAddress` remote-signer casts valid and **unchanged**.
- `TransactionService.{sendTransaction,validateTransaction,appendSigningValidation}` and `determineAuthRequirements` params → `Pick<WalletAccount, 'address' | 'type'>` (the only fields read; accepts both `WalletAccount` and `AccountMetadata`, no ripple to other callers).
- `LedgerSigningInfo.signerAddress` added as **optional** (`?: string`): the runtime `getLedgerSigningInfo` in `keyManager.ts` (out of scope) does not populate it, so a required field would break it. Runtime value is unchanged (= the Ledger account address where set, otherwise `undefined`).
- `simpleLedgerAuthController`: `simpleLedgerSigner.constructor.createSigningRequest(...)` → `SimpleLedgerSigner.createSigningRequest(...)` — the identical static method; on-device request bytes unchanged.
- `transactionAuthController`: declared `private connectingDeviceId` (previously a write-only field in `reset()`).
- Screens (non-crypto plumbing): `NetworkId` enum member/casts, `ImportAccountRequest.type`, `MappedAsset.primaryNetwork`, and `account` coercions matching the real runtime shapes. `TransactionConfirmation → TransactionResult` nav params extracted to intermediate consts to avoid a fresh-literal excess-property check unmasked by the `networkId` fix (fields preserved; `homeRoute` is read downstream).

### Codex crypto/signing review: **CLEAN**
> Signer/authAddress selection and Ledger request construction are unchanged. Rekeyed remote signing still uses `authAddress`; Ledger `sgnr` remains the Ledger account address when provided. No key/mnemonic leakage, synthetic legacy `WalletAccount` callers, or Algorand/Pera compatibility regression found.

### NEEDS DEVICE VERIFICATION of all signing paths
Standard send/sign · REKEYED sign (authAddress) · Ledger sign · Ledger-rekeyed · remote-signer/airgap · WalletConnect sign.

### Out of scope (left intentionally)
- `transactions/index.ts:931` `unit-name` on `AssetParams` — pre-existing, not part of this task; fixing it would change runtime behavior (owned by another P5x task).

https://claude.ai/code/session_012WoHuh1utAZRBTDiDZ2sEk
