### PR TITLE
feat(backup): scrypt v2 KDF envelope + real passphrase policy (TASK-30)

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -15,6 +15,7 @@
         "@ledgerhq/react-native-hid": "^6.32.10",
         "@ledgerhq/react-native-hw-transport-ble": "^6.35.3",
         "@ngraveio/bc-ur": "^1.1.13",
+        "@noble/hashes": "1.7.0",
         "@react-native-async-storage/async-storage": "^2.2.0",
         "@react-native-community/netinfo": "11.4.1",
         "@react-native-community/slider": "5.0.1",

--- a/package.json
+++ b/package.json
@@ -26,6 +26,7 @@
     "@ledgerhq/react-native-hid": "^6.32.10",
     "@ledgerhq/react-native-hw-transport-ble": "^6.35.3",
     "@ngraveio/bc-ur": "^1.1.13",
+    "@noble/hashes": "1.7.0",
     "@react-native-async-storage/async-storage": "^2.2.0",
     "@react-native-community/netinfo": "11.4.1",
     "@react-native-community/slider": "5.0.1",

--- a/src/services/backup/__tests__/createBackup.policy.test.ts
+++ b/src/services/backup/__tests__/createBackup.policy.test.ts
@@ -1,0 +1,101 @@
+// Unit tests for TASK-30 (Codex P2-1): BackupService.createBackup must enforce
+// the passphrase policy at the service boundary, so a direct caller that skips
+// the UI modal cannot create a backup (which protects every account's mnemonic)
+// under a weak password. The restore/import path must NOT be gated by this
+// policy — that is covered by encryption.test.ts round-trips.
+//
+// SECURITY NOTE: no real secret material — accounts collector is mocked to [].
+
+// Platform CSPRNG for the real scrypt/AES path used by encryptBackup.
+jest.mock('@/platform', () => {
+  const nodeCrypto = require('crypto');
+  return {
+    crypto: {
+      getRandomBytes: async (byteCount: number): Promise<Uint8Array> =>
+        Uint8Array.from(nodeCrypto.randomBytes(byteCount)),
+    },
+  };
+});
+
+// Mock the file-system + expo surface so createBackup can complete in Node.
+jest.mock('expo-file-system', () => {
+  class Directory {
+    get exists() {
+      return true;
+    }
+    async create() {}
+  }
+  class File {
+    uri = 'file:///mock/voi-wallet.voibackup';
+    async write() {}
+  }
+  return { Directory, File, Paths: { cache: 'file:///mock/cache' } };
+});
+jest.mock('expo-sharing', () => ({
+  isAvailableAsync: async () => false,
+  shareAsync: async () => {},
+}));
+jest.mock('expo-constants', () => ({
+  __esModule: true,
+  default: { expoConfig: { version: '9.9.9' } },
+}));
+
+// Mock the heavy collectors/restorers so their native dependency graph never
+// loads. createBackup calls collectAccounts FIRST (after the policy gate).
+jest.mock('../collectors', () => ({
+  collectAccounts: jest.fn(async () => []),
+  collectSettings: jest.fn(async () => ({
+    theme: {
+      mode: 'system',
+      nftTheme: null,
+      nftThemeEnabled: false,
+      selectedPaletteIndex: 0,
+      backgroundImageEnabled: false,
+      overlayIntensity: 0,
+    },
+    security: { pinTimeout: 5, biometricEnabled: false },
+    network: null,
+    assetFilters: {
+      sortBy: 'name',
+      sortOrder: 'asc',
+      balanceThreshold: 0,
+      valueThreshold: 0,
+      nativeTokensFirst: false,
+    },
+  })),
+  collectFriends: jest.fn(async () => []),
+  collectExperimental: jest.fn(async () => ({
+    swapEnabled: false,
+    messagingEnabled: false,
+  })),
+}));
+jest.mock('../restorers', () => ({ performFullRestore: jest.fn() }));
+
+import { BackupService } from '../index';
+import * as collectors from '../collectors';
+
+describe('BackupService.createBackup passphrase policy (TASK-30 P2-1)', () => {
+  it('rejects a short password before collecting any account data', async () => {
+    await expect(BackupService.createBackup('short')).rejects.toMatchObject({
+      code: 'WEAK_PASSWORD',
+    });
+    // Gate runs first: no mnemonic collection happened.
+    expect(collectors.collectAccounts).not.toHaveBeenCalled();
+  });
+
+  it('rejects a common/predictable password of sufficient length', async () => {
+    await expect(
+      BackupService.createBackup('password1234')
+    ).rejects.toMatchObject({ code: 'WEAK_PASSWORD' });
+    expect(collectors.collectAccounts).not.toHaveBeenCalled();
+  });
+
+  it('proceeds past the gate and produces a backup for a strong passphrase', async () => {
+    const result = await BackupService.createBackup(
+      'correct horse battery staple'
+    );
+    expect(collectors.collectAccounts).toHaveBeenCalled();
+    expect(result.filename).toMatch(/\.voibackup$/);
+    expect(result.accountCount).toBe(0);
+  });
+});

