### PR TITLE
perf(send): narrow fetchAssetOptions deps (TASK-52)

### DIFF
--- a/src/screens/wallet/SendScreen.tsx
+++ b/src/screens/wallet/SendScreen.tsx
@@ -469,7 +469,14 @@ export default function SendScreen() {
     let cancelled = false;
 
     const fetchAssetOptions = async () => {
-      if (!activeAccount) return;
+      if (!activeAccount) {
+        // Clear the spinner even though we build no options: a superseded
+        // (now-cancelled) earlier run may have left it on, and its guarded
+        // finally won't clear it. Clearing is always safe — only *overwriting
+        // options* must stay behind the cancelled guard.
+        setIsLoadingOptions(false);
+        return;
+      }
 
       setIsLoadingOptions(true);
       try {

--- a/src/screens/wallet/SendScreen.tsx
+++ b/src/screens/wallet/SendScreen.tsx
@@ -1,4 +1,4 @@
-import React, { useState, useEffect, useCallback } from 'react';
+import React, { useState, useEffect, useCallback, useMemo } from 'react';
 import algosdk from 'algosdk';
 import {
   View,
@@ -28,6 +28,7 @@ import { useTheme } from '@/contexts/ThemeContext';
 import { TransactionService } from '@/services/transactions';
 import VoiNetworkService, { NetworkService } from '@/services/network';
 import tokenMappingService from '@/services/token-mapping';
+import type { TokenMapping } from '@/services/token-mapping/types';
 import {
   useActiveAccount,
   useActiveAccountBalance,
@@ -342,49 +343,148 @@ export default function SendScreen() {
     activeAccount?.id || ''
   );
 
+  // The asset the send flow is scoped to (parsed from the route). Depended on
+  // by the option builder below, so keep it memoized (and reactive to BOTH
+  // `asset` and `assetId` route params).
+  const initialAssetId = useMemo(() => {
+    return routeParams?.asset
+      ? isNaN(parseInt(routeParams.asset, 10))
+        ? undefined
+        : parseInt(routeParams.asset, 10)
+      : routeParams?.assetId;
+  }, [routeParams?.asset, routeParams?.assetId]);
+
+  // Token mappings, held in state so the option builder (both the narrowing
+  // memo below and the effect) reacts to them loading. Seed synchronously from
+  // the cache (bundled defaults at worst — never empty) so there's no empty
+  // window, then refresh from the (possibly newer) fetched mappings. Using one
+  // state value for both keeps the memo and the effect from diverging.
+  const [tokenMappings, setTokenMappings] = useState<TokenMapping[]>(() =>
+    tokenMappingService.getCachedMappings()
+  );
+  useEffect(() => {
+    let cancelled = false;
+    tokenMappingService
+      .getTokenMappings()
+      .then((mappings) => {
+        if (!cancelled) setTokenMappings(mappings);
+      })
+      .catch(() => {
+        // Keep the seeded cache/defaults on failure.
+      });
+    return () => {
+      cancelled = true;
+    };
+  }, []);
+
+  // Narrow the multi-network balance down to only the mapped asset(s) the
+  // option builder needs, serialized to a stable string. multiNetworkBalance
+  // gets a fresh object reference on every balance refresh (screen focus,
+  // pull-to-refresh, post-transaction), so depending the effect directly on it
+  // re-runs the whole builder — and re-fetches — while the user is composing.
+  // Keying off the serialized relevant slice instead means the effect only
+  // re-runs when the data it actually consumes changes.
+  const relevantBalanceKey = useMemo(() => {
+    const assets = multiNetworkBalance?.assets;
+    if (!assets || assets.length === 0) return '[]';
+
+    const mappings = tokenMappings;
+
+    const relevant =
+      initialAssetId === undefined
+        ? // No asset context: every native-token mapping (native = assetId 0).
+          (() => {
+            const nativeMappingIds = new Set(
+              mappings
+                .filter((m) => m.tokens.some((t) => t.assetId === 0))
+                .map((m) => m.mappingId)
+            );
+            return assets.filter(
+              (a) =>
+                a.isMapped && !!a.mappingId && nativeMappingIds.has(a.mappingId)
+            );
+          })()
+        : // Scoped to one asset: just its mapping's balance entry.
+          (() => {
+            const mapping = contextMappingId
+              ? mappings.find((m) => m.mappingId === contextMappingId)
+              : mappings.find((m) =>
+                  m.tokens.some((t) => t.assetId === initialAssetId)
+                );
+            return mapping
+              ? assets.filter(
+                  (a) => a.isMapped && a.mappingId === mapping.mappingId
+                )
+              : [];
+          })();
+
+    const slim = relevant.map((a) => ({
+      mappingId: a.mappingId,
+      sourceBalances: (a.sourceBalances ?? []).map((s) => ({
+        networkId: s.networkId,
+        assetId: s.balance.assetId,
+        // bigint amounts don't survive JSON; keep as string and BigInt() later.
+        amount: s.balance.amount.toString(),
+        decimals: s.balance.decimals,
+        symbol: s.balance.symbol ?? '',
+        name: s.balance.name ?? '',
+        imageUrl: s.balance.imageUrl,
+      })),
+    }));
+    return JSON.stringify(slim);
+  }, [
+    multiNetworkBalance?.assets,
+    initialAssetId,
+    contextMappingId,
+    tokenMappings,
+  ]);
+
+  // Parsed form of the narrowed slice. Derived solely from the string key, so
+  // its reference stays stable across balance refreshes with identical data.
+  const relevantMappedAssets = useMemo(
+    () =>
+      JSON.parse(relevantBalanceKey) as {
+        mappingId?: string;
+        sourceBalances: {
+          networkId: NetworkId;
+          assetId: number;
+          amount: string;
+          decimals: number;
+          symbol: string;
+          name: string;
+          imageUrl?: string;
+        }[];
+      }[],
+    [relevantBalanceKey]
+  );
+
   // Fetch all available versions of this asset across networks
   useEffect(() => {
     const fetchAssetOptions = async () => {
       if (!activeAccount) return;
 
-      const initialAssetId = routeParams?.asset
-        ? isNaN(parseInt(routeParams.asset, 10))
-          ? undefined
-          : parseInt(routeParams.asset, 10)
-        : routeParams?.assetId;
-
       setIsLoadingOptions(true);
       try {
-        // Get mappings to find all versions of this asset
-        const mappings = await tokenMappingService.getTokenMappings();
+        // Same mappings the narrowing memo used (see relevantMappedAssets), so
+        // the mapping lookup below stays consistent with the pre-narrowed slice.
+        const mappings = tokenMappings;
         const options = [];
 
         // When no asset context is provided, show all network tokens (native + bridged)
         if (initialAssetId === undefined) {
-          // Find all mappings that contain native tokens (assetId: 0)
-          const nativeTokenMappings = mappings.filter((m) =>
-            m.tokens.some((t) => t.assetId === 0)
-          );
-
-          // For each native token mapping, get balances from multi-network balance
-          for (const mapping of nativeTokenMappings) {
-            const mappedAsset = multiNetworkBalance?.assets.find(
-              (a) => a.mappingId === mapping.mappingId && a.isMapped
-            );
-
-            if (mappedAsset && mappedAsset.sourceBalances) {
-              // Add all tokens in this mapping (native + bridged versions)
-              for (const source of mappedAsset.sourceBalances) {
-                options.push({
-                  networkId: source.networkId,
-                  assetId: source.balance.assetId,
-                  balance: BigInt(source.balance.amount),
-                  decimals: source.balance.decimals,
-                  symbol: source.balance.symbol || '',
-                  name: source.balance.name || '',
-                  imageUrl: source.balance.imageUrl,
-                });
-              }
+          // Build from the narrowed native-token mapped assets.
+          for (const mappedAsset of relevantMappedAssets) {
+            // Add all tokens in this mapping (native + bridged versions)
+            for (const source of mappedAsset.sourceBalances) {
+              options.push({
+                networkId: source.networkId,
+                assetId: source.assetId,
+                balance: BigInt(source.amount),
+                decimals: source.decimals,
+                symbol: source.symbol,
+                name: source.name,
+                imageUrl: source.imageUrl,
+              });
             }
           }
         } else {
@@ -397,26 +497,22 @@ export default function SendScreen() {
               );
 
           if (mapping) {
-            // Find the mapped asset in multi-network balance
-            const mappedAsset = multiNetworkBalance?.assets.find(
-              (a) => a.mappingId === mapping.mappingId && a.isMapped
+            // Find the mapped asset in the narrowed multi-network balance
+            const mappedAsset = relevantMappedAssets.find(
+              (a) => a.mappingId === mapping.mappingId
             );
 
-            if (
-              mappedAsset &&
-              mappedAsset.sourceBalances &&
-              mappedAsset.sourceBalances.length > 0
-            ) {
+            if (mappedAsset && mappedAsset.sourceBalances.length > 0) {
               // Build options from sourceBalances (includes native tokens with assetId 0)
               for (const source of mappedAsset.sourceBalances) {
                 options.push({
                   networkId: source.networkId,
-                  assetId: source.balance.assetId,
-                  balance: BigInt(source.balance.amount),
-                  decimals: source.balance.decimals,
-                  symbol: source.balance.symbol || contextAssetName || '',
-                  name: source.balance.name || contextAssetName || '',
-                  imageUrl: source.balance.imageUrl,
+                  assetId: source.assetId,
+                  balance: BigInt(source.amount),
+                  decimals: source.decimals,
+                  symbol: source.symbol || contextAssetName || '',
+                  name: source.name || contextAssetName || '',
+                  imageUrl: source.imageUrl,
                 });
               }
             } else {
@@ -469,22 +565,24 @@ export default function SendScreen() {
               }
             }
           } else {
-            // Not in a mapping, just show this one asset
+            // Not in a mapping, just show this one asset. Use a targeted lookup
+            // instead of the full getAccountBalance pipeline (pricing, rekey
+            // info, and a per-holding metadata loop) just to locate one asset.
+            // getSingleAssetBalance still discovers unmapped ARC-200 assets via
+            // Mimir, so this doesn't regress ARC-200 support.
             const networkId =
               (routeParams?.networkId as NetworkId) || currentNetwork;
+            const networkService = NetworkService.getInstance(networkId);
 
-            // First check if we have this asset in accountBalance (includes ARC-200)
-            const balance = await NetworkService.getInstance(
-              networkId
-            ).getAccountBalance(activeAccount.address);
-            const asset = balance.assets?.find(
-              (a) =>
-                a.assetId === initialAssetId ||
-                (a.assetType === 'arc200' && a.contractId === initialAssetId)
-            );
+            const asset = initialAssetId
+              ? await networkService.getSingleAssetBalance(
+                  activeAccount.address,
+                  initialAssetId
+                )
+              : null;
 
             if (asset) {
-              // Found in accountBalance (ASA or ARC-200)
+              // Found (ASA or ARC-200)
               options.push({
                 networkId,
                 assetId:
@@ -501,12 +599,17 @@ export default function SendScreen() {
                 imageUrl: asset.imageUrl,
               });
             } else if (initialAssetId === 0) {
-              // Native token
+              // Native token — resolve the native balance directly
+              // (getSingleAssetBalance intentionally doesn't handle assetId 0).
               const networkConfig = getNetworkConfig(networkId);
+              const accountInfo = await networkService
+                .getAlgodClient()
+                .accountInformation(activeAccount.address)
+                .do();
               options.push({
                 networkId,
                 assetId: 0,
-                balance: BigInt(balance.amount),
+                balance: BigInt(accountInfo.amount || 0),
                 decimals: 6,
                 symbol: networkConfig.nativeToken,
                 name: networkConfig.nativeToken,
@@ -572,11 +675,16 @@ export default function SendScreen() {
     fetchAssetOptions();
   }, [
     activeAccount?.address,
-    routeParams?.assetId,
+    initialAssetId,
     routeParams?.networkId,
     contextMappingId,
-    multiNetworkBalance?.assets,
+    contextAssetName,
     currentNetwork,
+    tokenMappings,
+    // Content-stable slice of the balance (see relevantBalanceKey) — replaces
+    // the whole multiNetworkBalance.assets array so the builder doesn't re-run
+    // on every balance refresh.
+    relevantMappedAssets,
   ]);
 
   // Balance is already in assetOptions - no need to fetch separately

--- a/src/screens/wallet/SendScreen.tsx
+++ b/src/screens/wallet/SendScreen.tsx
@@ -460,6 +460,14 @@ export default function SendScreen() {
 
   // Fetch all available versions of this asset across networks
   useEffect(() => {
+    // Guard against a stale async run overwriting fresher state. This effect
+    // can start a new run (mappings loading, balance changing) before an
+    // earlier run's awaited lookups resolve; without this, an older
+    // (e.g. direct/unmapped) result could land after a newer one and clobber
+    // good options — even replacing them with []. Cleanup flips this flag, so
+    // the superseded run bails before any setState.
+    let cancelled = false;
+
     const fetchAssetOptions = async () => {
       if (!activeAccount) return;
 
@@ -619,6 +627,9 @@ export default function SendScreen() {
           }
         }
 
+        // A newer run has superseded this one — don't clobber its state.
+        if (cancelled) return;
+
         setAssetOptions(options);
 
         // Auto-select based on route params or default to current network's native token
@@ -668,11 +679,17 @@ export default function SendScreen() {
       } catch (error) {
         console.error('Failed to fetch asset options:', error);
       } finally {
-        setIsLoadingOptions(false);
+        // Only the current run should clear the spinner; a superseded run
+        // clearing it would race the fresher run that's still loading.
+        if (!cancelled) setIsLoadingOptions(false);
       }
     };
 
     fetchAssetOptions();
+
+    return () => {
+      cancelled = true;
+    };
   }, [
     activeAccount?.address,
     initialAssetId,

--- a/src/services/network/__tests__/getSingleAssetBalance.test.ts
+++ b/src/services/network/__tests__/getSingleAssetBalance.test.ts
@@ -1,0 +1,185 @@
+import algosdk from 'algosdk';
+import { NetworkService } from '../index';
+import { NetworkId } from '@/types/network';
+import type { MimirAsset } from '@/services/mimir';
+
+// A syntactically valid address (all-zero public key) so isValidAddress passes.
+const ADDRESS = algosdk.encodeAddress(new Uint8Array(32));
+const ASSET_ID = 12345;
+
+function mimirAsa(overrides: Partial<MimirAsset> = {}): MimirAsset {
+  return {
+    name: 'Stale ASA',
+    symbol: 'STALE',
+    balance: '1000',
+    decimals: 6,
+    imageUrl: 'stale-img',
+    usdValue: '1',
+    verified: 0,
+    accountId: ADDRESS,
+    assetType: 'asa',
+    contractId: ASSET_ID,
+    ...overrides,
+  };
+}
+
+/**
+ * Regression coverage for getSingleAssetBalance's targeted lookup (TASK-52),
+ * focused on the financial-correctness edges: a genuine not-found ASA must not
+ * be papered over with stale Mimir metadata, and decimals must never be
+ * fabricated.
+ */
+describe('NetworkService.getSingleAssetBalance', () => {
+  let service: NetworkService;
+
+  beforeEach(() => {
+    service = NetworkService.getInstance(NetworkId.VOI_MAINNET);
+    // Account holds the ASA (algod is the source of truth for the holding).
+    (service as any).algodClient = {
+      accountInformation: () => ({
+        do: async () => ({
+          assets: [{ assetId: BigInt(ASSET_ID), amount: 1000n }],
+        }),
+      }),
+    };
+  });
+
+  afterEach(() => {
+    jest.restoreAllMocks();
+  });
+
+  it('returns null (not-found) when algod getAssetInfo returns null, even if Mimir has stale ASA metadata', async () => {
+    jest
+      .spyOn(service as any, 'getMimirAssets')
+      .mockResolvedValue([mimirAsa()]);
+    // Genuine 404 / not-found (getAssetInfo returns null, does not throw).
+    jest.spyOn(service as any, 'getAssetInfo').mockResolvedValue(null);
+
+    const result = await service.getSingleAssetBalance(ADDRESS, ASSET_ID);
+
+    expect(result).toBeNull();
+  });
+
+  it('falls back to Mimir decimals when getAssetInfo THROWS (transient error)', async () => {
+    jest
+      .spyOn(service as any, 'getMimirAssets')
+      .mockResolvedValue([
+        mimirAsa({ symbol: 'USDC', name: 'USDC', decimals: 6 }),
+      ]);
+    jest
+      .spyOn(service as any, 'getAssetInfo')
+      .mockRejectedValue(new Error('request timed out'));
+
+    const result = await service.getSingleAssetBalance(ADDRESS, ASSET_ID);
+
+    expect(result).not.toBeNull();
+    expect(result?.assetType).toBe('asa');
+    expect(result?.decimals).toBe(6);
+    expect(result?.symbol).toBe('USDC');
+    expect(result?.amount).toBe(1000n);
+  });
+
+  it('uses genuine algod decimals, preserving a legitimate decimals:0', async () => {
+    jest.spyOn(service as any, 'getMimirAssets').mockResolvedValue([]);
+    jest.spyOn(service as any, 'getAssetInfo').mockResolvedValue({
+      params: { decimals: 0, name: 'Zero Decimals', unitName: 'ZERO' },
+    });
+
+    const result = await service.getSingleAssetBalance(ADDRESS, ASSET_ID);
+
+    expect(result).not.toBeNull();
+    expect(result?.decimals).toBe(0);
+    expect(result?.name).toBe('Zero Decimals');
+    expect(result?.assetType).toBe('asa');
+  });
+
+  it('returns null when neither algod nor Mimir yields genuine decimals (never fabricates 0)', async () => {
+    jest.spyOn(service as any, 'getMimirAssets').mockResolvedValue([]);
+    // Asset exists but its params carry no usable decimals.
+    jest
+      .spyOn(service as any, 'getAssetInfo')
+      .mockResolvedValue({ params: { name: 'No Decimals' } });
+
+    const result = await service.getSingleAssetBalance(ADDRESS, ASSET_ID);
+
+    expect(result).toBeNull();
+  });
+
+  it('does NOT fall back to stale Mimir decimals when a reachable algod returned unusable params (throw-only fallback)', async () => {
+    // Mimir has decimals, but algod is REACHABLE (getAssetInfo resolves, does
+    // not throw) and its params lack usable decimals. Since algod is
+    // authoritative when reachable, we must not substitute Mimir here.
+    jest
+      .spyOn(service as any, 'getMimirAssets')
+      .mockResolvedValue([mimirAsa({ decimals: 6 })]);
+    jest
+      .spyOn(service as any, 'getAssetInfo')
+      .mockResolvedValue({ params: { name: 'Missing Decimals' } });
+
+    const result = await service.getSingleAssetBalance(ADDRESS, ASSET_ID);
+
+    expect(result).toBeNull();
+  });
+
+  it('rejects a non-integer/NaN decimals rather than returning a bad asset', async () => {
+    jest.spyOn(service as any, 'getMimirAssets').mockResolvedValue([]);
+    jest
+      .spyOn(service as any, 'getAssetInfo')
+      .mockResolvedValue({ params: { decimals: 'not-a-number', name: 'Bad' } });
+
+    const result = await service.getSingleAssetBalance(ADDRESS, ASSET_ID);
+
+    expect(result).toBeNull();
+  });
+
+  it('rejects a Number()-coercible malformed decimals (e.g. empty string) instead of fabricating 0', async () => {
+    // Mimir has real decimals, but a reachable algod returned decimals: ''.
+    // Number('') === 0, so a naive coercion would surface a fabricated 0 and an
+    // inflated balance; it must return null (algod reachable => no Mimir fallback).
+    jest
+      .spyOn(service as any, 'getMimirAssets')
+      .mockResolvedValue([mimirAsa({ decimals: 6 })]);
+    jest
+      .spyOn(service as any, 'getAssetInfo')
+      .mockResolvedValue({ params: { decimals: '', name: 'Empty Decimals' } });
+
+    const result = await service.getSingleAssetBalance(ADDRESS, ASSET_ID);
+
+    expect(result).toBeNull();
+  });
+
+  it('discovers an unmapped ARC-200 via Mimir without an algod asset lookup (no regression)', async () => {
+    jest.spyOn(service as any, 'getMimirAssets').mockResolvedValue([
+      mimirAsa({
+        assetType: 'arc200',
+        decimals: 8,
+        name: 'ARC Token',
+        symbol: 'ARC',
+        balance: '500',
+      }),
+    ]);
+    const getAssetInfoSpy = jest.spyOn(service as any, 'getAssetInfo');
+
+    const result = await service.getSingleAssetBalance(ADDRESS, ASSET_ID);
+
+    expect(result?.assetType).toBe('arc200');
+    expect(result?.contractId).toBe(ASSET_ID);
+    expect(result?.decimals).toBe(8);
+    expect(result?.amount).toBe(500n);
+    expect(getAssetInfoSpy).not.toHaveBeenCalled();
+  });
+
+  it('returns null for an ARC-200 whose Mimir decimals are missing/invalid', async () => {
+    jest.spyOn(service as any, 'getMimirAssets').mockResolvedValue([
+      mimirAsa({
+        assetType: 'arc200',
+        // Simulate a malformed runtime payload lacking decimals.
+        decimals: undefined as unknown as number,
+      }),
+    ]);
+
+    const result = await service.getSingleAssetBalance(ADDRESS, ASSET_ID);
+
+    expect(result).toBeNull();
+  });
+});

--- a/src/services/network/index.ts
+++ b/src/services/network/index.ts
@@ -397,15 +397,24 @@ export class NetworkService {
   /**
    * Coerce a decimals value read from an external source (algod/Mimir) into a
    * trustworthy integer. Returns null for anything that isn't a genuine,
-   * finite, non-negative integer (missing, null, NaN, negative, fractional) so
-   * callers can omit the asset instead of guessing — a fabricated 0 would
-   * inflate a displayed balance by 10^N. A real `decimals: 0` is preserved.
+   * finite, non-negative integer so callers can omit the asset instead of
+   * guessing — a fabricated 0 would inflate a displayed balance by 10^N. A
+   * real `decimals: 0` is preserved.
+   *
+   * Decimals legitimately only ever arrives as a `number` (Mimir) or
+   * `number | bigint` (algosdk), so only those types are accepted. Strings,
+   * booleans, and empty/whitespace values are rejected — `Number('')`,
+   * `Number('  ')`, `Number(false)`, `Number([])` all coerce to a deceptive 0.
    */
   private normalizeDecimals(value: unknown): number | null {
-    if (value === undefined || value === null) {
+    let n: number;
+    if (typeof value === 'number') {
+      n = value;
+    } else if (typeof value === 'bigint') {
+      n = Number(value);
+    } else {
       return null;
     }
-    const n = Number(value);
     if (!Number.isInteger(n) || n < 0) {
       return null;
     }
@@ -482,15 +491,26 @@ export class NetworkService {
       return null;
     }
 
-    // getAssetInfo returns null on a 404 but throws on timeout/other errors;
-    // tolerate that so we can still fall back to Mimir instead of rejecting the
-    // whole lookup.
+    // getAssetInfo returns null on a 404 (asset genuinely doesn't exist) but
+    // THROWS on timeout/other transient errors. Distinguish them: a transient
+    // failure should tolerate a Mimir fallback, but a genuine not-found must
+    // NOT be papered over with stale Mimir ASA metadata.
     let assetInfo: any = null;
+    let assetInfoThrew = false;
     try {
       assetInfo = await this.getAssetInfo(assetId);
     } catch (error) {
       console.warn(`Failed to fetch asset info for ${assetId}:`, error);
+      assetInfoThrew = true;
     }
+
+    // Genuine null (not a thrown error) = algod says this ASA doesn't exist.
+    // Report not-found rather than substituting Mimir data for a nonexistent
+    // asset. (ARC-200 discovery above is Mimir-first and unaffected.)
+    if (!assetInfoThrew && assetInfo === null) {
+      return null;
+    }
+
     const mimirMeta = mimirAssets.find(
       (m) => m.assetType === 'asa' && m.contractId === assetId
     );
@@ -498,12 +518,15 @@ export class NetworkService {
     // `decimals` is a REQUIRED ASA param, so treat "genuinely present" and
     // "absent" differently: 0 is a legitimate value, but getCachedAssetParams'
     // `?? 0` would fabricate a 0 for a missing/failed response and silently
-    // inflate the displayed balance by 10^N. Trust only a genuine decimals from
-    // algod (preferred), else Mimir; `??` keeps a real 0 while falling through
-    // on an unresolved (null) value. If neither resolves it, return null.
+    // inflate the displayed balance by 10^N. algod is authoritative when it's
+    // reachable — trust its decimals (0 included). Only when the algod lookup
+    // THREW (transient/unreachable) do we fall back to Mimir; a reachable algod
+    // that returned unusable params must NOT be papered over with (possibly
+    // stale) Mimir decimals. If neither resolves it, return null.
+    const algodDecimals = this.normalizeDecimals(assetInfo?.params?.decimals);
     const decimals =
-      this.normalizeDecimals(assetInfo?.params?.decimals) ??
-      this.normalizeDecimals(mimirMeta?.decimals);
+      algodDecimals ??
+      (assetInfoThrew ? this.normalizeDecimals(mimirMeta?.decimals) : null);
     if (decimals === null) {
       // Never guess decimals: 0 — that would show a 10^N-inflated balance.
       // Omit the asset until a later refresh can resolve its real params.

--- a/src/services/network/index.ts
+++ b/src/services/network/index.ts
@@ -395,6 +395,24 @@ export class NetworkService {
   }
 
   /**
+   * Coerce a decimals value read from an external source (algod/Mimir) into a
+   * trustworthy integer. Returns null for anything that isn't a genuine,
+   * finite, non-negative integer (missing, null, NaN, negative, fractional) so
+   * callers can omit the asset instead of guessing — a fabricated 0 would
+   * inflate a displayed balance by 10^N. A real `decimals: 0` is preserved.
+   */
+  private normalizeDecimals(value: unknown): number | null {
+    if (value === undefined || value === null) {
+      return null;
+    }
+    const n = Number(value);
+    if (!Number.isInteger(n) || n < 0) {
+      return null;
+    }
+    return n;
+  }
+
+  /**
    * Targeted balance lookup for a single asset (used by the send flow's asset
    * picker). Unlike getAccountBalance, this resolves only the requested asset
    * and skips the heavy parts of that pipeline — pricing, rekey info, and the
@@ -428,10 +446,16 @@ export class NetworkService {
       (m) => m.assetType === 'arc200' && m.contractId === assetId
     );
     if (arc200Match) {
+      const decimals = this.normalizeDecimals(arc200Match.decimals);
+      if (decimals === null) {
+        // Can't trust the magnitude without real decimals — omit rather than
+        // risk showing an inflated balance.
+        return null;
+      }
       return {
         assetId: arc200Match.contractId,
         amount: arc200Match.balance ? BigInt(arc200Match.balance) : 0n,
-        decimals: arc200Match.decimals,
+        decimals,
         name: arc200Match.name,
         symbol: arc200Match.symbol,
         imageUrl: arc200Match.imageUrl,
@@ -458,13 +482,29 @@ export class NetworkService {
       return null;
     }
 
-    const params = await this.getCachedAssetParams(assetId);
+    // getAssetInfo returns null on a 404 but throws on timeout/other errors;
+    // tolerate that so we can still fall back to Mimir instead of rejecting the
+    // whole lookup.
+    let assetInfo: any = null;
+    try {
+      assetInfo = await this.getAssetInfo(assetId);
+    } catch (error) {
+      console.warn(`Failed to fetch asset info for ${assetId}:`, error);
+    }
     const mimirMeta = mimirAssets.find(
       (m) => m.assetType === 'asa' && m.contractId === assetId
     );
 
-    const decimals = params?.decimals ?? mimirMeta?.decimals;
-    if (decimals === undefined) {
+    // `decimals` is a REQUIRED ASA param, so treat "genuinely present" and
+    // "absent" differently: 0 is a legitimate value, but getCachedAssetParams'
+    // `?? 0` would fabricate a 0 for a missing/failed response and silently
+    // inflate the displayed balance by 10^N. Trust only a genuine decimals from
+    // algod (preferred), else Mimir; `??` keeps a real 0 while falling through
+    // on an unresolved (null) value. If neither resolves it, return null.
+    const decimals =
+      this.normalizeDecimals(assetInfo?.params?.decimals) ??
+      this.normalizeDecimals(mimirMeta?.decimals);
+    if (decimals === null) {
       // Never guess decimals: 0 — that would show a 10^N-inflated balance.
       // Omit the asset until a later refresh can resolve its real params.
       return null;
@@ -474,8 +514,8 @@ export class NetworkService {
       assetId,
       amount: holding.amount,
       decimals,
-      name: params?.name ?? mimirMeta?.name,
-      unitName: params?.unitName,
+      name: assetInfo?.params?.name ?? mimirMeta?.name,
+      unitName: assetInfo?.params?.unitName,
       symbol: mimirMeta?.symbol,
       imageUrl: mimirMeta?.imageUrl,
       usdValue: mimirMeta?.usdValue,

--- a/src/services/network/index.ts
+++ b/src/services/network/index.ts
@@ -394,6 +394,97 @@ export class NetworkService {
     }
   }
 
+  /**
+   * Targeted balance lookup for a single asset (used by the send flow's asset
+   * picker). Unlike getAccountBalance, this resolves only the requested asset
+   * and skips the heavy parts of that pipeline — pricing, rekey info, and the
+   * sequential per-holding metadata loop.
+   *
+   * ARC-200 discovery is retained via Mimir (checked first), so unmapped
+   * ARC-200 assets still resolve; an ASA fallback uses algod holdings as the
+   * source of truth. `assetId` is an ASA asset ID or an ARC-200 contract ID.
+   * The native token (assetId 0) is intentionally not handled here — callers
+   * resolve it separately. Returns null when the account doesn't hold it (or
+   * when its decimals can't be resolved, to avoid displaying an inflated
+   * balance).
+   */
+  async getSingleAssetBalance(
+    address: string,
+    assetId: number
+  ): Promise<AssetBalance | null> {
+    if (!algosdk.isValidAddress(address)) {
+      throw new Error('Invalid Algorand address');
+    }
+    if (!assetId) {
+      return null;
+    }
+
+    // ARC-200 tokens live only in Mimir, so check there first — this is what
+    // keeps unmapped ARC-200 assets discoverable (parity with
+    // getAccountBalance -> mergeAssetsWithMimirData). getMimirAssets returns []
+    // when Mimir is unavailable on this network, so ASAs still resolve below.
+    const mimirAssets = await this.getMimirAssets(address);
+    const arc200Match = mimirAssets.find(
+      (m) => m.assetType === 'arc200' && m.contractId === assetId
+    );
+    if (arc200Match) {
+      return {
+        assetId: arc200Match.contractId,
+        amount: arc200Match.balance ? BigInt(arc200Match.balance) : 0n,
+        decimals: arc200Match.decimals,
+        name: arc200Match.name,
+        symbol: arc200Match.symbol,
+        imageUrl: arc200Match.imageUrl,
+        usdValue: arc200Match.usdValue,
+        verified: arc200Match.verified,
+        assetType: 'arc200',
+        contractId: arc200Match.contractId,
+      };
+    }
+
+    // Otherwise treat it as an ASA: algod holdings are the source of truth for
+    // whether the account actually holds it (mirrors mergeAssetsWithMimirData,
+    // which only surfaces ASAs present in the algod holdings).
+    const accountInfo = await this.withTimeout(
+      this.algodClient.accountInformation(address).do(),
+      'account info'
+    );
+    // algosdk v3 exposes `assetId` (a uint64 bigint); compare as strings so
+    // large IDs aren't collapsed by a lossy Number() cast.
+    const holding = accountInfo.assets?.find(
+      (a: any) => String(a.assetId) === String(assetId)
+    );
+    if (!holding) {
+      return null;
+    }
+
+    const params = await this.getCachedAssetParams(assetId);
+    const mimirMeta = mimirAssets.find(
+      (m) => m.assetType === 'asa' && m.contractId === assetId
+    );
+
+    const decimals = params?.decimals ?? mimirMeta?.decimals;
+    if (decimals === undefined) {
+      // Never guess decimals: 0 — that would show a 10^N-inflated balance.
+      // Omit the asset until a later refresh can resolve its real params.
+      return null;
+    }
+
+    return {
+      assetId,
+      amount: holding.amount,
+      decimals,
+      name: params?.name ?? mimirMeta?.name,
+      unitName: params?.unitName,
+      symbol: mimirMeta?.symbol,
+      imageUrl: mimirMeta?.imageUrl,
+      usdValue: mimirMeta?.usdValue,
+      verified: mimirMeta?.verified,
+      assetType: 'asa',
+      contractId: mimirMeta?.contractId,
+    };
+  }
+
   private async getMimirAssets(address: string): Promise<MimirAsset[]> {
     // Return empty array if Mimir is not available on this network
     if (!this.mimirService) {


### PR DESCRIPTION
## What & why (TASK-52 / P-10)

`SendScreen`'s `fetchAssetOptions` effect depended on the whole `multiNetworkBalance?.assets` array, which gets a **fresh object reference on every balance refresh** (screen focus, pull-to-refresh, post-transaction). That re-ran the entire option-builder — and, for an unmapped asset, re-fired the **full `NetworkService.getAccountBalance` pipeline** (algod account info + Mimir pagination + pricing + rekey info + a sequential per-holding `getAssetByID` loop) just to locate a single asset's balance — while the user was composing a send.

### Changes
- **Narrowed the effect dependency.** A memo derives only the mapped asset(s) the builder needs and serializes them to a stable string key (`relevantBalanceKey`); the effect now depends on the parsed, content-stable slice (`relevantMappedAssets`) instead of the whole `assets` array, so it no longer re-runs on unrelated balance refreshes.
- **Targeted asset lookup.** New `NetworkService.getSingleAssetBalance(address, assetId)` resolves just the one requested asset — **ARC-200 retained**: it checks Mimir first (same source as the full path's `mergeAssetsWithMimirData`, so unmapped ARC-200 assets are still discovered), then falls back to an ASA lookup via algod holdings + cached params. It skips pricing, rekey info, and the per-holding metadata loop. Returns `null` (never guesses `decimals: 0`) when the asset can't be resolved. The unmapped-asset branch now calls this instead of `getAccountBalance`.
- **Fixed a latent dep bug.** `routeParams.asset` was **omitted** from the dep array (only `routeParams.assetId` was listed), so a deep-link that used `asset` wouldn't re-run the builder. `initialAssetId` is now a memo over **both** `asset` and `assetId`, and is a dependency. Also added `contextAssetName`.
- **Consistent mapping source (Codex round 1 fix).** Both the narrowing memo and the effect now read a single `tokenMappings` React state (seeded synchronously from `getCachedMappings()` — never empty — then refreshed via `getTokenMappings()`), so they can't diverge when newer mappings load (which previously could leave options empty/stale).

Signing / transaction-building logic is untouched (only asset-option fetching changed).

### Gates
- `npm run typecheck` — 0 errors (baseline 0)
- `npm run lint` — 0 errors (SendScreen warnings unchanged at 33; all pre-existing)
- `npm test -- --ci` — 245 passed / 12 suites

### Codex review
CLEAN after 2 rounds. Round 1 flagged the memo (`getCachedMappings`) vs effect (`getTokenMappings`) divergence → fixed via the shared `tokenMappings` state. Round 2 CLEAN: confirmed ARC-200 discovery retained, `routeParams.asset` reactive, options don't go empty/stale, no tx/signing changes.

### To verify in-app
1. Open **Send** with no asset context → network tokens populate; default selection is current network's native token.
2. Pick a **mapped ASA** asset → all network versions populate correctly.
3. Pick an **unmapped ARC-200** asset → option populates (ARC-200 discovery retained).
4. Deep-link into Send with a **preselected asset** (via `asset` param) → the builder reacts and preselects it.
5. While composing, trigger a balance refresh (e.g. return focus / pull-to-refresh) → confirm **no full balance fetch fires** for the composing asset and the selection/options don't reset.


https://claude.ai/code/session_012WoHuh1utAZRBTDiDZ2sEk
