### PR TITLE
fix(logging): strip console.* in production + redact PII log sites (TASK-33)

### DIFF
--- a/babel.config.js
+++ b/babel.config.js
@@ -1,5 +1,15 @@
 module.exports = function (api) {
-  api.cache(true);
+  // The config now depends on the build environment (we only strip console.* in
+  // production), so the cache key must vary by env. Using api.cache(true) would
+  // freeze the first-seen env and mis-apply the console-strip plugin for later
+  // builds, so key the cache on the resolved env instead.
+  api.cache.using(
+    () => process.env.BABEL_ENV || process.env.NODE_ENV || 'development'
+  );
+
+  const isProd =
+    (process.env.BABEL_ENV || process.env.NODE_ENV) === 'production';
+
   return {
     // babel-preset-expo auto-adds react-native-worklets/plugin when the package
     // is installed (see babel-preset-expo index.js), and — with
@@ -8,5 +18,18 @@ module.exports = function (api) {
     // plugin runs before the preset (so before the compiler), which is the wrong
     // order for the React Compiler + Reanimated worklets.
     presets: ['babel-preset-expo'],
+    // Production-only: strip console.* from release bundles to keep app logs
+    // (which can carry addresses/amounts/URIs) out of shipped builds. Preserve
+    // console.error/console.warn for crash diagnostics. transform-remove-console
+    // is a plain AST transform applied as a top-level plugin and does not affect
+    // the preset's worklets/compiler plugin ordering described above.
+    plugins: isProd
+      ? [
+          [
+            'babel-plugin-transform-remove-console',
+            { exclude: ['error', 'warn'] },
+          ],
+        ]
+      : [],
   };
 };

--- a/package-lock.json
+++ b/package-lock.json
@@ -86,6 +86,7 @@
         "@typescript-eslint/eslint-plugin": "^8.43.0",
         "@typescript-eslint/parser": "^8.43.0",
         "babel-plugin-react-compiler": "1.0.0",
+        "babel-plugin-transform-remove-console": "6.9.4",
         "eslint": "^9.35.0",
         "eslint-config-expo": "57.0.0",
         "eslint-config-prettier": "^10.1.8",
@@ -6993,6 +6994,13 @@
       "dependencies": {
         "@babel/plugin-syntax-flow": "^7.12.1"
       }
+    },
+    "node_modules/babel-plugin-transform-remove-console": {
+      "version": "6.9.4",
+      "resolved": "https://registry.npmjs.org/babel-plugin-transform-remove-console/-/babel-plugin-transform-remove-console-6.9.4.tgz",
+      "integrity": "sha512-88blrUrMX3SPiGkT1GnvVY8E/7A+k6oj3MNvUtTIxJflFzXTw1bHkuJ/y039ouhFMp2prRn5cQGzokViYi1dsg==",
+      "dev": true,
+      "license": "MIT"
     },
     "node_modules/babel-preset-current-node-syntax": {
       "version": "1.2.0",

--- a/package.json
+++ b/package.json
@@ -97,6 +97,7 @@
     "@typescript-eslint/eslint-plugin": "^8.43.0",
     "@typescript-eslint/parser": "^8.43.0",
     "babel-plugin-react-compiler": "1.0.0",
+    "babel-plugin-transform-remove-console": "6.9.4",
     "eslint": "^9.35.0",
     "eslint-config-expo": "57.0.0",
     "eslint-config-prettier": "^10.1.8",

--- a/src/__tests__/babel-console-strip.test.ts
+++ b/src/__tests__/babel-console-strip.test.ts
@@ -1,0 +1,56 @@
+/**
+ * Verifies babel.config.js (TASK-33) strips console.log in production while
+ * preserving console.error / console.warn, and leaves everything intact in
+ * development. This exercises the real repo babel.config.js via @babel/core so
+ * the env-gated `babel-plugin-transform-remove-console` wiring is under test.
+ */
+import * as path from 'path';
+
+// @babel/core is available transitively via babel-preset-expo. Use require so
+// the test still resolves it if the ESM import shape ever changes.
+// eslint-disable-next-line @typescript-eslint/no-require-imports
+const babel = require('@babel/core');
+
+const CONFIG_FILE = path.resolve(__dirname, '..', '..', 'babel.config.js');
+const SNIPPET = `console.log('x'); console.error('y'); console.warn('z');`;
+
+function transformWithEnv(code: string, env: string): string {
+  const prevBabelEnv = process.env.BABEL_ENV;
+  // babel.config.js reads process.env.BABEL_ENV directly to decide isProd, so
+  // it must be set for the transform (envName alone is not enough here).
+  process.env.BABEL_ENV = env;
+  try {
+    const result = babel.transformSync(code, {
+      configFile: CONFIG_FILE,
+      babelrc: false,
+      envName: env,
+      filename: path.resolve(__dirname, 'console-strip-probe.ts'),
+    });
+    if (!result || result.code == null) {
+      throw new Error('babel transform produced no output');
+    }
+    return result.code;
+  } finally {
+    if (prevBabelEnv === undefined) {
+      delete process.env.BABEL_ENV;
+    } else {
+      process.env.BABEL_ENV = prevBabelEnv;
+    }
+  }
+}
+
+describe('babel.config.js console stripping', () => {
+  it('removes console.log but keeps console.error/console.warn in production', () => {
+    const out = transformWithEnv(SNIPPET, 'production');
+    expect(out).not.toMatch(/console\s*\.\s*log/);
+    expect(out).toMatch(/console\s*\.\s*error/);
+    expect(out).toMatch(/console\s*\.\s*warn/);
+  });
+
+  it('keeps all console.* calls in development', () => {
+    const out = transformWithEnv(SNIPPET, 'development');
+    expect(out).toMatch(/console\s*\.\s*log/);
+    expect(out).toMatch(/console\s*\.\s*error/);
+    expect(out).toMatch(/console\s*\.\s*warn/);
+  });
+});

--- a/src/services/debug/logger.ts
+++ b/src/services/debug/logger.ts
@@ -19,7 +19,14 @@ class DebugLogger {
   }
 
   private constructor() {
-    this.setupConsoleInterception();
+    // Only monkey-patch global console (and retain raw error args, which may
+    // include objects carrying addresses/amounts) in development. In production
+    // this interception + in-memory retention is not installed (TASK-33). The
+    // deliberate consumers (ledger ConnectionModal, DebugLogsModal) call
+    // addDebugEntry/getLogs directly and continue to work without it.
+    if (__DEV__) {
+      this.setupConsoleInterception();
+    }
   }
 
   private setupConsoleInterception() {

--- a/src/services/deeplink/index.ts
+++ b/src/services/deeplink/index.ts
@@ -52,6 +52,22 @@ const redactUri = (url: string): string => {
   return `${scheme}://[redacted]`;
 };
 
+// Strip sensitive values from an arbitrary log string (e.g. a caught error
+// message). Caught errors from the WalletConnect SDK can embed the full `wc:`
+// pairing URI whose query string carries the session symKey, and other errors
+// can embed a scheme://… URL or a full account address. Redact all three; the
+// whole URI (including query) is replaced so no symKey survives.
+const redactSensitiveForLog = (message: string): string =>
+  message
+    .replace(/wc:\S+/gi, 'wc:[redacted]')
+    .replace(/([a-z][a-z0-9+.-]*):\/\/\S*/gi, '$1://[redacted]')
+    .replace(/[A-Z2-7]{58}/g, (addr) => redactAddress(addr));
+
+// Convenience wrapper for the common `catch (error) { console.error(msg, error) }`
+// pattern: derive the message string and redact it before logging.
+const redactError = (error: unknown): string =>
+  redactSensitiveForLog(error instanceof Error ? error.message : String(error));
+
 // Summarize a notification for logs: keep non-sensitive routing fields but
 // truncate the sender/receiver addresses and redact the amount.
 const redactNotificationData = (
@@ -183,14 +199,17 @@ export class DeepLinkService {
       this.linkingSubscription = Linking.addEventListener('url', ({ url }) => {
         console.log('Received deep link:', redactUri(url));
         this.handleUrl(url).catch((error) => {
-          console.error('Failed to handle deep link:', error);
+          console.error('Failed to handle deep link:', redactError(error));
         });
       });
 
       // Set up notification tap handler for navigation
       this.setupNotificationHandler();
     } catch (error) {
-      console.error('Failed to initialize deep link service:', error);
+      console.error(
+        'Failed to initialize deep link service:',
+        redactError(error)
+      );
       throw error;
     }
   }
@@ -373,7 +392,7 @@ export class DeepLinkService {
       console.warn(`No handler registered for scheme: ${scheme}`);
       return false;
     } catch (error) {
-      console.error('Error handling deep link:', error);
+      console.error('Error handling deep link:', redactError(error));
       return false;
     }
   }
@@ -480,7 +499,10 @@ export class DeepLinkService {
       });
 
       v1Client.once('error', (error) => {
-        console.error('DeepLinkService: v1 connection error', error);
+        console.error(
+          'DeepLinkService: v1 connection error',
+          redactError(error)
+        );
         this.navigateToRoute({
           screen: 'WalletConnectError',
           params: {
@@ -500,7 +522,10 @@ export class DeepLinkService {
 
       return true;
     } catch (error) {
-      console.error('Failed to handle WalletConnect v1 URI:', error);
+      console.error(
+        'Failed to handle WalletConnect v1 URI:',
+        redactError(error)
+      );
       throw error;
     }
   }
@@ -538,7 +563,10 @@ export class DeepLinkService {
 
       return true;
     } catch (error) {
-      console.error('Failed to handle WalletConnect v2 URI:', error);
+      console.error(
+        'Failed to handle WalletConnect v2 URI:',
+        redactError(error)
+      );
       throw error;
     }
   }
@@ -633,7 +661,7 @@ export class DeepLinkService {
           return false;
       }
     } catch (error) {
-      console.error('[DeepLink] handleArc0090Uri - error:', error);
+      console.error('[DeepLink] handleArc0090Uri - error:', redactError(error));
       await showAlert(
         'Invalid Deep Link',
         error instanceof Error ? error.message : 'Failed to process URI'
@@ -683,7 +711,7 @@ export class DeepLinkService {
       await networkStore.switchNetwork(targetNetwork);
       return true;
     } catch (error) {
-      console.error('Failed to switch network:', error);
+      console.error('Failed to switch network:', redactError(error));
       await showAlert(
         'Network Switch Failed',
         `Failed to switch to ${targetConfig.name}. Please try again.`
@@ -757,7 +785,7 @@ export class DeepLinkService {
 
       return true;
     } catch (error) {
-      console.error('Failed to handle payment URI:', error);
+      console.error('Failed to handle payment URI:', redactError(error));
       return false;
     }
   }
@@ -847,7 +875,7 @@ export class DeepLinkService {
       console.log('[DeepLink] handleKeyregUri - navigation complete');
       return true;
     } catch (error) {
-      console.error('[DeepLink] handleKeyregUri - error:', error);
+      console.error('[DeepLink] handleKeyregUri - error:', redactError(error));
       return false;
     }
   }
@@ -893,7 +921,7 @@ export class DeepLinkService {
 
       return true;
     } catch (error) {
-      console.error('Failed to handle appl URI:', error);
+      console.error('Failed to handle appl URI:', redactError(error));
       return false;
     }
   }
@@ -922,7 +950,7 @@ export class DeepLinkService {
 
       return true;
     } catch (error) {
-      console.error('Failed to handle app query URI:', error);
+      console.error('Failed to handle app query URI:', redactError(error));
       return false;
     }
   }
@@ -954,7 +982,7 @@ export class DeepLinkService {
 
       return true;
     } catch (error) {
-      console.error('Failed to handle asset query URI:', error);
+      console.error('Failed to handle asset query URI:', redactError(error));
       return false;
     }
   }
@@ -1005,7 +1033,7 @@ export class DeepLinkService {
           return false;
       }
     } catch (error) {
-      console.error('Failed to handle legacy Voi URI:', error);
+      console.error('Failed to handle legacy Voi URI:', redactError(error));
       return false;
     }
   }