--- a/src/services/backup/__tests__/encryption.test.ts
+++ b/src/services/backup/__tests__/encryption.test.ts
@@ -1,0 +1,308 @@
+// Unit tests for TASK-30: backup encryption v2 (scrypt) envelope, v1 backward
+// compatibility, AAD/MAC parameter binding, bounded pre-scrypt validation, and
+// the length-based passphrase policy.
+//
+// SECURITY NOTE: no static/committed secret material is used. Passwords here are
+// throwaway test strings and the "backup" payloads are synthetic JSON — never a
+// real mnemonic. The point is the crypto invariants, not any real wallet.
+
+// Provide platform crypto (getRandomBytes) via Node's CSPRNG so the encryption
+// module runs under jest without the native/expo platform adapter.
+jest.mock('@/platform', () => {
+  const nodeCrypto = require('crypto');
+  return {
+    crypto: {
+      getRandomBytes: async (byteCount: number): Promise<Uint8Array> =>
+        Uint8Array.from(nodeCrypto.randomBytes(byteCount)),
+    },
+  };
+});
+
+import CryptoJS from 'crypto-js';
+import { randomBytes } from 'crypto';
+import {
+  encryptBackup,
+  decryptBackup,
+  validateEncryptedBackupFile,
+  validatePasswordStrength,
+} from '../encryption';
+import {
+  EncryptedBackupFileV1,
+  EncryptedBackupFileV2,
+  BackupError,
+} from '../types';
+
+const PASSWORD = 'correct horse battery staple backup!';
+const PAYLOAD = JSON.stringify({
+  version: 1,
+  hello: 'world',
+  nested: { a: 1, b: [2, 3, 4] },
+});
+
+function randomHex(byteLength: number): string {
+  return randomBytes(byteLength).toString('hex');
+}
+
+/**
+ * Build a v1 (legacy PBKDF2) envelope exactly the way the old writer did, so we
+ * can prove the retained v1 decrypt path still works.
+ */
+function makeLegacyV1Backup(
+  plaintext: string,
+  password: string
+): EncryptedBackupFileV1 {
+  const salt = randomHex(32);
+  const iv = randomHex(16);
+
+  const keyHex = CryptoJS.PBKDF2(password, CryptoJS.enc.Hex.parse(salt), {
+    keySize: 32 / 4,
+    iterations: 100000,
+    hasher: (CryptoJS.algo as any).SHA256,
+  }).toString(CryptoJS.enc.Hex);
+
+  const encrypted = CryptoJS.AES.encrypt(
+    plaintext,
+    CryptoJS.enc.Hex.parse(keyHex),
+    {
+      iv: CryptoJS.enc.Hex.parse(iv),
+      mode: CryptoJS.mode.CTR,
+      padding: CryptoJS.pad.NoPadding,
+    }
+  );
+  const ciphertext = encrypted.toString();
+
+  const hmacKey = CryptoJS.SHA256(keyHex + 'backup_hmac_salt').toString();
+  const hmac = CryptoJS.HmacSHA256(ciphertext, hmacKey).toString();
+
+  return { format: 'voibackup', version: 1, salt, iv, ciphertext, hmac };
+}
+
+describe('backup encryption v2 (scrypt) round-trip', () => {
+  it('encrypts as v2/scrypt and decrypts back to the original plaintext', async () => {
+    const envelope = (await encryptBackup(
+      PAYLOAD,
+      PASSWORD
+    )) as EncryptedBackupFileV2;
+
+    expect(envelope.format).toBe('voibackup');
+    expect(envelope.version).toBe(2);
+    expect(envelope.kdf).toBe('scrypt');
+    expect(envelope.kdfParams).toEqual({
+      N: 2 ** 15,
+      r: 8,
+      p: 1,
+      dkLen: 32,
+    });
+    // Salt (32 bytes) and IV (16 bytes) are hex of the expected length.
+    expect(envelope.salt).toMatch(/^[0-9a-f]{64}$/);
+    expect(envelope.iv).toMatch(/^[0-9a-f]{32}$/);
+    // No plaintext leaks into the envelope.
+    expect(envelope.ciphertext).not.toContain('world');
+
+    const decrypted = await decryptBackup(envelope, PASSWORD);
+    expect(decrypted).toBe(PAYLOAD);
+  });
+
+  it('fails to decrypt with the wrong password', async () => {
+    const envelope = await encryptBackup(PAYLOAD, PASSWORD);
+    await expect(
+      decryptBackup(envelope, 'a different password entirely')
+    ).rejects.toMatchObject({ code: 'INTEGRITY_CHECK_FAILED' });
+  });
+});
+
+describe('v1 backward compatibility', () => {
+  it('still decrypts a legacy v1 (PBKDF2) backup fixture', async () => {
+    const legacy = makeLegacyV1Backup(PAYLOAD, PASSWORD);
+    expect(legacy.version).toBe(1);
+
+    const decrypted = await decryptBackup(legacy, PASSWORD);
+    expect(decrypted).toBe(PAYLOAD);
+  });
+
+  it('rejects a legacy v1 backup with the wrong password', async () => {
+    const legacy = makeLegacyV1Backup(PAYLOAD, PASSWORD);
+    await expect(
+      decryptBackup(legacy, 'wrong password wrong password')
+    ).rejects.toMatchObject({ code: 'INTEGRITY_CHECK_FAILED' });
+  });
+});
+
+describe('AAD / MAC parameter binding (v2)', () => {
+  it('fails when the IV is tampered (IV is authenticated only via AAD)', async () => {
+    const envelope = (await encryptBackup(
+      PAYLOAD,
+      PASSWORD
+    )) as EncryptedBackupFileV2;
+
+    const tampered: EncryptedBackupFileV2 = {
+      ...envelope,
+      iv: randomHex(16),
+    };
+
+    await expect(decryptBackup(tampered, PASSWORD)).rejects.toMatchObject({
+      code: 'INTEGRITY_CHECK_FAILED',
+    });
+  });
+
+  it('fails when kdfParams are tampered (N flipped to another valid value)', async () => {
+    const envelope = (await encryptBackup(
+      PAYLOAD,
+      PASSWORD
+    )) as EncryptedBackupFileV2;
+
+    const tampered: EncryptedBackupFileV2 = {
+      ...envelope,
+      kdfParams: { ...envelope.kdfParams, N: 2 ** 14 },
+    };
+
+    await expect(decryptBackup(tampered, PASSWORD)).rejects.toBeInstanceOf(
+      BackupError
+    );
+  });
+
+  it('fails when the salt is tampered', async () => {
+    const envelope = (await encryptBackup(
+      PAYLOAD,
+      PASSWORD
+    )) as EncryptedBackupFileV2;
+
+    const tampered: EncryptedBackupFileV2 = {
+      ...envelope,
+      salt: randomHex(32),
+    };
+
+    await expect(decryptBackup(tampered, PASSWORD)).rejects.toBeInstanceOf(
+      BackupError
+    );
+  });
+
+  it('fails when the version is downgraded to 1', async () => {
+    const envelope = (await encryptBackup(
+      PAYLOAD,
+      PASSWORD
+    )) as EncryptedBackupFileV2;
+
+    // Route the (scrypt) ciphertext through the v1/PBKDF2 path — MAC must fail.
+    const downgraded = {
+      ...envelope,
+      version: 1,
+    } as unknown as EncryptedBackupFileV1;
+
+    await expect(decryptBackup(downgraded, PASSWORD)).rejects.toBeInstanceOf(
+      BackupError
+    );
+  });
+});
+
+describe('bounded validation before scrypt (DoS guard)', () => {
+  function baseV2(): Record<string, unknown> {
+    return {
+      format: 'voibackup',
+      version: 2,
+      kdf: 'scrypt',
+      kdfParams: { N: 2 ** 15, r: 8, p: 1, dkLen: 32 },
+      salt: randomHex(32),
+      iv: randomHex(16),
+      ciphertext: 'AAAA',
+      hmac: 'bb',
+    };
+  }
+
+  it('accepts a well-formed v2 envelope', () => {
+    expect(() => validateEncryptedBackupFile(baseV2())).not.toThrow();
+  });
+
+  it('rejects N over the cap (> 2^20) before deriving a key', () => {
+    const bad = {
+      ...baseV2(),
+      kdfParams: { N: 2 ** 21, r: 8, p: 1, dkLen: 32 },
+    };
+    expect(() => validateEncryptedBackupFile(bad)).toThrow(BackupError);
+  });
+
+  it('rejects N that is not a power of two', () => {
+    const bad = { ...baseV2(), kdfParams: { N: 30000, r: 8, p: 1, dkLen: 32 } };
+    expect(() => validateEncryptedBackupFile(bad)).toThrow(BackupError);
+  });
+
+  it('rejects r over the cap', () => {
+    const bad = {
+      ...baseV2(),
+      kdfParams: { N: 2 ** 15, r: 64, p: 1, dkLen: 32 },
+    };
+    expect(() => validateEncryptedBackupFile(bad)).toThrow(BackupError);
+  });
+
+  it('rejects a combined memory footprint over the ceiling', () => {
+    // N=2^20, r=32 -> 128*N*r = 4 GiB, well over the 128 MiB cap.
+    const bad = {
+      ...baseV2(),
+      kdfParams: { N: 2 ** 20, r: 32, p: 1, dkLen: 32 },
+    };
+    expect(() => validateEncryptedBackupFile(bad)).toThrow(BackupError);
+  });
+
+  it('rejects a wrong dkLen', () => {
+    const bad = {
+      ...baseV2(),
+      kdfParams: { N: 2 ** 15, r: 8, p: 1, dkLen: 64 },
+    };
+    expect(() => validateEncryptedBackupFile(bad)).toThrow(BackupError);
+  });
+
+  it('rejects a malformed salt length', () => {
+    const bad = { ...baseV2(), salt: 'deadbeef' };
+    expect(() => validateEncryptedBackupFile(bad)).toThrow(BackupError);
+  });
+
+  it('rejects an unknown version with a clear error', () => {
+    const bad = { ...baseV2(), version: 9 };
+    expect(() => validateEncryptedBackupFile(bad)).toThrow(
+      /Unsupported backup version/
+    );
+  });
+
+  it('rejects a non-object / wrong format', () => {
+    expect(() => validateEncryptedBackupFile(null)).toThrow(BackupError);
+    expect(() =>
+      validateEncryptedBackupFile({ format: 'nope', version: 2 })
+    ).toThrow(BackupError);
+  });
+});
+
+describe('passphrase policy (length-based, no composition rules)', () => {
+  it('rejects passphrases shorter than 12 characters', () => {
+    expect(validatePasswordStrength('short').isValid).toBe(false);
+    expect(validatePasswordStrength('abc123!X').isValid).toBe(false); // 8 chars
+    expect(validatePasswordStrength('elevenchars').isValid).toBe(false); // 11
+  });
+
+  it('accepts a strong 12+ passphrase without requiring composition', () => {
+    const result = validatePasswordStrength('correct horse battery staple');
+    expect(result.isValid).toBe(true);
+    // All-lowercase + spaces still valid (no upper/digit/symbol required).
+    expect(validatePasswordStrength('voyager tangerine mountain').isValid).toBe(
+      true
+    );
+  });
+
+  it('rejects common / predictable passphrases even at length >= 12', () => {
+    expect(validatePasswordStrength('password1234').isValid).toBe(false);
+    expect(validatePasswordStrength('123456789012').isValid).toBe(false);
+    expect(validatePasswordStrength('aaaaaaaaaaaa').isValid).toBe(false);
+    expect(validatePasswordStrength('abcdefghijkl').isValid).toBe(false);
+    expect(validatePasswordStrength('qwertyuiopas').isValid).toBe(false);
+  });
+
+  it('keeps a 0-4 meter score for the strength UI', () => {
+    const weak = validatePasswordStrength('short');
+    expect(weak.score).toBeGreaterThanOrEqual(0);
+    expect(weak.score).toBeLessThanOrEqual(1);
+
+    const strong = validatePasswordStrength('Tr0ubador&3xplr!ng-w1nter');
+    expect(strong.isValid).toBe(true);
+    expect(strong.score).toBeGreaterThanOrEqual(3);
+    expect(strong.score).toBeLessThanOrEqual(4);
+  });
+});

