### PR TITLE
chore(ci): gate typecheck + add Dependabot (TASK-67)

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,24 @@
+version: 2
+updates:
+  # npm dependencies — aligns with CLAUDE.md's "always use latest stable versions".
+  # Minor + patch bumps are grouped into a single weekly PR to cut noise; majors
+  # (and any security fix) open their own PR so they get a deliberate review — this
+  # is a self-custody wallet, so dependency changes to crypto/signing paths warrant it.
+  - package-ecosystem: npm
+    directory: "/"
+    schedule:
+      interval: weekly
+      day: monday
+    open-pull-requests-limit: 10
+    groups:
+      minor-and-patch:
+        update-types:
+          - minor
+          - patch
+
+  # Keep the GitHub Actions used by ci.yml current.
+  - package-ecosystem: github-actions
+    directory: "/"
+    schedule:
+      interval: weekly
+      day: monday

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -31,6 +31,21 @@ jobs:
       - name: Unit tests
         run: npm test -- --ci
 
-      # NOTE: `npm run typecheck` is intentionally NOT gated yet — there is a
-      # large pre-existing tsc backlog (see TASK-93). Add it here once that is
-      # burned down so a green typecheck becomes a required check too.
+  typecheck:
+    name: Typecheck
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+
+      - uses: actions/setup-node@v4
+        with:
+          node-version: 20
+          cache: npm
+
+      - name: Install dependencies
+        run: npm ci
+
+      # tsc --noEmit over the whole project. The backlog (TASK-93 / PLAN-110) is
+      # burned down and main is green (0 errors), so this is now a hard gate.
+      - name: Typecheck
+        run: npm run typecheck


### PR DESCRIPTION
Completes the remaining scope of TASK-67 / D-02 (the test-runner + CI foundation was delivered by PLAN-99).

- **Typecheck job** added to CI — the tsc backlog is burned down (272→0 via PLAN-110) and `main` is green, so a red typecheck now fails CI.
- **Dependabot** (`.github/dependabot.yml`): weekly npm (grouped minor/patch, majors separate) + github-actions updates.

Follow-ups (not in this PR): enabling branch protection to *require* these checks; remediating the 42 pre-existing prod `npm audit` vulns (1 critical / 13 high) — a separate dependency-bump task that needs its own verification.

https://claude.ai/code/session_012WoHuh1utAZRBTDiDZ2sEk