### PR TITLE
perf(network): batch asset metadata + dedupe accountInformation (TASK-46)

### DIFF
--- a/src/services/network/__tests__/getAccountBalance.test.ts
+++ b/src/services/network/__tests__/getAccountBalance.test.ts
@@ -1,0 +1,361 @@
+import algosdk from 'algosdk';
+import { NetworkService } from '../index';
+import { NetworkId } from '@/types/network';
+import AlgorandPriceService from '@/services/algorand-price';
+
+// A syntactically valid address (all-zero public key) so isValidAddress passes.
+const ADDRESS = algosdk.encodeAddress(new Uint8Array(32));
+// A distinct, valid auth address for the rekeyed-account cases.
+const AUTH_ADDR = algosdk.encodeAddress(new Uint8Array(32).fill(7));
+const AUTH_PUBLIC_KEY = algosdk.decodeAddress(AUTH_ADDR).publicKey;
+
+interface AlgodProbe {
+  algodClient: any;
+  accountInfoCalls: () => number;
+  getAssetByIDIds: () => number[];
+  maxInFlight: () => number;
+}
+
+/**
+ * Build a mock algod client that records how many times accountInformation is
+ * called (to prove the dedup) and the peak concurrency of getAssetByID (to
+ * prove the batch is concurrency-capped, not unbounded).
+ */
+function makeAlgodProbe(accountResponse: any, assetDelayMs = 5): AlgodProbe {
+  let accountInfoCalls = 0;
+  const getAssetByIDIds: number[] = [];
+  let inFlight = 0;
+  let maxInFlight = 0;
+
+  const algodClient = {
+    accountInformation: (_addr: string) => ({
+      do: async () => {
+        accountInfoCalls += 1;
+        return accountResponse;
+      },
+    }),
+    getAssetByID: (id: number) => ({
+      do: async () => {
+        getAssetByIDIds.push(id);
+        inFlight += 1;
+        maxInFlight = Math.max(maxInFlight, inFlight);
+        await new Promise((resolve) => setTimeout(resolve, assetDelayMs));
+        inFlight -= 1;
+        return {
+          params: { decimals: 6, name: `Asset ${id}`, unitName: `A${id}` },
+        };
+      },
+    }),
+  };
+
+  return {
+    algodClient,
+    accountInfoCalls: () => accountInfoCalls,
+    getAssetByIDIds: () => [...getAssetByIDIds],
+    maxInFlight: () => maxInFlight,
+  };
+}
+
+function makeAssets(count: number, startId = 1000) {
+  return Array.from({ length: count }, (_, i) => ({
+    assetId: BigInt(startId + i),
+    amount: BigInt(100 + i),
+  }));
+}
+
+describe('NetworkService.getAccountBalance (batch + dedupe, TASK-46)', () => {
+  let service: NetworkService;
+
+  beforeEach(() => {
+    service = NetworkService.getInstance(NetworkId.ALGORAND_MAINNET);
+    // Wipe shared-singleton caches so each test starts clean.
+    (service as any).assetParamsCache.clear();
+    (service as any).rekeyInfoCache.clear();
+    // Neutralise the heavy side-paths so we can focus on batching + dedupe.
+    jest.spyOn(service as any, 'getMimirAssets').mockResolvedValue([]);
+    jest.spyOn(service, 'isFeatureAvailable').mockReturnValue(true);
+    jest
+      .spyOn(AlgorandPriceService, 'getAssetPrices')
+      .mockResolvedValue(new Map<number, number>([[0, 1.5]]));
+  });
+
+  afterEach(() => {
+    jest.restoreAllMocks();
+  });
+
+  it('reads rekey authority from an INDEPENDENT fetch, not the shared balance snapshot (DR-1); dedupes only pricing', async () => {
+    // DR-1 guard: the balance snapshot is plain, but the rekey path's own
+    // (distinct, later) request shows the account rekeyed. The returned
+    // rekeyInfo MUST reflect rekey's own fetch — proving the shared balance
+    // snapshot is never fed into the signing-authority path. This is why the
+    // rekey fetch is intentionally NOT deduped (only pricing is).
+    const balanceSnapshot = {
+      amount: 5_000_000n,
+      minBalance: 100_000n,
+      assets: [],
+    };
+    const rekeySnapshot = {
+      amount: 5_000_000n,
+      minBalance: 100_000n,
+      assets: [],
+      authAddr: { publicKey: AUTH_PUBLIC_KEY },
+    };
+    let callCount = 0;
+    (service as any).algodClient = {
+      accountInformation: () => ({
+        do: async () => {
+          callCount += 1;
+          // Call 1 = balance (shared into pricing); call 2 = rekey's own fetch.
+          return callCount === 1 ? balanceSnapshot : rekeySnapshot;
+        },
+      }),
+    };
+    (service as any).indexerClient = {
+      lookupAccountTransactions: () => ({
+        txType: () => ({
+          limit: () => ({
+            do: async () => ({
+              transactions: [{ rekeyTo: AUTH_ADDR, roundTime: 1_700_000_000 }],
+            }),
+          }),
+        }),
+      }),
+    };
+
+    const result = await service.getAccountBalance(ADDRESS);
+
+    // rekeyInfo reflects rekey's OWN (rekeyed) snapshot, not the plain balance
+    // snapshot — byte-identical to pre-refactor independent-fetch behavior.
+    expect(result.rekeyInfo).toEqual({
+      isRekeyed: true,
+      authAddress: AUTH_ADDR,
+      rekeyedAt: 1_700_000_000 * 1000,
+    });
+    // Exactly 2 accountInformation calls on Algorand: balance (reused by
+    // pricing) + rekey's independent fetch. Pre-refactor was 3 (pricing
+    // re-fetched); the pricing dedup removes that third call.
+    expect(callCount).toBe(2);
+    // Pricing ran off the shared balance snapshot (no assets → just ALGO).
+    expect(AlgorandPriceService.getAssetPrices).toHaveBeenCalledWith([0]);
+  });
+
+  it('resolves ASA metadata in a concurrency-capped batch (not serial, not unbounded)', async () => {
+    const HOLDINGS = 20;
+    const probe = makeAlgodProbe({
+      amount: 5_000_000n,
+      minBalance: 100_000n,
+      assets: makeAssets(HOLDINGS),
+    });
+    (service as any).algodClient = probe.algodClient;
+
+    const result = await service.getAccountBalance(ADDRESS);
+
+    // Every holding is looked up...
+    expect(probe.getAssetByIDIds()).toHaveLength(HOLDINGS);
+    expect(result.assets).toHaveLength(HOLDINGS);
+    // ...concurrently (peak > 1, so it's not the old serial loop)...
+    expect(probe.maxInFlight()).toBeGreaterThan(1);
+    // ...but bounded by the cap of 8 (never fans out to all 20 at once).
+    expect(probe.maxInFlight()).toBeLessThanOrEqual(8);
+    // Output order matches the account's holdings order.
+    expect(result.assets.map((a) => a.assetId)).toEqual(
+      makeAssets(HOLDINGS).map((a) => Number(a.assetId))
+    );
+  });
+
+  it('preserves the assetParamsCache: a second load re-uses cached params (no repeat getAssetByID)', async () => {
+    const probe = makeAlgodProbe({
+      amount: 5_000_000n,
+      minBalance: 100_000n,
+      assets: makeAssets(4),
+    });
+    (service as any).algodClient = probe.algodClient;
+
+    await service.getAccountBalance(ADDRESS);
+    expect(probe.getAssetByIDIds()).toHaveLength(4);
+
+    await service.getAccountBalance(ADDRESS);
+    // Still 4 total — the second load hit the immutable-params cache.
+    expect(probe.getAssetByIDIds()).toHaveLength(4);
+  });
+
+  it('omits (does not fabricate) an asset whose getAssetByID rejects, without failing the batch', async () => {
+    const probe = makeAlgodProbe({
+      amount: 5_000_000n,
+      minBalance: 100_000n,
+      assets: makeAssets(3),
+    });
+    // Make the middle asset's lookup reject; the other two must still resolve.
+    const failingId = 1001;
+    const originalGetAssetByID = probe.algodClient.getAssetByID;
+    probe.algodClient.getAssetByID = (id: number) => {
+      if (id === failingId) {
+        return { do: async () => Promise.reject(new Error('boom')) };
+      }
+      return originalGetAssetByID(id);
+    };
+    (service as any).algodClient = probe.algodClient;
+
+    const result = await service.getAccountBalance(ADDRESS);
+
+    expect(result.assets.map((a) => a.assetId)).toEqual([1000, 1002]);
+  });
+
+  it('omits (and does not cache a fabricated 0 for) a FULFILLED asset with undefined/invalid decimals, but keeps a real decimals:0', async () => {
+    const undefinedDecId = 1000; // fulfilled but params.decimals is missing
+    const zeroDecId = 1001; // legitimate 0-decimals ASA (defined 0)
+    (service as any).algodClient = {
+      accountInformation: () => ({
+        do: async () => ({
+          amount: 1n,
+          minBalance: 1n,
+          assets: [
+            { assetId: BigInt(undefinedDecId), amount: 5n },
+            { assetId: BigInt(zeroDecId), amount: 7n },
+          ],
+        }),
+      }),
+      getAssetByID: (id: number) => ({
+        do: async () =>
+          id === undefinedDecId
+            ? { params: { name: 'No Decimals', unitName: 'NODEC' } }
+            : {
+                params: {
+                  decimals: 0,
+                  name: 'Zero Decimals',
+                  unitName: 'ZERO',
+                },
+              },
+      }),
+    };
+
+    const result = await service.getAccountBalance(ADDRESS);
+
+    // Malformed-decimals asset omitted (never fabricated to 0); real 0 kept.
+    expect(result.assets.map((a) => a.assetId)).toEqual([zeroDecId]);
+    expect(result.assets.find((a) => a.assetId === zeroDecId)?.decimals).toBe(
+      0
+    );
+    // No fabricated 0 cached for the malformed asset...
+    expect((service as any).assetParamsCache.has(String(undefinedDecId))).toBe(
+      false
+    );
+    // ...but the genuine 0-decimals asset IS cached.
+    expect(
+      (service as any).assetParamsCache.get(String(zeroDecId))?.decimals
+    ).toBe(0);
+  });
+});
+
+describe('NetworkService.getAccountRekeyInfo (independent fetch, DR-1)', () => {
+  let service: NetworkService;
+
+  const makeIndexer = () => ({
+    lookupAccountTransactions: () => ({
+      txType: () => ({
+        limit: () => ({
+          do: async () => ({
+            transactions: [{ rekeyTo: AUTH_ADDR, roundTime: 1_700_000_000 }],
+          }),
+        }),
+      }),
+    }),
+  });
+
+  beforeEach(() => {
+    service = NetworkService.getInstance(NetworkId.ALGORAND_MAINNET);
+    (service as any).rekeyInfoCache.clear();
+    (service as any).indexerClient = makeIndexer();
+  });
+
+  afterEach(() => {
+    jest.restoreAllMocks();
+  });
+
+  it('a PLAIN account resolves to { isRekeyed: false } from its own accountInformation fetch', async () => {
+    const plainAccount = { amount: 1n, minBalance: 1n, assets: [] };
+    let accountInfoCalls = 0;
+    (service as any).algodClient = {
+      accountInformation: () => ({
+        do: async () => {
+          accountInfoCalls += 1;
+          return plainAccount;
+        },
+      }),
+    };
+
+    const result = await service.getAccountRekeyInfo(ADDRESS);
+
+    expect(result).toEqual({ isRekeyed: false });
+    expect(accountInfoCalls).toBe(1);
+  });
+
+  it('a REKEYED account resolves authAddress + rekeyedAt from its own fetch + indexer lookup', async () => {
+    const rekeyedAccount = {
+      amount: 1n,
+      minBalance: 1n,
+      assets: [],
+      authAddr: { publicKey: AUTH_PUBLIC_KEY },
+    };
+    let accountInfoCalls = 0;
+    (service as any).algodClient = {
+      accountInformation: () => ({
+        do: async () => {
+          accountInfoCalls += 1;
+          return rekeyedAccount;
+        },
+      }),
+    };
+
+    const result = await service.getAccountRekeyInfo(ADDRESS);
+
+    // This is the signing-authority surface persisted into canSign/authAddress.
+    expect(result).toEqual({
+      isRekeyed: true,
+      authAddress: AUTH_ADDR,
+      rekeyedAt: 1_700_000_000 * 1000,
+    });
+    expect(accountInfoCalls).toBe(1);
+  });
+
+  it('skips the rekeyedAt indexer lookup when skipTimestamp is true (signing path), unchanged', async () => {
+    const rekeyedAccount = { authAddr: { publicKey: AUTH_PUBLIC_KEY } };
+    (service as any).algodClient = {
+      accountInformation: () => ({ do: async () => rekeyedAccount }),
+    };
+    let indexerCalls = 0;
+    (service as any).indexerClient = {
+      lookupAccountTransactions: () => {
+        indexerCalls += 1;
+        return makeIndexer().lookupAccountTransactions();
+      },
+    };
+
+    const result = await service.getAccountRekeyInfo(ADDRESS, true);
+
+    expect(result).toEqual({ isRekeyed: true, authAddress: AUTH_ADDR });
+    expect(indexerCalls).toBe(0);
+  });
+
+  it('returns a fresh cache entry without a network fetch (cache semantics preserved)', async () => {
+    const cachedInfo = { isRekeyed: false };
+    (service as any).rekeyInfoCache.set(ADDRESS, {
+      info: cachedInfo,
+      timestamp: Date.now(),
+    });
+    let accountInfoCalls = 0;
+    (service as any).algodClient = {
+      accountInformation: () => ({
+        do: async () => {
+          accountInfoCalls += 1;
+          return { authAddr: { publicKey: AUTH_PUBLIC_KEY } };
+        },
+      }),
+    };
+
+    const result = await service.getAccountRekeyInfo(ADDRESS);
+
+    expect(result).toBe(cachedInfo);
+    expect(accountInfoCalls).toBe(0);
+  });
+});

