### PR TITLE
fix(remote-signer): airgap import uses active-network genesis + 64/32-byte key handling + key zeroing (TASK-112)

### DIFF
--- a/src/screens/remoteSigner/ImportFromOnlineWalletScreen.tsx
+++ b/src/screens/remoteSigner/ImportFromOnlineWalletScreen.tsx
@@ -38,6 +38,7 @@ import {
 } from '@/utils/arc0300';
 import { MultiAccountWalletService } from '@/services/wallet';
 import { RemoteSignerService } from '@/services/remoteSigner';
+import { getNetworkConfig } from '@/services/network/config';
 import { useCurrentNetwork } from '@/store/networkStore';
 import { useWalletStore } from '@/store/walletStore';
 import { StandardAccountMetadata, AccountType } from '@/types/wallet';
@@ -51,6 +52,17 @@ type ImportState =
   | 'complete'
   | 'error';
 
+/**
+ * Non-secret projection of the imported account, used purely for display.
+ * Deliberately excludes the 25-word `mnemonic` (and any other secret material)
+ * carried by StandardAccountMetadata so no secret is ever held in React state,
+ * dev tools, or a memory snapshot.
+ */
+type ImportedAccountSummary = {
+  label?: string;
+  address: string;
+};
+
 export default function ImportFromOnlineWalletScreen() {
   const navigation = useNavigation<any>();
   const { theme } = useTheme();
@@ -61,7 +73,7 @@ export default function ImportFromOnlineWalletScreen() {
   const [state, setState] = useState<ImportState>('disclaimer');
   const [error, setError] = useState<string | null>(null);
   const [importedAccount, setImportedAccount] =
-    useState<StandardAccountMetadata | null>(null);
+    useState<ImportedAccountSummary | null>(null);
   const [confirmationQrData, setConfirmationQrData] = useState<string | null>(
     null
   );
@@ -92,6 +104,10 @@ export default function ImportFromOnlineWalletScreen() {
     async (data: string) => {
       setState('importing');
 
+      // Hoisted so the finally block can zero the raw secret key on EVERY
+      // path (success, error, and early throw/abort), not just success.
+      let privateKeyBytes: Uint8Array | null = null;
+
       try {
         // Parse the ARC-300 URI
         const parsed = parseArc0300AccountImportUri(data);
@@ -120,19 +136,16 @@ export default function ImportFromOnlineWalletScreen() {
           throw new Error('No private key found in QR code.');
         }
 
-        // Convert base64 private key to bytes
-        // The private key is URL-safe base64, need to convert back
-        const base64Standard = entry.privateKeyBase64
-          .replace(/-/g, '+')
-          .replace(/_/g, '/');
-        // Add padding if needed
-        const paddedBase64 =
-          base64Standard + '='.repeat((4 - (base64Standard.length % 4)) % 4);
-        const privateKeyBytes = new Uint8Array(
-          Buffer.from(paddedBase64, 'base64')
-        );
+        // Normalize the scanned key to a full 64-byte Ed25519 secret key using
+        // the SAME expansion the import branch uses (normalizeBase64ToHex):
+        // 64-byte secret keys pass through as-is, 32-byte seeds are expanded to
+        // the full secret key, and any other length throws a clear error BEFORE
+        // we slice(32)/encodeAddress/signTxn. This keeps the signing path and
+        // the import path behaviorally identical.
+        const privateKeyHex = normalizeBase64ToHex(entry.privateKeyBase64);
+        privateKeyBytes = new Uint8Array(Buffer.from(privateKeyHex, 'hex'));
 
-        // Derive the address from the private key
+        // Derive the address from the private key (bytes 32..64 are the pubkey)
         const publicKeyBytes = privateKeyBytes.slice(32);
         const address = algosdk.encodeAddress(publicKeyBytes);
 
@@ -147,10 +160,8 @@ export default function ImportFromOnlineWalletScreen() {
           // Account already exists - use it instead of re-importing
           account = existingAccount as StandardAccountMetadata;
         } else {
-          // Convert base64 private key to hex for import
-          const privateKeyHex = normalizeBase64ToHex(entry.privateKeyBase64);
-
-          // Import the account
+          // Import the account (reuse the hex normalized above so the import
+          // and signing paths derive from the exact same key material)
           account = await MultiAccountWalletService.importStandardAccount({
             type: AccountType.STANDARD,
             privateKey: privateKeyHex,
@@ -161,18 +172,22 @@ export default function ImportFromOnlineWalletScreen() {
           await refresh();
         }
 
-        setImportedAccount(account);
+        // Store ONLY a non-secret projection (label + address). The full
+        // StandardAccountMetadata carries the 25-word mnemonic, which must
+        // never linger in component state / React devtools / memory snapshots.
+        setImportedAccount({ label: account.label, address: account.address });
         setState('signing');
 
-        // Build a simple verification transaction
-        // We're in airgap mode so use default/hardcoded params
-        // Using Voi mainnet genesis hash as default
-        const genesisHashBase64 =
-          'IXnoWtviVVJW5LGivNFc0Dq14V3kqaXuK2u5OQrdVZo=';
+        // Build a verification transaction using the ACTIVE network's genesis
+        // so the airgap device signs a payload for the correct chain (a stale
+        // hardcoded genesis was a wrong-chain bug). firstValid/lastValid stay
+        // 1/1000 below so this self-payment is already-expired and cannot be
+        // broadcast.
+        const netConfig = getNetworkConfig(networkId);
         const genesisHashBytes = new Uint8Array(
-          Buffer.from(genesisHashBase64, 'base64')
+          Buffer.from(netConfig.genesisHash, 'base64')
         );
-        const genesisId = 'voi-mainnet';
+        const genesisId = netConfig.genesisId;
 
         // Create a minimal verification transaction (zero-amount self-payment)
         const suggestedParams: algosdk.SuggestedParams = {
@@ -209,14 +224,15 @@ export default function ImportFromOnlineWalletScreen() {
         const payload = RemoteSignerService.encodePayload(response);
         setConfirmationQrData(payload);
         setState('displaying_confirmation');
-
-        // Zero out the private key from memory
-        privateKeyBytes.fill(0);
       } catch (err) {
         const message =
           err instanceof Error ? err.message : 'Failed to import account';
         setError(message);
         setState('error');
+      } finally {
+        // Zero the raw secret key on EVERY path (success, error, early throw)
+        // so it never lingers in memory after this handler returns.
+        privateKeyBytes?.fill(0);
       }
     },
     [networkId]

--- a/src/screens/remoteSigner/SignatureDisplayScreen.tsx
+++ b/src/screens/remoteSigner/SignatureDisplayScreen.tsx
@@ -148,12 +148,15 @@ export default function SignatureDisplayScreen() {
             );
           }
 
-          // Sign the transaction
-          const signedTxn = txn.signTxn(privateKey);
-          signedTxns.push(signedTxn);
-
-          // Clear private key from memory
-          privateKey.fill(0);
+          try {
+            // Sign the transaction
+            const signedTxn = txn.signTxn(privateKey);
+            signedTxns.push(signedTxn);
+          } finally {
+            // Zero the raw secret key on EVERY path (success OR a signing
+            // error), so it is never left lingering in memory.
+            privateKey.fill(0);
+          }
         }
 
         // Create success response

--- a/src/services/network/__tests__/config.test.ts
+++ b/src/services/network/__tests__/config.test.ts
@@ -1,0 +1,63 @@
+import { Buffer } from 'buffer';
+import { NetworkId } from '@/types/network';
+import { NETWORK_CONFIGURATIONS, getNetworkConfig } from '../config';
+
+// Genesis identity is what the airgap signer stamps onto the payload it signs.
+// A wrong/stale value = a wrong-chain signed transaction, so these constants are
+// pinned here as a regression guard: they are VERIFIED-AGAINST-LIVE-NODES and
+// must not drift. (See ImportFromOnlineWalletScreen, which sources genesis from
+// the active network's config rather than a hardcoded literal.)
+const EXPECTED = {
+  [NetworkId.VOI_MAINNET]: {
+    genesisId: 'voimain-v1.0',
+    genesisHash: 'r20fSQI8gWe/kFZziNonSPCXLwcQmH/nxROvnnueWOk=',
+  },
+  [NetworkId.ALGORAND_MAINNET]: {
+    genesisId: 'mainnet-v1.0',
+    genesisHash: 'wGHE2Pwdvd7S12BL5FaOP20EGYesN73ktiC1qzkkit8=',
+  },
+} as const;
+
+describe('network config genesis identity', () => {
+  for (const networkId of Object.values(NetworkId)) {
+    const expected = EXPECTED[networkId];
+
+    describe(networkId, () => {
+      it('exposes the exact verified genesisId and genesisHash', () => {
+        const config = getNetworkConfig(networkId);
+        expect(config.genesisId).toBe(expected.genesisId);
+        expect(config.genesisHash).toBe(expected.genesisHash);
+      });
+
+      it('genesisHash base64-decodes to exactly 32 bytes', () => {
+        const bytes = Buffer.from(
+          getNetworkConfig(networkId).genesisHash,
+          'base64'
+        );
+        expect(bytes.length).toBe(32);
+      });
+
+      it('genesisHash is not the truncated 24-byte CAIP-2 chainId ref', () => {
+        // The WalletConnect chainId carries a URL-safe, 24-byte-truncated
+        // genesis ref (algorand:<ref>). It must never be used as the genesis
+        // hash the raw key signs over.
+        const config = getNetworkConfig(networkId);
+        const chainRef = config.chainId.split(':')[1];
+        const chainRefBytes = Buffer.from(
+          chainRef.replace(/-/g, '+').replace(/_/g, '/'),
+          'base64'
+        );
+        expect(chainRefBytes.length).toBeLessThan(32);
+      });
+    });
+  }
+
+  it('every configured network has genesis identity populated', () => {
+    for (const config of Object.values(NETWORK_CONFIGURATIONS)) {
+      expect(typeof config.genesisId).toBe('string');
+      expect(config.genesisId.length).toBeGreaterThan(0);
+      expect(typeof config.genesisHash).toBe('string');
+      expect(Buffer.from(config.genesisHash, 'base64').length).toBe(32);
+    }
+  });
+});

--- a/src/services/network/config.ts
+++ b/src/services/network/config.ts
@@ -30,6 +30,10 @@ export const NETWORK_CONFIGURATIONS: Record<NetworkId, NetworkConfiguration> = {
     // WalletConnect configuration
     chainId: 'algorand:r20fSQI8gWe_kFZziNonSPCXLwcQmH_n',
 
+    // Chain identity (verified against live nodes)
+    genesisId: 'voimain-v1.0',
+    genesisHash: 'r20fSQI8gWe/kFZziNonSPCXLwcQmH/nxROvnnueWOk=',
+
     // Available features
     features: {
       mimir: true,
@@ -66,6 +70,10 @@ export const NETWORK_CONFIGURATIONS: Record<NetworkId, NetworkConfiguration> = {
 
     // WalletConnect configuration
     chainId: 'algorand:wGHE2Pwdvd7S12BL5FaOP20EGYesN73k',
+
+    // Chain identity (verified against live nodes)
+    genesisId: 'mainnet-v1.0',
+    genesisHash: 'wGHE2Pwdvd7S12BL5FaOP20EGYesN73ktiC1qzkkit8=',
 
     // Limited features compared to Voi
     features: {

--- a/src/types/network.ts
+++ b/src/types/network.ts
@@ -62,6 +62,12 @@ export interface NetworkConfiguration {
   /** WalletConnect chain identifier */
   chainId: string;
 
+  // Chain identity (used for airgap/offline transaction construction)
+  /** Genesis ID of the network (e.g., 'voimain-v1.0') */
+  genesisId: string;
+  /** Base64-encoded genesis hash of the network */
+  genesisHash: string;
+
   // Feature flags
   /** Available features on this network */
   features: NetworkFeatures;


### PR DESCRIPTION
## Summary (TASK-112 — security hardening)

Fixes a **wrong-chain bug** and hardens key hygiene in the airgap remote-signer import flow.

### SITE A — genesis from the active network (wrong-chain fix)
The airgap import verification self-payment was signed against a **stale, hardcoded Voi-TESTNET genesis** (`IXnoWtviVVJW...`). It now sources `genesisId`/`genesisHash` from the active network config:
- Added `genesisId` + base64 `genesisHash` to `NetworkConfiguration` and populated both networks with VERIFIED-AGAINST-LIVE-NODES constants (Voi `voimain-v1.0` / `r20fSQI8gWe/kFZziNonSPCXLwcQmH/nxROvnnueWOk=`, Algorand `mainnet-v1.0` / `wGHE2Pwdvd7S12BL5FaOP20EGYesN73ktiC1qzkkit8=`). Codex verified both against official network docs.
- `firstValid`/`lastValid` stay `1`/`1000` so the self-payment remains already-expired and non-broadcastable.

### SITE B — 64/32-byte key handling
The signing path now normalizes the scanned key via `normalizeBase64ToHex` (the same helper the import path uses): 64-byte secret keys pass through, 32-byte seeds expand to the full Ed25519 secret key, and any other length throws a clear error **before** `slice(32)`/`encodeAddress`/`signTxn`. Both branches now derive from identical key material.

### SITE C — key zeroing on all paths
Raw secret key bytes are hoisted and zeroed in a `finally` so they are wiped on success, error, and early-throw paths — in both `ImportFromOnlineWalletScreen` and `SignatureDisplayScreen`'s signing loop (previously cleared only on success).

### Additional key-hygiene fix (from Codex review)
`ImportFromOnlineWalletScreen` now stores only a non-secret `{label, address}` projection in React state instead of the full `StandardAccountMetadata`, which carries the 25-word `mnemonic`.

### Behavior note
`verifySignedTransaction` is genesis-agnostic, so end-to-end airgap verification is **behavior-preserving** on both networks; this only corrects the on-chain genesis bytes the raw key signs and hardens key zeroing/length handling.

### Out of scope (pre-existing, non-owned files — flagged for follow-up)
- General remote-signer flow does not validate an incoming transaction's genesis against the active network (`remoteSignerStore.ts`).
- `AccountSecureStorage`'s plaintext key cache is not cleared after signing.

### Gates
- typecheck: **0** errors
- lint: no new errors on touched files
- tests: **232 passed** (added `src/services/network/__tests__/config.test.ts`, +7)
- Codex crypto review: **CLEAN**

**NEEDS DEVICE VERIFICATION** — airgap import/sign flow exercised via types/tests only, not on-device.

https://claude.ai/code/session_012WoHuh1utAZRBTDiDZ2sEk