@@ -1046,7 +1074,7 @@ export class DeepLinkService {
       console.warn('Unknown universal link path:', urlObj.pathname);
       return false;
     } catch (error) {
-      console.error('Failed to handle universal link:', error);
+      console.error('Failed to handle universal link:', redactError(error));
       return false;
     }
   }
@@ -1129,7 +1157,7 @@ export class DeepLinkService {
         '[DeepLink] navigateToRoute - Failed to navigate:',
         route.screen,
         route.params ? Object.keys(route.params) : [],
-        error
+        redactError(error)
       );
       throw error;
     }

--- a/src/services/deeplink/index.ts
+++ b/src/services/deeplink/index.ts
@@ -46,20 +46,24 @@ const redactAddress = (address?: string): string =>
     ? `${address.slice(0, 6)}…[redacted]`
     : '[redacted]';
 
-const redactUri = (url: string): string => {
-  const schemeEnd = url.indexOf('://');
-  const scheme = schemeEnd > 0 ? url.slice(0, schemeEnd) : 'uri';
-  return `${scheme}://[redacted]`;
-};
-
-// Strip sensitive values from an arbitrary log string (e.g. a caught error
-// message). Caught errors from the WalletConnect SDK can embed the full `wc:`
-// pairing URI whose query string carries the session symKey, and other errors
-// can embed a scheme://… URL or a full account address. Redact all three; the
-// whole URI (including query) is replaced so no symKey survives.
+// Strip sensitive values from an arbitrary log string — a caught error message
+// OR untrusted deep-link input (scheme/host/path/query/params). Redacts, in
+// order:
+//  - raw and percent-encoded WalletConnect URIs (`wc:` / `wc%3A`), whose query
+//    string carries the session symKey;
+//  - any stray `symKey=` / `symKey%3D` token (raw or encoded), belt-and-braces
+//    so a symKey can never survive regardless of surrounding format;
+//  - any scheme://… URL (voi://, https://, universal links, …) — whole URI
+//    including the query string;
+//  - full 58-char Algorand addresses, run LAST on the whole string so an
+//    address used as a pseudo-scheme (ADDR://…) is still truncated.
+// Used only for LOGGED output — thrown/surfaced errors keep the full value so
+// user-facing messages are unchanged (TASK-33).
 const redactSensitiveForLog = (message: string): string =>
   message
     .replace(/wc:\S+/gi, 'wc:[redacted]')