--- a/src/services/network/index.ts
+++ b/src/services/network/index.ts
@@ -28,6 +28,20 @@ export interface RekeyInfo {
   rekeyedAt?: number;
 }
 
+// Resolved shape of `algodClient.accountInformation(address).do()`. Used to pass
+// the balance load's already-fetched account response into getPricingData so
+// Algorand pricing (which only needs the asset IDs) doesn't re-fetch the same
+// address. NOTE: it is deliberately NOT passed to getAccountRekeyInfo, which
+// keeps its own independent request for the signing-authority read (DR-1).
+type AlgodAccountInfo = Awaited<
+  ReturnType<ReturnType<algosdk.Algodv2['accountInformation']>['do']>
+>;
+
+// Max concurrent algod getAssetByID lookups when resolving ASA metadata for a
+// balance load. Bounded (not unbounded Promise.all) so an account holding many
+// ASAs can't fan out and rate-limit the node.
+const ASSET_METADATA_CONCURRENCY = 8;
+
 // Re-export types for backwards compatibility
 export type {
   NetworkConfiguration as NetworkConfig,
@@ -280,15 +294,25 @@ export class NetworkService {
         throw new Error('Invalid Algorand address');
       }
 
-      // Fetch basic account info, Mimir assets, pricing, and rekey info in parallel
+      // Fetch the account info once and share the single in-flight promise with
+      // the PRICING path only — it needs just the asset IDs, so reusing this
+      // snapshot removes the redundant accountInformation round-trip it did on
+      // Algorand. getAccountRekeyInfo deliberately keeps its OWN independent
+      // request (not deduped against this snapshot): its authAddr read feeds
+      // canSign/authAddress persisted to wallet metadata and consumed by signing
+      // (DR-1), so it must observe the account's authority on its own fetch,
+      // byte-identical to pre-refactor behavior. All four still start
+      // concurrently, exactly as before.
+      const accountInfoPromise = this.withTimeout(
+        this.algodClient.accountInformation(address).do(),
+        'account info'
+      );
+
       const [accountInfo, mimirAssets, priceData, rekeyInfo] =
         await Promise.allSettled([
-          this.withTimeout(
-            this.algodClient.accountInformation(address).do(),
-            'account info'
-          ),
+          accountInfoPromise,
           this.getMimirAssets(address),
-          this.getPricingData(address),
+          this.getPricingData(address, accountInfoPromise),
           this.getAccountRekeyInfo(address),
         ]);
 
@@ -296,62 +320,110 @@ export class NetworkService {
         throw new Error(`Failed to fetch account info: ${accountInfo.reason}`);
       }
 
-      const algodAssets: AssetBalance[] = [];
       // Guard the cache writes below against a network switch during this
       // refresh: switchNetwork clears assetParamsCache and bumps the
       // generation, so a stale response can't repopulate the cleared cache
       // (holds even across a switch-and-back within the loop).
       const requestGeneration = this.assetCacheGeneration;
-      if (accountInfo.value.assets) {
-        for (const asset of accountInfo.value.assets) {
-          const assetId = Number(asset.assetId);
-          const assetKey = String(asset.assetId);
+      const accountAssets = accountInfo.value.assets ?? [];
 
-          // Asset params are immutable: reuse the cached entry and skip the
-          // network call entirely once we've seen this asset before.
-          const cachedParams = this.assetParamsCache.get(assetKey);
-          if (cachedParams) {
-            algodAssets.push({
-              assetId,
-              amount: asset.amount,
-              decimals: cachedParams.decimals,
-              name: cachedParams.name,
-              unitName: cachedParams.unitName,
-              assetType: 'asa',
-            });
-            continue;
-          }
+      // Resolve a single ASA holding to an AssetBalance, or null to omit it.
+      // Cache hits skip the network entirely; misses fetch the immutable params
+      // and populate the cache (guarded against a mid-refresh network switch).
+      const resolveAssetBalance = async (
+        asset: (typeof accountAssets)[number]
+      ): Promise<AssetBalance | null> => {
+        const assetId = Number(asset.assetId);
+        const assetKey = String(asset.assetId);
 
-          try {
-            const assetInfo = await this.withTimeout(
-              this.algodClient.getAssetByID(assetId).do(),
-              `asset ${assetId}`
-            );
-            const params = {
-              decimals: Number(assetInfo.params.decimals ?? 0),
-              name: assetInfo.params.name,
-              unitName: assetInfo.params.unitName,
-            };
-            if (this.assetCacheGeneration === requestGeneration) {
-              this.assetParamsCache.set(assetKey, params);
-            }
-            algodAssets.push({
-              assetId,
-              amount: asset.amount,
-              decimals: params.decimals,
-              name: params.name,
-              unitName: params.unitName,
-              assetType: 'asa',
-            });
-          } catch (assetError) {
+        // Asset params are immutable: reuse the cached entry and skip the
+        // network call entirely once we've seen this asset before.
+        const cachedParams = this.assetParamsCache.get(assetKey);
+        if (cachedParams) {
+          return {
+            assetId,
+            amount: asset.amount,
+            decimals: cachedParams.decimals,
+            name: cachedParams.name,
+            unitName: cachedParams.unitName,
+            assetType: 'asa',
+          };
+        }
+
+        try {
+          const assetInfo = await this.withTimeout(
+            this.algodClient.getAssetByID(assetId).do(),
+            `asset ${assetId}`
+          );
+          // Only trust a genuine finite non-negative integer decimals. A real
+          // 0-decimals ASA returns a DEFINED 0 (preserved), but a fulfilled-yet-
+          // malformed response with undefined/invalid decimals must be treated
+          // as unresolved — omit the asset and do NOT cache a fabricated 0,
+          // which would inflate the displayed balance by 10^N (same
+          // financial-correctness class as TASK-52). This mirrors the rejection
+          // branch below: an unusable response resolves to null.
+          const decimals = this.normalizeDecimals(assetInfo.params.decimals);
+          if (decimals === null) {
             console.warn(
-              `Failed to fetch asset info for ${asset.assetId}:`,
-              assetError
+              `Omitting asset ${asset.assetId}: algod returned no usable decimals`,
+              assetInfo.params.decimals
             );
-            // Never fall back to decimals: 0 for an unknown asset — that would
-            // display a 10^N x inflated balance. Omit the asset until a later
-            // refresh can resolve its real params.
-            continue;
+            return null;
+          }
+          const params = {
+            decimals,
+            name: assetInfo.params.name,
+            unitName: assetInfo.params.unitName,
+          };
+          if (this.assetCacheGeneration === requestGeneration) {
+            this.assetParamsCache.set(assetKey, params);
+          }
+          return {
+            assetId,
+            amount: asset.amount,
+            decimals: params.decimals,
+            name: params.name,
+            unitName: params.unitName,
+            assetType: 'asa',
+          };
+        } catch (assetError) {
+          console.warn(
+            `Failed to fetch asset info for ${asset.assetId}:`,
+            assetError
+          );
+          // Never fall back to decimals: 0 for an unknown asset — that would
+          // display a 10^N x inflated balance. Omit the asset until a later
+          // refresh can resolve its real params.
+          return null;
+        }
+      };
+
+      // Resolve holdings in concurrency-capped batches so cache-miss lookups run
+      // in parallel instead of one-at-a-time, without fanning out to all N at
+      // once (which could rate-limit the node). Each holding is isolated — a
+      // rejected lookup resolves to null and only omits that one asset — and
+      // output order matches the holdings order.
+      //
+      // NOTE: this caps how many lookups are DISPATCHED per batch, not the total
+      // live requests. withTimeout (shared, unchanged here) is a non-aborting
+      // Promise.race, so on a hung node a batch can all time out while their
+      // underlying requests stay live, and the next batch dispatches on top —
+      // in-flight can exceed the cap (more aggressively than the old serial
+      // loop, which added one per timeout). It never drops or fabricates assets,
+      // so this is an acceptable resource residual on a degraded-node path; a
+      // true hard cap on live requests would require an AbortController on the
+      // shared withTimeout (out of scope here).
+      const algodAssets: AssetBalance[] = [];
+      for (
+        let i = 0;
+        i < accountAssets.length;
+        i += ASSET_METADATA_CONCURRENCY
+      ) {
+        const batch = accountAssets.slice(i, i + ASSET_METADATA_CONCURRENCY);
+        const resolved = await Promise.all(batch.map(resolveAssetBalance));
+        for (const assetBalance of resolved) {
+          if (assetBalance) {
+            algodAssets.push(assetBalance);
           }
         }
       }
@@ -563,7 +635,8 @@ export class NetworkService {
   }
 
   private async getPricingData(
-    address: string
+    address: string,
+    prefetchedAccountInfo?: Promise<AlgodAccountInfo>
   ): Promise<{ nativePrice?: number; assetPrices?: Map<number, number> }> {
     if (!this.isFeatureAvailable('pricing')) {
       return {};
@@ -575,10 +648,12 @@ export class NetworkService {
         const voiPrice = await VoiPriceService.getVoiPrice();
         return { nativePrice: voiPrice };
       } else if (this.currentNetworkId === NetworkId.ALGORAND_MAINNET) {
-        // For Algorand, get prices for ALGO and all user's assets
-        const accountInfo = await this.algodClient
-          .accountInformation(address)
-          .do();
+        // For Algorand, get prices for ALGO and all user's assets. Reuse the
+        // caller's in-flight account request when provided so this path doesn't
+        // issue a duplicate accountInformation call for the same address; fall
+        // back to fetching when called standalone.
+        const accountInfo = await (prefetchedAccountInfo ??
+          this.algodClient.accountInformation(address).do());
         const assetIds: number[] = [0]; // Always include ALGO (asset ID 0)
 
         // Collect all asset IDs from user's assets
@@ -1219,6 +1294,14 @@ export class NetworkService {
         return cached.info;
       }
 
+      // Deliberately issue an INDEPENDENT accountInformation request here rather
+      // than reusing a snapshot fetched elsewhere (e.g. getAccountBalance's).
+      // The authAddr read below feeds canSign / authAddress that get persisted
+      // to wallet metadata (DR-1) and consumed by signing, so this must observe
+      // the account's authority on its own request — byte-identical to prior
+      // behavior. Reusing a shared snapshot would change which round-consistent
+      // view the rekey state is read from (e.g. across a rekey confirmation),
+      // so the rekey fetch is intentionally NOT deduped against the balance load.
       const accountInfo = await this.algodClient
         .accountInformation(address)
         .do();


### PR DESCRIPTION
## What & why (TASK-46)

Two performance changes to `NetworkService.getAccountBalance` (`src/services/network/index.ts`), resolving audit items P-01 (partial) / P-03:

1. **Batch the N+1 `getAssetByID` loop.** The per-ASA metadata lookup was a serial `await` inside the holdings loop. It now resolves holdings in **concurrency-capped batches** (`ASSET_METADATA_CONCURRENCY = 8`, `Promise.all` per chunk — chunked, **not** unbounded `Promise.all`). The `assetParamsCache` reuse and the network-switch generation guard (`assetCacheGeneration`) are preserved; output order matches holdings order; a single rejected lookup resolves to `null` and only omits that one asset (never fabricates `decimals: 0`).

2. **Dedupe the `accountInformation` fetch — for `getPricingData` ONLY.** `getPricingData` (Algorand-only) re-fetched the same address just to read its asset IDs; it now reuses the balance load's single in-flight account promise, removing that third round-trip. **On Algorand, per-refresh `accountInformation` drops 3 → 2; on Voi it stays 2** (Voi pricing never fetched), while ASA metadata is now batched on both.

3. **Financial-correctness fix (TASK-52 class) in the refactored loop.** A *fulfilled* `getAssetByID` whose `params.decimals` is `undefined`/invalid previously coerced to `decimals: 0` and cached it — a 10^N-inflated balance. It now runs `normalizeDecimals` and, on an unusable value, **omits the asset and caches nothing** (mirroring the rejection branch). A legitimate `decimals: 0` (a *defined* 0 from algod) is still preserved and cached. This is asset-metadata only — it does not touch the rekey/signing path.

## DR-1: rekeyInfo / canSign kept strictly byte-identical

An earlier revision also deduped `getAccountRekeyInfo` against the shared snapshot. That was **reverted** after crypto review: feeding the balance's single snapshot into the rekey path changes the *authority-observation semantics* — if a rekey confirms in the window between what were two independent fetches (or the node serves different snapshots), the deduped view could observe a different `authAddr` than `main` would, producing a transiently wrong `authAddress`/`canSign` persisted to wallet metadata and cached 10 s. Not byte-identical for the signing-authority field → unacceptable per CLAUDE.md.

**Fix:** `getAccountRekeyInfo` keeps its **OWN independent `accountInformation` request**, exactly as on `main` (a code comment documents why it must not be deduped). Its `authAddr` decode, `rekeyedAt` indexer lookup, cache read/write, and return contract are unchanged, so `rekeyInfo` — and the downstream `canSign`/`authAddress`/`account.type` in `rekeyManager.updateAccountWithRekeyInfo` — is byte-identical for both plain and rekeyed accounts. The pricing dedup is safe because pricing only reads asset IDs and never touches the rekey/signing path. No key/mnemonic/SecureStore access added; stays Algorand-compatible.

## Concurrency-cap honesty (R1)

The cap bounds how many `getAssetByID` lookups are **dispatched per batch**, not total live requests. The shared `withTimeout` helper is a non-aborting `Promise.race`, so on a hung node a batch can all time out while their underlying requests stay live and the next batch dispatches on top — in-flight can exceed 8 (more aggressively than the old serial loop's one-per-timeout). It never drops or fabricates assets, so this is an accepted resource residual on a degraded-node path; a true hard cap on live requests would require an `AbortController` on the shared `withTimeout` (out of scope here). The code comment states this plainly — **no hard-cap claim is made.**

## Gates
- `npm run typecheck` — 0 errors (baseline preserved)
- `npm run lint` — 0 errors (685 pre-existing warnings unchanged)
- `npm test` — 263 passing (14 suites). Added `src/services/network/__tests__/getAccountBalance.test.ts` (9 tests): a **DR-1 guard** proving `getAccountBalance`'s `rekeyInfo` reflects rekey's own independent snapshot (rekeyed) and NOT the shared balance snapshot (plain); pricing dedup (`accountInformation` 3 → 2 on Algorand); concurrency cap (peak in-flight ≤ 8, > 1); `assetParamsCache` reuse; per-asset rejection isolation; **fulfilled-but-undefined-decimals asset omitted with no cached 0 while a real `decimals: 0` is kept**; and `getAccountRekeyInfo` plain / rekeyed / `skipTimestamp` / fresh-cache contract.

## Codex crypto-review verdict — DR-1 CLEAN, decimals fix sound
Ran the mandatory Codex crypto review (5 rounds). Final round: **"DR-1 holds: rekey uses its own `accountInformation` request; pricing only consumes asset IDs from the shared snapshot; authAddr parsing and downstream canSign inputs are unchanged. The decimals fix is correct: invalid/missing values resolve to `null` before caching; defined `0` is preserved by `normalizeDecimals`. A rejected lookup omits only that asset. No key, mnemonic, or SecureStore leakage."** The only residual it reports is the concurrency resource note above — documented honestly, not a crypto/output regression.

## To verify in-app (incl. a REKEYED account)
- Balances load correctly on **Voi mainnet** and **Algorand mainnet** (native + ASA metadata/decimals correct, especially an account holding many ASAs).
- A **rekeyed account** still shows the correct signable state (send enabled/disabled matching its auth address) and the correct rekey banner/timestamp — the signing-authority read is unchanged.
- Network inspector shows **one fewer `accountInformation` request per refresh on Algorand** (2 instead of 3), with no duplicate pricing fetch.

Ref: TASK-46

https://claude.ai/code/session_012WoHuh1utAZRBTDiDZ2sEk
