### PR TITLE
feat(ux): add haptic feedback to auth/PIN flows (TASK-126)

### DIFF
--- a/src/components/UnifiedAuthModal.tsx
+++ b/src/components/UnifiedAuthModal.tsx
@@ -15,6 +15,7 @@ import { Theme } from '@/constants/themes';
 import { useAuth } from '@/contexts/AuthContext';
 import { AccountSecureStorage } from '@/services/secure';
 import { LedgerDeviceInfo } from '@/services/ledger/transport';
+import { hapticNotify } from '@/utils/haptics';
 
 // Cross-platform alert helper
 const showAlert = (
@@ -28,14 +29,6 @@ const showAlert = (
   } else {
     const { Alert } = require('react-native');
     Alert.alert(title, message, buttons);
-  }
-};
-
-// Cross-platform vibration helper
-const vibrate = (duration: number) => {
-  if (Platform.OS !== 'web') {
-    const { Vibration } = require('react-native');
-    Vibration.vibrate(duration);
   }
 };
 
@@ -255,7 +248,7 @@ export default function UnifiedAuthModal({
         const newAttempts = attempts + 1;
         setAttempts(newAttempts);
         setPin('');
-        vibrate(500);
+        hapticNotify('error');
 
         if (newAttempts >= MAX_ATTEMPTS) {
           setIsLocked(true);

--- a/src/components/UnifiedTransactionAuthModal.tsx
+++ b/src/components/UnifiedTransactionAuthModal.tsx
@@ -26,14 +26,7 @@ import {
   isRemoteSignerResponse,
   RemoteSignerResponse,
 } from '@/types/remoteSigner';
-
-// Cross-platform vibration helper
-const vibrate = (duration: number) => {
-  if (Platform.OS !== 'web') {
-    const { Vibration } = require('react-native');
-    Vibration.vibrate(duration);
-  }
-};
+import { hapticNotify } from '@/utils/haptics';
 
 interface UnifiedTransactionAuthModalProps {
   visible: boolean;
@@ -186,7 +179,7 @@ export default function UnifiedTransactionAuthModal({
       const success = await controller.authenticateWithPin(enteredPin);
       if (!success) {
         setPin('');
-        vibrate(500);
+        hapticNotify('error');
       }
     } catch (error) {
       console.error('PIN authentication error:', error);

--- a/src/components/remoteSigner/SignerAuthModal.tsx
+++ b/src/components/remoteSigner/SignerAuthModal.tsx
@@ -22,14 +22,7 @@ import { useThemedStyles } from '@/hooks/useThemedStyles';
 import { useTheme } from '@/contexts/ThemeContext';
 import { Theme } from '@/constants/themes';
 import { AccountSecureStorage } from '@/services/secure';
-
-// Cross-platform vibration helper
-const vibrate = (duration: number) => {
-  if (Platform.OS !== 'web') {
-    const { Vibration } = require('react-native');
-    Vibration.vibrate(duration);
-  }
-};
+import { hapticNotify } from '@/utils/haptics';
 
 interface SignerAuthModalProps {
   visible: boolean;
@@ -142,7 +135,7 @@ export default function SignerAuthModal({
         const attempts = pinAttempts + 1;
         setPinAttempts(attempts);
         setPin('');
-        vibrate(500);
+        hapticNotify('error');
 
         if (attempts >= MAX_ATTEMPTS) {
           setIsLocked(true);

--- a/src/screens/auth/LockScreen.tsx
+++ b/src/screens/auth/LockScreen.tsx
@@ -14,6 +14,7 @@ import { Theme } from '@/constants/themes';
 import { useAuth } from '@/contexts/AuthContext';
 import { AccountSecureStorage } from '@/services/secure';
 import { MultiAccountWalletService } from '@/services/wallet';
+import { hapticNotify } from '@/utils/haptics';
 
 // Cross-platform alert helper
 const showAlert = (
@@ -40,14 +41,6 @@ const showAlert = (
   }
 };
 
-// Cross-platform vibration helper
-const vibrate = (duration: number) => {
-  if (Platform.OS !== 'web') {
-    const { Vibration } = require('react-native');
-    Vibration.vibrate(duration);
-  }
-};
-
 export default function LockScreen() {
   const { theme } = useTheme();
   const styles = useThemedStyles(createStyles);
@@ -69,9 +62,11 @@ export default function LockScreen() {
   const promptBiometric = async () => {
     try {
       const success = await unlockWithBiometrics();
-      if (!success) {
-        // Biometric failed, user will need to use PIN
+      if (success) {
+        hapticNotify('success');
       }
+      // On !success the user cancelled or biometrics failed; no error haptic —
+      // a cancel is a normal path to the PIN pad and shouldn't buzz.
     } catch (error) {
       console.error('Biometric authentication error:', error);
     }
@@ -100,11 +95,12 @@ export default function LockScreen() {
       if (success) {
         setPin('');
         setAttempts(0);
+        hapticNotify('success');
       } else {
         const newAttempts = attempts + 1;
         setAttempts(newAttempts);
         setPin('');
-        vibrate(500);
+        hapticNotify('error');
 
         if (newAttempts >= MAX_ATTEMPTS) {
           setIsLocked(true);
@@ -126,6 +122,7 @@ export default function LockScreen() {
       }
     } catch (error) {
       console.error('PIN verification error:', error);
+      hapticNotify('error');
       showAlert('Error', 'Failed to verify PIN');
     }
   };

--- a/src/utils/__tests__/haptics.test.ts
+++ b/src/utils/__tests__/haptics.test.ts
@@ -48,7 +48,7 @@ describe('haptics', () => {
     });
   });
 
-  it('swallows rejections (fire-and-forget, never throws)', async () => {
+  it('swallows async rejections (fire-and-forget, never throws)', async () => {
     (Haptics.impactAsync as jest.Mock).mockRejectedValueOnce(
       new Error('no haptic engine')
     );
@@ -66,5 +66,24 @@ describe('haptics', () => {
     // Let the rejected promises settle to prove the .catch() handles them
     // (an unhandled rejection would fail the test run).
     await new Promise((resolve) => setImmediate(resolve));
+  });
+
+  it('swallows SYNCHRONOUS throws so it can never perturb a caller', () => {
+    // e.g. native module unlinked → the *Async fn itself throws before .catch.
+    // Auth/lockout code calls these, so a sync throw must never escape.
+    (Haptics.impactAsync as jest.Mock).mockImplementationOnce(() => {
+      throw new Error('native module unavailable');
+    });
+    (Haptics.notificationAsync as jest.Mock).mockImplementationOnce(() => {
+      throw new Error('native module unavailable');
+    });
+    (Haptics.selectionAsync as jest.Mock).mockImplementationOnce(() => {
+      throw new Error('native module unavailable');
+    });
+    expect(() => {
+      hapticImpact();
+      hapticNotify('error');
+      hapticSelection();
+    }).not.toThrow();
   });
 });

--- a/src/utils/haptics.ts
+++ b/src/utils/haptics.ts
@@ -17,32 +17,51 @@ const isSupported = Platform.OS === 'ios' || Platform.OS === 'android';
 export type HapticImpactStyle = 'light' | 'medium' | 'heavy';
 export type HapticNotifyType = 'success' | 'warning' | 'error';
 
+// Fully exception-proof: guard the whole body in try/catch, not just the
+// promise. These are called from control-flow-sensitive paths (e.g. the
+// LockScreen wrong-PIN / lockout branch), and a cosmetic haptic must NEVER be
+// able to throw synchronously (e.g. if the native module were unlinked) and
+// perturb a caller. The .catch handles async rejection; the try/catch handles a
+// synchronous throw. Net guarantee: these functions never throw.
+
 /** Light/medium/heavy tap — use for button presses and discrete selections. */
 export function hapticImpact(style: HapticImpactStyle = 'light'): void {
   if (!isSupported) return;
-  const impactStyle =
-    style === 'heavy'
-      ? Haptics.ImpactFeedbackStyle.Heavy
-      : style === 'medium'
-        ? Haptics.ImpactFeedbackStyle.Medium
-        : Haptics.ImpactFeedbackStyle.Light;
-  Haptics.impactAsync(impactStyle).catch(() => {});
+  try {
+    const impactStyle =
+      style === 'heavy'
+        ? Haptics.ImpactFeedbackStyle.Heavy
+        : style === 'medium'
+          ? Haptics.ImpactFeedbackStyle.Medium
+          : Haptics.ImpactFeedbackStyle.Light;
+    Haptics.impactAsync(impactStyle).catch(() => {});
+  } catch {
+    // ignore — haptics are best-effort feedback
+  }
 }
 
 /** Success/warning/error notification — use for operation outcomes. */
 export function hapticNotify(type: HapticNotifyType): void {
   if (!isSupported) return;
-  const notifyType =
-    type === 'success'
-      ? Haptics.NotificationFeedbackType.Success
-      : type === 'warning'
-        ? Haptics.NotificationFeedbackType.Warning
-        : Haptics.NotificationFeedbackType.Error;
-  Haptics.notificationAsync(notifyType).catch(() => {});
+  try {
+    const notifyType =
+      type === 'success'
+        ? Haptics.NotificationFeedbackType.Success
+        : type === 'warning'
+          ? Haptics.NotificationFeedbackType.Warning
+          : Haptics.NotificationFeedbackType.Error;
+    Haptics.notificationAsync(notifyType).catch(() => {});
+  } catch {
+    // ignore — haptics are best-effort feedback
+  }
 }
 
 /** Selection tick — use for pickers / segmented controls. */
 export function hapticSelection(): void {
   if (!isSupported) return;
-  Haptics.selectionAsync().catch(() => {});
+  try {
+    Haptics.selectionAsync().catch(() => {});
+  } catch {
+    // ignore — haptics are best-effort feedback
+  }
 }


### PR DESCRIPTION
## What

Completes U-11's auth-flow haptics — the slice carved out of TASK-38 for maintainer sign-off (**approved via HT-127**). Uses the fire-and-forget `src/utils/haptics.ts` wrapper added in #86.

## Change (strictly additive — no auth logic touched)

- **`LockScreen`**: `hapticNotify('success')` on PIN unlock + biometric success; `hapticNotify('error')` on wrong PIN and on a verify exception. Biometric **non**-success stays silent (usually a Face ID cancel on the way to the PIN pad — shouldn't buzz).
- **`UnifiedTransactionAuthModal`, `UnifiedAuthModal`, `SignerAuthModal`**: replace the wrong-PIN `vibrate(500)` with `hapticNotify('error')` for consistent PIN-error feedback on every auth surface. **Success paths left untouched** (they flow into their own success UI / the transaction-result haptic — no double-buzz).
- Remove the now-dead per-file `vibrate` helpers (also clears 4 `no-require-imports` warnings: **689 → 685**).

No unlock/verify/lockout/attempt-counter state or branch changed; `hapticNotify` receives only the literals `'success'`/`'error'` — never a PIN/key/mnemonic.

## Review (auth-sensitive surface — reviewed harder)

- **Codex oracle** — **CLEAN**: no secret leakage, no control-flow/lockout change, no signing-path regression, web-safe.
- **Adversarial multi-lens Claude review** (4 independent lenses: control-flow preservation, secret-leak, correctness/cross-target, regression scan) — *(verdict recorded on merge)*.

## Scope / risk

- No OTA impact beyond #86 (`expo-haptics` already added there).
- Cross-target: safe on web/extension (platform-guarded no-op).

## Gates

- `npm run typecheck` — clean
- `npm run lint` — 0 errors (**685** warnings, down from 685… i.e. reduced from the 689 baseline)
- `npm test -- --ci` — 244/244

## Verification note

On-device verification of the PIN-error / unlock haptics delegated to the maintainer per the run's merge policy (needs a native dev-client build).

Resolves U-11 · TASK-126 · closes HT-127 · part of PLAN-11.

https://claude.ai/code/session_012WoHuh1utAZRBTDiDZ2sEk