### PR TITLE
fix(transactions): unitName straggler — typecheck 272→0 (TASK-93)

### DIFF
--- a/src/services/transactions/index.ts
+++ b/src/services/transactions/index.ts
@@ -928,7 +928,7 @@ export class TransactionService {
                   .do();
                 const assetName =
                   assetInfo.params.name ||
-                  assetInfo.params['unit-name'] ||
+                  assetInfo.params.unitName ||
                   `Asset ${params.assetId}`;
                 errors.push(
                   `Recipient must opt-in to receive ${assetName} (Asset ID: ${params.assetId}). ` +


### PR DESCRIPTION
Final 1-line fix completing the [[PLAN-110]] typecheck burndown: `assetInfo.params['unit-name']` → `.unitName` (algosdk-3 rename; the kebab key was a dead undefined fallback). Brings `npm run typecheck` to **0 errors** on main.

https://claude.ai/code/session_012WoHuh1utAZRBTDiDZ2sEk