### PR TITLE
perf(wallet): in-flight dedup for loadAccountBalance (TASK-49)

### DIFF
--- a/src/store/__tests__/loadAccountBalance.dedup.test.ts
+++ b/src/store/__tests__/loadAccountBalance.dedup.test.ts
@@ -1,0 +1,171 @@
+// TASK-49: in-flight request dedup for loadAccountBalance (walletStore).
+//
+// Proves that concurrent loadAccountBalance calls for the SAME account+network
+// share a single underlying getAccountBalance request (and therefore run the
+// expensive fetch + rekey persist exactly once), while a DIFFERENT network is
+// NOT deduped together — because the in-flight key includes the networkId, a
+// mid-load network switch starts its own fetch instead of joining (and
+// inheriting/persisting) the previous network's result.
+//
+// The heavy service graph is mocked so the store imports lightweight; only the
+// two dependencies loadAccountBalance actually drives (NetworkService +
+// MultiAccountWalletService) carry behavior.
+
+const mockGetAccountBalance = jest.fn();
+const mockGetCurrentNetworkId = jest.fn(() => 'voi-mainnet');
+const mockGetAccount = jest.fn(async (id: string) => ({
+  id,
+  address: `ADDR-${id}`,
+  type: 'standard',
+}));
+
+jest.mock('@/services/network', () => ({
+  NetworkService: {
+    getInstance: () => ({
+      getAccountBalance: (...args: unknown[]) => mockGetAccountBalance(...args),
+      getCurrentNetworkId: () => mockGetCurrentNetworkId(),
+    }),
+  },
+  VoiNetworkService: {},
+}));
+
+jest.mock('@/services/wallet', () => ({
+  MultiAccountWalletService: {
+    getAccount: (id: string) => mockGetAccount(id),
+    updateAccountMetadata: jest.fn(async () => {}),
+  },
+}));
+
+jest.mock('@/services/wallet/rekeyManager', () => ({
+  __esModule: true,
+  default: { updateAccountWithRekeyInfo: jest.fn() },
+}));
+
+jest.mock('@/services/envoi', () => ({ __esModule: true, default: {} }));
+jest.mock('@/services/mimir', () => ({ MimirApiService: {} }));
+jest.mock('@/services/token-mapping', () => ({
+  __esModule: true,
+  default: {},
+  TokenMappingService: {},
+}));
+jest.mock('@/services/network/multi-network', () => ({
+  MultiNetworkBalanceService: {},
+}));
+jest.mock('@/services/notifications', () => ({
+  notificationService: {},
+  DEFAULT_NOTIFICATION_PREFERENCES: {},
+}));
+jest.mock('@/services/realtime', () => ({ realtimeService: {} }));
+
+jest.mock('@react-native-async-storage/async-storage', () => ({
+  __esModule: true,
+  default: {
+    getItem: jest.fn(async () => null),
+    setItem: jest.fn(async () => {}),
+    removeItem: jest.fn(async () => {}),
+    multiGet: jest.fn(async () => []),
+    multiSet: jest.fn(async () => {}),
+  },
+}));
+
+import { useWalletStore } from '../walletStore';
+
+// Drain microtasks + 0ms timers so the shared in-flight promise advances to the
+// (still-pending) getAccountBalance call.
+const flush = () => new Promise((resolve) => setTimeout(resolve, 0));
+
+describe('loadAccountBalance in-flight dedup (TASK-49)', () => {
+  beforeEach(() => {
+    mockGetAccountBalance.mockReset();
+    mockGetAccount.mockClear();
+    mockGetCurrentNetworkId.mockReset();
+    mockGetCurrentNetworkId.mockReturnValue('voi-mainnet');
+    // Clear cached balance state so the cache-freshness guard never short-circuits.
+    useWalletStore.setState({ accountStates: {}, wallet: null });
+  });
+
+  it('shares a single request across concurrent callers for the same account+network', async () => {
+    let resolveBalance!: (value: unknown) => void;
+    mockGetAccountBalance.mockImplementation(
+      () =>
+        new Promise((resolve) => {
+          resolveBalance = resolve as (value: unknown) => void;
+        })
+    );
+
+    const { loadAccountBalance } = useWalletStore.getState();
+
+    // Two overlapping callers (e.g. HomeScreen mount + pull-to-refresh) fired
+    // before the first fetch settles.
+    const p1 = loadAccountBalance('acc-1', true);
+    const p2 = loadAccountBalance('acc-1', true);
+
+    await flush();
+
+    // The expensive chain (getAccount + getAccountBalance) ran exactly once and
+    // is shared by both callers.
+    expect(mockGetAccount).toHaveBeenCalledTimes(1);
+    expect(mockGetAccountBalance).toHaveBeenCalledTimes(1);
+
+    resolveBalance({});
+    await Promise.all([p1, p2]);
+
+    expect(mockGetAccountBalance).toHaveBeenCalledTimes(1);
+  });
+
+  it('does NOT dedup across networks — a mid-load network switch starts its own fetch', async () => {
+    const resolvers: ((value: unknown) => void)[] = [];
+    mockGetAccountBalance.mockImplementation(
+      () =>
+        new Promise((resolve) => {
+          resolvers.push(resolve as (value: unknown) => void);
+        })
+    );
+
+    const { loadAccountBalance } = useWalletStore.getState();
+
+    mockGetCurrentNetworkId.mockReturnValue('voi-mainnet');
+    const p1 = loadAccountBalance('acc-1', true);
+    await flush();
+
+    // Network switches while the mainnet load is still in flight.
+    mockGetCurrentNetworkId.mockReturnValue('voi-testnet');
+    const p2 = loadAccountBalance('acc-1', true);
+    await flush();
+
+    // Two distinct fetches: the testnet caller did NOT join the mainnet
+    // in-flight load, so no wrong-network balance can be applied/persisted.
+    expect(mockGetAccountBalance).toHaveBeenCalledTimes(2);
+
+    resolvers.forEach((resolve) => resolve({}));
+    await Promise.all([p1, p2]);
+  });
+
+  it('clears the in-flight entry so a later forced load runs again (finally cleanup)', async () => {
+    mockGetAccountBalance.mockResolvedValue({});
+
+    const { loadAccountBalance } = useWalletStore.getState();
+
+    await loadAccountBalance('acc-1', true);
+    expect(mockGetAccountBalance).toHaveBeenCalledTimes(1);
+
+    // The map entry was removed in `finally`, so a subsequent forceRefresh is
+    // free to start a fresh load rather than being wedged.
+    await loadAccountBalance('acc-1', true);
+    expect(mockGetAccountBalance).toHaveBeenCalledTimes(2);
+  });
+
+  it('clears the in-flight entry even when the load throws (no wedged future loads)', async () => {
+    mockGetAccountBalance.mockRejectedValueOnce(new Error('network down'));
+
+    const { loadAccountBalance } = useWalletStore.getState();
+
+    // The failed load must not reject to callers (errors are handled to state)…
+    await expect(loadAccountBalance('acc-1', true)).resolves.toBeUndefined();
+
+    // …and must not wedge future loads: the next attempt fetches again.
+    mockGetAccountBalance.mockResolvedValueOnce({});
+    await loadAccountBalance('acc-1', true);
+    expect(mockGetAccountBalance).toHaveBeenCalledTimes(2);
+  });
+});

