### PR TITLE
fix(wallet): strip restored mnemonic from general storage + reject pubkey-mismatched keys + error narrowing (TASK-111, TASK-124)

### DIFF
--- a/src/services/backup/restorers.ts
+++ b/src/services/backup/restorers.ts
@@ -201,7 +201,11 @@ export async function restoreAccounts(accounts: BackupAccountData[]): Promise<{
             importedAt: backupAccount.importedAt,
             lastUsed: new Date().toISOString(),
             avatarUrl: backupAccount.avatarUrl,
-            mnemonic: backupAccount.mnemonic,
+            // TASK-111: Never persist the 25-word mnemonic to general storage.
+            // The secret key is passed separately to storeAccount() below
+            // (expo-secure-store); getMnemonic() re-derives the phrase from the
+            // sk on demand, so Show-Recovery-Phrase still works.
+            mnemonic: '',
             derivationPath: backupAccount.derivationPath,
             hasBackup: backupAccount.hasBackup || true, // Restored = backed up
           };
@@ -367,8 +371,11 @@ export async function restoreAccounts(accounts: BackupAccountData[]): Promise<{
         },
       };
 
-      // Store wallet metadata
-      await storage.setItem(STORAGE_KEYS.WALLET_KEY, JSON.stringify(wallet));
+      // Store wallet metadata.
+      // TASK-111: route through the sanitizing wrapper instead of a raw
+      // storage.setItem so any per-account mnemonic is stripped before
+      // persistence and legacy secure-store copies are cleared.
+      await MultiAccountWalletService.persistRestoredWallet(wallet);
     }
 
     return counts;

