### PR TITLE
perf(wallet): coalesce duplicate initialize on cold start (TASK-51)

### DIFF
--- a/src/screens/wallet/HomeScreen.tsx
+++ b/src/screens/wallet/HomeScreen.tsx
@@ -293,10 +293,19 @@ export default function HomeScreen() {
     ]
   );
 
+  // Load wallet data and mark activity once when Home mounts. Kept separate from
+  // the remote-signer effect below so that the remote-signer store flipping
+  // isInitialized false→true does not re-trigger walletStore.initialize() (a
+  // redundant accountStates rebuild + balance refetch/flicker on cold start).
+  // The store's initialize() coalescer dedupes any residual concurrent calls.
   useEffect(() => {
     initializeWallet();
     updateActivity();
-    // Initialize remote signer store to get app mode
+  }, []);
+
+  // Initialize the remote-signer store (used to resolve app mode) once it is not
+  // yet initialized. This runs independently of the wallet init above.
+  useEffect(() => {
     if (!isRemoteSignerInitialized) {
       initializeRemoteSigner();
     }

--- a/src/store/walletStore.ts
+++ b/src/store/walletStore.ts
@@ -404,6 +404,14 @@ const persistMultiNetworkBalanceToStorage = async (
   }
 };
 
+// Coalescer for the wallet-store initialize(): a single shared in-flight promise
+// so duplicate/concurrent initialize() calls (e.g. HomeScreen's mount effect
+// firing a second time when the remote-signer store finishes initializing) dedupe
+// into one init pass instead of rebuilding accountStates and refetching balances
+// twice on cold start. It is reset on settle, so a later explicit
+// initialize()/refresh()/account-switch still re-runs initialization normally.
+let walletInitializationPromise: Promise<void> | null = null;
+
 export const useWalletStore = create<WalletState>()(
   subscribeWithSelector((set, get) => ({
     // Initial state
@@ -433,6 +441,19 @@ export const useWalletStore = create<WalletState>()(
 
     // Initialization
     initialize: async () => {
+      // If an initialize() is already in flight, share it instead of starting a
+      // second full init pass (this dedupes the double mount-effect fire). The
+      // promise is cleared in the finally below, so later explicit
+      // initialize()/refresh()/account-switch calls still re-initialize.
+      if (walletInitializationPromise) {
+        return walletInitializationPromise;
+      }
+
+      let resolveInitialization: () => void = () => {};
+      walletInitializationPromise = new Promise<void>((resolve) => {
+        resolveInitialization = resolve;
+      });
+
       try {
         set({ isLoading: true, lastError: null });
 
@@ -545,12 +566,21 @@ export const useWalletStore = create<WalletState>()(
         });
       } finally {
         set({ isLoading: false });
+        walletInitializationPromise = null;
+        resolveInitialization();
       }
     },
 
     refresh: async () => {
-      const { initialize } = get();
-      await initialize();
+      // Explicit refreshes (pull-to-refresh, post-import/switch, error recovery)
+      // must reflect the latest persisted state, so they must never coalesce onto
+      // an init that is already in flight and may predate the caller's storage
+      // mutation. Wait for any in-flight pass to settle (the coalescer clears the
+      // promise in its finally), then run a guaranteed-fresh initialize().
+      if (walletInitializationPromise) {
+        await walletInitializationPromise;
+      }
+      await get().initialize();
     },
 
     // Account management


### PR DESCRIPTION
## What & why (TASK-51 / P-07)

On cold start, `HomeScreen`'s mount effect depended on the remote-signer store's `isInitialized`. When that store flipped `false→true`, the effect re-ran and called `walletStore.initialize()` a **second time**, rebuilding `accountStates` from scratch (`createInitialAccountState` for every account), re-reading 4+ AsyncStorage keys, and triggering a redundant balance refetch + UI flicker.

### Changes
1. **Coalescer in `walletStore.initialize()`** (`src/store/walletStore.ts`) — a single shared in-flight `walletInitializationPromise`. If an `initialize()` is already running, duplicate/concurrent calls share that one promise instead of starting a second full init pass. The promise resets in `finally`, so later explicit re-inits still run.
2. **`refresh()` never coalesces onto a stale pass** — it awaits any in-flight init, then runs a **guaranteed-fresh** `initialize()`. This preserves explicit refresh semantics (pull-to-refresh, post-import/switch, error recovery) that mutate storage before refreshing.
3. **Split the HomeScreen mount effect** (`src/screens/wallet/HomeScreen.tsx`) — wallet init + activity now run once on mount; remote-signer init lives in its own effect. This structurally prevents the remote-signer flip from re-triggering `initialize()` at all (the coalescer is defense-in-depth for any residual concurrent calls).

### Why a coalescer, not an `isInitialized` early-return
Per Codex Phase D: `refresh()` intentionally re-calls `initialize()` (including error recovery), and a legitimate re-init must reload persisted state. A hard `isInitialized` early-return would break those paths. The coalescer only dedupes the double mount-effect fire while leaving explicit re-init fully functional. Account add/switch go through `setActiveAccount`/`createAccount` (direct state updates, not `initialize()`), so they are unaffected.

### Gate results
- `npm run typecheck` — 0 errors (baseline 0)
- `npm run lint` — 0 errors, 685 warnings (unchanged from baseline)
- `npm test -- --ci` — 12 suites / 245 tests passing

### Codex review
CLEAN after 2 rounds. Round 1 flagged that `refresh()` could coalesce onto a stale in-flight pass (missing a newly-imported account); fixed in change (2) above. Round 2: CLEAN — verified refresh runs a fresh pass, recovery callers use refresh, coalescer clears on settle, no stuck `isLoading`.

## To verify in-app
- **Cold start**: single balance load, no flicker (previously a second init pass fired when the remote-signer store finished initializing).
- **Pull-to-refresh**: still refreshes balances.
- **Add / switch account**: still re-initializes / updates correctly (e.g. import-from-online-wallet shows the new account).

JS-only / OTA-shippable — no native deps, no version bump.

https://claude.ai/code/session_012WoHuh1utAZRBTDiDZ2sEk