### PR TITLE
feat(secure): v2 key envelope + multi-blob types + trial-decrypt reader (TASK-27 PR1, no behavior change)

### DIFF
--- a/src/services/secure/AccountSecureStorage.ts
+++ b/src/services/secure/AccountSecureStorage.ts
@@ -33,6 +33,11 @@ import {
   AccountNotFoundError,
   AuthenticationRequiredError,
 } from '../../types/wallet';
+import {
+  KeyEnvelopeV2,
+  decryptKeyEnvelopeV2,
+  MAX_KEY_BLOBS,
+} from './envelopeV2';
 
 type PersistedAccountMetadata = Omit<
   SecureAccountStorage,
@@ -41,8 +46,23 @@ type PersistedAccountMetadata = Omit<
 
 interface AccountSecretPayload {
   accountId: string;
+  /**
+   * Legacy 4-colon (Format A/B/C) ciphertext, OR '' once fully migrated to v2.
+   * Retained for back-compat reads.
+   */
   encryptedPrivateKey: string;
+  /** Unlock-convenience hint — NO LONGER authoritative for decryption (R3). */
   authMethod: 'biometric' | 'pin';
+  /**
+   * Ordering hint only, MAC-anchored + untrusted (DOC-137 R3): 2 = v2 blobs
+   * present. Absent on all pre-Wave-2 payloads.
+   */
+  version?: 1 | 2;
+  /**
+   * v2 key envelopes (DOC-137 §2.3/§2.4). Normally 1; transiently 2 during a
+   * dual-slot re-wrap. HARD-CAPPED at MAX_KEY_BLOBS. Absent on legacy payloads.
+   */
+  blobs?: KeyEnvelopeV2[];
 }
 
 // PBKDF2 using CryptoJS with SHA256; returns hex string of keyLength bytes
@@ -437,24 +457,40 @@ export class AccountSecureStorage {
         }
 
         const parsed: AccountSecretPayload = JSON.parse(secretPayloadRaw);