--- a/src/services/secure/AccountSecureStorage.ts
+++ b/src/services/secure/AccountSecureStorage.ts
@@ -607,7 +607,7 @@ export class AccountSecureStorage {
       return `${saltHex}:${ivHex}:${encrypted.toString()}:${hmac}`;
     } catch (error) {
       throw new AccountStorageError(
-        `Failed to encrypt private key: ${error instanceof Error ? error.message : String(error)}`
+        `Failed to encrypt private key: ${error instanceof Error ? error.message : 'Unknown error'}`
       );
     } finally {
       // Clear sensitive data from memory
@@ -671,7 +671,7 @@ export class AccountSecureStorage {
       return new Uint8Array(Buffer.from(privateKeyHex, 'hex'));
     } catch (error) {
       throw new AccountStorageError(
-        `Failed to decrypt private key: ${error instanceof Error ? error.message : String(error)}`
+        `Failed to decrypt private key: ${error instanceof Error ? error.message : 'Unknown error'}`
       );
     } finally {
       // Clear sensitive data from memory
@@ -734,7 +734,7 @@ export class AccountSecureStorage {
       return new Uint8Array(Buffer.from(privateKeyHex, 'hex'));
     } catch (error) {
       throw new AccountStorageError(
-        `Failed to decrypt private key: ${error instanceof Error ? error.message : String(error)}`
+        `Failed to decrypt private key: ${error instanceof Error ? error.message : 'Unknown error'}`
       );
     } finally {
       if (keyMaterial) {
@@ -767,7 +767,7 @@ export class AccountSecureStorage {
       return key;
     } catch (error) {
       throw new AccountStorageError(
-        `Failed to derive encryption key: ${error instanceof Error ? error.message : String(error)}`
+        `Failed to derive encryption key: ${error instanceof Error ? error.message : 'Unknown error'}`
       );
     }
   }
@@ -792,7 +792,7 @@ export class AccountSecureStorage {
       return key;
     } catch (error) {
       throw new AccountStorageError(
-        `Failed to derive encryption key: ${error instanceof Error ? error.message : String(error)}`
+        `Failed to derive encryption key: ${error instanceof Error ? error.message : 'Unknown error'}`
       );
     }
   }

--- a/src/services/wallet/__tests__/importFromPrivateKey.test.ts
+++ b/src/services/wallet/__tests__/importFromPrivateKey.test.ts
@@ -1,0 +1,104 @@
+// Unit tests for TASK-124: MultiAccountWalletService.importFromPrivateKey and
+// the shared validateAndParseSecretKey helper it delegates to.
+//
+// SECURITY NOTE: no static/committed secret material is used. Every key here is
+// generated fresh in-process by algosdk (ephemeral, throwaway). The test's whole
+// point is the crypto invariant that an Algorand secret key is seed(32) ||
+// publicKey(32) and that a key whose appended public key no longer matches the
+// seed MUST be rejected rather than silently imported at the wrong address.
+//
+// We exercise the public importFromPrivateKey (used by the QR-preview path via
+// accountQRParser), which shares validateAndParseSecretKey with the real import
+// path (parsePrivateKey), so both stay in sync.
+
+// Mock the heavy/native side of the wallet dependency graph. importFromPrivateKey
+// only uses algosdk, so these mocks keep the import lightweight without touching
+// the code under test. (The Ledger transport pulls in untranspilable native ESM.)
+jest.mock('@/services/ledger/transport', () => ({
+  ledgerTransportService: {},
+}));
+jest.mock('@/services/ledger/algorand', () => ({
+  ledgerAlgorandService: {},
+}));
+jest.mock('@/services/network', () => ({
+  NetworkService: {},
+}));
+jest.mock('../../secure/AccountSecureStorage', () => ({
+  AccountSecureStorage: {},
+}));
+
+import algosdk from 'algosdk';
+import { Buffer } from 'buffer';
+import { MultiAccountWalletService } from '../index';
+
+function skToHex(sk: Uint8Array): string {
+  return Buffer.from(sk).toString('hex');
+}
+
+describe('MultiAccountWalletService.importFromPrivateKey (TASK-124)', () => {
+  it('accepts a freshly generated, well-formed key and returns its address', () => {
+    const account = algosdk.generateAccount();
+    const hex = skToHex(account.sk);
+
+    const result = MultiAccountWalletService.importFromPrivateKey(hex);
+
+    expect(result.address).toBe(account.addr.toString());
+    expect(Buffer.from(result.publicKey).toString('hex')).toBe(
+      skToHex(account.sk.slice(32))
+    );
+  });
+
+  it('accepts a valid key with a 0x prefix and surrounding whitespace', () => {
+    const account = algosdk.generateAccount();
+    const hex = `  0x${skToHex(account.sk)}  `;
+
+    const result = MultiAccountWalletService.importFromPrivateKey(hex);
+
+    expect(result.address).toBe(account.addr.toString());
+  });
+
+  it('round-trips a mnemonic-exported key unchanged (Pera/algosdk compatibility)', () => {
+    const account = algosdk.generateAccount();
+    const mnemonic = algosdk.secretKeyToMnemonic(account.sk);
+    const reDerived = algosdk.mnemonicToSecretKey(mnemonic);
+
+    const result = MultiAccountWalletService.importFromPrivateKey(
+      skToHex(reDerived.sk)
+    );
+
+    expect(result.address).toBe(account.addr.toString());
+  });
+
+  it('rejects a key whose appended public key was byte-flipped (pubkey/seed mismatch)', () => {
+    const account = algosdk.generateAccount();
+    const corrupted = Uint8Array.from(account.sk);
+    // Flip a bit in the appended public-key half (last 32 bytes) so it no longer
+    // matches the seed. The seed (first 32 bytes) is untouched.
+    corrupted[40] ^= 0xff;
+
+    expect(() =>
+      MultiAccountWalletService.importFromPrivateKey(skToHex(corrupted))
+    ).toThrow('public key does not match the seed');
+  });
+
+  it('rejects a non-hex key', () => {
+    expect(() =>
+      MultiAccountWalletService.importFromPrivateKey('z'.repeat(128))
+    ).toThrow('must be hexadecimal');
+  });
+
+  it('rejects a key of the wrong length', () => {
+    const account = algosdk.generateAccount();
+    const shortHex = skToHex(account.sk).slice(0, 126);
+
+    expect(() =>
+      MultiAccountWalletService.importFromPrivateKey(shortHex)
+    ).toThrow('128 hex characters');
+  });
+
+  it('rejects an empty key', () => {
+    expect(() => MultiAccountWalletService.importFromPrivateKey('')).toThrow(
+      'non-empty string'
+    );
+  });
+});

--- a/src/services/wallet/index.ts
+++ b/src/services/wallet/index.ts
@@ -1009,41 +1009,19 @@ export class MultiAccountWalletService {
   }
 
   static importFromPrivateKey(privateKeyHex: string): WalletAccount {
-    if (!privateKeyHex || typeof privateKeyHex !== 'string') {
-      throw new Error('Private key must be a non-empty string');
-    }
+    // TASK-124: Share the same validate-and-parse helper as the real import
+    // path (parsePrivateKey) so the QR preview address and the account that is
+    // actually imported stay in sync, and a pubkey-mismatched key is rejected
+    // identically in both places.
+    const privateKey = this.validateAndParseSecretKey(privateKeyHex);
+    const publicKey = privateKey.slice(32);
+    const address = algosdk.encodeAddress(publicKey);
 
-    const cleanHex = privateKeyHex.trim().replace(/^0x/i, '');
-
-    if (!/^[0-9a-fA-F]+$/.test(cleanHex)) {
-      throw new Error('Invalid private key: must be hexadecimal format');
-    }
-
-    if (cleanHex.length !== 128) {
-      throw new Error(
-        'Invalid private key: must be 64 bytes (128 hex characters)'
-      );
-    }
-
-    try {
-      const privateKey = new Uint8Array(
-        cleanHex.match(/.{1,2}/g)!.map((byte) => parseInt(byte, 16))
-      );
-
-      const publicKey = privateKey.slice(32);
-      const address = algosdk.encodeAddress(publicKey);
-
-      return {
-        address,
-        publicKey,
-        // privateKey removed - will be handled by SecureKeyManager
-      };
-    } catch (error) {
-      throw new Error(
-        'Failed to parse private key: ' +
-          (error instanceof Error ? error.message : 'Unknown error')
-      );
-    }
+    return {
+      address,
+      publicKey,
+      // privateKey removed - will be handled by SecureKeyManager
+    };
   }
 
   static validateAddress(address: string): boolean {
@@ -1169,7 +1147,28 @@ export class MultiAccountWalletService {
       .join(' ');
   }
 
-  private static parsePrivateKey(privateKeyHex: string): Uint8Array {
+  /**
+   * TASK-124: Parse a hex-encoded 64-byte Algorand secret key and verify that
+   * its appended public key actually matches the seed.
+   *
+   * An Algorand `sk` is `seed(32) || publicKey(32)`. A corrupted or hand-edited
+   * key whose trailing 32 bytes no longer correspond to the seed would be
+   * imported at one address (derived from the appended pubkey) yet sign for a
+   * different address (derived from the seed), silently producing an
+   * unrecoverable account. We reject on mismatch instead.
+   *
+   * The check uses the algosdk round-trip `sk -> mnemonic -> sk`, which rebuilds
+   * the sk from the seed alone, then compares the seed-derived address to the
+   * address encoded from the appended pubkey. Public keys are not secret, so a
+   * plain string comparison is fine (no constant-time compare needed). Every
+   * legitimately generated key (algosdk / Pera / mnemonic export) round-trips
+   * unchanged; only mismatched keys are rejected.
+   */
+  private static validateAndParseSecretKey(privateKeyHex: string): Uint8Array {
+    if (!privateKeyHex || typeof privateKeyHex !== 'string') {
+      throw new Error('Private key must be a non-empty string');
+    }
+
     const cleanHex = privateKeyHex.trim().replace(/^0x/i, '');
 
     if (!/^[0-9a-fA-F]+$/.test(cleanHex)) {
@@ -1182,9 +1181,26 @@ export class MultiAccountWalletService {
       );
     }
 
-    return new Uint8Array(
+    const sk = new Uint8Array(
       cleanHex.match(/.{1,2}/g)!.map((byte) => parseInt(byte, 16))
     );
+
+    // Reject keys whose appended public key does not match the seed.
+    const seedAddr = algosdk
+      .mnemonicToSecretKey(algosdk.secretKeyToMnemonic(sk))
+      .addr.toString();
+    const appendedAddr = algosdk.encodeAddress(sk.slice(32));
+    if (seedAddr !== appendedAddr) {
+      throw new Error(
+        'Invalid private key: public key does not match the seed'
+      );
+    }
+
+    return sk;
+  }
+
+  private static parsePrivateKey(privateKeyHex: string): Uint8Array {
+    return this.validateAndParseSecretKey(privateKeyHex);
   }
 
   // Public so auth-account-discovery can reuse the same lookup/dedup logic.

--- a/src/services/wallet/index.ts
+++ b/src/services/wallet/index.ts
@@ -1358,6 +1358,18 @@ export class MultiAccountWalletService {
     await this.storeValue(this.WALLET_KEY, JSON.stringify(persistencePayload));
   }
 
+  /**
+   * TASK-111: Public wrapper used by the backup/restore flow to persist a
+   * restored wallet through the same sanitizing path as every other write.
+   * Delegates to the private storeWallet(), which strips per-account mnemonics
+   * via sanitizeWalletForPersistence() and clears any legacy secure-store copy.
+   * Restore code MUST use this instead of a raw storage.setItem so a restored
+   * wallet can never leak a mnemonic into general storage.
+   */
+  static async persistRestoredWallet(wallet: Wallet): Promise<void> {
+    await this.storeWallet(wallet);
+  }
+
   private static getDefaultWalletSettings(): WalletSettings {
     return {
       theme: 'system',


### PR DESCRIPTION
## Summary

Two wallet-security hardening tasks (two commits), scoped to `src/services/backup/restorers.ts`, `src/services/wallet/index.ts`, and `src/services/secure/AccountSecureStorage.ts`.

### TASK-111 — restored mnemonic no longer persisted to general storage
- `restorers.ts`: the restored `StandardAccountMetadata.mnemonic` is set to `''`. The secret key is still stored via `AccountSecureStorage.storeAccount` (expo-secure-store), and `getMnemonic()` re-derives the 25-word phrase from the sk on demand, so **Show-Recovery-Phrase still works**.
- `restorers.ts`: the raw `storage.setItem(WALLET_KEY, ...)` that bypassed the sanitizer is replaced with a new `MultiAccountWalletService.persistRestoredWallet()` wrapper that routes through the private `storeWallet()` -> `sanitizeWalletForPersistence()` (strips per-account mnemonics, clears legacy secure-store copies). Confirmed this was the only raw general-storage wallet write carrying a mnemonic.

### TASK-124 — reject pubkey-mismatched keys + error narrowing
- `wallet/index.ts`: new shared private `validateAndParseSecretKey()` builds the 64-byte key (128 hex chars, tolerates a `0x` prefix / whitespace) and verifies the appended public key matches the seed via the algosdk-3 round-trip `sk -> mnemonic -> sk`, rejecting on mismatch. Public keys are not secret, so a plain string compare is used (no constant-time compare needed). Every legitimately generated key (algosdk / Pera / mnemonic export) round-trips unchanged; only corrupted/mismatched keys are rejected.
- Reused in BOTH `parsePrivateKey` (real import path) AND `importFromPrivateKey` (legacy QR-preview path via `accountQRParser`) so the preview address and the real import stay in sync.
- `AccountSecureStorage.ts`: narrowed the 5 remaining `String(error)` else-branches to `'Unknown error'` (P5e pattern) — pure hardening, unchanged for real Error throws; none interpolate secret material.
- Added `importFromPrivateKey` unit tests: a byte-flipped (mismatched) key is rejected while valid / `0x`-prefixed / mnemonic-round-tripped keys parse.

## Gates
- `typecheck`: 0 errors
- `npm test -- --ci`: 232 passed (10 suites; +7 new tests)
- `lint`: 0 new errors on touched files
- Codex crypto review: CLEAN (round 2; independently verified the round-trip discriminates valid vs. byte-flipped keys)

Security hardening; behavior-preserving except the intended hardening. **NEEDS DEVICE VERIFICATION** (restore flow + QR key import on a real device).

> Note for follow-up / other agent: Codex flagged (out of scope here) that transaction-signing paths in `remoteSigner/index.ts` and `walletconnect/index.ts` do not validate `genesisHash` against the selected/session network before signing — a pre-existing wrong-chain-signature gap unrelated to this diff, owned by the network-config agent.

https://claude.ai/code/session_012WoHuh1utAZRBTDiDZ2sEk