### PR TITLE
fix(ui): enforce 44pt minimum touch targets on icon-only buttons (TASK-37)

### DIFF
--- a/src/screens/wallet/SendScreen.tsx
+++ b/src/screens/wallet/SendScreen.tsx
@@ -1883,6 +1883,7 @@ export default function SendScreen() {
                 <TouchableOpacity
                   onPress={() => setShowAssetSelector(false)}
                   style={styles.modalCloseButton}
+                  hitSlop={{ top: 10, bottom: 10, left: 10, right: 10 }}
                 >
                   <Ionicons
                     name="close"
@@ -2073,7 +2074,8 @@ const createStyles = (theme: Theme) =>
           : 'rgba(255, 255, 255, 0.3)',
       borderRadius: theme.borderRadius.sm,
       padding: theme.spacing.md,
-      paddingRight: 100, // Make room for both buttons
+      // Room for the absolute button cluster: right:16 + (44 + 4)*2 = 112.
+      paddingRight: 112,
       fontSize: 16,
       borderWidth: 1,
       borderColor:
@@ -2090,6 +2092,10 @@ const createStyles = (theme: Theme) =>
       alignItems: 'center',
     },
     inputButton: {
+      // 44x44 minimum touch target (contacts + QR buttons sit side by side, so
+      // a real min-size beats hitSlop, which would overlap across the 4pt gap).
+      minWidth: 44,
+      minHeight: 44,
       padding: theme.spacing.xs,
       marginLeft: theme.spacing.xs,
       justifyContent: 'center',

--- a/src/screens/wallet/TransactionHistoryScreen.tsx
+++ b/src/screens/wallet/TransactionHistoryScreen.tsx
@@ -268,6 +268,7 @@ export default function TransactionHistoryScreen() {
           <TouchableOpacity
             style={styles.backButton}
             onPress={() => navigation.goBack()}
+            hitSlop={{ top: 10, bottom: 10, left: 10, right: 10 }}
           >
             <Ionicons
               name="arrow-back"


### PR DESCRIPTION
## What

Icon-only action buttons used `padding: theme.spacing.xs` (4) around a 22–24pt icon, yielding ~30–32pt touch targets — below the 44pt iOS/Android minimum. On the Send screen (recipient entry) mis-taps are costly.

## Change

- **SendScreen `inputButton`** (contacts + QR-scan): `minWidth/minHeight: 44`. These two buttons sit side by side with a 4pt gap, so a real min-size is correct — `hitSlop` would overlap across the gap and cause ambiguous taps.
- **SendScreen `textInputWithButtonInContainer`**: `paddingRight` 100 → **112**. The absolute button cluster (`right:16` + two 44pt buttons w/ 4pt margins) now spans 112pt from the edge, so the input's reserved padding is widened to match and keep trailing text clear of the buttons. *(Caught by Codex review.)*
- **SendScreen `modalCloseButton`** and **TransactionHistoryScreen `backButton`**: `hitSlop={{10,10,10,10}}` (matching the existing `UniversalHeader` pattern). Standalone buttons → hitSlop expands the touch area to ~52pt with no visual/layout change.

## Scope / risk

- **JS-only** — ships over-the-air.
- No crypto/key/signing/auth surface.
- Targets: mobile + extension/web (shared screens).

## Gates

- `npm run typecheck` — clean
- `npm run lint` — 0 errors (unchanged 689-warning baseline)
- `npm test -- --ci` — 239/239 pass
- Codex review — **CLEAN** (after fixing the paddingRight overlap it flagged)

## Verification note

On-device tap-target verification delegated to the maintainer per the run's agreed merge policy.

Resolves U-08 · TASK-37 · part of PLAN-11 (Voi Wallet Audit: Quick Wins).

https://claude.ai/code/session_012WoHuh1utAZRBTDiDZ2sEk