### PR TITLE
feat(ux): add haptic feedback to buttons and transaction results (TASK-38)

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -43,6 +43,7 @@
         "expo-device": "~8.0.10",
         "expo-document-picker": "~14.0.8",
         "expo-file-system": "~19.0.19",
+        "expo-haptics": "~15.0.8",
         "expo-linear-gradient": "~15.0.8",
         "expo-local-authentication": "~17.0.8",
         "expo-notifications": "~0.32.15",
@@ -9919,6 +9920,15 @@
         "expo": "*",
         "react": "*",
         "react-native": "*"
+      }
+    },
+    "node_modules/expo-haptics": {
+      "version": "15.0.8",
+      "resolved": "https://registry.npmjs.org/expo-haptics/-/expo-haptics-15.0.8.tgz",
+      "integrity": "sha512-lftutojy8Qs8zaDzzjwM3gKHFZ8bOOEZDCkmh2Ddpe95Ra6kt2izeOfOfKuP/QEh0MZ1j9TfqippyHdRd1ZM9g==",
+      "license": "MIT",
+      "peerDependencies": {
+        "expo": "*"
       }
     },
     "node_modules/expo-json-utils": {

--- a/package.json
+++ b/package.json
@@ -54,6 +54,7 @@
     "expo-device": "~8.0.10",
     "expo-document-picker": "~14.0.8",
     "expo-file-system": "~19.0.19",
+    "expo-haptics": "~15.0.8",
     "expo-linear-gradient": "~15.0.8",
     "expo-local-authentication": "~17.0.8",
     "expo-notifications": "~0.32.15",

--- a/src/components/common/GlassButton.tsx
+++ b/src/components/common/GlassButton.tsx
@@ -29,6 +29,7 @@ import Animated, {
 import { useTheme } from '@/contexts/ThemeContext';
 import { SafeBlurView } from './SafeBlurView';
 import { springConfigs, timingConfigs } from '@/utils/animations';
+import { hapticImpact } from '@/utils/haptics';
 
 export type ButtonVariant = 'primary' | 'secondary' | 'ghost' | 'danger';
 export type ButtonSize = 'sm' | 'md' | 'lg';
@@ -239,6 +240,9 @@ export const GlassButton: React.FC<GlassButtonProps> = ({
 
   const handlePress = useCallback(() => {
     if (disabled || loading) return;
+    // Light tactile confirmation on every primary/secondary/ghost/danger press;
+    // wiring it here propagates haptics to buttons app-wide. Fire-and-forget.
+    hapticImpact('light');
     onPress();
   }, [disabled, loading, onPress]);
 

--- a/src/screens/wallet/TransactionResultScreen.tsx
+++ b/src/screens/wallet/TransactionResultScreen.tsx
@@ -1,4 +1,4 @@
-import React from 'react';
+import React, { useEffect } from 'react';
 import {
   View,
   Text,
@@ -17,6 +17,7 @@ import UniversalHeader from '@/components/common/UniversalHeader';
 import { WalletStackParamList } from '@/navigation/AppNavigator';
 import { copyToClipboard } from '@/utils/clipboard';
 import { getTransactionUrl } from '@/utils/blockExplorer';
+import { hapticNotify } from '@/utils/haptics';
 import { NetworkId } from '@/types/network';
 import { useThemedStyles } from '@/hooks/useThemedStyles';
 import { Theme } from '@/constants/themes';
@@ -58,6 +59,14 @@ export default function TransactionResultScreen() {
   const params = route.params as TransactionResultParams;
   const styles = useThemedStyles(createStyles);
   const { theme } = useTheme();
+
+  // One-time outcome haptic on mount, matching the screen's success/failure UI
+  // (params.isSuccess drives the icon/title/color below). Fire-and-forget.
+  useEffect(() => {
+    hapticNotify(params.isSuccess ? 'success' : 'error');
+    // Result params are fixed for a given screen instance; fire once on mount.
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, []);
 
   const handleViewInExplorer = async () => {
     if (!params.transactionId) return;

--- a/src/utils/__tests__/haptics.test.ts
+++ b/src/utils/__tests__/haptics.test.ts
@@ -1,0 +1,70 @@
+import * as Haptics from 'expo-haptics';
+import { hapticImpact, hapticNotify, hapticSelection } from '../haptics';
+
+jest.mock('expo-haptics', () => ({
+  ImpactFeedbackStyle: { Light: 'light', Medium: 'medium', Heavy: 'heavy' },
+  NotificationFeedbackType: {
+    Success: 'success',
+    Warning: 'warning',
+    Error: 'error',
+  },
+  impactAsync: jest.fn(() => Promise.resolve()),
+  notificationAsync: jest.fn(() => Promise.resolve()),
+  selectionAsync: jest.fn(() => Promise.resolve()),
+}));
+
+// jest-expo defaults Platform.OS to 'ios', so the platform guard is satisfied.
+
+describe('haptics', () => {
+  describe('hapticImpact', () => {
+    it('defaults to a light impact', () => {
+      hapticImpact();
+      expect(Haptics.impactAsync).toHaveBeenCalledWith('light');
+    });
+
+    it('maps each style to the expo constant', () => {
+      hapticImpact('medium');
+      expect(Haptics.impactAsync).toHaveBeenCalledWith('medium');
+      hapticImpact('heavy');
+      expect(Haptics.impactAsync).toHaveBeenCalledWith('heavy');
+    });
+  });
+
+  describe('hapticNotify', () => {
+    it('maps each type to the expo constant', () => {
+      hapticNotify('success');
+      expect(Haptics.notificationAsync).toHaveBeenCalledWith('success');
+      hapticNotify('warning');
+      expect(Haptics.notificationAsync).toHaveBeenCalledWith('warning');
+      hapticNotify('error');
+      expect(Haptics.notificationAsync).toHaveBeenCalledWith('error');
+    });
+  });
+
+  describe('hapticSelection', () => {
+    it('triggers a selection tick', () => {
+      hapticSelection();
+      expect(Haptics.selectionAsync).toHaveBeenCalledTimes(1);
+    });
+  });
+
+  it('swallows rejections (fire-and-forget, never throws)', async () => {
+    (Haptics.impactAsync as jest.Mock).mockRejectedValueOnce(
+      new Error('no haptic engine')
+    );
+    (Haptics.notificationAsync as jest.Mock).mockRejectedValueOnce(
+      new Error('no haptic engine')
+    );
+    (Haptics.selectionAsync as jest.Mock).mockRejectedValueOnce(
+      new Error('no haptic engine')
+    );
+    expect(() => {
+      hapticImpact();
+      hapticNotify('error');
+      hapticSelection();
+    }).not.toThrow();
+    // Let the rejected promises settle to prove the .catch() handles them
+    // (an unhandled rejection would fail the test run).
+    await new Promise((resolve) => setImmediate(resolve));
+  });
+});

--- a/src/utils/haptics.ts
+++ b/src/utils/haptics.ts
@@ -1,0 +1,48 @@
+/**
+ * Thin, safe wrapper around expo-haptics.
+ *
+ * Every call is fire-and-forget: haptics are cosmetic feedback and must never
+ * surface an error to the user. The native module rejects on hardware without a
+ * haptic engine and is unavailable on the web/extension target, so we guard on
+ * platform and swallow any rejection. Centralizing the calls here also keeps the
+ * ImpactFeedbackStyle / NotificationFeedbackType mapping in one place.
+ */
+import * as Haptics from 'expo-haptics';
+import { Platform } from 'react-native';
+
+// Only iOS and Android have a haptic engine; react-native-web (extension/web
+// target) does not, so no-op there rather than importing native behavior.
+const isSupported = Platform.OS === 'ios' || Platform.OS === 'android';
+
+export type HapticImpactStyle = 'light' | 'medium' | 'heavy';
+export type HapticNotifyType = 'success' | 'warning' | 'error';
+
+/** Light/medium/heavy tap — use for button presses and discrete selections. */
+export function hapticImpact(style: HapticImpactStyle = 'light'): void {
+  if (!isSupported) return;
+  const impactStyle =
+    style === 'heavy'
+      ? Haptics.ImpactFeedbackStyle.Heavy
+      : style === 'medium'
+        ? Haptics.ImpactFeedbackStyle.Medium
+        : Haptics.ImpactFeedbackStyle.Light;
+  Haptics.impactAsync(impactStyle).catch(() => {});
+}
+
+/** Success/warning/error notification — use for operation outcomes. */
+export function hapticNotify(type: HapticNotifyType): void {
+  if (!isSupported) return;
+  const notifyType =
+    type === 'success'
+      ? Haptics.NotificationFeedbackType.Success
+      : type === 'warning'
+        ? Haptics.NotificationFeedbackType.Warning
+        : Haptics.NotificationFeedbackType.Error;
+  Haptics.notificationAsync(notifyType).catch(() => {});
+}
+
+/** Selection tick — use for pickers / segmented controls. */
+export function hapticSelection(): void {
+  if (!isSupported) return;
+  Haptics.selectionAsync().catch(() => {});
+}


### PR DESCRIPTION
## What

The app had no haptics anywhere (`expo-haptics` wasn't installed). Add tactile feedback at the highest-value, non-auth moments.

## Change

- **Install `expo-haptics` (~15.0.8, SDK 54).**
- **`src/utils/haptics.ts`** — a fire-and-forget wrapper (`hapticImpact` / `hapticNotify` / `hapticSelection`) that guards on platform (no-op on web/extension) and swallows rejections, so a device without a haptic engine can never surface an error. Unit-tested (enum mapping + rejection-swallowing).
- **`GlassButton`** — light impact on every press → haptics propagate to primary/secondary/ghost/danger buttons app-wide (respects `disabled`/`loading`, doesn't block `onPress`).
- **`TransactionResultScreen`** — success/error notification haptic on mount, keyed on the same `params.isSuccess` that drives the result icon/title.

## ⚠️ OTA-vs-native

`expo-haptics` is a **native module**. This reaches users **only via a new native build + store submission** — it will **not** ship over-the-air. A **runtime-version bump** is required at release.

## Scope / risk

- No crypto/key/signing/auth surface. The **auth-flow haptics** (LockScreen biometric/PIN — CLAUDE.md-sensitive, and already has PIN-error vibration) are **deliberately carved out to a Human Task** for maintainer sign-off, not folded in here.
- Cross-target: safe on the extension/web target (platform-guarded no-op).

## Gates

- `npm run typecheck` — clean
- `npm run lint` — 0 errors (unchanged 689-warning baseline)
- `npm test -- --ci` — **244/244** (new `haptics.test.ts`: 5 tests)
- Codex review — **CLEAN**

## Verification note

On-device haptic verification (feeling the taps) delegated to the maintainer per the run's agreed merge policy — requires a **native dev-client build** (`npm run ios`/`android`), not Metro reload, since a native module was added.

Partially resolves U-11 · TASK-38 · part of PLAN-11 (Voi Wallet Audit: Quick Wins).

https://claude.ai/code/session_012WoHuh1utAZRBTDiDZ2sEk