+    .replace(/wc%3[Aa]\S*/g, 'wc:[redacted]')
+    .replace(/symKey(=|%3[Dd])[^&\s"']+/gi, 'symKey=[redacted]')
     .replace(/([a-z][a-z0-9+.-]*):\/\/\S*/gi, '$1://[redacted]')
     .replace(/[A-Z2-7]{58}/g, (addr) => redactAddress(addr));
 
@@ -191,13 +195,16 @@ export class DeepLinkService {
       // Handle initial URL if app was opened via deep link
       const initialUrl = await Linking.getInitialURL();
       if (initialUrl) {
-        console.log('Handling initial deep link:', redactUri(initialUrl));
+        console.log(
+          'Handling initial deep link:',
+          redactSensitiveForLog(initialUrl)
+        );
         await this.handleUrl(initialUrl);
       }
 
       // Listen for incoming deep links
       this.linkingSubscription = Linking.addEventListener('url', ({ url }) => {
-        console.log('Received deep link:', redactUri(url));
+        console.log('Received deep link:', redactSensitiveForLog(url));
         this.handleUrl(url).catch((error) => {
           console.error('Failed to handle deep link:', redactError(error));
         });
@@ -380,7 +387,7 @@ export class DeepLinkService {
     try {
       const scheme = this.extractScheme(url);
       if (!scheme) {
-        console.warn('No scheme found in URL:', redactUri(url));
+        console.warn('No scheme found in URL:', redactSensitiveForLog(url));
         return false;
       }
 
@@ -389,7 +396,10 @@ export class DeepLinkService {
         return await handler(url);
       }
 
-      console.warn(`No handler registered for scheme: ${scheme}`);
+      console.warn(
+        'No handler registered for scheme:',
+        redactSensitiveForLog(scheme)
+      );
       return false;
     } catch (error) {
       console.error('Error handling deep link:', redactError(error));
@@ -579,7 +589,7 @@ export class DeepLinkService {
     try {
       console.log(
         '[DeepLink] handleArc0090Uri - received URI:',
-        redactUri(url)
+        redactSensitiveForLog(url)
       );
 
       // Check for legacy voi:// format first (voi://send?to=...)
@@ -599,7 +609,10 @@ export class DeepLinkService {
       const uriType = getArc0090UriType(url);
       console.log('[DeepLink] handleArc0090Uri - uriType:', uriType);
       if (!uriType) {
-        console.warn('[DeepLink] Unknown ARC-0090 URI type:', redactUri(url));
+        console.warn(
+          '[DeepLink] Unknown ARC-0090 URI type:',
+          redactSensitiveForLog(url)
+        );
         return false;
       }
 
@@ -618,7 +631,7 @@ export class DeepLinkService {
       if (!parsed) {
         console.error(
           '[DeepLink] Failed to parse ARC-0090 URI:',
-          redactUri(url)
+          redactSensitiveForLog(url)
         );
         return false;
       }
@@ -657,7 +670,10 @@ export class DeepLinkService {
         case 'asset-query':
           return await this.handleAssetQueryUri(parsed as Arc0090AssetQueryUri);
         default:
-          console.warn('Unhandled ARC-0090 URI type:', uriType);
+          console.warn(
+            'Unhandled ARC-0090 URI type:',
+            redactSensitiveForLog(uriType)
+          );
           return false;
       }
     } catch (error) {
@@ -728,7 +744,10 @@ export class DeepLinkService {
       // Validate payment URI
       const validation = validatePaymentUri(parsed);
       if (!validation.valid) {
-        console.error('Invalid payment URI:', validation.errors);
+        console.error(
+          'Invalid payment URI:',
+          redactSensitiveForLog(validation.errors.join('; '))
+        );
         await showAlert(
           'Invalid Payment Request',
           validation.errors.join('\n')
@@ -813,7 +832,10 @@ export class DeepLinkService {
       const validation = validateKeyregUri(parsed);
       console.log('[DeepLink] handleKeyregUri - validation:', validation);
       if (!validation.valid) {
-        console.error('Invalid keyreg URI:', validation.errors);
+        console.error(
+          'Invalid keyreg URI:',
+          redactSensitiveForLog(validation.errors.join('; '))
+        );
         await showAlert(
           'Invalid Key Registration Request',
           validation.errors.join('\n')
@@ -888,7 +910,10 @@ export class DeepLinkService {
       // Validate appl URI
       const validation = validateApplUri(parsed);
       if (!validation.valid) {
-        console.error('Invalid appl URI:', validation.errors);
+        console.error(
+          'Invalid appl URI:',
+          redactSensitiveForLog(validation.errors.join('; '))
+        );
         await showAlert(
           'Invalid Application Call Request',
           validation.errors.join('\n')
@@ -1029,7 +1054,10 @@ export class DeepLinkService {
           return await this.handleWalletConnectUri(parsed.params.wc_uri || '');
 
         default:
-          console.warn('Unknown Voi URI action:', parsed.action);
+          console.warn(
+            'Unknown Voi URI action:',
+            redactSensitiveForLog(parsed.action)
+          );
           return false;
       }
     } catch (error) {
@@ -1044,7 +1072,10 @@ export class DeepLinkService {
       const urlObj = new URL(url);
 
       if (urlObj.hostname !== 'www.getvoi.app') {
-        console.warn('Universal link not for www.getvoi.app:', redactUri(url));
+        console.warn(
+          'Universal link not for www.getvoi.app:',
+          redactSensitiveForLog(url)
+        );
         return false;
       }
 
@@ -1059,19 +1090,22 @@ export class DeepLinkService {
           const decodedUri = decodeURIComponent(wcUri);
           console.log(
             'Handling WalletConnect URI from universal link:',
-            redactUri(decodedUri)
+            redactSensitiveForLog(decodedUri)
           );
           return await this.handleWalletConnectUri(decodedUri);
         } else {
           console.warn(
             'No WalletConnect URI found in universal link:',
-            redactUri(url)
+            redactSensitiveForLog(url)
           );
           return false;
         }
       }
 
-      console.warn('Unknown universal link path:', urlObj.pathname);
+      console.warn(
+        'Unknown universal link path:',
+        redactSensitiveForLog(urlObj.pathname)
+      );
       return false;
     } catch (error) {
       console.error('Failed to handle universal link:', redactError(error));

--- a/src/services/deeplink/index.ts
+++ b/src/services/deeplink/index.ts
@@ -52,6 +52,22 @@ const redactUri = (url: string): string => {
   return `${scheme}://[redacted]`;
 };
 
+// Summarize a notification for logs: keep non-sensitive routing fields but
+// truncate the sender/receiver addresses and redact the amount.
+const redactNotificationData = (
+  data: NotificationData
+): Record<string, unknown> => ({
+  type: data.type,
+  eventType: data.eventType,
+  sender: data.sender ? redactAddress(data.sender) : undefined,
+  receiver: data.receiver ? redactAddress(data.receiver) : undefined,
+  amount: data.amount !== undefined ? '[redacted]' : undefined,
+  hasTxId: !!data.txId,
+  contractId: data.contractId,
+  tokenId: data.tokenId,
+  round: data.round,
+});
+
 export type DeepLinkHandler = (url: string) => Promise<boolean>;
 
 export interface DeepLinkRoute {
@@ -139,7 +155,7 @@ export class DeepLinkService {
     if (isUnlocked && !wasUnlocked && this.pendingNotification) {
       console.log(
         '[DeepLink] App unlocked, processing pending notification:',
-        this.pendingNotification
+        redactNotificationData(this.pendingNotification)
       );
       const pendingData = this.pendingNotification;
       this.pendingNotification = null;
@@ -159,13 +175,13 @@ export class DeepLinkService {
       // Handle initial URL if app was opened via deep link
       const initialUrl = await Linking.getInitialURL();
       if (initialUrl) {
-        console.log('Handling initial deep link:', initialUrl);
+        console.log('Handling initial deep link:', redactUri(initialUrl));
         await this.handleUrl(initialUrl);
       }
 
       // Listen for incoming deep links
       this.linkingSubscription = Linking.addEventListener('url', ({ url }) => {
-        console.log('Received deep link:', url);
+        console.log('Received deep link:', redactUri(url));
         this.handleUrl(url).catch((error) => {
           console.error('Failed to handle deep link:', error);
         });
@@ -189,7 +205,7 @@ export class DeepLinkService {
           '[DeepLink] Notification tap handler called, isAppUnlocked:',
           this.isAppUnlocked,
           'data:',
-          data
+          redactNotificationData(data)
         );
 
         // If app is locked, store the notification for later processing after unlock
@@ -213,7 +229,10 @@ export class DeepLinkService {
   private async handleNotificationNavigation(
     data: NotificationData
   ): Promise<void> {
-    console.log('Processing notification navigation:', data);
+    console.log(
+      'Processing notification navigation:',
+      redactNotificationData(data)
+    );
 
     switch (data.type) {
       case 'message':
@@ -231,7 +250,7 @@ export class DeepLinkService {
             ) {
               console.log(
                 'Switching to receiver account:',
-                receiverAccount.address
+                redactAddress(receiverAccount.address)
               );
               await walletStore.setActiveAccount(receiverAccount.id);
             }
@@ -342,7 +361,7 @@ export class DeepLinkService {
     try {
       const scheme = this.extractScheme(url);
       if (!scheme) {
-        console.warn('No scheme found in URL:', url);
+        console.warn('No scheme found in URL:', redactUri(url));
         return false;
       }
 
@@ -748,10 +767,19 @@ export class DeepLinkService {
    */
   private async handleKeyregUri(parsed: Arc0090KeyregUri): Promise<boolean> {
     try {
-      console.log(
-        '[DeepLink] handleKeyregUri - parsed:',
-        JSON.stringify(parsed, null, 2)
-      );
+      // Redacted summary only: parsed carries the address plus participation/
+      // vote/selection keys, fee and note, none of which belong in logs.
+      console.log('[DeepLink] handleKeyregUri - parsed:', {
+        type: parsed.type,
+        network: parsed.network,
+        scheme: parsed.scheme,
+        address: redactAddress(parsed.address),
+        isOnline: parsed.isOnline,
+        participationKeys: '[redacted]',
+        fee: parsed.params.fee !== undefined ? '[redacted]' : undefined,
+        note:
+          parsed.params.xnote || parsed.params.note ? '[redacted]' : undefined,
+      });
 
       // Validate keyreg URI
       const validation = validateKeyregUri(parsed);
@@ -790,9 +818,21 @@ export class DeepLinkService {
         isOnline: parsed.isOnline,
         networkId: currentNetwork,
       };
+      // Redacted: navParams carries the address, participation keys, fee and
+      // note. Log only the non-sensitive routing/round fields.
       console.log(
         '[DeepLink] handleKeyregUri - navigating to KeyregConfirm with params:',
-        navParams
+        {
+          address: redactAddress(navParams.address),
+          isOnline: navParams.isOnline,
+          networkId: navParams.networkId,
+          votefst: navParams.votefst,
+          votelst: navParams.votelst,
+          votekd: navParams.votekd,
+          participationKeys: '[redacted]',
+          fee: navParams.fee !== undefined ? '[redacted]' : undefined,
+          note: navParams.note ? '[redacted]' : undefined,
+        }
       );
 
       // Use replace to dismiss the QRScanner and show KeyregConfirm in its place
@@ -976,7 +1016,7 @@ export class DeepLinkService {
       const urlObj = new URL(url);
 
       if (urlObj.hostname !== 'www.getvoi.app') {
-        console.warn('Universal link not for www.getvoi.app:', url);
+        console.warn('Universal link not for www.getvoi.app:', redactUri(url));
         return false;
       }
 
@@ -991,11 +1031,14 @@ export class DeepLinkService {
           const decodedUri = decodeURIComponent(wcUri);
           console.log(
             'Handling WalletConnect URI from universal link:',
-            decodedUri
+            redactUri(decodedUri)
           );
           return await this.handleWalletConnectUri(decodedUri);
         } else {
-          console.warn('No WalletConnect URI found in universal link:', url);
+          console.warn(
+            'No WalletConnect URI found in universal link:',
+            redactUri(url)
+          );
           return false;
         }
       }
@@ -1036,11 +1079,13 @@ export class DeepLinkService {
     route: DeepLinkRoute,
     options?: { replace?: boolean }
   ): Promise<void> {
+    // Log route name + param keys only; param values can carry
+    // recipient addresses, amounts, notes and keyreg key material.
     console.log(
       '[DeepLink] navigateToRoute - route:',
       route.screen,
-      'params:',
-      JSON.stringify(route.params),
+      'paramKeys:',
+      route.params ? Object.keys(route.params) : [],
       'replace:',
       options?.replace
     );
@@ -1082,7 +1127,8 @@ export class DeepLinkService {
     } catch (error) {
       console.error(
         '[DeepLink] navigateToRoute - Failed to navigate:',
-        route,
+        route.screen,
+        route.params ? Object.keys(route.params) : [],
         error
       );
       throw error;

--- a/src/services/deeplink/index.ts
+++ b/src/services/deeplink/index.ts
@@ -37,6 +37,21 @@ import { useNetworkStore } from '@/store/networkStore';
 import { NetworkId } from '@/types/network';
 import { getNetworkConfig } from '@/services/network/config';
 
+// Log-redaction helpers (TASK-33): deep-link URIs and their parsed contents can
+// embed full addresses, amounts, notes and other PII. These keep debug logs
+// useful (request type, network, truncated address) without emitting the
+// sensitive payload. Used for the console.* sites in handleArc0090Uri.
+const redactAddress = (address?: string): string =>
+  address && address.length > 6
+    ? `${address.slice(0, 6)}…[redacted]`
+    : '[redacted]';
+
+const redactUri = (url: string): string => {
+  const schemeEnd = url.indexOf('://');
+  const scheme = schemeEnd > 0 ? url.slice(0, schemeEnd) : 'uri';
+  return `${scheme}://[redacted]`;
+};
+
 export type DeepLinkHandler = (url: string) => Promise<boolean>;
 
 export interface DeepLinkRoute {
@@ -515,7 +530,10 @@ export class DeepLinkService {
    */
   private async handleArc0090Uri(url: string): Promise<boolean> {
     try {
-      console.log('[DeepLink] handleArc0090Uri - url:', url);
+      console.log(
+        '[DeepLink] handleArc0090Uri - received URI:',
+        redactUri(url)
+      );
 
       // Check for legacy voi:// format first (voi://send?to=...)
       if (isLegacyVoiUri(url)) {
@@ -534,17 +552,27 @@ export class DeepLinkService {
       const uriType = getArc0090UriType(url);
       console.log('[DeepLink] handleArc0090Uri - uriType:', uriType);
       if (!uriType) {
-        console.warn('Unknown ARC-0090 URI type:', url);
+        console.warn('[DeepLink] Unknown ARC-0090 URI type:', redactUri(url));
         return false;
       }
 
       const parsed = parseArc0090Uri(url);
-      console.log(
-        '[DeepLink] handleArc0090Uri - parsed:',
-        JSON.stringify(parsed, null, 2)
-      );
+      // Redacted summary only: parsed contains full address + amount/note params.
+      console.log('[DeepLink] handleArc0090Uri - parsed:', {
+        type: parsed?.type,
+        network: parsed?.network,
+        scheme: parsed?.scheme,
+        address:
+          parsed && 'address' in parsed
+            ? redactAddress(parsed.address)
+            : undefined,
+        params: '[redacted]',
+      });
       if (!parsed) {
-        console.error('Failed to parse ARC-0090 URI:', url);
+        console.error(
+          '[DeepLink] Failed to parse ARC-0090 URI:',
+          redactUri(url)
+        );
         return false;
       }
 

--- a/src/services/walletconnect/index.ts
+++ b/src/services/walletconnect/index.ts
@@ -313,14 +313,20 @@ export class WalletConnectService extends EventEmitter {
         },
       };
 
+      // Redacted (TASK-33): log chain ids + counts, not full account addresses.
       console.log('[WalletConnect] Proposal namespaces:', {
-        required: proposal.requiredNamespaces,
-        optional: proposal.optionalNamespaces,
+        requiredChains: proposal.requiredNamespaces?.algorand?.chains ?? [],
+        optionalChains: proposal.optionalNamespaces?.algorand?.chains ?? [],
+        requiredMethods:
+          proposal.requiredNamespaces?.algorand?.methods?.length ?? 0,
+        optionalMethods:
+          proposal.optionalNamespaces?.algorand?.methods?.length ?? 0,
       });
-      console.log(
-        '[WalletConnect] Our supported namespaces:',
-        supportedNamespaces
-      );
+      console.log('[WalletConnect] Our supported namespaces:', {
+        chains: supportedNamespaces.algorand.chains,
+        methods: supportedNamespaces.algorand.methods.length,
+        accounts: supportedNamespaces.algorand.accounts.length,
+      });
 
       // Use WalletConnect's buildApprovedNamespaces utility
       // This handles all the complex validation logic for us
@@ -329,10 +335,11 @@ export class WalletConnectService extends EventEmitter {
         supportedNamespaces,
       });
 
-      console.log(
-        '[WalletConnect] Approved namespaces built:',
-        approvedNamespaces
-      );
+      console.log('[WalletConnect] Approved namespaces built:', {
+        chains: approvedNamespaces.algorand?.chains ?? [],
+        accounts: approvedNamespaces.algorand?.accounts?.length ?? 0,
+        methods: approvedNamespaces.algorand?.methods?.length ?? 0,
+      });
 
       const session = await signClient.approve({
         id: proposal.id,

--- a/src/services/walletconnect/index.ts
+++ b/src/services/walletconnect/index.ts
@@ -36,12 +36,23 @@ import type { WalletConnectV1StoredSession } from '@/services/walletconnect/v1/t
 import { WalletConnectV1Client } from '@/services/walletconnect/v1';
 import { WC_V1_SESSION_STORAGE_KEY } from '@/services/walletconnect/v1/config';
 
-// Redact full 58-char Algorand addresses from a string before logging (e.g.
-// the rekey/auth-address error message at signTransactions), replacing each
-// with its truncated form. Used only for LOGGED output — thrown errors keep the
-// full address so user-facing messages are unchanged (TASK-33).
-const redactAddressesForLog = (message: string): string =>
-  message.replace(/[A-Z2-7]{58}/g, (addr) => truncateAddress(addr));
+// Strip sensitive values from a string before logging (e.g. a caught error
+// message). WalletConnect SDK errors can embed the full `wc:` pairing URI whose
+// query string carries the session symKey, and signing errors can embed a full
+// account address (the rekey auth-address). Redact wc:/scheme:// URIs (whole
+// URI incl. query, so no symKey survives) and full 58-char addresses. Used only
+// for LOGGED output — thrown errors keep the full value so user-facing messages
+// are unchanged (TASK-33).
+const redactSensitiveForLog = (message: string): string =>
+  message
+    .replace(/wc:\S+/gi, 'wc:[redacted]')
+    .replace(/([a-z][a-z0-9+.-]*):\/\/\S*/gi, '$1://[redacted]')
+    .replace(/[A-Z2-7]{58}/g, (addr) => truncateAddress(addr));
+
+// Convenience wrapper for the common `catch (error) { console.error(msg, error) }`
+// pattern: derive the message string and redact it before logging.
+const redactError = (error: unknown): string =>
+  redactSensitiveForLog(error instanceof Error ? error.message : String(error));
 
 export class WalletConnectService extends EventEmitter {
   private static instance: WalletConnectService;
@@ -80,7 +91,10 @@ export class WalletConnectService extends EventEmitter {
       this.initialized = true;
       console.log('WalletConnect service initialized successfully');
     } catch (error) {
-      console.error('Failed to initialize WalletConnect service:', error);
+      console.error(
+        'Failed to initialize WalletConnect service:',
+        redactError(error)
+      );
       throw error;
     }
   }
@@ -129,7 +143,11 @@ export class WalletConnectService extends EventEmitter {
               const parsed = JSON.parse(raw) as WalletConnectV1StoredSession;
               return { key, session: parsed };
             } catch (error) {
-              console.warn('Skipping malformed v1 session entry', key, error);
+              console.warn(
+                'Skipping malformed v1 session entry',
+                key,
+                redactError(error)
+              );
               return null;
             }
           })
@@ -223,7 +241,7 @@ export class WalletConnectService extends EventEmitter {
         });
       });
     } catch (error) {
-      console.error('Failed to load v1 sessions:', error);
+      console.error('Failed to load v1 sessions:', redactError(error));
       // Don't throw - v1 session restoration failure shouldn't block app startup
     }
   }
@@ -369,7 +387,7 @@ export class WalletConnectService extends EventEmitter {
       this.emit('session_approved', sessionWithMetadata);
       this.emit('sessions_changed');
     } catch (error) {
-      console.error('Failed to approve session:', error);
+      console.error('Failed to approve session:', redactError(error));
       throw new Error(
         `Session approval failed: ${error instanceof Error ? error.message : 'Unknown error'}`
       );
@@ -387,7 +405,7 @@ export class WalletConnectService extends EventEmitter {
 
       this.emit('session_rejected', proposal);
     } catch (error) {
-      console.error('Failed to reject session:', error);
+      console.error('Failed to reject session:', redactError(error));
       throw new Error(
         `Session rejection failed: ${error instanceof Error ? error.message : 'Unknown error'}`
       );
@@ -420,7 +438,7 @@ export class WalletConnectService extends EventEmitter {
       this.emit('session_disconnected', topic);
       this.emit('sessions_changed');
     } catch (error) {
-      console.error('Failed to disconnect session:', error);
+      console.error('Failed to disconnect session:', redactError(error));
       throw new Error(
         `Session disconnect failed: ${error instanceof Error ? error.message : 'Unknown error'}`
       );
@@ -491,7 +509,7 @@ export class WalletConnectService extends EventEmitter {
 
       return [v1Session];
     } catch (error) {
-      console.error('Failed to get v1 sessions:', error);
+      console.error('Failed to get v1 sessions:', redactError(error));
       return [];
     }
   }
@@ -551,11 +569,7 @@ export class WalletConnectService extends EventEmitter {
     } catch (error) {
       // Redact any full address (e.g. the rekey auth-address) from the log; the
       // re-thrown error below preserves the full message for the caller/UX.
-      const message = error instanceof Error ? error.message : String(error);
-      console.error(
-        'Failed to sign transactions:',
-        redactAddressesForLog(message)
-      );
+      console.error('Failed to sign transactions:', redactError(error));
       throw new Error(
         `Transaction signing failed: ${error instanceof Error ? error.message : 'Unknown error'}`
       );
@@ -580,7 +594,7 @@ export class WalletConnectService extends EventEmitter {
         },
       });
     } catch (error) {
-      console.error('Failed to respond to request:', error);
+      console.error('Failed to respond to request:', redactError(error));
       throw new Error(
         `Request response failed: ${error instanceof Error ? error.message : 'Unknown error'}`
       );
@@ -604,7 +618,7 @@ export class WalletConnectService extends EventEmitter {
         },
       });
     } catch (err) {
-      console.error('Failed to reject request:', err);
+      console.error('Failed to reject request:', redactError(err));
       throw new Error(
         `Request rejection failed: ${err instanceof Error ? err.message : 'Unknown error'}`
       );
@@ -639,7 +653,7 @@ export class WalletConnectService extends EventEmitter {
         }
       }
     } catch (error) {
-      console.error('Failed to load existing sessions:', error);
+      console.error('Failed to load existing sessions:', redactError(error));
     }
   }
 
@@ -708,7 +722,7 @@ export class WalletConnectService extends EventEmitter {
         this.emit('sessions_changed');
       }
     } catch (e) {
-      console.warn('Failed to handle session_update:', e);
+      console.warn('Failed to handle session_update:', redactError(e));
     }
   }
 

--- a/src/services/walletconnect/index.ts
+++ b/src/services/walletconnect/index.ts
@@ -25,6 +25,7 @@ import {
   isSessionExpired,
   detectRequestedChains,
   areRequiredChainsSupported,
+  truncateAddress,
 } from './utils';
 import {
   DEFAULT_NAMESPACES,
@@ -34,6 +35,13 @@ import {
 import type { WalletConnectV1StoredSession } from '@/services/walletconnect/v1/types';
 import { WalletConnectV1Client } from '@/services/walletconnect/v1';
 import { WC_V1_SESSION_STORAGE_KEY } from '@/services/walletconnect/v1/config';
+
+// Redact full 58-char Algorand addresses from a string before logging (e.g.
+// the rekey/auth-address error message at signTransactions), replacing each
+// with its truncated form. Used only for LOGGED output — thrown errors keep the
+// full address so user-facing messages are unchanged (TASK-33).
+const redactAddressesForLog = (message: string): string =>
+  message.replace(/[A-Z2-7]{58}/g, (addr) => truncateAddress(addr));
 
 export class WalletConnectService extends EventEmitter {
   private static instance: WalletConnectService;
@@ -541,7 +549,13 @@ export class WalletConnectService extends EventEmitter {
 
       return signedTxns;
     } catch (error) {
-      console.error('Failed to sign transactions:', error);
+      // Redact any full address (e.g. the rekey auth-address) from the log; the
+      // re-thrown error below preserves the full message for the caller/UX.
+      const message = error instanceof Error ? error.message : String(error);
+      console.error(
+        'Failed to sign transactions:',
+        redactAddressesForLog(message)
+      );
       throw new Error(
         `Transaction signing failed: ${error instanceof Error ? error.message : 'Unknown error'}`
       );

--- a/src/services/walletconnect/index.ts
+++ b/src/services/walletconnect/index.ts
@@ -36,16 +36,22 @@ import type { WalletConnectV1StoredSession } from '@/services/walletconnect/v1/t
 import { WalletConnectV1Client } from '@/services/walletconnect/v1';
 import { WC_V1_SESSION_STORAGE_KEY } from '@/services/walletconnect/v1/config';
 
-// Strip sensitive values from a string before logging (e.g. a caught error
-// message). WalletConnect SDK errors can embed the full `wc:` pairing URI whose
-// query string carries the session symKey, and signing errors can embed a full
-// account address (the rekey auth-address). Redact wc:/scheme:// URIs (whole
-// URI incl. query, so no symKey survives) and full 58-char addresses. Used only
-// for LOGGED output — thrown errors keep the full value so user-facing messages
-// are unchanged (TASK-33).
+// Strip sensitive values from a string before logging (a caught error message
+// or any untrusted value). Redacts, in order:
+//  - raw and percent-encoded WalletConnect URIs (`wc:` / `wc%3A`), whose query
+//    string carries the session symKey;
+//  - any stray `symKey=` / `symKey%3D` token (raw or encoded), belt-and-braces
+//    so a symKey can never survive regardless of surrounding format;
+//  - any scheme://… URL (whole URI including the query string);
+//  - full 58-char Algorand addresses, run LAST on the whole string so an
+//    address used as a pseudo-scheme (ADDR://…) is still truncated.
+// Used only for LOGGED output — thrown errors keep the full value so
+// user-facing messages are unchanged (TASK-33).
 const redactSensitiveForLog = (message: string): string =>
   message
     .replace(/wc:\S+/gi, 'wc:[redacted]')
+    .replace(/wc%3[Aa]\S*/g, 'wc:[redacted]')
+    .replace(/symKey(=|%3[Dd])[^&\s"']+/gi, 'symKey=[redacted]')
     .replace(/([a-z][a-z0-9+.-]*):\/\/\S*/gi, '$1://[redacted]')
     .replace(/[A-Z2-7]{58}/g, (addr) => truncateAddress(addr));
 
@@ -145,7 +151,7 @@ export class WalletConnectService extends EventEmitter {
             } catch (error) {
               console.warn(
                 'Skipping malformed v1 session entry',
-                key,
+                redactSensitiveForLog(key),
                 redactError(error)
               );
               return null;


### PR DESCRIPTION
## What changed

Wave 1 of PLAN-10 — keep addresses, amounts, and URIs out of shipped logs.

- **`babel.config.js`** — apply `babel-plugin-transform-remove-console` **production-only** with `{ exclude: ['error', 'warn'] }`. Because the config now depends on the build env, `api.cache(true)` is replaced with an env-sensitive cache key (`api.cache.using(() => process.env.BABEL_ENV || process.env.NODE_ENV || 'development')`) so the strip is not frozen to the first-seen env. Production is detected via `BABEL_ENV || NODE_ENV === 'production'`. The `presets: ['babel-preset-expo']` setup and the worklets/react-compiler ordering comment are preserved; `transform-remove-console` is a plain top-level AST transform and does not affect that ordering. Added as a **devDependency** (package.json + package-lock.json).
- **`src/services/deeplink/index.ts`** — redacted the `handleArc0090Uri` log sites. The raw deep-link URL is logged as `scheme://[redacted]`, and the previously full `JSON.stringify(parsed)` (which dumps address/amount/note params) is now a non-sensitive summary: request `type`/`network`/`scheme` + a first-6-char truncated address + `params: '[redacted]'`. Warn/error paths that logged the raw URL now use the redacted form too.
- **`src/services/walletconnect/index.ts`** — redacted the proposal/supported/approved namespace logs: emit chain ids plus method/account **counts** instead of full account addresses.
- **`src/services/debug/logger.ts`** — gate the global `console` monkey-patch and its raw-arg (object) retention behind `__DEV__`. The two deliberate consumers (ledger `ConnectionModal`, `DebugLogsModal`) call `addDebugEntry`/`getLogs`/`addListener` directly and are unaffected in dev or prod.
- **`src/__tests__/babel-console-strip.test.ts`** — hardware-free verification: transforms `console.log/error/warn` through the real repo `babel.config.js` via `@babel/core` and asserts `console.log` is stripped while `error`/`warn` survive in production, and all three survive in development.

## Why

Audit findings **S-09 / P-11 / Q-07**: console output in release builds leaked wallet addresses, amounts, and deep-link/WalletConnect URIs. Defense-in-depth: the babel strip removes `console.log`/`.info`/`.debug` from production bundles, and the hand-redactions cover any `warn`/`error` that survive (and improve dev logs too).

## OTA-eligibility note

This is a **JS/build-config-only** change (no native modules). The redactions ship via normal JS. The babel console-strip only takes effect in a **fresh production bundle** (new EAS build or a production-profile OTA update built with `BABEL_ENV/NODE_ENV=production`); it is not applied to an already-installed bundle until it is rebundled. An OTA update carrying a production-built bundle is sufficient — no store submission required.

## Gate results

- `npm run typecheck` — 0 errors
- `npm run lint` — 0 errors (684 pre-existing warnings, none introduced)
- `npm test -- --ci` — 18 suites / 284 tests passing (incl. 2 new)