--- a/src/services/backup/__tests__/encryption.test.ts
+++ b/src/services/backup/__tests__/encryption.test.ts
@@ -205,7 +205,7 @@ describe('bounded validation before scrypt (DoS guard)', () => {
       salt: randomHex(32),
       iv: randomHex(16),
       ciphertext: 'AAAA',
-      hmac: 'bb',
+      hmac: 'ab'.repeat(32), // 64 lowercase hex chars (shape-valid placeholder)
     };
   }
 
@@ -254,6 +254,25 @@ describe('bounded validation before scrypt (DoS guard)', () => {
   it('rejects a malformed salt length', () => {
     const bad = { ...baseV2(), salt: 'deadbeef' };
     expect(() => validateEncryptedBackupFile(bad)).toThrow(BackupError);
+  });
+
+  it('rejects a v2 hmac that is not exactly 64 lowercase hex chars', () => {
+    // Too short
+    expect(() =>
+      validateEncryptedBackupFile({ ...baseV2(), hmac: 'abcd' })
+    ).toThrow(BackupError);
+    // Non-hex
+    expect(() =>
+      validateEncryptedBackupFile({ ...baseV2(), hmac: 'z'.repeat(64) })
+    ).toThrow(BackupError);
+    // Uppercase (writer emits lowercase)
+    expect(() =>
+      validateEncryptedBackupFile({ ...baseV2(), hmac: 'A'.repeat(64) })
+    ).toThrow(BackupError);
+    // Correct length + lowercase hex passes shape validation
+    expect(() =>
+      validateEncryptedBackupFile({ ...baseV2(), hmac: 'a'.repeat(64) })
+    ).not.toThrow();
   });
 
   it('rejects an unknown version with a clear error', () => {

--- a/src/services/backup/encryption.ts
+++ b/src/services/backup/encryption.ts
@@ -81,16 +81,39 @@ function deriveKeyPbkdf2(password: string, saltHex: string): string {
 }
 
 /**
- * scrypt key derivation (v2). Returns the derived key as a hex string.
+ * Best-effort scrub of a CryptoJS WordArray's backing words.
+ *
+ * SECURITY / defense-in-depth only: JS/Hermes strings are immutable and cannot
+ * be reliably zeroed, so this reduces (does not eliminate) copies of key
+ * material left in memory. WordArrays store their bytes in a plain number[],
+ * which we CAN overwrite.
+ */
+function wipeWordArray(wa: CryptoJS.lib.WordArray | null | undefined): void {
+  if (wa && Array.isArray(wa.words)) {
+    wa.words.fill(0);
+    wa.sigBytes = 0;
+  }
+}
+
+/**
+ * scrypt key derivation (v2). Returns the AES key and HMAC key as CryptoJS
+ * WordArrays (which can be scrubbed) derived directly from the scrypt output,
+ * avoiding an unnecessary hex-string copy of the key material.
  *
  * Uses the ASYNC variant which yields to the event loop during the multi-second
  * derivation so it doesn't freeze the RN UI thread.
+ *
+ * The caller MUST wipe both returned WordArrays in a `finally` (see
+ * wipeWordArray for the defense-in-depth caveat).
  */
-async function deriveKeyScryptHex(
+async function deriveV2KeyMaterial(
   password: string,
   saltHex: string,
   params: ScryptKdfParams
-): Promise<string> {
+): Promise<{
+  keyWordArray: CryptoJS.lib.WordArray;
+  hmacKeyWordArray: CryptoJS.lib.WordArray;
+}> {
   const saltBytes = Uint8Array.from(Buffer.from(saltHex, 'hex'));
   const derived = await scryptAsync(password, saltBytes, {
     N: params.N,
@@ -98,10 +121,17 @@ async function deriveKeyScryptHex(
     p: params.p,
     dkLen: params.dkLen,
   });
-  const hex = Buffer.from(derived).toString('hex');
-  // Scrub the raw derived-key bytes; the hex copy is scrubbed by the caller.
-  derived.fill(0);
-  return hex;
+  const keyWordArray = CryptoJS.lib.WordArray.create(derived);
+  derived.fill(0); // scrub the raw scrypt bytes immediately
+
+  // HMAC key = SHA256(key || tweak). `concat` mutates the receiver, so clone the
+  // key first and wipe the throwaway input afterwards.
+  const tweakWordArray = CryptoJS.enc.Utf8.parse(HMAC_KEY_TWEAK);
+  const hmacKeyInput = keyWordArray.clone().concat(tweakWordArray);
+  const hmacKeyWordArray = CryptoJS.SHA256(hmacKeyInput);
+  wipeWordArray(hmacKeyInput);
+
+  return { keyWordArray, hmacKeyWordArray };
 }
 
 /**
@@ -228,6 +258,15 @@ export function validateEncryptedBackupFile(
     if (obj.kdf !== 'scrypt') {
       throw new BackupError('Unsupported backup KDF', 'VERSION_MISMATCH');
     }
+    // v2 writes the HMAC as exactly 32 bytes of lowercase hex. Reject a
+    // malformed/short hmac up front so it never reaches the length-dependent
+    // constant-time compare. (v1 hmac format is intentionally left unchecked.)
+    if (!/^[0-9a-f]{64}$/.test(obj.hmac)) {
+      throw new BackupError(
+        'Invalid backup file format',
+        'INVALID_FILE_FORMAT'
+      );
+    }
     const rawParams = obj.kdfParams;
     if (typeof rawParams !== 'object' || rawParams === null) {
       throw new BackupError(
@@ -312,7 +351,8 @@ export async function encryptBackup(
   data: string,
   password: string
 ): Promise<EncryptedBackupFile> {
-  let keyHex: string | null = null;
+  let keyWordArray: CryptoJS.lib.WordArray | null = null;
+  let hmacKeyWordArray: CryptoJS.lib.WordArray | null = null;
 
   try {
     // Generate random salt and IV
@@ -326,11 +366,13 @@ export async function encryptBackup(
       dkLen: KEY_LENGTH,
     };
 
-    // Derive encryption key from password (memory-hard scrypt)
-    keyHex = await deriveKeyScryptHex(password, salt, kdfParams);
+    // Derive encryption + MAC keys from password (memory-hard scrypt)
+    ({ keyWordArray, hmacKeyWordArray } = await deriveV2KeyMaterial(
+      password,
+      salt,
+      kdfParams
+    ));
 
-    // Prepare key and IV as WordArrays for CryptoJS
-    const keyWordArray = CryptoJS.enc.Hex.parse(keyHex);
     const ivWordArray = CryptoJS.enc.Hex.parse(iv);
 
     // Encrypt with AES-256-CTR (matches the existing cipher; the change is the
@@ -346,7 +388,6 @@ export async function encryptBackup(
 
     // Encrypt-then-MAC. The MAC covers the canonical envelope params (AAD) plus
     // the ciphertext, binding N/r/p/dkLen/salt/iv/version to the ciphertext.
-    const hmacKey = CryptoJS.SHA256(keyHex + HMAC_KEY_TWEAK).toString();
     const aad = canonicalV2Aad({
       version: 2,
       kdf: 'scrypt',
@@ -354,7 +395,10 @@ export async function encryptBackup(
       salt,
       iv,
     });
-    const hmac = CryptoJS.HmacSHA256(aad + ciphertext, hmacKey).toString();
+    const hmac = CryptoJS.HmacSHA256(
+      aad + ciphertext,
+      hmacKeyWordArray
+    ).toString();
 
     return {
       format: 'voibackup',
@@ -372,10 +416,9 @@ export async function encryptBackup(
       'ENCRYPTION_FAILED'
     );
   } finally {
-    // Scrub derived key material from memory
-    if (keyHex) {
-      keyHex = '0'.repeat(keyHex.length);
-    }
+    // Scrub derived key material from memory (defense-in-depth)
+    wipeWordArray(keyWordArray);
+    wipeWordArray(hmacKeyWordArray);
   }
 }
 
@@ -443,24 +486,24 @@ async function decryptBackupV2(
   encrypted: EncryptedBackupFileV2,
   password: string
 ): Promise<string> {
-  let keyHex: string | null = null;
+  let keyWordArray: CryptoJS.lib.WordArray | null = null;
+  let hmacKeyWordArray: CryptoJS.lib.WordArray | null = null;
 
   try {
-    // Derive encryption key from password (memory-hard scrypt)
-    keyHex = await deriveKeyScryptHex(
+    // Derive encryption + MAC keys from password (memory-hard scrypt)
+    ({ keyWordArray, hmacKeyWordArray } = await deriveV2KeyMaterial(
       password,
       encrypted.salt,
       encrypted.kdfParams
-    );
+    ));
 
     // Verify the MAC over the canonical envelope params + ciphertext. Any
     // tampering with version/kdf/N/r/p/dkLen/salt/iv changes the recomputed AAD
     // and fails this check (in addition to salt/N/r/p already feeding scrypt).
-    const hmacKey = CryptoJS.SHA256(keyHex + HMAC_KEY_TWEAK).toString();
     const aad = canonicalV2Aad(encrypted);
     const computedHmac = CryptoJS.HmacSHA256(
       aad + encrypted.ciphertext,
-      hmacKey
+      hmacKeyWordArray
     ).toString();
 
     if (!constantTimeEqualHex(computedHmac, encrypted.hmac)) {
@@ -470,8 +513,7 @@ async function decryptBackupV2(
       );
     }
 
-    // Prepare key and IV as WordArrays
-    const keyWordArray = CryptoJS.enc.Hex.parse(keyHex);
+    // Prepare IV as WordArray
     const ivWordArray = CryptoJS.enc.Hex.parse(encrypted.iv);
 
     // Decrypt
@@ -492,9 +534,9 @@ async function decryptBackupV2(
 
     return plaintext;
   } finally {
-    if (keyHex) {
-      keyHex = '0'.repeat(keyHex.length);
-    }
+    // Scrub derived key material from memory (defense-in-depth)
+    wipeWordArray(keyWordArray);
+    wipeWordArray(hmacKeyWordArray);
   }
 }
 

--- a/src/services/backup/encryption.ts
+++ b/src/services/backup/encryption.ts
@@ -1,8 +1,18 @@
 /**
  * Backup Encryption Module
  *
- * Password-based encryption for wallet backups using PBKDF2 + AES-256-CTR + HMAC.
- * Follows the same security patterns as AccountSecureStorage.
+ * Password-based encryption for wallet backups.
+ *
+ * Envelope versions (discriminated on `version`):
+ *  - v1 (LEGACY, read-only): PBKDF2-SHA256 100k + AES-256-CTR + HMAC-SHA256.
+ *    New backups are NO LONGER written as v1, but existing v1 files MUST still
+ *    decrypt — the v1 path below is intentionally left untouched.
+ *  - v2 (current): scrypt (memory-hard) + AES-256-CTR + encrypt-then-MAC, with
+ *    the HMAC binding the envelope parameters (AAD) so N/r/p/salt/iv/version
+ *    cannot be tampered without failing integrity verification.
+ *
+ * SECURITY: this module never logs the password, mnemonic, derived key, or any
+ * plaintext. Derived key material is scrubbed in `finally` blocks.
  */
 
 import CryptoJS from 'crypto-js';
@@ -14,20 +24,53 @@ import 'crypto-js/pad-nopadding';
 import 'crypto-js/enc-hex';
 import 'crypto-js/enc-base64';
 import 'crypto-js/pbkdf2';
+import { scryptAsync } from '@noble/hashes/scrypt';
 import { Buffer } from 'buffer';
 import { crypto as platformCrypto } from '@/platform';
-import { EncryptedBackupFile, BackupError } from './types';
+import {
+  EncryptedBackupFile,
+  EncryptedBackupFileV1,
+  EncryptedBackupFileV2,
+  ScryptKdfParams,
+  BackupError,
+} from './types';
 
-// Encryption parameters - higher iterations for backup since we have more time
-const PBKDF2_ITERATIONS = 100000;
+// --- Shared envelope parameters -------------------------------------------
 const SALT_LENGTH = 32; // 256 bits
 const IV_LENGTH = 16; // 128 bits for AES
 const KEY_LENGTH = 32; // 256 bits for AES-256
 
+// --- v1 (legacy PBKDF2) parameters ----------------------------------------
+const PBKDF2_ITERATIONS = 100000;
+
+// --- v2 (scrypt) writer parameters ----------------------------------------
+// Chosen conservatively for pure-JS Hermes on low-end Android. Memory footprint
+// is ~128 * N * r bytes = 32 MiB here. Benchmark (Node v24 / V8, scryptAsync):
+//   N=2^14 -> ~31ms/16MiB, N=2^15 -> ~63ms/32MiB, N=2^16 -> ~125ms/64MiB,
+//   N=2^17 -> ~250ms/128MiB. Backup is an occasional operation, so a memory-hard
+//   KDF taking ~1s (Hermes is materially slower than V8) is an acceptable
+//   trade-off. 32 MiB stays comfortably clear of OOM on low-end devices.
+//   NOTE: real Hermes / low-end-Android timing is a follow-up device check.
+const SCRYPT_N = 2 ** 15; // 32768
+const SCRYPT_R = 8;
+const SCRYPT_P = 1;
+
+// --- v2 validation caps (DoS guard) ---------------------------------------
+// A malicious/oversized v2 backup must be rejected BEFORE scrypt runs so it
+// cannot force a huge memory allocation. N is additionally checked to be a
+// power of two, and the combined 128*N*r footprint is bounded.
+const V2_MAX_N = 2 ** 20; // 1,048,576
+const V2_MAX_R = 32;
+const V2_MAX_P = 4;
+const V2_DK_LEN = 32;
+const V2_MAX_KDF_MEMORY_BYTES = 128 * 1024 * 1024; // 128 MiB ceiling on 128*N*r
+
+const HMAC_KEY_TWEAK = 'backup_hmac_salt';
+
 /**
- * PBKDF2 key derivation using CryptoJS with SHA256
+ * PBKDF2 key derivation using CryptoJS with SHA256 (v1 legacy path).
  */
-function deriveKey(password: string, saltHex: string): string {
+function deriveKeyPbkdf2(password: string, saltHex: string): string {
   const saltWA = CryptoJS.enc.Hex.parse(saltHex);
   const derived = CryptoJS.PBKDF2(password, saltWA, {
     keySize: KEY_LENGTH / 4, // CryptoJS keySize is in 32-bit words
@@ -35,6 +78,30 @@ function deriveKey(password: string, saltHex: string): string {
     hasher: (CryptoJS.algo as any).SHA256,
   });
   return derived.toString(CryptoJS.enc.Hex);
+}
+
+/**
+ * scrypt key derivation (v2). Returns the derived key as a hex string.
+ *
+ * Uses the ASYNC variant which yields to the event loop during the multi-second
+ * derivation so it doesn't freeze the RN UI thread.
+ */
+async function deriveKeyScryptHex(
+  password: string,
+  saltHex: string,
+  params: ScryptKdfParams
+): Promise<string> {
+  const saltBytes = Uint8Array.from(Buffer.from(saltHex, 'hex'));
+  const derived = await scryptAsync(password, saltBytes, {
+    N: params.N,
+    r: params.r,
+    p: params.p,
+    dkLen: params.dkLen,
+  });
+  const hex = Buffer.from(derived).toString('hex');
+  // Scrub the raw derived-key bytes; the hex copy is scrubbed by the caller.
+  derived.fill(0);
+  return hex;
 }
 
 /**
@@ -48,50 +115,252 @@ async function generateRandomHex(byteLength: number): Promise<string> {
 }
 
 /**
- * Encrypt backup data with a user-provided password
+ * Canonical serialization of the v2 envelope parameters used as AAD for the
+ * HMAC. Building the object with a fixed key order makes JSON.stringify a
+ * deterministic canonical form. The MAC is computed over this string
+ * concatenated with the ciphertext, so version/kdf/N/r/p/dkLen/salt/iv are all
+ * authenticated and cannot be tampered without failing verification.
+ */
+function canonicalV2Aad(params: {
+  version: 2;
+  kdf: 'scrypt';
+  kdfParams: ScryptKdfParams;
+  salt: string;
+  iv: string;
+}): string {
+  return JSON.stringify({
+    version: params.version,
+    kdf: params.kdf,
+    kdfParams: {
+      N: params.kdfParams.N,
+      r: params.kdfParams.r,
+      p: params.kdfParams.p,
+      dkLen: params.kdfParams.dkLen,
+    },
+    salt: params.salt,
+    iv: params.iv,
+  });
+}
+
+/**
+ * Constant-time comparison for equal-length hex strings (v2 MAC check).
+ */
+function constantTimeEqualHex(a: string, b: string): boolean {
+  if (a.length !== b.length) {
+    return false;
+  }
+  let diff = 0;
+  for (let i = 0; i < a.length; i++) {
+    diff |= a.charCodeAt(i) ^ b.charCodeAt(i);
+  }
+  return diff === 0;
+}
+
+/**
+ * True for integers > 1 that are an exact power of two.
+ */
+function isPowerOfTwo(n: number): boolean {
+  return Number.isInteger(n) && n > 1 && (n & (n - 1)) === 0;
+}
+
+/**
+ * True when `value` is a hex string of exactly `byteLength` bytes.
+ */
+function isHexOfBytes(value: unknown, byteLength: number): value is string {
+  return (
+    typeof value === 'string' &&
+    value.length === byteLength * 2 &&
+    /^[0-9a-fA-F]+$/.test(value)
+  );
+}
+
+/**
+ * Strictly validate a parsed (untrusted) backup envelope and normalize it to a
+ * typed EncryptedBackupFile.
+ *
+ * For v2 this CAPS the KDF parameters BEFORE any scrypt work happens, so a
+ * malicious backup cannot force a huge/slow memory allocation (DoS). Both the
+ * import and validation paths parse untrusted JSON, so this runs on both, and
+ * decryptBackup re-runs it as a final gate before deriving the key.
+ */
+export function validateEncryptedBackupFile(
+  parsed: unknown
+): EncryptedBackupFile {
+  if (typeof parsed !== 'object' || parsed === null) {
+    throw new BackupError('Invalid backup file format', 'INVALID_FILE_FORMAT');
+  }
+  const obj = parsed as Record<string, unknown>;
+
+  if (obj.format !== 'voibackup') {
+    throw new BackupError(
+      'Not a valid Voi Wallet backup file',
+      'INVALID_FILE_FORMAT'
+    );
+  }
+
+  // Fields common to every version.
+  if (typeof obj.ciphertext !== 'string' || obj.ciphertext.length === 0) {
+    throw new BackupError('Invalid backup file format', 'INVALID_FILE_FORMAT');
+  }
+  if (typeof obj.hmac !== 'string' || obj.hmac.length === 0) {
+    throw new BackupError('Invalid backup file format', 'INVALID_FILE_FORMAT');
+  }
+  if (!isHexOfBytes(obj.iv, IV_LENGTH)) {
+    throw new BackupError('Invalid backup file format', 'INVALID_FILE_FORMAT');
+  }
+  if (!isHexOfBytes(obj.salt, SALT_LENGTH)) {
+    throw new BackupError('Invalid backup file format', 'INVALID_FILE_FORMAT');
+  }
+
+  if (obj.version === 1) {
+    const v1: EncryptedBackupFileV1 = {
+      format: 'voibackup',
+      version: 1,
+      salt: obj.salt as string,
+      iv: obj.iv as string,
+      ciphertext: obj.ciphertext,
+      hmac: obj.hmac,
+    };
+    return v1;
+  }
+
+  if (obj.version === 2) {
+    if (obj.kdf !== 'scrypt') {
+      throw new BackupError('Unsupported backup KDF', 'VERSION_MISMATCH');
+    }
+    const rawParams = obj.kdfParams;
+    if (typeof rawParams !== 'object' || rawParams === null) {
+      throw new BackupError(
+        'Invalid backup KDF parameters',
+        'INVALID_FILE_FORMAT'
+      );
+    }
+    const { N, r, p, dkLen } = rawParams as Record<string, unknown>;
+    if (
+      typeof N !== 'number' ||
+      typeof r !== 'number' ||
+      typeof p !== 'number' ||
+      typeof dkLen !== 'number'
+    ) {
+      throw new BackupError(
+        'Invalid backup KDF parameters',
+        'INVALID_FILE_FORMAT'
+      );
+    }
+    // Cap the KDF parameters BEFORE scrypt runs (DoS guard).
+    if (!isPowerOfTwo(N) || N > V2_MAX_N) {
+      throw new BackupError(
+        'Backup KDF parameters exceed safe limits',
+        'INVALID_FILE_FORMAT'
+      );
+    }
+    if (!Number.isInteger(r) || r < 1 || r > V2_MAX_R) {
+      throw new BackupError(
+        'Backup KDF parameters exceed safe limits',
+        'INVALID_FILE_FORMAT'
+      );
+    }
+    if (!Number.isInteger(p) || p < 1 || p > V2_MAX_P) {
+      throw new BackupError(
+        'Backup KDF parameters exceed safe limits',
+        'INVALID_FILE_FORMAT'
+      );
+    }
+    if (dkLen !== V2_DK_LEN) {
+      throw new BackupError(
+        'Backup KDF parameters exceed safe limits',
+        'INVALID_FILE_FORMAT'
+      );
+    }
+    // Bound the combined memory footprint (~128 * N * r bytes).
+    if (128 * N * r > V2_MAX_KDF_MEMORY_BYTES) {
+      throw new BackupError(
+        'Backup KDF parameters exceed safe limits',
+        'INVALID_FILE_FORMAT'
+      );
+    }
+
+    const v2: EncryptedBackupFileV2 = {
+      format: 'voibackup',
+      version: 2,
+      kdf: 'scrypt',
+      kdfParams: { N, r, p, dkLen },
+      salt: obj.salt as string,
+      iv: obj.iv as string,
+      ciphertext: obj.ciphertext,
+      hmac: obj.hmac,
+    };
+    return v2;
+  }
+
+  throw new BackupError(
+    `Unsupported backup version: ${String(obj.version)}`,
+    'VERSION_MISMATCH'
+  );
+}
+
+/**
+ * Encrypt backup data with a user-provided password.
+ *
+ * New backups are written as v2 (scrypt + AES-256-CTR + encrypt-then-MAC).
  *
  * @param data - JSON string of backup data to encrypt
  * @param password - User's chosen password
- * @returns Encrypted backup file structure
+ * @returns Encrypted backup file structure (v2)
  */
 export async function encryptBackup(
   data: string,
   password: string
 ): Promise<EncryptedBackupFile> {
-  let keyMaterial: string | null = null;
+  let keyHex: string | null = null;
 
   try {
     // Generate random salt and IV
     const salt = await generateRandomHex(SALT_LENGTH);
     const iv = await generateRandomHex(IV_LENGTH);
 
-    // Derive encryption key from password
-    keyMaterial = deriveKey(password, salt);
+    const kdfParams: ScryptKdfParams = {
+      N: SCRYPT_N,
+      r: SCRYPT_R,
+      p: SCRYPT_P,
+      dkLen: KEY_LENGTH,
+    };
+
+    // Derive encryption key from password (memory-hard scrypt)
+    keyHex = await deriveKeyScryptHex(password, salt, kdfParams);
 
     // Prepare key and IV as WordArrays for CryptoJS
-    const keyWordArray = CryptoJS.enc.Hex.parse(keyMaterial);
+    const keyWordArray = CryptoJS.enc.Hex.parse(keyHex);
     const ivWordArray = CryptoJS.enc.Hex.parse(iv);
 
-    // Encrypt with AES-256-CTR
+    // Encrypt with AES-256-CTR (matches the existing cipher; the change is the
+    // KDF + envelope, not the cipher)
     const encrypted = CryptoJS.AES.encrypt(data, keyWordArray, {
       iv: ivWordArray,
       mode: CryptoJS.mode.CTR,
       padding: CryptoJS.pad.NoPadding,
     });
 
-    // Get ciphertext as base64
-    const ciphertext = encrypted.toString(); // Already base64
+    // Ciphertext as base64
+    const ciphertext = encrypted.toString();
 
-    // Generate HMAC for authentication
-    // Use a derived HMAC key (key + 'hmac_salt' hashed)
-    const hmacKey = CryptoJS.SHA256(
-      keyMaterial + 'backup_hmac_salt'
-    ).toString();
-    const hmac = CryptoJS.HmacSHA256(ciphertext, hmacKey).toString();
+    // Encrypt-then-MAC. The MAC covers the canonical envelope params (AAD) plus
+    // the ciphertext, binding N/r/p/dkLen/salt/iv/version to the ciphertext.
+    const hmacKey = CryptoJS.SHA256(keyHex + HMAC_KEY_TWEAK).toString();
+    const aad = canonicalV2Aad({
+      version: 2,
+      kdf: 'scrypt',
+      kdfParams,
+      salt,
+      iv,
+    });
+    const hmac = CryptoJS.HmacSHA256(aad + ciphertext, hmacKey).toString();
 
     return {
       format: 'voibackup',
-      version: 1,
+      version: 2,
+      kdf: 'scrypt',
+      kdfParams,
       salt,
       iv,
       ciphertext,
@@ -103,49 +372,30 @@ export async function encryptBackup(
       'ENCRYPTION_FAILED'
     );
   } finally {
-    // Clear sensitive key material from memory
-    if (keyMaterial) {
-      keyMaterial = '0'.repeat(keyMaterial.length);
+    // Scrub derived key material from memory
+    if (keyHex) {
+      keyHex = '0'.repeat(keyHex.length);
     }
   }
 }
 
 /**
- * Decrypt backup data with a user-provided password
+ * Decrypt a v1 (legacy PBKDF2) backup envelope.
  *
- * @param encrypted - Encrypted backup file structure
- * @param password - User's password
- * @returns Decrypted JSON string of backup data
+ * LEGACY: kept intact for backward compatibility — do not change.
  */
-export async function decryptBackup(
-  encrypted: EncryptedBackupFile,
+async function decryptBackupV1(
+  encrypted: EncryptedBackupFileV1,
   password: string
 ): Promise<string> {
   let keyMaterial: string | null = null;
 
   try {
-    // Validate format
-    if (encrypted.format !== 'voibackup') {
-      throw new BackupError(
-        'Invalid backup file format',
-        'INVALID_FILE_FORMAT'
-      );
-    }
-
-    if (encrypted.version !== 1) {
-      throw new BackupError(
-        `Unsupported backup version: ${encrypted.version}`,
-        'VERSION_MISMATCH'
-      );
-    }
-
     // Derive encryption key from password
-    keyMaterial = deriveKey(password, encrypted.salt);
+    keyMaterial = deriveKeyPbkdf2(password, encrypted.salt);
 
     // Verify HMAC first (authenticate before decrypt)
-    const hmacKey = CryptoJS.SHA256(
-      keyMaterial + 'backup_hmac_salt'
-    ).toString();
+    const hmacKey = CryptoJS.SHA256(keyMaterial + HMAC_KEY_TWEAK).toString();
     const computedHmac = CryptoJS.HmacSHA256(
       encrypted.ciphertext,
       hmacKey
@@ -169,7 +419,6 @@ export async function decryptBackup(
       padding: CryptoJS.pad.NoPadding,
     });
 
-    // Convert to UTF-8 string
     const plaintext = decrypted.toString(CryptoJS.enc.Utf8);
 
     if (!plaintext || plaintext.length === 0) {
@@ -180,6 +429,97 @@ export async function decryptBackup(
     }
 
     return plaintext;
+  } finally {
+    if (keyMaterial) {
+      keyMaterial = '0'.repeat(keyMaterial.length);
+    }
+  }
+}
+
+/**
+ * Decrypt a v2 (scrypt) backup envelope.
+ */
+async function decryptBackupV2(
+  encrypted: EncryptedBackupFileV2,
+  password: string
+): Promise<string> {
+  let keyHex: string | null = null;
+
+  try {
+    // Derive encryption key from password (memory-hard scrypt)
+    keyHex = await deriveKeyScryptHex(
+      password,
+      encrypted.salt,
+      encrypted.kdfParams
+    );
+
+    // Verify the MAC over the canonical envelope params + ciphertext. Any
+    // tampering with version/kdf/N/r/p/dkLen/salt/iv changes the recomputed AAD
+    // and fails this check (in addition to salt/N/r/p already feeding scrypt).
+    const hmacKey = CryptoJS.SHA256(keyHex + HMAC_KEY_TWEAK).toString();
+    const aad = canonicalV2Aad(encrypted);
+    const computedHmac = CryptoJS.HmacSHA256(
+      aad + encrypted.ciphertext,
+      hmacKey
+    ).toString();
+
+    if (!constantTimeEqualHex(computedHmac, encrypted.hmac)) {
+      throw new BackupError(
+        'Integrity check failed - wrong password or corrupted file',
+        'INTEGRITY_CHECK_FAILED'
+      );
+    }
+
+    // Prepare key and IV as WordArrays
+    const keyWordArray = CryptoJS.enc.Hex.parse(keyHex);
+    const ivWordArray = CryptoJS.enc.Hex.parse(encrypted.iv);
+
+    // Decrypt
+    const decrypted = CryptoJS.AES.decrypt(encrypted.ciphertext, keyWordArray, {
+      iv: ivWordArray,
+      mode: CryptoJS.mode.CTR,
+      padding: CryptoJS.pad.NoPadding,
+    });
+
+    const plaintext = decrypted.toString(CryptoJS.enc.Utf8);
+
+    if (!plaintext || plaintext.length === 0) {
+      throw new BackupError(
+        'Decryption failed - invalid result',
+        'DECRYPTION_FAILED'
+      );
+    }
+
+    return plaintext;
+  } finally {
+    if (keyHex) {
+      keyHex = '0'.repeat(keyHex.length);
+    }
+  }
+}
+
+/**
+ * Decrypt backup data with a user-provided password.
+ *
+ * Dispatches on the envelope `version`: v1 -> legacy PBKDF2, v2 -> scrypt.
+ * Validates + caps the (untrusted) envelope first, so v2 parameter caps are
+ * enforced before scrypt runs even when called directly.
+ *
+ * @param encrypted - Encrypted backup file structure
+ * @param password - User's password
+ * @returns Decrypted JSON string of backup data
+ */
+export async function decryptBackup(
+  encrypted: EncryptedBackupFile,
+  password: string
+): Promise<string> {
+  try {
+    const envelope = validateEncryptedBackupFile(encrypted);
+
+    if (envelope.version === 1) {
+      return await decryptBackupV1(envelope, password);
+    }
+    return await decryptBackupV2(envelope, password);
   } catch (error) {
     if (error instanceof BackupError) {
       throw error;
@@ -188,19 +528,138 @@ export async function decryptBackup(
       `Decryption failed: ${error instanceof Error ? error.message : String(error)}`,
       'DECRYPTION_FAILED'
     );
-  } finally {
-    // Clear sensitive key material from memory
-    if (keyMaterial) {
-      keyMaterial = '0'.repeat(keyMaterial.length);
-    }
   }
 }
 
+// --- Passphrase policy -----------------------------------------------------
+
+/** Minimum passphrase length for a NEW backup. */
+const MIN_PASSPHRASE_LENGTH = 12;
+
 /**
- * Validate password strength
+ * A small denylist of obviously-weak passphrases (compared lowercased/trimmed).
+ * This is a lightweight guard, not an exhaustive list — the goal is to reject
+ * the most predictable choices, not to replace a full strength estimator.
+ */
+const COMMON_PASSWORD_DENYLIST = new Set([
+  'password',
+  'passw0rd',
+  'password1',
+  'password12',
+  'password123',
+  'password1234',
+  'passwordpassword',
+  'letmein',
+  'letmein12345',
+  'welcome',
+  'welcome12345',
+  'iloveyou',
+  'iloveyou1234',
+  'trustno1',
+  'adminadmin',
+  'administrator',
+  'qwertyuiop',
+  'qwerty123456',
+  '1234567890',
+  '123456789012',
+  'voipassword',
+  'voiwallet123',
+  'voiwalletvoi',
+  'changeme1234',
+]);
+
+/**
+ * Base tokens that, once trailing digits/symbols are stripped, mark a
+ * passphrase as predictable (e.g. "password1234", "qwerty!!!").
+ */
+const COMMON_BASE_TOKENS = new Set([
+  'password',
+  'passw0rd',
+  'qwerty',
+  'qwertyuiop',
+  'letmein',
+  'welcome',
+  'iloveyou',
+  'trustno',
+  'monkey',
+  'dragon',
+  'admin',
+  'changeme',
+  'voiwallet',
+  'voipassword',
+]);
+
+// Ordered character runs used to detect purely-sequential passphrases.
+const SEQUENCES = [
+  '0123456789',
+  'abcdefghijklmnopqrstuvwxyz',
+  'qwertyuiopasdfghjklzxcvbnm',
+];
+
+/**
+ * True when the whole (lowercased) string is a contiguous run of one of the
+ * known sequences (ascending or descending), e.g. "abcdefghijkl",
+ * "123456789012", "qwertyuiopas".
+ */
+function isSequentialRun(lower: string): boolean {
+  for (const seq of SEQUENCES) {
+    const doubled = seq + seq; // covers digit "wrap" like ...9012
+    const reversed = [...doubled].reverse().join('');
+    if (doubled.includes(lower) || reversed.includes(lower)) {
+      return true;
+    }
+  }
+  return false;
+}
+
+/**
+ * Lightweight weak-passphrase check (no heavy deps like zxcvbn). Rejects the
+ * obviously-predictable inputs while deliberately NOT requiring character
+ * composition, so strong multi-word passphrases still pass.
+ */
+function isWeakPassphrase(password: string): boolean {
+  const lower = password.toLowerCase().trim();
+
+  // Exact common passwords.
+  if (COMMON_PASSWORD_DENYLIST.has(lower)) {
+    return true;
+  }
+
+  // Common base word padded with a trailing digit/symbol run.
+  const base = lower.replace(/[0-9!@#$%^&*()_+\-=[\]{};':"\\|,.<>/?`~ ]+$/, '');
+  if (base.length > 0 && COMMON_BASE_TOKENS.has(base)) {
+    return true;
+  }
+
+  // Too little variety (e.g. "aaaaaaaaaaaa", "abababababab").
+  if (new Set(lower).size < 5) {
+    return true;
+  }
+
+  // Purely sequential runs (keyboard / alphabet / digits).
+  if (isSequentialRun(lower)) {
+    return true;
+  }
+
+  return false;
+}
+
+/**
+ * Validate passphrase strength for a NEW backup.
+ *
+ * Policy (length-based, not composition rules):
+ *  - `isValid` requires a minimum length of 12 AND rejects obviously-weak
+ *    inputs (common-password denylist + lightweight entropy/sequence checks).
+ *  - It intentionally does NOT mandate upper/lower/digit/symbol composition,
+ *    which would reject strong passphrases like "correct horse battery staple".
+ *  - The complexity `score` (0-4) is retained for the strength METER only and
+ *    does not gate `isValid`.
+ *
+ * NOTE: import/restore validates against the backup file, not this policy, so
+ * old backups created under the weaker rules are never blocked from importing.
  *
  * @param password - Password to validate
- * @returns Object with isValid boolean and feedback messages
+ * @returns Object with isValid boolean, meter score, and feedback messages
  */
 export function validatePasswordStrength(password: string): {
   isValid: boolean;
@@ -208,51 +667,38 @@ export function validatePasswordStrength(password: string): {
   feedback: string[];
 } {
   const feedback: string[] = [];
+
+  // --- Policy (gates isValid) ---
+  let isValid = true;
+  if (password.length < MIN_PASSPHRASE_LENGTH) {
+    feedback.push(`Use at least ${MIN_PASSPHRASE_LENGTH} characters`);
+    isValid = false;
+  } else if (isWeakPassphrase(password)) {
+    feedback.push('This password is too common or predictable');
+    isValid = false;
+  }
+
+  // --- Strength meter score (hint only; does NOT gate isValid) ---
   let score = 0;
+  if (password.length >= 8) score++;
+  if (password.length >= 12) score++;
+  if (password.length >= 16) score++;
 
-  // Minimum length
-  if (password.length < 8) {
-    feedback.push('Password must be at least 8 characters');
-  } else {
-    score++;
-    if (password.length >= 12) {
-      score++;
-    }
+  let classes = 0;
+  if (/[a-z]/.test(password)) classes++;
+  if (/[A-Z]/.test(password)) classes++;
+  if (/\d/.test(password)) classes++;
+  if (/[^a-zA-Z0-9]/.test(password)) classes++;
+  if (classes >= 3) score++;
+
+  score = Math.min(score, 4);
+  // A passphrase that fails the policy should never read as strong.
+  if (!isValid) {
+    score = Math.min(score, 1);
   }
-
-  // Has lowercase
-  if (!/[a-z]/.test(password)) {
-    feedback.push('Add lowercase letters');
-  } else {
-    score += 0.5;
-  }
-
-  // Has uppercase
-  if (!/[A-Z]/.test(password)) {
-    feedback.push('Add uppercase letters');
-  } else {
-    score += 0.5;
-  }
-
-  // Has numbers
-  if (!/\d/.test(password)) {
-    feedback.push('Add numbers');
-  } else {
-    score += 0.5;
-  }
-
-  // Has special characters
-  if (!/[!@#$%^&*()_+\-=\[\]{};':"\\|,.<>\/?]/.test(password)) {
-    feedback.push('Add special characters');
-  } else {
-    score += 0.5;
-  }
-
-  // Cap score at 4
-  score = Math.min(Math.floor(score), 4);
 
   return {
-    isValid: password.length >= 8,
+    isValid,
     score,
     feedback,
   };

--- a/src/services/backup/index.ts
+++ b/src/services/backup/index.ts
@@ -21,6 +21,7 @@ import {
   encryptBackup,
   decryptBackup,
   validateEncryptedBackupFile,
+  validatePasswordStrength,
 } from './encryption';
 import {
   collectAccounts,
@@ -106,6 +107,21 @@ export class BackupService {
     pin?: string
   ): Promise<BackupResult> {
     try {
+      // Step 0: Enforce the passphrase policy at the service boundary. The UI
+      // modal already gates on this, but a direct caller must not be able to
+      // create a backup protecting mnemonics under a weak password.
+      // NOTE: this gate applies to CREATION only — restore/import intentionally
+      // never validates against this policy, so any older/any backup still
+      // imports.
+      const strength = validatePasswordStrength(password);
+      if (!strength.isValid) {
+        throw new BackupError(
+          strength.feedback[0] ||
+            'Password does not meet the minimum strength requirements',
+          'WEAK_PASSWORD'
+        );
+      }
+
       // Step 1: Collect accounts
       this.reportProgress({
         step: 'collecting',

--- a/src/services/backup/index.ts
+++ b/src/services/backup/index.ts
@@ -17,7 +17,11 @@ import {
   RestoreProgress,
   BackupError,
 } from './types';
-import { encryptBackup, decryptBackup } from './encryption';
+import {
+  encryptBackup,
+  decryptBackup,
+  validateEncryptedBackupFile,
+} from './encryption';
 import {
   collectAccounts,
   collectSettings,
@@ -219,26 +223,23 @@ export class BackupService {
       const sourceFile = new File(fileUri);
       const fileContent = await sourceFile.text();
 
-      let encrypted: EncryptedBackupFile;
-      try {
-        encrypted = JSON.parse(fileContent) as EncryptedBackupFile;
-      } catch {
-        throw new BackupError(
-          'Invalid backup file format',
-          'INVALID_FILE_FORMAT'
-        );
-      }
-
-      // Step 2: Validate format
+      // Step 2: Validate format + envelope shape (and cap v2 KDF params before
+      // any scrypt work — this parses untrusted JSON).
       this.reportProgress({
         step: 'validating',
         progress: 20,
         message: 'Validating backup...',
       });
 
-      if (encrypted.format !== 'voibackup') {
+      let encrypted: EncryptedBackupFile;
+      try {
+        encrypted = validateEncryptedBackupFile(JSON.parse(fileContent));
+      } catch (parseError) {
+        if (parseError instanceof BackupError) {
+          throw parseError;
+        }
         throw new BackupError(
-          'Not a valid Voi Wallet backup file',
+          'Invalid backup file format',
           'INVALID_FILE_FORMAT'
         );
       }
@@ -322,20 +323,17 @@ export class BackupService {
       const sourceFile = new File(fileUri);
       const fileContent = await sourceFile.text();
 
+      // Validate format + envelope shape (and cap v2 KDF params before any
+      // scrypt work — this parses untrusted JSON).
       let encrypted: EncryptedBackupFile;
       try {
-        encrypted = JSON.parse(fileContent) as EncryptedBackupFile;
-      } catch {
+        encrypted = validateEncryptedBackupFile(JSON.parse(fileContent));
+      } catch (parseError) {
+        if (parseError instanceof BackupError) {
+          throw parseError;
+        }
         throw new BackupError(
           'Invalid backup file format',
-          'INVALID_FILE_FORMAT'
-        );
-      }
-
-      // Validate format
-      if (encrypted.format !== 'voibackup') {
-        throw new BackupError(
-          'Not a valid Voi Wallet backup file',
           'INVALID_FILE_FORMAT'
         );
       }

--- a/src/services/backup/types.ts
+++ b/src/services/backup/types.ts
@@ -226,9 +226,30 @@ export interface BackupExperimentalFlags {
 }
 
 /**
- * Encrypted backup file structure (written to .voibackup file)
+ * scrypt KDF parameters (v2 envelope).
+ *
+ * Memory footprint of scrypt is ~128 * N * r bytes. These are validated and
+ * capped before the KDF runs (see encryption.ts) so a tampered/oversized
+ * backup can never force a huge allocation.
  */
-export interface EncryptedBackupFile {
+export interface ScryptKdfParams {
+  /** CPU/memory cost — must be a power of two */
+  N: number;
+  /** Block size */
+  r: number;
+  /** Parallelization */
+  p: number;
+  /** Derived key length in bytes (32 for AES-256) */
+  dkLen: number;
+}
+
+/**
+ * v1 encrypted backup envelope (PBKDF2-SHA256 + AES-256-CTR + HMAC).
+ *
+ * LEGACY / read-only: new backups are written as v2, but existing v1 files MUST
+ * still decrypt. Do not change this shape or the v1 decrypt path.
+ */
+export interface EncryptedBackupFileV1 {
   /** File format identifier */
   format: 'voibackup';
   /** Encryption format version */
@@ -242,6 +263,39 @@ export interface EncryptedBackupFile {
   /** HMAC for authentication (hex) */
   hmac: string;
 }
+
+/**
+ * v2 encrypted backup envelope (scrypt + AES-256-CTR + encrypt-then-MAC).
+ *
+ * The HMAC binds the envelope parameters (version/kdf/kdfParams/salt/iv), not
+ * just the ciphertext, so none of them can be tampered without failing the
+ * integrity check (see canonicalV2Aad in encryption.ts).
+ */
+export interface EncryptedBackupFileV2 {
+  /** File format identifier */
+  format: 'voibackup';
+  /** Encryption format version */
+  version: 2;
+  /** Key derivation function identifier */
+  kdf: 'scrypt';
+  /** scrypt parameters (validated + capped before use) */
+  kdfParams: ScryptKdfParams;
+  /** Salt for scrypt key derivation (hex) */
+  salt: string;
+  /** Initialization vector for AES (hex) */
+  iv: string;
+  /** Encrypted backup data (base64) */
+  ciphertext: string;
+  /** HMAC over canonical(envelope params) + ciphertext (hex) */
+  hmac: string;
+}
+
+/**
+ * Encrypted backup file structure (written to .voibackup file).
+ *
+ * Discriminated union on `version`: v1 = legacy PBKDF2, v2 = scrypt.
+ */
+export type EncryptedBackupFile = EncryptedBackupFileV1 | EncryptedBackupFileV2;
 
 /**
  * Result of creating a backup

--- a/src/services/backup/types.ts
+++ b/src/services/backup/types.ts
@@ -404,6 +404,7 @@ export class BackupError extends Error {
 
 export type BackupErrorCode =
   | 'INVALID_PASSWORD'
+  | 'WEAK_PASSWORD'
   | 'INVALID_FILE_FORMAT'
   | 'DECRYPTION_FAILED'
   | 'INTEGRITY_CHECK_FAILED'


### PR DESCRIPTION
## TASK-30 — Strengthen backup KDF (scrypt v2) + enforce a real passphrase policy

The full-wallet `.voibackup` file encrypts **every account's 25-word mnemonic**, so it's the highest-value artifact we protect. This hardens its key derivation and stops weak backup passwords, while keeping every existing v1 backup importable.

### What changed
- **KDF upgraded to memory-hard scrypt for new backups.** Replaced PBKDF2-SHA256 (100k, not memory-hard, GPU/ASIC-friendly) with scrypt via `@noble/hashes` (`scryptAsync` — the async variant yields to the event loop so it won't freeze the RN UI thread during derivation).
- **Additive, versioned envelope.** `EncryptedBackupFile` is now a discriminated union on `version`:
  - `v1` = `{version:1, salt, iv, ciphertext, hmac}` — legacy PBKDF2 path, **unchanged and read-only**.
  - `v2` = `{version:2, kdf:'scrypt', kdfParams:{N,r,p,dkLen}, salt, iv, ciphertext, hmac}`.
- **Cipher unchanged** — still AES-256-CTR + encrypt-then-MAC (HMAC-SHA256). The change is the KDF + envelope, not the cipher.
- **Passphrase policy** rewritten to reflect real strength (length-based, not composition rules).
- **New dependency:** `@noble/hashes` promoted to a **pinned direct dependency at `1.7.0`** — the version already hoisted in the tree, so no bump is forced. Only `package.json`/lock reference changes.

### Decided design (implemented as specified)
- **scrypt / @noble** for the memory-hard KDF; async variant for UI responsiveness.
- **v2-additive, keep-v1**: writer always emits v2; reader dispatches on `version` (v1 → PBKDF2 decrypt kept intact, v2 → scrypt, unknown → clear thrown error).
- **AAD / MAC parameter binding (v2):** the HMAC is computed over a *canonical serialization* of `{version, kdf, kdfParams, salt, iv}` concatenated with the ciphertext (`canonicalV2Aad` builds the object in fixed key order → deterministic `JSON.stringify`). So `N/r/p/dkLen/salt/iv/version` are all authenticated — tampering any of them fails the integrity check. (`iv` in particular is authenticated *only* via the AAD, since encrypt-then-MAC over CTR ciphertext alone wouldn't catch IV tampering.) v2 uses a constant-time MAC compare; **v1's MAC is left byte-for-byte unchanged** for compatibility.
- **Bounded validation BEFORE scrypt (DoS guard):** `validateEncryptedBackupFile()` strictly validates the parsed envelope and caps the KDF params **before any scrypt work**: `N` power-of-two and ≤ 2^20, `r` ≤ 32, `p` ≤ 4, `dkLen === 32`, salt/iv exact byte lengths, plus a combined `128·N·r ≤ 128 MiB` memory ceiling. Runs on **both** untrusted-JSON paths (`restoreBackup`, `validateBackupFile`) and again inside `decryptBackup` as a final gate — so a malicious/oversized backup can never force a huge allocation.
- **Length-based passphrase policy:** `isValid` requires **min length 12** AND rejects obviously weak inputs (small common-password denylist + base-token strip + low-variety + sequential-run checks). It does **not** mandate upper/lower/digit/symbol composition (that would reject strong passphrases like `correct horse battery staple`). The 0–4 complexity `score` is retained for the strength **meter only** and does not gate `isValid`. No heavy dep (no zxcvbn). The create-mode modal already gates its button on `passwordStrength.isValid`, so it now enforces the stronger policy for new backups.

### Scrypt parameters + benchmark
Throwaway Node benchmark (Node v24 / V8, `scryptAsync`, memory = `128·N·r`):

| Params | Memory | avg time |
|---|---|---|
| N=2^14, r=8, p=1 | 16 MiB | ~31 ms |
| N=2^15, r=8, p=1 | 32 MiB | ~63 ms |
| N=2^16, r=8, p=1 | 64 MiB | ~125 ms |
| N=2^17, r=8, p=1 | 128 MiB | ~250 ms |

**Chosen: N=2^15 (32768), r=8, p=1, dkLen=32 → 32 MiB.** Biased conservative: Hermes (pure-JS) is materially slower than V8 and low-end Android RAM is the binding constraint, so 32 MiB stays comfortably clear of OOM while still being ~0.6–1s of memory-hard work for an occasional operation — a large improvement over PBKDF2-100k. Documented in a code comment next to the constants. **Follow-up: confirm real Hermes / low-end-Android timing on device.**

### Backward-compatibility guarantee
Existing **v1 backups still import and decrypt** — the v1 PBKDF2 path (including its exact HMAC-over-ciphertext scheme) is untouched, and restore still routes the recovered mnemonic through `algosdk.mnemonicToSecretKey` (Pera/algosdk compatibility preserved). Import/restore validates against the file's own envelope, **not** the new passphrase policy, so old backups made under the weaker rules are never blocked.

### Tests (hardware-free, Layer-1) — `src/services/backup/__tests__/encryption.test.ts`
- v2 round-trip encrypt→decrypt (scrypt); wrong-password rejection.
- **v1 backward-compat**: a legacy v1 fixture (built via the exact old PBKDF2 scheme) still decrypts; wrong-password rejected.
- **AAD binding**: mutating `iv` / `kdfParams.N` / `salt` / downgrading `version` all make decrypt FAIL (MAC).
- **Bounded validation**: N over cap, non-power-of-two N, r over cap, over-ceiling `128·N·r`, wrong `dkLen`, malformed salt length, unknown version, non-object — all rejected before scrypt.
- **Passphrase policy**: length<12 → invalid; strong 12+ (incl. all-lowercase multi-word, no composition) → valid; common/predictable → invalid; 0–4 meter score retained.

### Gates
- `npm run typecheck` → **0 errors**
- `npm run lint` → **0 new errors** (1 warning: an unavoidable `require()` inside a hoisted `jest.mock` factory, same pattern as `jest.setup.js`)
- `npm test -- --ci` → **19 suites / 305 tests pass** (21 new)

### Security & OTA
- No secrets logged anywhere (password / mnemonic / derived key / plaintext); derived key material scrubbed in `finally`. No plaintext at rest.
- **OTA-eligible:** JS-only — `@noble/hashes` is pure JS (no native modules), so this ships over-the-air with no rebuild.

Do not merge — awaiting Codex review.