--- a/src/store/walletStore.ts
+++ b/src/store/walletStore.ts
@@ -412,6 +412,18 @@ const persistMultiNetworkBalanceToStorage = async (
 // initialize()/refresh()/account-switch still re-runs initialization normally.
 let walletInitializationPromise: Promise<void> | null = null;
 
+// In-flight balance-load dedup. Keyed by `${accountId}:${networkId}` (NOT
+// accountId alone): loadAccountBalance captures the network before its await and
+// persists a network-scoped cache, so a network switch mid-load must NOT let a
+// caller on the new network join (and receive/persist) the previous network's
+// result. Concurrent callers for the same account+network (HomeScreen mount,
+// pull-to-refresh, SendScreen, the transactionSuccess force-refresh) share one
+// promise, so the expensive fetch chain and the rekeyInfo→canSign persist run
+// exactly once. Module-level (not a store field) so it survives initialize()'s
+// accountStates reset. Entries are always removed in a `finally`, so a failed
+// load can never wedge future loads.
+const balanceLoadsInFlight = new Map<string, Promise<void>>();
+
 export const useWalletStore = create<WalletState>()(
   subscribeWithSelector((set, get) => ({
     // Initial state
@@ -980,150 +992,202 @@ export const useWalletStore = create<WalletState>()(
 
     // Balance and transaction management
     loadAccountBalance: async (accountId: string, forceRefresh = false) => {
-      try {
-        const { accountStates } = get();
-        const accountState =
-          accountStates[accountId] || createInitialAccountState();
+      const { accountStates } = get();
+      const accountState =
+        accountStates[accountId] || createInitialAccountState();
 
-        // Define cache expiry time (30 seconds for background refresh logic)
-        const CACHE_EXPIRY_MS = 30 * 1000;
-        const now = Date.now();
-        const isCacheExpired =
-          now - accountState.balanceLastUpdated > CACHE_EXPIRY_MS;
-        const hasExistingBalance = !!accountState.balance;
+      // Define cache expiry time (30 seconds for background refresh logic)
+      const CACHE_EXPIRY_MS = 30 * 1000;
+      const now = Date.now();
+      const isCacheExpired =
+        now - accountState.balanceLastUpdated > CACHE_EXPIRY_MS;
+      const hasExistingBalance = !!accountState.balance;
 
-        // If we have cached data and not forcing refresh, check if we need background update
-        if (!forceRefresh && hasExistingBalance) {
-          // If cache is fresh, don't refresh at all
-          if (!isCacheExpired) {
-            return;
-          }
-          // If cache is stale, do background refresh (don't show loading state)
-          // This allows cached data to stay visible while refreshing
+      // If we have cached data and not forcing refresh, check if we need background update
+      if (!forceRefresh && hasExistingBalance) {
+        // If cache is fresh, don't refresh at all
+        if (!isCacheExpired) {
+          return;
         }
+        // If cache is stale, do background refresh (don't show loading state)
+        // This allows cached data to stay visible while refreshing
+      }
 
-        // Resolve account fresh from service (repairs missing addresses if needed)
-        const account = await MultiAccountWalletService.getAccount(accountId);
+      // Key the in-flight entry by the network at call time so a caller that
+      // arrives after a network switch gets a different key and starts its own
+      // load instead of joining — and inheriting — the previous network's request.
+      // (The network the balance is actually fetched/persisted on is re-read
+      // inside the load below, right before the fetch, so persistence always
+      // matches the fetched network exactly as it did before this change.)
+      const networkService = NetworkService.getInstance();
+      const keyNetworkId = networkService.getCurrentNetworkId();
+      const inFlightKey = `${accountId}:${keyNetworkId}`;
 
-        // Determine loading state based on cache availability
-        const shouldShowLoading = !hasExistingBalance || forceRefresh;
-        const shouldShowBackgroundRefresh = hasExistingBalance && !forceRefresh;
+      // In-flight dedup: concurrent callers (HomeScreen mount, pull-to-refresh,
+      // SendScreen, the transactionSuccess force-refresh) for the same
+      // account+network share this one promise, so the expensive fetch chain and
+      // the rekeyInfo→canSign persist below run exactly once and every caller sees
+      // the same result. forceRefresh joins an active load rather than launching a
+      // duplicate; when nothing is in flight it still starts a fresh load (the
+      // cache-freshness early-return above already honored forceRefresh's
+      // "ignore fresh cache" semantics).
+      const existingLoad = balanceLoadsInFlight.get(inFlightKey);
+      if (existingLoad) {
+        return existingLoad;
+      }
 
-        set({
-          accountStates: {
-            ...accountStates,
-            [accountId]: {
-              ...accountState,
-              isBalanceLoading: shouldShowLoading,
-              isBackgroundRefreshing: shouldShowBackgroundRefresh,
-              lastError: null,
+      const loadPromise = (async () => {
+        try {
+          // Resolve account fresh from service (repairs missing addresses if needed)
+          const account = await MultiAccountWalletService.getAccount(accountId);
+
+          // Determine loading state based on cache availability
+          const shouldShowLoading = !hasExistingBalance || forceRefresh;
+          const shouldShowBackgroundRefresh =
+            hasExistingBalance && !forceRefresh;
+
+          set({
+            accountStates: {
+              ...accountStates,
+              [accountId]: {
+                ...accountState,
+                isBalanceLoading: shouldShowLoading,
+                isBackgroundRefreshing: shouldShowBackgroundRefresh,
+                lastError: null,
+              },
             },
-          },
-        });
+          });
 
-        const networkService = NetworkService.getInstance();
-        const currentNetworkId = networkService.getCurrentNetworkId();
-        const balance = await networkService.getAccountBalance(account.address);
-
-        // Process rekey information if available (both rekeyed and non-rekeyed states)
-        let updatedWallet = get().wallet;
-        if (balance.rekeyInfo && updatedWallet) {
-          // Update the account with rekey information
-          const updatedAccount = await rekeyManager.updateAccountWithRekeyInfo(
-            account,
-            balance.rekeyInfo,
-            updatedWallet
+          // Re-read the network right before the fetch so the balance is
+          // persisted under the network it was actually fetched on (a switch
+          // during the getAccount await above must not persist under the stale
+          // key-network). The dedup key already isolated cross-network callers.
+          const currentNetworkId = networkService.getCurrentNetworkId();
+          const balance = await networkService.getAccountBalance(
+            account.address
           );
 
-          let shouldPersistMetadata = account.type !== updatedAccount.type;
-
-          if (
-            !shouldPersistMetadata &&
-            updatedAccount.type === AccountType.REKEYED &&
-            account.type === AccountType.REKEYED
-          ) {
-            const existingRekeyed = account as RekeyedAccountMetadata;
-            const newRekeyed = updatedAccount as RekeyedAccountMetadata;
-
-            shouldPersistMetadata =
-              existingRekeyed.authAddress !== newRekeyed.authAddress ||
-              existingRekeyed.canSign !== newRekeyed.canSign ||
-              existingRekeyed.rekeyedAt !== newRekeyed.rekeyedAt;
-          }
-
-          if (shouldPersistMetadata) {
-            try {
-              await MultiAccountWalletService.updateAccountMetadata(
-                updatedAccount
+          // Process rekey information if available (both rekeyed and non-rekeyed states)
+          let updatedWallet = get().wallet;
+          if (balance.rekeyInfo && updatedWallet) {
+            // Update the account with rekey information
+            const updatedAccount =
+              await rekeyManager.updateAccountWithRekeyInfo(
+                account,
+                balance.rekeyInfo,
+                updatedWallet
               );
-            } catch (persistError) {
-              console.warn(
-                'Failed to persist rekey metadata update:',
-                persistError
-              );
+
+            let shouldPersistMetadata = account.type !== updatedAccount.type;
+
+            if (
+              !shouldPersistMetadata &&
+              updatedAccount.type === AccountType.REKEYED &&
+              account.type === AccountType.REKEYED
+            ) {
+              const existingRekeyed = account as RekeyedAccountMetadata;
+              const newRekeyed = updatedAccount as RekeyedAccountMetadata;
+
+              shouldPersistMetadata =
+                existingRekeyed.authAddress !== newRekeyed.authAddress ||
+                existingRekeyed.canSign !== newRekeyed.canSign ||
+                existingRekeyed.rekeyedAt !== newRekeyed.rekeyedAt;
             }
+
+            if (shouldPersistMetadata) {
+              try {
+                await MultiAccountWalletService.updateAccountMetadata(
+                  updatedAccount
+                );
+              } catch (persistError) {
+                console.warn(
+                  'Failed to persist rekey metadata update:',
+                  persistError
+                );
+              }
+            }
+
+            // Update the wallet with the new account metadata
+            const updatedAccounts = updatedWallet.accounts.map((acc) =>
+              acc.id === accountId ? updatedAccount : acc
+            );
+
+            updatedWallet = { ...updatedWallet, accounts: updatedAccounts };
+
+            set({
+              wallet: updatedWallet,
+              accountStates: {
+                ...get().accountStates,
+                [accountId]: {
+                  ...get().accountStates[accountId],
+                  balance,
+                  isBalanceLoading: false,
+                  isBackgroundRefreshing: false,
+                  balanceLastUpdated: now,
+                },
+              },
+            });
+
+            // Persist the updated balance cache with network ID
+            setTimeout(() => {
+              persistBalanceToStorage(
+                accountId,
+                balance,
+                now,
+                currentNetworkId
+              );
+            }, 0);
+          } else {
+            set({
+              accountStates: {
+                ...get().accountStates,
+                [accountId]: {
+                  ...get().accountStates[accountId],
+                  balance,
+                  isBalanceLoading: false,
+                  isBackgroundRefreshing: false,
+                  balanceLastUpdated: now,
+                },
+              },
+            });
+
+            // Persist the updated balance cache with network ID
+            setTimeout(() => {
+              persistBalanceToStorage(
+                accountId,
+                balance,
+                now,
+                currentNetworkId
+              );
+            }, 0);
           }
-
-          // Update the wallet with the new account metadata
-          const updatedAccounts = updatedWallet.accounts.map((acc) =>
-            acc.id === accountId ? updatedAccount : acc
-          );
-
-          updatedWallet = { ...updatedWallet, accounts: updatedAccounts };
-
+        } catch (error) {
+          const { accountStates: latestAccountStates } = get();
           set({
-            wallet: updatedWallet,
             accountStates: {
-              ...get().accountStates,
+              ...latestAccountStates,
               [accountId]: {
-                ...get().accountStates[accountId],
-                balance,
+                ...latestAccountStates[accountId],
+                lastError:
+                  error instanceof Error
+                    ? error.message
+                    : 'Failed to load balance',
                 isBalanceLoading: false,
                 isBackgroundRefreshing: false,
-                balanceLastUpdated: now,
               },
             },
           });
-
-          // Persist the updated balance cache with network ID
-          setTimeout(() => {
-            persistBalanceToStorage(accountId, balance, now, currentNetworkId);
-          }, 0);
-        } else {
-          set({
-            accountStates: {
-              ...get().accountStates,
-              [accountId]: {
-                ...get().accountStates[accountId],
-                balance,
-                isBalanceLoading: false,
-                isBackgroundRefreshing: false,
-                balanceLastUpdated: now,
-              },
-            },
-          });
-
-          // Persist the updated balance cache with network ID
-          setTimeout(() => {
-            persistBalanceToStorage(accountId, balance, now, currentNetworkId);
-          }, 0);
         }
-      } catch (error) {
-        const { accountStates } = get();
-        set({
-          accountStates: {
-            ...accountStates,
-            [accountId]: {
-              ...accountStates[accountId],
-              lastError:
-                error instanceof Error
-                  ? error.message
-                  : 'Failed to load balance',
-              isBalanceLoading: false,
-              isBackgroundRefreshing: false,
-            },
-          },
-        });
+      })();
+
+      // Register before the first await inside the promise has a chance to settle
+      // so overlapping callers observe and join it, and always clear it in
+      // `finally` — even on throw — so a failed load can never wedge future loads.
+      balanceLoadsInFlight.set(inFlightKey, loadPromise);
+      try {
+        await loadPromise;
+      } finally {
+        balanceLoadsInFlight.delete(inFlightKey);
       }
     },
 


### PR DESCRIPTION
## What & why (TASK-49 · resolves P-06)

`loadAccountBalance` had a cache-freshness early-return but **no in-flight dedup** (unlike `loadAccountTransactions`, which early-returns on `isTransactionsLoading`). HomeScreen mount, pull-to-refresh, SendScreen, and the `transactionSuccess` force-refresh can all fire overlapping loads for the same account, each running the full expensive chain (accountInformation + Mimir pagination + pricing + per-asset metadata) **and** the rekey `rekeyInfo→canSign` metadata persist.

This adds a **module-level in-flight promise `Map`** so concurrent callers for the same account+network share one request; the expensive fetch chain and the rekey persist run **exactly once**, and every caller resolves off the same promise.

## Keying rationale: `accountId` **+** `networkId` (not accountId alone)

The persisted balance cache is **network-scoped**. The map key is `` `${accountId}:${networkId}` `` using the network captured **at call time**, so a caller that arrives *after* a network switch gets a different key and starts its own load instead of joining — and inheriting/persisting — the previous network's result. A store-field guard (`isBalanceLoading`) was deliberately **not** used: `initialize()` resets `accountStates`, which would clear such a guard; a module-level Map survives that reset.

The network the balance is actually **fetched and persisted** under is re-read *inside* the load, immediately before the fetch (`currentNetworkId`), preserving the pre-change persist timing so a switch during the `getAccount` await can never persist under a stale network id. (This addressed the one High finding from Codex review round 1.)

## rekey-persist-runs-once guarantee

The dedup wraps the **entire** post-cache-miss flow: `getAccountBalance` → `rekeyInfo→canSign` processing/`updateAccountMetadata` persist → state update. Because concurrent callers share the single in-flight promise, the rekey block runs exactly once (never skipped, never doubled) and all callers observe the same processed result. The map entry is removed in a **`finally`** (even on throw), so a failed load can never wedge future loads. `forceRefresh` **joins** an in-flight load rather than duplicating it; when nothing is in flight it still forces a fresh load (the cache-freshness early-return already honors force). No signing/key logic changed.

## Gates
- `npm run typecheck`: **0 errors** (baseline 0, unchanged)
- `npm run lint`: **0 errors** (pre-existing warnings only)
- `npm test -- --ci`: **267 passed / 15 suites**, incl. 4 new tests in `src/store/__tests__/loadAccountBalance.dedup.test.ts` proving concurrent callers for one account+network share a single underlying request, a different/mid-switch network is NOT deduped together, the `finally` clears the entry so later loads run, and a throwing load doesn't wedge or reject to callers.

## Codex verdict
**CLEAN** after 2 rounds. Round 1 flagged that the initial version captured the persist network id before the `getAccount` await (could persist under a stale id on a mid-await switch); fixed by re-reading it right before the fetch. Round 2: CLEAN.

## To verify in-app
1. Cold-start so HomeScreen mounts, immediately pull-to-refresh, and open Send for the same account — via a network inspector, confirm a **single** balance request per account instead of overlapping duplicates.
2. Switch network mid-refresh and confirm **no wrong-network balance** is applied/persisted (the switched-to network starts its own load; the in-flight one persists under the network it fetched).

Ref: TASK-49

https://claude.ai/code/session_012WoHuh1utAZRBTDiDZ2sEk