-        if (!parsed.encryptedPrivateKey) {
-          throw new AccountStorageError(
-            'Private key not available for this account'
-          );
+
+        let privateKey: Uint8Array | undefined;
+
+        // Candidate 1 (v2 blobs) — tried FIRST when a verified user secret is
+        // available. INERT today: no production writer emits blobs yet, so every
+        // existing payload (no `blobs`) skips this and behaves exactly as before.
+        // Security anchor: every accepted result MUST pass the envelope MAC — a
+        // wrong secret cannot forge it, so the ladder simply falls through.
+        if (pin && Array.isArray(parsed.blobs) && parsed.blobs.length > 0) {
+          privateKey = await this.tryDecryptV2Blobs(parsed.blobs, pin);
         }
 
-        let privateKey: Uint8Array;
-
-        try {
-          privateKey = await this.decryptPrivateKey(parsed.encryptedPrivateKey);
-        } catch (error) {
-          if (unlockMethod === 'pin' && pin) {
-            privateKey = await this.decryptPrivateKeyWithPin(
-              parsed.encryptedPrivateKey,
-              pin
+        // Candidates 2 & 3 (unchanged) — Format A (device key), then Format C
+        // (legacy PIN-mixed). Reached whenever no v2 blob verified.
+        if (!privateKey) {
+          if (!parsed.encryptedPrivateKey) {
+            throw new AccountStorageError(
+              'Private key not available for this account'
             );
-          } else {
-            throw error;
+          }
+
+          try {
+            privateKey = await this.decryptPrivateKey(
+              parsed.encryptedPrivateKey
+            );
+          } catch (error) {
+            if (unlockMethod === 'pin' && pin) {
+              privateKey = await this.decryptPrivateKeyWithPin(
+                parsed.encryptedPrivateKey,
+                pin
+              );
+            } else {
+              throw error;
+            }
           }
         }
 
@@ -493,6 +529,38 @@ export class AccountSecureStorage {
       // Always remove from in-flight requests when done (success or failure)
       this.inFlightRequests.delete(cacheKey);
     }
+  }
+
+  /**
+   * Trial-decrypt the v2 blob candidates under a verified user secret
+   * (DOC-137 §4.3, candidate 1). Returns the first blob whose envelope MAC
+   * verifies, or `undefined` to fall through to the legacy formats.
+   *
+   * Only up to MAX_KEY_BLOBS blobs are attempted — each attempt runs a memory-
+   * hard scrypt, so capping the attempt count is itself a DoS guard. A wrong
+   * secret cannot forge the MAC, so a non-matching blob returns null and the
+   * ladder continues.
+   */
+  private static async tryDecryptV2Blobs(
+    blobs: KeyEnvelopeV2[],
+    secret: string
+  ): Promise<Uint8Array | undefined> {
+    const deviceSecret = await this.getStableDeviceId();
+    for (const blob of blobs.slice(0, MAX_KEY_BLOBS)) {
+      try {
+        const privateKey = await decryptKeyEnvelopeV2(
+          blob,
+          secret,
+          deviceSecret
+        );
+        if (privateKey) {
+          return privateKey;
+        }
+      } catch {
+        // Structurally invalid / out-of-cap blob — try the next candidate.
+      }
+    }
+    return undefined;
   }
 
   /**

--- a/src/services/secure/__tests__/envelopeV2.test.ts
+++ b/src/services/secure/__tests__/envelopeV2.test.ts
@@ -1,0 +1,317 @@
+// Unit tests for the Wave-2 at-rest key envelope (DOC-137 §2.3/§2.4, PR1).
+//
+// Covers: byte-exact round-trip of arbitrary-length key material (incl. the full
+// 64-byte algosdk sk — never hardcode 32), encrypt-then-MAC binding of EVERY
+// header field, the optional device post-mix, trial-decrypt fall-through on a
+// wrong secret, param-cap validation BEFORE scrypt (DoS guard), and the
+// 2-blob / <2048-byte payload budget.
+//
+// SECURITY NOTE: no real key material is used — plaintexts are synthetic byte
+// patterns and secrets are throwaway test strings. The point is the crypto
+// invariants.
+
+// Provide platform crypto (getRandomBytes) via Node's CSPRNG so the envelope
+// module runs under jest without the native/expo platform adapter.
+jest.mock('@/platform', () => {
+  const nodeCrypto = require('crypto');
+  return {
+    crypto: {
+      getRandomBytes: async (byteCount: number): Promise<Uint8Array> =>
+        Uint8Array.from(nodeCrypto.randomBytes(byteCount)),
+    },
+  };
+});
+
+import { randomBytes } from 'crypto';
+import {
+  KeyEnvelopeV2,
+  encryptKeyEnvelopeV2,
+  decryptKeyEnvelopeV2,
+  deriveWrapKey,
+  assertScryptParamsWithinCaps,
+  assertValidKeyEnvelopeV2,
+  assertPayloadSizeWithinLimit,
+  MAX_KEY_BLOBS,
+  SECURE_STORE_VALUE_LIMIT,
+} from '../envelopeV2';
+import type { ScryptKdfParams } from '../../backup/types';
+
+// Small (but still power-of-two and within caps) scrypt params keep the test
+// suite fast; production uses AT_REST_KDF_PARAMS (N=2^14).
+const FAST_PARAMS: ScryptKdfParams = { N: 2 ** 12, r: 8, p: 1, dkLen: 32 };
+
+const SECRET = '123456'; // throwaway 6-digit PIN-shaped secret
+const DEVICE = 'test-device-idfv-0001';
+
+/** Deterministic synthetic key bytes of a given length (NOT a real key). */
+function fakeKey(length: number): Uint8Array {
+  return Uint8Array.from({ length }, (_, i) => (i * 7 + 3) & 0xff);
+}
+
+function hex(bytes: Uint8Array): string {
+  return Buffer.from(bytes).toString('hex');
+}
+
+function randomHex(byteLength: number): string {
+  return randomBytes(byteLength).toString('hex');
+}
+
+describe('envelopeV2 round-trip (byte-exact, length-agnostic)', () => {
+  it('round-trips the full 64-byte algosdk sk byte-identically', async () => {
+    const sk = fakeKey(64);
+    const envelope = await encryptKeyEnvelopeV2({
+      plaintext: sk,
+      secret: SECRET,
+      secretSource: 'pin',
+      kdfParams: FAST_PARAMS,
+    });
+
+    expect(envelope.version).toBe(2);
+    expect(envelope.kdf).toBe('scrypt');
+    expect(envelope.secretSource).toBe('pin');
+    expect(envelope.deviceBound).toBe(false);
+    expect(envelope.salt).toMatch(/^[0-9a-f]{64}$/);
+    expect(envelope.iv).toMatch(/^[0-9a-f]{32}$/);
+    expect(envelope.mac).toMatch(/^[0-9a-f]{64}$/);
+    // No plaintext leaks into the envelope.
+    expect(envelope.ct).not.toContain(hex(sk));
+
+    const out = await decryptKeyEnvelopeV2(envelope, SECRET);
+    expect(out).not.toBeNull();
+    expect(hex(out as Uint8Array)).toBe(hex(sk)); // byte-identical
+    expect((out as Uint8Array).length).toBe(64);
+  });
+
+  it('round-trips a 32-byte seed too (never hardcodes 64 either)', async () => {
+    const seed = fakeKey(32);
+    const envelope = await encryptKeyEnvelopeV2({
+      plaintext: seed,
+      secret: SECRET,
+      secretSource: 'passphrase',
+      kdfParams: FAST_PARAMS,
+    });
+    const out = await decryptKeyEnvelopeV2(envelope, SECRET);
+    expect(hex(out as Uint8Array)).toBe(hex(seed));
+    expect(envelope.secretSource).toBe('passphrase');
+  });
+
+  it('returns null (falls through) on the wrong secret', async () => {
+    const sk = fakeKey(64);
+    const envelope = await encryptKeyEnvelopeV2({
+      plaintext: sk,
+      secret: SECRET,
+      secretSource: 'pin',
+      kdfParams: FAST_PARAMS,
+    });
+    const out = await decryptKeyEnvelopeV2(envelope, '000000');
+    expect(out).toBeNull();
+  });
+});
+
+describe('envelopeV2 device post-mix (deviceBound)', () => {
+  it('round-trips a device-bound blob and requires the same device secret', async () => {
+    const sk = fakeKey(64);
+    const envelope = await encryptKeyEnvelopeV2({
+      plaintext: sk,
+      secret: SECRET,
+      secretSource: 'pin',
+      deviceSecret: DEVICE,
+      kdfParams: FAST_PARAMS,
+    });
+    expect(envelope.deviceBound).toBe(true);
+
+    // Correct device secret -> success.
+    const ok = await decryptKeyEnvelopeV2(envelope, SECRET, DEVICE);
+    expect(hex(ok as Uint8Array)).toBe(hex(sk));
+
+    // Wrong device secret -> MAC fails -> null.
+    const wrongDevice = await decryptKeyEnvelopeV2(
+      envelope,
+      SECRET,
+      'a-different-device'
+    );
+    expect(wrongDevice).toBeNull();
+
+    // Missing device secret on a device-bound blob -> null (never throws).
+    const noDevice = await decryptKeyEnvelopeV2(envelope, SECRET);
+    expect(noDevice).toBeNull();
+  });
+
+  it('deriveWrapKey device post-mix changes the wrap key', async () => {
+    const salt = randomHex(32);
+    const plain = await deriveWrapKey(SECRET, salt, FAST_PARAMS);
+    const mixed = await deriveWrapKey(SECRET, salt, FAST_PARAMS, DEVICE);
+    expect(plain.length).toBe(32);
+    expect(mixed.length).toBe(32);
+    expect(hex(mixed)).not.toBe(hex(plain));
+  });
+});
+
+describe('envelopeV2 MAC binds every header field', () => {
+  let base: KeyEnvelopeV2;
+  let sk: Uint8Array;
+
+  beforeAll(async () => {
+    sk = fakeKey(64);
+    base = await encryptKeyEnvelopeV2({
+      plaintext: sk,
+      secret: SECRET,
+      secretSource: 'pin',
+      kdfParams: FAST_PARAMS,
+    });
+  });
+
+  it('sanity: the untampered envelope still decrypts', async () => {
+    const out = await decryptKeyEnvelopeV2({ ...base }, SECRET);
+    expect(hex(out as Uint8Array)).toBe(hex(sk));
+  });
+
+  // Each of these is authenticated via the canonical AAD, so tampering flips the
+  // recomputed MAC and decryption returns null instead of forging a plaintext.
+  it('rejects a tampered kdfParams.N (valid -> another valid power of two)', async () => {
+    const tampered: KeyEnvelopeV2 = {
+      ...base,
+      kdfParams: { ...base.kdfParams, N: 2 ** 13 },
+    };
+    expect(await decryptKeyEnvelopeV2(tampered, SECRET)).toBeNull();
+  });
+
+  it('rejects a tampered secretSource', async () => {
+    const tampered: KeyEnvelopeV2 = { ...base, secretSource: 'passphrase' };
+    expect(await decryptKeyEnvelopeV2(tampered, SECRET)).toBeNull();
+  });
+
+  it('rejects a tampered deviceBound flag', async () => {
+    const tampered: KeyEnvelopeV2 = { ...base, deviceBound: true };
+    expect(await decryptKeyEnvelopeV2(tampered, SECRET, DEVICE)).toBeNull();
+  });
+
+  it('rejects a tampered salt', async () => {
+    const tampered: KeyEnvelopeV2 = { ...base, salt: randomHex(32) };
+    expect(await decryptKeyEnvelopeV2(tampered, SECRET)).toBeNull();
+  });
+
+  it('rejects a tampered iv (iv is authenticated only via AAD)', async () => {
+    const tampered: KeyEnvelopeV2 = { ...base, iv: randomHex(16) };
+    expect(await decryptKeyEnvelopeV2(tampered, SECRET)).toBeNull();
+  });
+
+  it('rejects a tampered version (structural + AAD-bound)', async () => {
+    const tampered = { ...base, version: 3 } as unknown as KeyEnvelopeV2;
+    await expect(decryptKeyEnvelopeV2(tampered, SECRET)).rejects.toThrow();
+  });
+
+  it('rejects a tampered ct (ciphertext is MACed)', async () => {
+    const tampered: KeyEnvelopeV2 = {
+      ...base,
+      ct: Buffer.from(randomBytes(64)).toString('base64'),
+    };
+    expect(await decryptKeyEnvelopeV2(tampered, SECRET)).toBeNull();
+  });
+});
+
+describe('envelopeV2 param-cap validation (DoS guard, before scrypt)', () => {
+  it('assertScryptParamsWithinCaps rejects an oversized N synchronously', () => {
+    expect(() =>
+      assertScryptParamsWithinCaps({ N: 2 ** 21, r: 8, p: 1, dkLen: 32 })
+    ).toThrow(/safe limits/);
+  });
+
+  it('rejects a non-power-of-two N', () => {
+    expect(() =>
+      assertScryptParamsWithinCaps({ N: 30000, r: 8, p: 1, dkLen: 32 })
+    ).toThrow(/safe limits/);
+  });
+
+  it('rejects an oversized r and a combined memory footprint over the ceiling', () => {
+    expect(() =>
+      assertScryptParamsWithinCaps({ N: 2 ** 12, r: 64, p: 1, dkLen: 32 })
+    ).toThrow(/safe limits/);
+    // N=2^20, r=32 -> 128*N*r = 4 GiB, well over the 128 MiB cap.
+    expect(() =>
+      assertScryptParamsWithinCaps({ N: 2 ** 20, r: 32, p: 1, dkLen: 32 })
+    ).toThrow(/safe limits/);
+  });
+
+  it('rejects a wrong dkLen', () => {
+    expect(() =>
+      assertScryptParamsWithinCaps({ N: 2 ** 12, r: 8, p: 1, dkLen: 64 })
+    ).toThrow(/safe limits/);
+  });
+
+  it('decryptKeyEnvelopeV2 rejects an out-of-cap N before running scrypt', async () => {
+    const sk = fakeKey(64);
+    const envelope = await encryptKeyEnvelopeV2({
+      plaintext: sk,
+      secret: SECRET,
+      secretSource: 'pin',
+      kdfParams: FAST_PARAMS,
+    });
+    // Oversized N would force a huge scrypt allocation; the validator must throw
+    // first. (Also proves no scrypt ran: assertValidKeyEnvelopeV2 has no KDF.)
+    const evil: KeyEnvelopeV2 = {
+      ...envelope,
+      kdfParams: { ...envelope.kdfParams, N: 2 ** 21 },
+    };
+    await expect(decryptKeyEnvelopeV2(evil, SECRET)).rejects.toThrow(
+      /safe limits/
+    );
+  });
+
+  it('assertValidKeyEnvelopeV2 rejects structurally malformed envelopes', () => {
+    expect(() => assertValidKeyEnvelopeV2(null)).toThrow();
+    expect(() =>
+      assertValidKeyEnvelopeV2({ version: 1, kdf: 'scrypt' })
+    ).toThrow(/version/);
+  });
+});
+
+describe('multi-blob payload budget (2 blobs, <2048 bytes)', () => {
+  it('a realistic 2-blob payload (64-byte sk) is well under 2048 bytes', async () => {
+    const sk = fakeKey(64);
+    // Two blobs = the transient dual-slot state, worst case for size.
+    const blobA = await encryptKeyEnvelopeV2({
+      plaintext: sk,
+      secret: SECRET,
+      secretSource: 'pin',
+      // production-realistic params (bigger numbers => longer JSON) to be honest
+      kdfParams: { N: 2 ** 14, r: 8, p: 1, dkLen: 32 },
+    });
+    const blobB = await encryptKeyEnvelopeV2({
+      plaintext: sk,
+      secret: '654321',
+      secretSource: 'passphrase',
+      deviceSecret: DEVICE,
+      kdfParams: { N: 2 ** 14, r: 8, p: 1, dkLen: 32 },
+    });
+
+    const payload = {
+      accountId: 'acct-1234567890abcdef',
+      encryptedPrivateKey: '',
+      authMethod: 'pin' as const,
+      version: 2 as const,
+      blobs: [blobA, blobB],
+    };
+    const serialized = JSON.stringify(payload);
+    const byteLength = Buffer.byteLength(serialized, 'utf8');
+
+    // Well under the 2048-byte SecureStore value limit.
+    expect(byteLength).toBeLessThan(SECURE_STORE_VALUE_LIMIT);
+    expect(byteLength).toBeLessThan(1200); // comfortable headroom
+    expect(() =>
+      assertPayloadSizeWithinLimit(serialized, payload.blobs.length)
+    ).not.toThrow();
+  });
+
+  it('rejects more than MAX_KEY_BLOBS blobs', () => {
+    expect(MAX_KEY_BLOBS).toBe(2);
+    expect(() => assertPayloadSizeWithinLimit('{}', 3)).toThrow(
+      /Too many key blobs/
+    );
+  });
+
+  it('rejects a serialized payload at/over the 2048-byte limit', () => {
+    const tooBig = 'x'.repeat(SECURE_STORE_VALUE_LIMIT);
+    expect(() => assertPayloadSizeWithinLimit(tooBig, 1)).toThrow(/too large/);
+  });
+});

--- a/src/services/secure/__tests__/getPrivateKey.reader.test.ts
+++ b/src/services/secure/__tests__/getPrivateKey.reader.test.ts
@@ -1,0 +1,299 @@
+// Unit tests for the extended getPrivateKey trial-decrypt reader (DOC-137 §4.3,
+// PR1). Proves the reader:
+//   - reads a NEW v2 blob (candidate 1) when a verified secret is available,
+//   - still reads a legacy Format-A (device-key) blob EXACTLY as before,
+//   - falls through v2 -> Format A when the v2 secret does not match,
+//   - fails cleanly on a v2-only payload with the wrong secret.
+//
+// This is the NO-BEHAVIOR-CHANGE guarantee for existing data: payloads without
+// `blobs` never enter the v2 branch.
+//
+// SECURITY NOTE: synthetic byte patterns stand in for key material; secrets are
+// throwaway test strings. No real mnemonic/key is used.
+
+// In-memory platform mock (SecureStore/AsyncStorage/deviceId/crypto). getRandomBytes
+// and sha256 are backed by Node so the real device-key + envelope crypto runs.
+jest.mock('@/platform', () => {
+  const nodeCrypto = require('crypto');
+  const secure = new Map<string, string>();
+  const kv = new Map<string, string>();
+  return {
+    __secure: secure,
+    __kv: kv,
+    __reset: () => {
+      secure.clear();
+      kv.clear();
+    },
+    crypto: {
+      getRandomBytes: async (n: number): Promise<Uint8Array> =>
+        Uint8Array.from(nodeCrypto.randomBytes(n)),
+      sha256: async (input: string): Promise<string> =>
+        nodeCrypto.createHash('sha256').update(input).digest('hex'),
+      randomUUID: () => nodeCrypto.randomUUID(),
+    },
+    secureStorage: {
+      getItem: async (k: string) => (secure.has(k) ? secure.get(k)! : null),
+      setItem: async (k: string, v: string) => {
+        secure.set(k, v);
+      },
+      deleteItem: async (k: string) => {
+        secure.delete(k);
+      },
+      getItemWithAuth: async (k: string) =>
+        secure.has(k) ? secure.get(k)! : null,
+    },
+    storage: {
+      getItem: async (k: string) => (kv.has(k) ? kv.get(k)! : null),
+      setItem: async (k: string, v: string) => {
+        kv.set(k, v);
+      },
+      removeItem: async (k: string) => {
+        kv.delete(k);
+      },
+    },
+    biometrics: {
+      isAvailable: async () => false,
+      isEnrolled: async () => false,
+    },
+    deviceId: {
+      getDeviceId: async () => 'reader-test-device-idfv',
+    },
+  };
+});
+
+import CryptoJS from 'crypto-js';
+import 'crypto-js/hmac-sha256';
+import 'crypto-js/sha256';
+import 'crypto-js/aes';
+import 'crypto-js/mode-ctr';
+import 'crypto-js/pad-nopadding';
+import 'crypto-js/enc-hex';
+import 'crypto-js/pbkdf2';
+import { createHash, randomBytes } from 'crypto';
+import * as platform from '@/platform';
+import { AccountSecureStorage } from '../AccountSecureStorage';
+import { AccountStorageError } from '../../../types/wallet';
+import { encryptKeyEnvelopeV2, KeyEnvelopeV2 } from '../envelopeV2';
+import type { ScryptKdfParams } from '../../backup/types';
+
+const DEVICE_ID = 'reader-test-device-idfv';
+const PIN = '123456';
+const FAST_PARAMS: ScryptKdfParams = { N: 2 ** 12, r: 8, p: 1, dkLen: 32 };
+
+// Access the in-memory mock stores/reset.
+const mockPlatform = platform as unknown as {
+  __secure: Map<string, string>;
+  __reset: () => void;
+};
+
+function fakeKey(length: number): Uint8Array {
+  return Uint8Array.from({ length }, (_, i) => (i * 11 + 5) & 0xff);
+}
+
+function hex(bytes: Uint8Array): string {
+  return Buffer.from(bytes).toString('hex');
+}
+
+function nodeSha256Hex(input: string): string {
+  return createHash('sha256').update(input).digest('hex');
+}
+
+function customPBKDF2(
+  password: string,
+  saltHex: string,
+  iterations: number,
+  keyLength: number
+): string {
+  const saltWA = CryptoJS.enc.Hex.parse(saltHex);
+  const derived = CryptoJS.PBKDF2(password, saltWA, {
+    keySize: keyLength / 4,
+    iterations,
+    hasher: (CryptoJS.algo as unknown as { SHA256: object }).SHA256,
+  });
+  return derived.toString(CryptoJS.enc.Hex);
+}
+
+/**
+ * Build a legacy Format-A (device-key) 4-colon blob EXACTLY the way
+ * `AccountSecureStorage.encryptPrivateKey` does, so the reader path under test
+ * is the real one.
+ */
+function makeFormatA(privateKey: Uint8Array): string {
+  const saltHex = randomBytes(32).toString('hex');
+  const ivHex = randomBytes(16).toString('hex');
+  const baseEntropy = nodeSha256Hex(`voi_wallet_${DEVICE_ID}`);
+  const keyMaterial = customPBKDF2(baseEntropy, saltHex, 10000, 32);
+
+  const privateKeyHex = hex(privateKey);
+  const encrypted = CryptoJS.AES.encrypt(
+    privateKeyHex,
+    CryptoJS.enc.Hex.parse(keyMaterial),
+    {
+      iv: CryptoJS.enc.Hex.parse(ivHex),
+      mode: CryptoJS.mode.CTR,
+      padding: CryptoJS.pad.NoPadding,
+    }
+  );
+  const ct = encrypted.toString();
+  const hmacKey = CryptoJS.SHA256(keyMaterial + 'hmac_salt').toString();
+  const hmac = CryptoJS.HmacSHA256(ct, hmacKey).toString();
+  return `${saltHex}:${ivHex}:${ct}:${hmac}`;
+}
+
+function seedSecret(accountId: string, payload: object): void {
+  mockPlatform.__secure.set(
+    `voi_account_secret_${accountId}`,
+    JSON.stringify(payload)
+  );
+}
+
+beforeEach(() => {
+  mockPlatform.__reset();
+  AccountSecureStorage.clearPrivateKeyCache();
+  // The reader gates the v2 candidate on a *verified* secret. verifyPin is
+  // exercised elsewhere (backup/throttle tests); here we stub it true so we can
+  // focus on the trial-decrypt ladder with an arbitrary supplied secret.
+  jest
+    .spyOn(AccountSecureStorage, 'verifyPin')
+    .mockResolvedValue(true as unknown as boolean);
+});
+
+afterEach(() => {
+  jest.restoreAllMocks();
+});
+
+describe('getPrivateKey trial-decrypt reader (PR1)', () => {
+  it('reads a legacy Format-A (device-key) blob unchanged — no blobs present', async () => {
+    const sk = fakeKey(64);
+    const accountId = 'acct-legacy-a';
+    seedSecret(accountId, {
+      accountId,
+      encryptedPrivateKey: makeFormatA(sk),
+      authMethod: 'pin',
+    });
+
+    const out = await AccountSecureStorage.getPrivateKey(accountId, PIN);
+    expect(hex(out)).toBe(hex(sk));
+  });
+
+  it('reads a v2 blob (candidate 1) when a verified secret is supplied', async () => {
+    const sk = fakeKey(64);
+    const accountId = 'acct-v2';
+    const blob = await encryptKeyEnvelopeV2({
+      plaintext: sk,
+      secret: PIN,
+      secretSource: 'pin',
+      kdfParams: FAST_PARAMS,
+    });
+    seedSecret(accountId, {
+      accountId,
+      encryptedPrivateKey: '', // fully migrated
+      authMethod: 'pin',
+      version: 2,
+      blobs: [blob],
+    });
+
+    const out = await AccountSecureStorage.getPrivateKey(accountId, PIN);
+    expect(hex(out)).toBe(hex(sk));
+  });
+
+  it('reads a device-bound v2 blob using the stable device id', async () => {
+    const sk = fakeKey(64);
+    const accountId = 'acct-v2-devicebound';
+    const blob = await encryptKeyEnvelopeV2({
+      plaintext: sk,
+      secret: PIN,
+      secretSource: 'pin',
+      deviceSecret: DEVICE_ID, // reader supplies the same via getStableDeviceId()
+      kdfParams: FAST_PARAMS,
+    });
+    expect(blob.deviceBound).toBe(true);
+    seedSecret(accountId, {
+      accountId,
+      encryptedPrivateKey: '',
+      authMethod: 'pin',
+      version: 2,
+      blobs: [blob],
+    });
+
+    const out = await AccountSecureStorage.getPrivateKey(accountId, PIN);
+    expect(hex(out)).toBe(hex(sk));
+  });
+
+  it('falls through v2 -> Format A when the v2 secret does not match (dual-slot)', async () => {
+    const sk = fakeKey(64);
+    const accountId = 'acct-mixed';
+    const wrongBlob = await encryptKeyEnvelopeV2({
+      plaintext: sk,
+      secret: 'aaaaaa', // blob wrapped under a DIFFERENT secret
+      secretSource: 'pin',
+      kdfParams: FAST_PARAMS,
+    });
+    seedSecret(accountId, {
+      accountId,
+      // Old copy still present (device-key Format A of the same key).
+      encryptedPrivateKey: makeFormatA(sk),
+      authMethod: 'pin',
+      version: 2,
+      blobs: [wrongBlob],
+    });
+
+    // v2 blob fails to MAC-verify under this secret -> ladder falls through to
+    // the device-key Format A, which is pin-independent -> success.
+    const out = await AccountSecureStorage.getPrivateKey(accountId, 'bbbbbb');
+    expect(hex(out)).toBe(hex(sk));
+  });
+
+  it('fails on a v2-only payload when the secret is wrong (nothing to fall to)', async () => {
+    const sk = fakeKey(64);
+    const accountId = 'acct-v2-wrong';
+    const blob = await encryptKeyEnvelopeV2({
+      plaintext: sk,
+      secret: PIN,
+      secretSource: 'pin',
+      kdfParams: FAST_PARAMS,
+    });
+    seedSecret(accountId, {
+      accountId,
+      encryptedPrivateKey: '',
+      authMethod: 'pin',
+      version: 2,
+      blobs: [blob],
+    });
+
+    await expect(
+      AccountSecureStorage.getPrivateKey(accountId, '000000')
+    ).rejects.toBeInstanceOf(AccountStorageError);
+  });
+
+  it('caps v2 attempts at MAX_KEY_BLOBS (extra blobs are not tried)', async () => {
+    const sk = fakeKey(64);
+    const accountId = 'acct-cap';
+    // Two non-matching blobs first, then the correct one 3rd — which must NOT be
+    // reached because the reader only attempts the first MAX_KEY_BLOBS (=2).
+    const decoy = (): Promise<KeyEnvelopeV2> =>
+      encryptKeyEnvelopeV2({
+        plaintext: fakeKey(64),
+        secret: 'zzzzzz',
+        secretSource: 'pin',
+        kdfParams: FAST_PARAMS,
+      });
+    const correct = await encryptKeyEnvelopeV2({
+      plaintext: sk,
+      secret: PIN,
+      secretSource: 'pin',
+      kdfParams: FAST_PARAMS,
+    });
+    seedSecret(accountId, {
+      accountId,
+      encryptedPrivateKey: '',
+      authMethod: 'pin',
+      version: 2,
+      blobs: [await decoy(), await decoy(), correct],
+    });
+
+    await expect(
+      AccountSecureStorage.getPrivateKey(accountId, PIN)
+    ).rejects.toBeInstanceOf(AccountStorageError);
+  });
+});

--- a/src/services/secure/__tests__/getPrivateKey.reader.test.ts
+++ b/src/services/secure/__tests__/getPrivateKey.reader.test.ts
@@ -108,7 +108,7 @@ function customPBKDF2(
   const derived = CryptoJS.PBKDF2(password, saltWA, {
     keySize: keyLength / 4,
     iterations,
-    hasher: (CryptoJS.algo as unknown as { SHA256: object }).SHA256,
+    hasher: CryptoJS.algo.SHA256,
   });
   return derived.toString(CryptoJS.enc.Hex);
 }

--- a/src/services/secure/envelopeV2.ts
+++ b/src/services/secure/envelopeV2.ts
@@ -1,0 +1,554 @@
+/**
+ * At-Rest Key Envelope (v2)
+ *
+ * A memory-hard scrypt + AES-256-CTR + encrypt-then-MAC envelope for wrapping
+ * account private keys at rest under a USER-SECRET-derived key (Wave-2, DR-2).
+ * This is the per-blob unit of `AccountSecretPayload.blobs[]` (see DOC-137 §2.3).
+ *
+ * The recipe is the same audited memory-hard construction already shipped for
+ * backups in `src/services/backup/encryption.ts` (scrypt via @noble/hashes,
+ * encrypt-then-MAC with the HMAC binding the whole canonical header/AAD, a
+ * constant-time MAC compare, and a DoS param-cap validator that runs BEFORE
+ * scrypt). It is re-implemented here with AT-REST-SPECIFIC domain separation
+ * (distinct HMAC tweak + optional device post-mix) so the at-rest and backup
+ * envelopes cannot be confused.
+ *
+ * TODO(wave2): unify with the backup envelope. This module deliberately does NOT
+ * refactor `backup/encryption.ts` in PR1 — byte-for-byte back-compat of existing
+ * `.voibackup` files is non-negotiable, and the safest guarantee that every
+ * backup test passes unchanged and backup ciphertext is identical is to leave the
+ * audited backup module untouched. The two envelopes differ in plaintext shape
+ * (backup encrypts a UTF-8 JSON string; at-rest encrypts the raw key bytes) and
+ * in AAD/KDF (at-rest binds `secretSource`/`deviceBound` and applies a device
+ * post-mix), so a shared core is a follow-up PR with dedicated golden-vector
+ * byte-identity tests.
+ *
+ * SECURITY: this module never logs the secret, the derived wrap key, or the
+ * plaintext key. Derived CryptoJS WordArrays are scrubbed in `finally` blocks
+ * (defense-in-depth; JS strings/typed arrays cannot be reliably zeroed).
+ *
+ * Byte-oriented plaintext: unlike the legacy Format-A at-rest blob (which
+ * encrypts a HEX STRING of the key — `AccountSecureStorage.encryptPrivateKey`),
+ * this envelope encrypts and returns the EXACT raw key bytes (the full 64-byte
+ * algosdk `sk`, or whatever length is stored — never hardcode 32; see DOC-137 §0
+ * P1-A). This round-trips the stored bytes byte-identically and is more
+ * size-efficient (no hex doubling), which helps the 2-blob / 2048-byte payload
+ * budget (§2.4). v2 is a fresh format with no on-disk history, so there is no
+ * back-compat cost to this choice.
+ */
+
+import CryptoJS from 'crypto-js';
+import 'crypto-js/hmac-sha256';
+import 'crypto-js/sha256';
+import 'crypto-js/aes';
+import 'crypto-js/mode-ctr';
+import 'crypto-js/pad-nopadding';
+import 'crypto-js/enc-hex';
+import 'crypto-js/enc-utf8';
+import { scryptAsync } from '@noble/hashes/scrypt';
+import { Buffer } from 'buffer';
+import { crypto as platformCrypto } from '@/platform';
+import type { ScryptKdfParams } from '../backup/types';
+
+// --- Envelope shape ---------------------------------------------------------
+
+/**
+ * The canonical per-blob at-rest key envelope (DOC-137 §2.3).
+ *
+ * The MAC binds the WHOLE header (version/kdf/kdfParams/secretSource/deviceBound
+ * /salt/iv) plus the ciphertext, so the version marker and every parameter are
+ * authenticated but never trusted for control flow (trial-decrypt: only the
+ * correct derived key reproduces the stored MAC).
+ */
+export interface KeyEnvelopeV2 {
+  /** Envelope format version. */
+  version: 2;
+  /** Key derivation function identifier. */
+  kdf: 'scrypt';
+  /** scrypt parameters (validated + capped before use). Reuses ScryptKdfParams. */
+  kdfParams: ScryptKdfParams;
+  /** UX hint ONLY — never a security gate (DOC-137 R3). */
+  secretSource: 'pin' | 'passphrase';
+  /** Whether the device post-mix (§2.2) was applied when deriving the wrap key. */
+  deviceBound: boolean;
+  /** Salt for scrypt, hex, 32 bytes, per-blob (platformCrypto.getRandomBytes). */
+  salt: string;
+  /** AES-CTR initialization vector, hex, 16 bytes. */
+  iv: string;
+  /** AES-256-CTR ciphertext of the raw key bytes, base64. */
+  ct: string;
+  /** HMAC-SHA256 over canonicalAtRestAad(header) + ct, hex (64 lowercase). */
+  mac: string;
+}
+
+// --- Shared parameters ------------------------------------------------------
+
+const SALT_LENGTH = 32; // 256 bits
+const IV_LENGTH = 16; // 128 bits for AES-CTR
+const KEY_LENGTH = 32; // 256 bits for AES-256
+
+/**
+ * At-rest KDF domain separation (distinct from backup's 'backup_hmac_salt').
+ * - HMAC tweak: hmacKey = SHA256(wrapKey || AT_REST_HMAC_TWEAK).
+ * - Device post-mix: wrapKey = HMAC-SHA256(key=rawKey, AT_REST_DEVICE_TWEAK_PREFIX + deviceId).
+ */
+const AT_REST_HMAC_TWEAK = 'voi_atrest_hmac';
+const AT_REST_DEVICE_TWEAK_PREFIX = 'voi_atrest_v2|';
+
+/**
+ * Default scrypt params for the AT-REST UNLOCK path (DOC-137 §2.2): 16 MiB /
+ * derivation. Unlock is frequent, so this is lighter than backup's occasional
+ * 2^15. The envelope self-describes `kdfParams`, so N can be raised for NEW
+ * writes later with zero impact on existing ciphertext.
+ *
+ * HONEST ENTROPY NOTE: scrypt cannot manufacture entropy. A 6-digit PIN is
+ * ~20 bits (10^6 candidates); memory-hard scrypt makes each guess expensive and
+ * denies cheap GPU/ASIC parallelism, but 10^6 guesses remain exhaustible by a
+ * motivated attacker who has extracted the blob. Raising N scales attacker cost
+ * and user unlock latency by the same linear factor. The optional passphrase is
+ * the only lever that changes the attacker/defender ratio.
+ */
+export const AT_REST_KDF_PARAMS: ScryptKdfParams = {
+  N: 2 ** 14, // 16384
+  r: 8,
+  p: 1,
+  dkLen: KEY_LENGTH,
+};
+
+// --- Multi-blob payload budget (DOC-137 §2.4) -------------------------------
+
+/**
+ * Hard cap on the number of v2 blobs in one `AccountSecretPayload`. During a
+ * re-wrap the payload transiently holds two blobs (old + new = the "dual slot");
+ * never more.
+ */
+export const MAX_KEY_BLOBS = 2;
+
+/**
+ * expo-secure-store rejects values >= 2048 bytes
+ * (node_modules/expo-secure-store/src/SecureStore.ts). A full 2-blob payload
+ * MUST serialize under this limit.
+ */
+export const SECURE_STORE_VALUE_LIMIT = 2048;
+
+// --- v2 param caps (DoS guard, mirrors backup encryption.ts) ----------------
+
+const V2_MAX_N = 2 ** 20; // 1,048,576
+const V2_MAX_R = 32;
+const V2_MAX_P = 4;
+const V2_DK_LEN = KEY_LENGTH;
+const V2_MAX_KDF_MEMORY_BYTES = 128 * 1024 * 1024; // 128 MiB ceiling on 128*N*r
+// noble maxmem must sit comfortably above the largest allowed 128*N*r footprint
+// so a future N bump for new writes never silently trips noble's guard.
+const SCRYPT_MAXMEM = 2 * V2_MAX_KDF_MEMORY_BYTES; // 256 MiB
+
+// --- Low-level helpers (audited lift from backup/encryption.ts) -------------
+
+/**
+ * Best-effort scrub of a CryptoJS WordArray's backing words (defense-in-depth).
+ */
+function wipeWordArray(wa: CryptoJS.lib.WordArray | null | undefined): void {
+  if (wa && Array.isArray(wa.words)) {
+    wa.words.fill(0);
+    wa.sigBytes = 0;
+  }
+}
+
+/**
+ * Constant-time comparison for equal-length hex strings (MAC check).
+ */
+function constantTimeEqualHex(a: string, b: string): boolean {
+  if (a.length !== b.length) {
+    return false;
+  }
+  let diff = 0;
+  for (let i = 0; i < a.length; i++) {
+    diff |= a.charCodeAt(i) ^ b.charCodeAt(i);
+  }
+  return diff === 0;
+}
+
+/** True for integers > 1 that are an exact power of two. */
+function isPowerOfTwo(n: number): boolean {
+  return Number.isInteger(n) && n > 1 && (n & (n - 1)) === 0;
+}
+
+/** True when `value` is a hex string of exactly `byteLength` bytes. */
+function isHexOfBytes(value: unknown, byteLength: number): value is string {
+  return (
+    typeof value === 'string' &&
+    value.length === byteLength * 2 &&
+    /^[0-9a-fA-F]+$/.test(value)
+  );
+}
+
+/** Convert a CryptoJS WordArray to a byte-exact Uint8Array (sigBytes bytes). */
+function wordArrayToUint8Array(wa: CryptoJS.lib.WordArray): Uint8Array {
+  const { words, sigBytes } = wa;
+  const out = new Uint8Array(sigBytes);
+  for (let i = 0; i < sigBytes; i++) {
+    out[i] = (words[i >>> 2] >>> (24 - (i % 4) * 8)) & 0xff;
+  }
+  return out;
+}
+
+/** Cryptographically secure random bytes as a hex string. */
+async function generateRandomHex(byteLength: number): Promise<string> {
+  const randomBytes = await platformCrypto.getRandomBytes(byteLength);
+  return Array.from(randomBytes, (byte) =>
+    byte.toString(16).padStart(2, '0')
+  ).join('');
+}
+
+// --- Param validation (runs BEFORE scrypt) ----------------------------------
+
+/**
+ * Cap the scrypt parameters BEFORE any scrypt work happens, so a malicious/
+ * oversized blob cannot force a huge/slow memory allocation (DoS). Throws on any
+ * violation. N is additionally required to be a power of two and the combined
+ * 128*N*r footprint is bounded.
+ */
+export function assertScryptParamsWithinCaps(params: ScryptKdfParams): void {
+  const { N, r, p, dkLen } = params;
+  if (
+    typeof N !== 'number' ||
+    typeof r !== 'number' ||
+    typeof p !== 'number' ||
+    typeof dkLen !== 'number'
+  ) {
+    throw new Error('Invalid scrypt parameters');
+  }
+  if (!isPowerOfTwo(N) || N > V2_MAX_N) {
+    throw new Error('scrypt parameters exceed safe limits');
+  }
+  if (!Number.isInteger(r) || r < 1 || r > V2_MAX_R) {
+    throw new Error('scrypt parameters exceed safe limits');
+  }
+  if (!Number.isInteger(p) || p < 1 || p > V2_MAX_P) {
+    throw new Error('scrypt parameters exceed safe limits');
+  }
+  if (dkLen !== V2_DK_LEN) {
+    throw new Error('scrypt parameters exceed safe limits');
+  }
+  if (128 * N * r > V2_MAX_KDF_MEMORY_BYTES) {
+    throw new Error('scrypt parameters exceed safe limits');
+  }
+}
+
+/**
+ * Strictly validate an (untrusted) parsed KeyEnvelopeV2 shape and CAP its KDF
+ * params before scrypt. Throws on any structural or param violation. Defense in
+ * depth even though the reader parses a self-written blob.
+ */
+export function assertValidKeyEnvelopeV2(
+  envelope: unknown
+): asserts envelope is KeyEnvelopeV2 {
+  if (typeof envelope !== 'object' || envelope === null) {
+    throw new Error('Invalid key envelope');
+  }
+  const e = envelope as Record<string, unknown>;
+  if (e.version !== 2) {
+    throw new Error('Unsupported key envelope version');
+  }
+  if (e.kdf !== 'scrypt') {
+    throw new Error('Unsupported key envelope KDF');
+  }
+  if (e.secretSource !== 'pin' && e.secretSource !== 'passphrase') {
+    throw new Error('Invalid key envelope secretSource');
+  }
+  if (typeof e.deviceBound !== 'boolean') {
+    throw new Error('Invalid key envelope deviceBound');
+  }
+  if (!isHexOfBytes(e.salt, SALT_LENGTH)) {
+    throw new Error('Invalid key envelope salt');
+  }
+  if (!isHexOfBytes(e.iv, IV_LENGTH)) {
+    throw new Error('Invalid key envelope iv');
+  }
+  if (typeof e.ct !== 'string' || e.ct.length === 0) {
+    throw new Error('Invalid key envelope ciphertext');
+  }
+  // The writer emits the HMAC as exactly 32 bytes of lowercase hex; reject a
+  // malformed mac up front so it never reaches the length-dependent compare.
+  if (typeof e.mac !== 'string' || !/^[0-9a-f]{64}$/.test(e.mac)) {
+    throw new Error('Invalid key envelope mac');
+  }
+  const rawParams = e.kdfParams;
+  if (typeof rawParams !== 'object' || rawParams === null) {
+    throw new Error('Invalid key envelope kdfParams');
+  }
+  assertScryptParamsWithinCaps(rawParams as ScryptKdfParams);
+}
+
+/**
+ * Guard the multi-blob payload budget (DOC-137 §2.4). Throws if the blob count
+ * exceeds MAX_KEY_BLOBS or the serialized payload would not fit under the
+ * expo-secure-store 2048-byte value limit. Callers pass the exact string they
+ * intend to persist.
+ */
+export function assertPayloadSizeWithinLimit(
+  serializedPayload: string,
+  blobCount: number
+): void {
+  if (blobCount > MAX_KEY_BLOBS) {
+    throw new Error(`Too many key blobs: ${blobCount} (max ${MAX_KEY_BLOBS})`);
+  }
+  // Byte length (SecureStore limits bytes, not UTF-16 code units).
+  const byteLength = Buffer.byteLength(serializedPayload, 'utf8');
+  if (byteLength >= SECURE_STORE_VALUE_LIMIT) {
+    throw new Error(
+      `Secret payload too large: ${byteLength} bytes (limit ${SECURE_STORE_VALUE_LIMIT})`
+    );
+  }
+}
+
+// --- Canonical AAD ----------------------------------------------------------
+
+/**
+ * Canonical, fixed-key-order serialization of the envelope header used as AAD
+ * for the HMAC. The MAC is computed over this string concatenated with the
+ * ciphertext, so version/kdf/N/r/p/dkLen/secretSource/deviceBound/salt/iv are
+ * all authenticated and cannot be tampered without failing verification.
+ */
+function canonicalAtRestAad(header: {
+  version: 2;
+  kdf: 'scrypt';
+  kdfParams: ScryptKdfParams;
+  secretSource: 'pin' | 'passphrase';
+  deviceBound: boolean;
+  salt: string;
+  iv: string;
+}): string {
+  return JSON.stringify({
+    version: header.version,
+    kdf: header.kdf,
+    kdfParams: {
+      N: header.kdfParams.N,
+      r: header.kdfParams.r,
+      p: header.kdfParams.p,
+      dkLen: header.kdfParams.dkLen,
+    },
+    secretSource: header.secretSource,
+    deviceBound: header.deviceBound,
+    salt: header.salt,
+    iv: header.iv,
+  });
+}
+
+// --- KDF (the at-rest wrapping key, DOC-137 §2.2) ---------------------------
+
+/**
+ * Derive the 32-byte at-rest wrap key from a user secret (DOC-137 §2.2):
+ *
+ *   rawKey  = scrypt(utf8(secret), saltBytes, { N, r, p, dkLen: 32 })
+ *   wrapKey = deviceSecret ? HMAC-SHA256(key=rawKey, "voi_atrest_v2|"+deviceSecret) : rawKey
+ *
+ * All memory-hardness is over the user secret — scrypt is the brute-force
+ * barrier. The device post-mix is a single cheap HMAC (mild defense-in-depth,
+ * NOT a strong second factor: the device id is IDFV/Android ID, not a secret).
+ * Params are capped before scrypt runs.
+ *
+ * @param secret       UTF-8 user secret (PIN or passphrase).
+ * @param saltHex      Per-blob salt, hex (32 bytes).
+ * @param kdfParams    scrypt parameters (validated/capped here).
+ * @param deviceSecret Optional device id; when present the post-mix is applied.
+ */
+export async function deriveWrapKey(
+  secret: string,
+  saltHex: string,
+  kdfParams: ScryptKdfParams,
+  deviceSecret?: string
+): Promise<Uint8Array> {
+  assertScryptParamsWithinCaps(kdfParams);
+  const saltBytes = Uint8Array.from(Buffer.from(saltHex, 'hex'));
+  const rawKey = await scryptAsync(secret, saltBytes, {
+    N: kdfParams.N,
+    r: kdfParams.r,
+    p: kdfParams.p,
+    dkLen: kdfParams.dkLen,
+    maxmem: SCRYPT_MAXMEM,
+  });
+
+  if (!deviceSecret) {
+    return rawKey;
+  }
+
+  // Device post-mix: HMAC-SHA256 keyed by rawKey over the device tweak.
+  let rawKeyWA: CryptoJS.lib.WordArray | null = null;
+  let mixedWA: CryptoJS.lib.WordArray | null = null;
+  try {
+    rawKeyWA = CryptoJS.lib.WordArray.create(rawKey);
+    mixedWA = CryptoJS.HmacSHA256(
+      AT_REST_DEVICE_TWEAK_PREFIX + deviceSecret,
+      rawKeyWA
+    );
+    return wordArrayToUint8Array(mixedWA);
+  } finally {
+    rawKey.fill(0);
+    wipeWordArray(rawKeyWA);
+    wipeWordArray(mixedWA);
+  }
+}
+
+/**
+ * Derive the AES and HMAC key WordArrays from a 32-byte wrap key.
+ *   aesKey  = wrapKey
+ *   hmacKey = SHA256(wrapKey || AT_REST_HMAC_TWEAK)
+ * The caller MUST wipe both returned WordArrays in a `finally`.
+ */
+function keyMaterialFromWrapKey(wrapKey: Uint8Array): {
+  aesKeyWA: CryptoJS.lib.WordArray;
+  hmacKeyWA: CryptoJS.lib.WordArray;
+} {
+  const aesKeyWA = CryptoJS.lib.WordArray.create(wrapKey);
+  const tweakWA = CryptoJS.enc.Utf8.parse(AT_REST_HMAC_TWEAK);
+  const hmacKeyInput = aesKeyWA.clone().concat(tweakWA);
+  const hmacKeyWA = CryptoJS.SHA256(hmacKeyInput);
+  wipeWordArray(hmacKeyInput);
+  return { aesKeyWA, hmacKeyWA };
+}
+
+// --- Envelope encrypt / decrypt ---------------------------------------------
+
+/**
+ * Encrypt raw key bytes into a KeyEnvelopeV2 (scrypt + AES-256-CTR +
+ * encrypt-then-MAC). Round-trips the EXACT input bytes, whatever their length.
+ *
+ * NOTE: no production code calls this in PR1 (no writer/migration lands here);
+ * it exists for the future PR4 writer and to let tests construct v2 blobs.
+ *
+ * @param plaintext    Raw key bytes to wrap (e.g. the full 64-byte algosdk sk).
+ * @param secret       UTF-8 user secret.
+ * @param secretSource UX hint recorded in the header (not a security gate).
+ * @param deviceSecret Optional device id; present => deviceBound = true.
+ * @param kdfParams    scrypt params (defaults to AT_REST_KDF_PARAMS).
+ * @param saltHex/ivHex Optional overrides for deterministic tests; random by default.
+ */
+export async function encryptKeyEnvelopeV2(input: {
+  plaintext: Uint8Array;
+  secret: string;
+  secretSource: 'pin' | 'passphrase';
+  deviceSecret?: string;
+  kdfParams?: ScryptKdfParams;
+  saltHex?: string;
+  ivHex?: string;
+}): Promise<KeyEnvelopeV2> {
+  const kdfParams = input.kdfParams ?? AT_REST_KDF_PARAMS;
+  const deviceBound = input.deviceSecret != null;
+
+  let wrapKey: Uint8Array | null = null;
+  let aesKeyWA: CryptoJS.lib.WordArray | null = null;
+  let hmacKeyWA: CryptoJS.lib.WordArray | null = null;
+  let plaintextWA: CryptoJS.lib.WordArray | null = null;
+
+  try {
+    const salt = input.saltHex ?? (await generateRandomHex(SALT_LENGTH));
+    const iv = input.ivHex ?? (await generateRandomHex(IV_LENGTH));
+
+    wrapKey = await deriveWrapKey(
+      input.secret,
+      salt,
+      kdfParams,
+      input.deviceSecret
+    );
+    ({ aesKeyWA, hmacKeyWA } = keyMaterialFromWrapKey(wrapKey));
+
+    plaintextWA = CryptoJS.lib.WordArray.create(input.plaintext);
+    const encrypted = CryptoJS.AES.encrypt(plaintextWA, aesKeyWA, {
+      iv: CryptoJS.enc.Hex.parse(iv),
+      mode: CryptoJS.mode.CTR,
+      padding: CryptoJS.pad.NoPadding,
+    });
+    const ct = encrypted.toString();
+
+    const header = {
+      version: 2 as const,
+      kdf: 'scrypt' as const,
+      kdfParams: {
+        N: kdfParams.N,
+        r: kdfParams.r,
+        p: kdfParams.p,
+        dkLen: kdfParams.dkLen,
+      },
+      secretSource: input.secretSource,
+      deviceBound,
+      salt,
+      iv,
+    };
+    const mac = CryptoJS.HmacSHA256(
+      canonicalAtRestAad(header) + ct,
+      hmacKeyWA
+    ).toString();
+
+    return { ...header, ct, mac };
+  } finally {
+    if (wrapKey) {
+      wrapKey.fill(0);
+    }
+    wipeWordArray(aesKeyWA);
+    wipeWordArray(hmacKeyWA);
+    wipeWordArray(plaintextWA);
+  }
+}
+
+/**
+ * Trial-decrypt a KeyEnvelopeV2 under a candidate secret.
+ *
+ * Returns the exact wrapped key bytes on success, or `null` when the MAC does
+ * not verify (wrong secret or tampered header — the safe "fall through to the
+ * next candidate" signal). THROWS only on a structurally invalid envelope or
+ * out-of-cap KDF params — and it validates/caps BEFORE running scrypt, so an
+ * oversized N can never force a huge allocation.
+ *
+ * SECURITY: the MAC is keyed by the derived wrap key, so only the correct
+ * derivation reproduces the stored MAC. A wrong key cannot forge it; a flipped
+ * marker cannot make a wrong key verify.
+ *
+ * @param deviceSecret Device id; used only when `envelope.deviceBound` is true.
+ */
+export async function decryptKeyEnvelopeV2(
+  envelope: KeyEnvelopeV2,
+  secret: string,
+  deviceSecret?: string
+): Promise<Uint8Array | null> {
+  // Structural + param-cap validation BEFORE any scrypt work.
+  assertValidKeyEnvelopeV2(envelope);
+
+  let wrapKey: Uint8Array | null = null;
+  let aesKeyWA: CryptoJS.lib.WordArray | null = null;
+  let hmacKeyWA: CryptoJS.lib.WordArray | null = null;
+  let decryptedWA: CryptoJS.lib.WordArray | null = null;
+
+  try {
+    wrapKey = await deriveWrapKey(
+      secret,
+      envelope.salt,
+      envelope.kdfParams,
+      envelope.deviceBound ? deviceSecret : undefined
+    );
+    ({ aesKeyWA, hmacKeyWA } = keyMaterialFromWrapKey(wrapKey));
+
+    const aad = canonicalAtRestAad(envelope);
+    const computedMac = CryptoJS.HmacSHA256(
+      aad + envelope.ct,
+      hmacKeyWA
+    ).toString();
+    if (!constantTimeEqualHex(computedMac, envelope.mac)) {
+      return null; // wrong key / tampered header -> fall through
+    }
+
+    decryptedWA = CryptoJS.AES.decrypt(envelope.ct, aesKeyWA, {
+      iv: CryptoJS.enc.Hex.parse(envelope.iv),
+      mode: CryptoJS.mode.CTR,
+      padding: CryptoJS.pad.NoPadding,
+    });
+    return wordArrayToUint8Array(decryptedWA);
+  } finally {
+    if (wrapKey) {
+      wrapKey.fill(0);
+    }
+    wipeWordArray(aesKeyWA);
+    wipeWordArray(hmacKeyWA);
+    wipeWordArray(decryptedWA);
+  }
+}


### PR DESCRIPTION
## PR1 of 7 — Wave-2 key-migration foundation (TASK-27)

Design: DOC-137 §2.1/§2.3/§2.4/§4.3, §9 (PR1 row). **This PR is deliberately NO-BEHAVIOR-CHANGE.** It lays the crypto/type/reader foundation only — **no production writer and no migration** — so existing wallets read exactly as today.

### What PR1 does
- **`src/services/secure/envelopeV2.ts` (new)** — a memory-hard **scrypt + AES-256-CTR + encrypt-then-MAC** at-rest key envelope, mirroring the audited backup v2 recipe with **at-rest-specific domain separation** (`voi_atrest_hmac` HMAC tweak; optional `voi_atrest_v2|<deviceId>` device post-mix). Exports:
  - `encryptKeyEnvelopeV2` (used by TESTS and the future PR4 writer — **no production code calls it here**),
  - `decryptKeyEnvelopeV2` (used by the reader; returns `null` on MAC mismatch, throws only on structural/param-cap violations),
  - `deriveWrapKey(secret, salt, kdfParams, deviceSecret?)` (DOC-137 §2.2),
  - param-cap validator (`assertScryptParamsWithinCaps`) that runs **before scrypt**, envelope-shape validator, and the payload-budget guard.
- **v2 types** — `KeyEnvelopeV2 { version; kdf; kdfParams; secretSource; deviceBound; salt; iv; ct; mac }` (reuses `ScryptKdfParams` from `backup/types`), and `AccountSecretPayload` extended with `version?: 1|2` and `blobs?: KeyEnvelopeV2[]`.
- **Reader** (`AccountSecureStorage.getPrivateKey`) — adds a **v2-blob candidate tried FIRST** when a verified secret is available (`deriveWrapKey` → MAC-verify → decrypt), keeping the existing device-key (Format A) and legacy PIN-mixed (Format C) candidates **exactly as today**. Because no v2 blobs exist yet, this is **inert for all existing data** — payloads without `blobs` skip the branch and hit the identical legacy ladder. Every accepted result MUST pass MAC verification (a wrong key can't forge the HMAC).

### No-behavior-change guarantee
- `git diff` touches only `AccountSecureStorage.ts` (reader + types) and adds `envelopeV2.ts` + tests. **`src/services/backup/*` is byte-for-byte untouched.**
- No writer, no migration, no `saveSecret`/`setItem`, no opportunistic-upgrade call added.
- The reader is a strict superset: for existing payloads (no `blobs`) the control flow is identical to `main`.

### 64-byte `sk` handling (DOC-137 §0 P1-A)
The envelope is **byte-oriented**: it encrypts and returns the EXACT stored bytes whatever their length — the full 64-byte algosdk `sk` (seed‖pubkey), never hardcoding 32. A dedicated test round-trips a 64-byte buffer AND a 32-byte buffer byte-identically. (This differs from the legacy Format-A blob, which encrypts a hex string of the key; v2 is a fresh format with no on-disk history, and byte-oriented plaintext is also more size-efficient for the payload budget.)

### 2-blob / 2048-byte cap enforcement
- `MAX_KEY_BLOBS = 2`, `SECURE_STORE_VALUE_LIMIT = 2048` (expo-secure-store value limit).
- `assertPayloadSizeWithinLimit(serialized, blobCount)` throws on >2 blobs or a serialized payload ≥ 2048 bytes (byte length, not UTF-16 units) — for the future writer; exercised directly here.
- The reader **caps attempts at `MAX_KEY_BLOBS`** (`.slice(0, 2)`) — each attempt is a scrypt, so this is also a DoS guard.
- Test proves a realistic **2-blob payload with a 64-byte sk serializes to < 1200 bytes** — comfortably under 2048.

### Shared with backup, or deferred?
**Deferred (backup left 100% untouched), with a `// TODO(wave2): unify with backup envelope` note in `envelopeV2.ts`.** Rationale: back-compat of existing `.voibackup` files is non-negotiable, and the surest guarantee that all 25 backup tests pass unchanged and backup ciphertext stays identical is to not edit the audited backup module. The two envelopes also genuinely differ — backup encrypts a UTF-8 JSON string, at-rest encrypts raw key bytes; at-rest binds extra header fields (`secretSource`/`deviceBound`) and applies a device post-mix with a distinct HMAC tweak — so a shared core is a follow-up PR with dedicated golden-vector byte-identity tests. `envelopeV2.ts` is a faithful re-implementation of the same audited recipe.

### Tests (28 new; all green) + gates
- `envelopeV2.test.ts` (22): byte-exact 64-byte + 32-byte round-trip; MAC rejects tampering of **each** header field (version/kdfParams/secretSource/deviceBound/salt/iv/ct); device post-mix round-trip + wrong/missing device secret; wrong-secret null; param-cap rejects oversized N **before scrypt**; 2-blob cap + <2048-byte size guard.
- `getPrivateKey.reader.test.ts` (6): reads a constructed v2 blob (incl. device-bound); still reads a real legacy Format-A blob unchanged; falls through v2→Format A on secret mismatch (dual-slot); fails cleanly on a v2-only payload with the wrong secret; caps attempts at 2.
- **Gates:** `typecheck` 0 errors · `lint` 0 errors (pre-existing warnings only) · `test` **348 passed / 24 suites**, incl. all **25 backup tests unchanged**.

### Security notes
- No key, secret, or derived wrap key is ever logged. Derived CryptoJS WordArrays are scrubbed in `finally` blocks.
- MAC is keyed by the derived wrap key → trial-decrypt is safe (a flipped/untrusted version marker can't make a wrong key verify).

**PR chain:** PR1 of 7. Writer + PIN-lifecycle (PR4) and the migration engine (PR5, gated on on-device testing) come later. Do **not** merge before Codex review.
