### PR TITLE
feat(security): persistent PIN throttle in verifyPin (survives relaunch) — TASK-26

### DIFF
--- a/src/screens/auth/LockScreen.tsx
+++ b/src/screens/auth/LockScreen.tsx
@@ -66,12 +66,19 @@ export default function LockScreen() {
     attemptsRemaining: SECURITY_CONFIG.PIN_ATTEMPT_LIMIT,
   });
   const [nowTick, setNowTick] = useState(() => Date.now());
+  // Until the FIRST persisted-throttle read resolves we don't know whether the
+  // wallet is locked out, so PIN entry stays disabled — the UI must never
+  // momentarily look unlocked while the persisted state is actually locked
+  // (Codex P2 hydration flicker).
+  const [hydrated, setHydrated] = useState(false);
 
   const isLocked =
     throttle.lockedUntil !== null && nowTick < throttle.lockedUntil;
   const lockRemainingMs = isLocked
     ? Math.max(0, (throttle.lockedUntil ?? 0) - nowTick)
     : 0;
+  // Gate all PIN input on both the lockout AND hydration.
+  const inputDisabled = isLocked || !hydrated;
 
   const refreshThrottle = useCallback(async () => {
     try {
@@ -79,6 +86,10 @@ export default function LockScreen() {
       setThrottle(state);
     } catch (error) {
       console.error('Failed to read PIN throttle state:', error);
+    } finally {
+      // Hydrated regardless of success — on a read error the service still
+      // fails closed, and we don't want to strand input disabled forever.
+      setHydrated(true);
     }
   }, []);
 
@@ -127,7 +138,7 @@ export default function LockScreen() {
   };
 
   const handleNumberPress = (number: string) => {
-    if (isLocked || pin.length >= 6) return;
+    if (inputDisabled || pin.length >= 6) return;
 
     const newPin = pin + number;
     setPin(newPin);
@@ -138,7 +149,7 @@ export default function LockScreen() {
   };
 
   const handleBackspace = () => {
-    if (isLocked) return;
+    if (inputDisabled) return;
     setPin(pin.slice(0, -1));
   };
 
@@ -292,7 +303,7 @@ export default function LockScreen() {
                     key={itemIndex}
                     style={styles.keypadButton}
                     onPress={handleBackspace}
-                    disabled={isLocked}
+                    disabled={inputDisabled}
                   >
                     <Ionicons
                       name="backspace-outline"
@@ -308,7 +319,7 @@ export default function LockScreen() {
                   key={itemIndex}
                   style={styles.keypadButton}
                   onPress={() => handleNumberPress(item)}
-                  disabled={isLocked}
+                  disabled={inputDisabled}
                 >
                   <Text style={styles.keypadButtonText}>{item}</Text>
                 </TouchableOpacity>
@@ -326,7 +337,9 @@ export default function LockScreen() {
         <View style={styles.header}>
           <Ionicons name="lock-closed" size={48} color={theme.colors.primary} />
           <Text style={styles.title}>Wallet Locked</Text>
-          <Text style={styles.subtitle}>Enter your PIN to unlock</Text>
+          <Text style={styles.subtitle}>
+            {hydrated ? 'Enter your PIN to unlock' : 'Checking status…'}
+          </Text>
         </View>
 
         {renderPinDots()}

--- a/src/screens/auth/LockScreen.tsx
+++ b/src/screens/auth/LockScreen.tsx
@@ -99,6 +99,12 @@ export default function LockScreen() {
       await refreshThrottle();
     };
     loadThrottleState();
+    // Defensive: if the throttle read hangs, don't strand PIN input disabled
+    // forever. Flip hydrated after 3s regardless — the service is still the real
+    // gate (verifyPin rejects a locked PIN), so failing the UI toward "enabled"
+    // is safe.
+    const hydrationTimeout = setTimeout(() => setHydrated(true), 3000);
+    return () => clearTimeout(hydrationTimeout);
   }, [refreshThrottle]);
 
   // While locked, tick every second to drive the countdown and auto-unlock when

--- a/src/screens/auth/LockScreen.tsx
+++ b/src/screens/auth/LockScreen.tsx
@@ -1,4 +1,4 @@
-import React, { useState, useEffect } from 'react';
+import React, { useState, useEffect, useCallback } from 'react';
 import {
   View,
   Text,
@@ -13,8 +13,10 @@ import { useTheme } from '@/contexts/ThemeContext';
 import { Theme } from '@/constants/themes';
 import { useAuth } from '@/contexts/AuthContext';
 import { AccountSecureStorage } from '@/services/secure';
+import type { PinThrottleState } from '@/services/secure';
 import { MultiAccountWalletService } from '@/services/wallet';
 import { hapticNotify } from '@/utils/haptics';
+import { SECURITY_CONFIG, SECURITY_MESSAGES } from '@/config/security';
 
 // Cross-platform alert helper
 const showAlert = (
@@ -41,17 +43,69 @@ const showAlert = (
   }
 };
 
+// Format a remaining-lockout duration as M:SS for the live countdown.
+const formatCountdown = (ms: number): string => {
+  const totalSeconds = Math.ceil(ms / 1000);
+  const minutes = Math.floor(totalSeconds / 60);
+  const seconds = totalSeconds % 60;
+  return `${minutes}:${seconds.toString().padStart(2, '0')}`;
+};
+
 export default function LockScreen() {
   const { theme } = useTheme();
   const styles = useThemedStyles(createStyles);
   const { authState, unlock, unlockWithBiometrics, recheckAuthState } =
     useAuth();
   const [pin, setPin] = useState('');
-  const [attempts, setAttempts] = useState(0);
-  const [isLocked, setIsLocked] = useState(false);
 
-  const MAX_ATTEMPTS = 5;
-  const LOCKOUT_TIME = 30000; // 30 seconds
+  // Lockout state is now sourced from the PERSISTENT throttle in
+  // AccountSecureStorage (DOC-137 §8 / TASK-26) instead of local React state, so
+  // it survives an app relaunch. `nowTick` drives the live countdown.
+  const [throttle, setThrottle] = useState<PinThrottleState>({
+    lockedUntil: null,
+    attemptsRemaining: SECURITY_CONFIG.PIN_ATTEMPT_LIMIT,
+  });
+  const [nowTick, setNowTick] = useState(() => Date.now());
+
+  const isLocked =
+    throttle.lockedUntil !== null && nowTick < throttle.lockedUntil;
+  const lockRemainingMs = isLocked
+    ? Math.max(0, (throttle.lockedUntil ?? 0) - nowTick)
+    : 0;
+
+  const refreshThrottle = useCallback(async () => {
+    try {
+      const state = await AccountSecureStorage.getPinThrottleState();
+      setThrottle(state);
+    } catch (error) {
+      console.error('Failed to read PIN throttle state:', error);
+    }
+  }, []);
+
+  // Load persisted lockout on mount so a relaunch during a lockout stays locked.
+  useEffect(() => {
+    const loadThrottleState = async () => {
+      await refreshThrottle();
+    };
+    loadThrottleState();
+  }, [refreshThrottle]);
+
+  // While locked, tick every second to drive the countdown and auto-unlock when
+  // the window elapses (re-reading the persisted state to clear the lockout).
+  useEffect(() => {
+    if (throttle.lockedUntil === null) {
+      return;
+    }
+    const interval = setInterval(() => {
+      const t = Date.now();
+      if (t >= (throttle.lockedUntil ?? 0)) {
+        refreshThrottle();
+      } else {
+        setNowTick(t);
+      }
+    }, 1000);
+    return () => clearInterval(interval);
+  }, [throttle.lockedUntil, refreshThrottle]);
 
   useEffect(() => {
     if (authState.biometricEnabled) {
@@ -90,35 +144,38 @@ export default function LockScreen() {
 
   const verifyPin = async (enteredPin: string) => {
     try {
+      // unlock() -> AccountSecureStorage.verifyPin() applies the persistent
+      // throttle internally (and returns a plain boolean). We read the resulting
+      // lockout/remaining-attempts back via the separate throttle-state query.
       const success = await unlock(enteredPin);
+      setPin('');
 
       if (success) {
-        setPin('');
-        setAttempts(0);
         hapticNotify('success');
+        setThrottle({
+          lockedUntil: null,
+          attemptsRemaining: SECURITY_CONFIG.PIN_ATTEMPT_LIMIT,
+        });
+        return;
+      }
+
+      hapticNotify('error');
+      // getPinThrottleState() returns lockedUntil=null once a lockout has
+      // elapsed, so a non-null value here means "currently locked".
+      const state = await AccountSecureStorage.getPinThrottleState();
+      setThrottle(state);
+
+      if (state.lockedUntil !== null) {
+        showAlert('Too Many Attempts', SECURITY_MESSAGES.PIN_ATTEMPTS_EXCEEDED);
+      } else if (state.attemptsRemaining > 0) {
+        showAlert(
+          'Incorrect PIN',
+          `${state.attemptsRemaining} attempt${
+            state.attemptsRemaining === 1 ? '' : 's'
+          } remaining`
+        );
       } else {
-        const newAttempts = attempts + 1;
-        setAttempts(newAttempts);
-        setPin('');
-        hapticNotify('error');
-
-        if (newAttempts >= MAX_ATTEMPTS) {
-          setIsLocked(true);
-          showAlert(
-            'Too Many Attempts',
-            `Wallet locked for ${LOCKOUT_TIME / 1000} seconds`
-          );
-
-          setTimeout(() => {
-            setIsLocked(false);
-            setAttempts(0);
-          }, LOCKOUT_TIME);
-        } else {
-          showAlert(
-            'Incorrect PIN',
-            `${MAX_ATTEMPTS - newAttempts} attempts remaining`
-          );
-        }
+        showAlert('Incorrect PIN', SECURITY_MESSAGES.PIN_ATTEMPTS_EXCEEDED);
       }
     } catch (error) {
       console.error('PIN verification error:', error);
@@ -171,10 +228,12 @@ export default function LockScreen() {
       // Clear wallet data
       await MultiAccountWalletService.clearAllWallets();
 
-      // Reset local state
+      // Reset local state (clearAll() also wipes the persisted PIN throttle).
       setPin('');
-      setAttempts(0);
-      setIsLocked(false);
+      setThrottle({
+        lockedUntil: null,
+        attemptsRemaining: SECURITY_CONFIG.PIN_ATTEMPT_LIMIT,
+      });
 
       // Force the AuthContext to re-check the initial state
       await recheckAuthState();
@@ -288,15 +347,28 @@ export default function LockScreen() {
 
         {renderKeypad()}
 
-        {isLocked && (
+        {isLocked ? (
           <View style={styles.lockoutContainer}>
             <Text style={styles.lockoutText}>
-              Wallet temporarily locked due to too many failed attempts
+              {SECURITY_MESSAGES.PIN_ATTEMPTS_EXCEEDED}
+            </Text>
+            <Text style={styles.lockoutCountdown}>
+              Try again in {formatCountdown(lockRemainingMs)}
             </Text>
           </View>
+        ) : (
+          throttle.attemptsRemaining < SECURITY_CONFIG.PIN_ATTEMPT_LIMIT &&
+          throttle.attemptsRemaining > 0 && (
+            <View style={styles.lockoutContainer}>
+              <Text style={styles.lockoutText}>
+                {throttle.attemptsRemaining} attempt
+                {throttle.attemptsRemaining === 1 ? '' : 's'} remaining
+              </Text>
+            </View>
+          )
         )}
 
-        {attempts >= 3 && (
+        {(isLocked || throttle.attemptsRemaining <= 2) && (
           <View style={styles.resetContainer}>
             <Text style={styles.resetHelpText}>
               Forgot your PIN? You can reset the application, but this will
@@ -405,6 +477,14 @@ const createStyles = (theme: Theme) =>
       color: theme.colors.error,
       textAlign: 'center',
       lineHeight: 20,
+    },
+    lockoutCountdown: {
+      fontSize: 18,
+      fontWeight: '600',
+      color: theme.colors.error,
+      textAlign: 'center',
+      marginTop: theme.spacing.sm,
+      fontVariant: ['tabular-nums'],
     },
     resetContainer: {
       marginTop: theme.spacing.xxl,

--- a/src/services/secure/AccountSecureStorage.ts
+++ b/src/services/secure/AccountSecureStorage.ts
@@ -1322,14 +1322,19 @@ export class AccountSecureStorage {
 
   /**
    * Clear the throttle on a verified PIN. Clears the in-memory mirror
-   * SYNCHRONOUSLY so the session resets immediately, then fires the persisted
-   * delete FIRE-AND-FORGET — a correct PIN must never hang on the delete. A
-   * slow/failed delete just leaves a stale persisted counter, which fails safe
-   * (worst case the user is nearer a lockout, never further from one).
+   * SYNCHRONOUSLY so the session resets immediately, then ENQUEUES the persisted
+   * delete onto the SAME serialization chain that increments use — so any later
+   * wrong-PIN increment queues AFTER this delete and cannot be clobbered by it
+   * (a fire-and-forget delete could otherwise complete late and erase a newer
+   * increment, leaving a stale counter after a force-kill). The delete is NOT
+   * awaited by verifyPin, so a correct PIN never hangs on it; a slow/failed
+   * delete just leaves a stale persisted counter, which fails safe.
    */
   private static resetThrottle(): void {
     this.throttleMirror = { failCount: 0, lockoutUntil: null, lastFailAt: 0 };
-    void secureStorage.deleteItem(this.PIN_THROTTLE_KEY).catch(() => {});
+    this.throttleChain = this.throttleChain
+      .then(() => secureStorage.deleteItem(this.PIN_THROTTLE_KEY))
+      .catch(() => {});
   }
 
   /**

--- a/src/services/secure/AccountSecureStorage.ts
+++ b/src/services/secure/AccountSecureStorage.ts
@@ -1682,7 +1682,6 @@ export class AccountSecureStorage {
         this.BIOMETRIC_ENABLED_KEY,
         this.METADATA_LIST_KEY,
         this.PIN_TIMEOUT_KEY,
-        this.PIN_THROTTLE_KEY,
       ]);
       // Clear from secure storage
       await Promise.all([
@@ -1691,12 +1690,16 @@ export class AccountSecureStorage {
         secureStorage.deleteItem(this.BIOMETRIC_ENABLED_KEY).catch(() => {}),
         secureStorage.deleteItem(this.METADATA_LIST_KEY).catch(() => {}),
         secureStorage.deleteItem(this.PIN_TIMEOUT_KEY).catch(() => {}),
-        // Reset the persistent PIN throttle so a fresh wallet starts unlocked.
-        secureStorage.deleteItem(this.PIN_THROTTLE_KEY).catch(() => {}),
       ]);
-      // Also clear the in-memory throttle mirror so the fresh wallet isn't
-      // held under a prior session's lockout.
-      this.throttleMirror = null;
+      // Wipe the persistent PIN throttle THROUGH the same serialization mutex
+      // verifyPin uses, as the FINAL throttle mutation. Any in-flight verifyPin
+      // increment is serialized ahead of this block, so it persists FIRST and is
+      // then wiped here — it can never land AFTER the wipe and leave a stale
+      // lockout (which would phantom-lock the freshly reset/restored wallet).
+      await this.runThrottleExclusive(async () => {
+        await secureStorage.deleteItem(this.PIN_THROTTLE_KEY).catch(() => {});
+        this.throttleMirror = null;
+      });
     } catch (error) {
       throw new AccountStorageError('Failed to clear all secure storage');
     }

--- a/src/services/secure/AccountSecureStorage.ts
+++ b/src/services/secure/AccountSecureStorage.ts
@@ -60,6 +60,15 @@ import { SECURITY_CONFIG } from '../../config/security';
 // user passphrase (Wave-2 later PRs) and optional root/jailbreak detection
 // (deferred). Do NOT extend this throttle to claim it defends rooted devices.
 //
+// ORDERING / CONCURRENCY: throttle persist writes (both the wrong-PIN increment
+// and the correct-PIN reset) are plain awaits INSIDE the serialization mutex,
+// like every other awaited secure write in the app (unlock already awaits the
+// PIN hash); a hung keychain hanging verifyPin is the same accepted device-
+// broken condition (do NOT add a timeout — timeouts caused out-of-order bugs).
+// Reset requires the correct PIN, so reset/increment interleavings are not
+// attacker-reachable; any such race is a benign self-race that fails safe
+// (under-counts, never bypasses).
+//
 // PIN_ATTEMPT_LIMIT = fails per window before a lockout; PIN_LOCKOUT_DURATION =
 // base lockout, doubled each window (see pinLockoutBackoff). Wired from the
 // previously-dead security config.
@@ -1106,11 +1115,10 @@ export class AccountSecureStorage {
         const matched = await this.checkPinHash(pin);
 
         if (matched) {
-          // Success — clear the throttle. resetThrottle clears the session
-          // mirror SYNCHRONOUSLY and fires the persisted delete WITHOUT waiting,
-          // so a correct PIN can never hang on a slow/failing delete (a stale
-          // persisted counter just fails safe — worst case nearer lockout).
-          this.resetThrottle();
+          // Success — clear the throttle, AWAITING the persisted delete inside
+          // the mutex, exactly like the wrong-PIN path awaits saveThrottle. Both
+          // writes are serialized by the mutex, so ordering is trivially correct.
+          await this.resetThrottle();
           return true;
         }
 
@@ -1321,20 +1329,19 @@ export class AccountSecureStorage {
   }
 
   /**
-   * Clear the throttle on a verified PIN. Clears the in-memory mirror
-   * SYNCHRONOUSLY so the session resets immediately, then ENQUEUES the persisted
-   * delete onto the SAME serialization chain that increments use — so any later
-   * wrong-PIN increment queues AFTER this delete and cannot be clobbered by it
-   * (a fire-and-forget delete could otherwise complete late and erase a newer
-   * increment, leaving a stale counter after a force-kill). The delete is NOT
-   * awaited by verifyPin, so a correct PIN never hangs on it; a slow/failed
-   * delete just leaves a stale persisted counter, which fails safe.
+   * Clear the throttle on a verified PIN. Clears the in-memory mirror, then
+   * AWAITS the persisted delete INSIDE the mutex — symmetric with the wrong-PIN
+   * path's awaited saveThrottle. Because both writes are plain awaits within the
+   * same serialization mutex, they can never interleave (no reset landing after
+   * a later increment), and each verifyPin awaits only its OWN write before
+   * releasing the mutex. Reset requires the correct PIN, so this path is never
+   * attacker-reachable; a genuinely hung keychain here is the same accepted
+   * device-broken condition as every other awaited secure write (see THREAT
+   * MODEL) — not special-cased.
    */
-  private static resetThrottle(): void {
+  private static async resetThrottle(): Promise<void> {
     this.throttleMirror = { failCount: 0, lockoutUntil: null, lastFailAt: 0 };
-    this.throttleChain = this.throttleChain
-      .then(() => secureStorage.deleteItem(this.PIN_THROTTLE_KEY))
-      .catch(() => {});
+    await secureStorage.deleteItem(this.PIN_THROTTLE_KEY).catch(() => {});
   }
 
   /**

--- a/src/services/secure/AccountSecureStorage.ts
+++ b/src/services/secure/AccountSecureStorage.ts
@@ -40,11 +40,37 @@ import {
 } from './envelopeV2';
 import { SECURITY_CONFIG } from '../../config/security';
 
-// Persistent PIN throttle (DOC-137 §8 / TASK-26). PIN_ATTEMPT_LIMIT = fails per
-// window before a lockout; PIN_LOCKOUT_DURATION = base lockout, doubled each
-// window (see pinLockoutBackoff). Wired from the previously-dead security config.
+// ─────────────────────────────────────────────────────────────────────────────
+// PIN THROTTLE — THREAT MODEL (DOC-137 §8 / TASK-26). READ BEFORE CHANGING.
+//
+// WHAT THIS DEFENDS: ONLINE, on-device PIN guessing against the RUNNING app on a
+// NON-rooted / non-jailbroken device. The counter is persisted (survives force-
+// kill/relaunch) and mirrored in memory (survives a swallowed write), so a user
+// or thief holding an unrooted phone cannot brute-force the 6-digit PIN by
+// guessing-and-relaunching.
+//
+// WHAT THIS DELIBERATELY DOES NOT DEFEND: an attacker with ROOT / direct write
+// access to SecureStore. Such an attacker can reset or overwrite this record
+// (even with a validly-shaped one) to bypass the throttle — but that same
+// attacker can also read the encrypted key blob straight out of SecureStore and
+// mount an OFFLINE attack the throttle never sees. A client-side throttle (or a
+// MAC / hardware counter on this record — intentionally NOT added, since the
+// attacker reads that key/counter too) cannot close this hole. The rooted /
+// offline threat is instead mitigated by the memory-hard KDF wrap + optional
+// user passphrase (Wave-2 later PRs) and optional root/jailbreak detection
+// (deferred). Do NOT extend this throttle to claim it defends rooted devices.
+//
+// PIN_ATTEMPT_LIMIT = fails per window before a lockout; PIN_LOCKOUT_DURATION =
+// base lockout, doubled each window (see pinLockoutBackoff). Wired from the
+// previously-dead security config.
+// ─────────────────────────────────────────────────────────────────────────────
 const { PIN_ATTEMPT_LIMIT, PIN_LOCKOUT_DURATION } = SECURITY_CONFIG;
 const THROTTLE_BACKOFF_CAP_MS = 24 * 60 * 60 * 1000; // hard cap: 24h
+// Upper bound on how long a wrong-PIN persist may block unlock. The normal path
+// awaits the write (so a force-kill can't race it on a non-rooted device); if
+// SecureStore hangs past this, we stop waiting — the in-memory mirror already
+// enforces the increment for the session.
+const THROTTLE_PERSIST_TIMEOUT_MS = 2000;
 
 /**
  * Persisted PIN-throttle record. Lives in SecureStore under
@@ -1110,7 +1136,11 @@ export class AccountSecureStorage {
         // Update the mirror FIRST so the session keeps enforcing the increment
         // even if the persisted write below fails (write fails CLOSED).
         this.throttleMirror = updated;
-        await this.saveThrottle(updated);
+        // Durably persist the increment BEFORE resolving, so a force-kill
+        // immediately after a failed guess can't race the write on a non-rooted
+        // device — the counter is already on disk when the attacker sees the
+        // rejection. Bounded so a hung SecureStore write can't hang unlock.
+        await this.saveThrottleBounded(updated);
         return false;
       } catch (error) {
         console.warn('PIN verification failed');
@@ -1287,6 +1317,30 @@ export class AccountSecureStorage {
     } catch {
       console.warn('Failed to persist PIN throttle record');
     }
+  }
+
+  /**
+   * Persist the throttle, but never block unlock for longer than
+   * THROTTLE_PERSIST_TIMEOUT_MS. `saveThrottle` never rejects (it swallows write
+   * errors), so the normal path resolves as soon as the write completes — making
+   * the increment durable before verifyPin returns. If SecureStore hangs, the
+   * timeout wins and we proceed; the in-memory mirror still enforces the count.
+   */
+  private static saveThrottleBounded(record: PinThrottleRecord): Promise<void> {
+    return new Promise<void>((resolve) => {
+      let settled = false;
+      const finish = () => {
+        if (!settled) {
+          settled = true;
+          resolve();
+        }
+      };
+      const timer = setTimeout(finish, THROTTLE_PERSIST_TIMEOUT_MS);
+      void this.saveThrottle(record).finally(() => {
+        clearTimeout(timer);
+        finish();
+      });
+    });
   }
 
   private static async resetThrottle(): Promise<void> {

--- a/src/services/secure/AccountSecureStorage.ts
+++ b/src/services/secure/AccountSecureStorage.ts
@@ -66,11 +66,6 @@ import { SECURITY_CONFIG } from '../../config/security';
 // ─────────────────────────────────────────────────────────────────────────────
 const { PIN_ATTEMPT_LIMIT, PIN_LOCKOUT_DURATION } = SECURITY_CONFIG;
 const THROTTLE_BACKOFF_CAP_MS = 24 * 60 * 60 * 1000; // hard cap: 24h
-// Upper bound on how long a wrong-PIN persist may block unlock. The normal path
-// awaits the write (so a force-kill can't race it on a non-rooted device); if
-// SecureStore hangs past this, we stop waiting — the in-memory mirror already
-// enforces the increment for the session.
-const THROTTLE_PERSIST_TIMEOUT_MS = 2000;
 
 /**
  * Persisted PIN-throttle record. Lives in SecureStore under
@@ -1111,8 +1106,11 @@ export class AccountSecureStorage {
         const matched = await this.checkPinHash(pin);
 
         if (matched) {
-          // Success — clear the throttle so the user starts from a clean slate.
-          await this.resetThrottle();
+          // Success — clear the throttle. resetThrottle clears the session
+          // mirror SYNCHRONOUSLY and fires the persisted delete WITHOUT waiting,
+          // so a correct PIN can never hang on a slow/failing delete (a stale
+          // persisted counter just fails safe — worst case nearer lockout).
+          this.resetThrottle();
           return true;
         }
 
@@ -1136,11 +1134,14 @@ export class AccountSecureStorage {
         // Update the mirror FIRST so the session keeps enforcing the increment
         // even if the persisted write below fails (write fails CLOSED).
         this.throttleMirror = updated;
-        // Durably persist the increment BEFORE resolving, so a force-kill
-        // immediately after a failed guess can't race the write on a non-rooted
-        // device — the counter is already on disk when the attacker sees the
-        // rejection. Bounded so a hung SecureStore write can't hang unlock.
-        await this.saveThrottleBounded(updated);
+        // Durably persist the increment BEFORE resolving, inside the mutex, so a
+        // force-kill immediately after a failed guess can't race the write on a
+        // non-rooted device (the counter is on disk when the attacker sees the
+        // rejection), and the mutex guarantees writes land in order. This is a
+        // plain unbounded await like every other SecureStore write in the app —
+        // a genuine keychain hang is a device-broken condition, not the
+        // throttle's job to special-case.
+        await this.saveThrottle(updated);
         return false;
       } catch (error) {
         console.warn('PIN verification failed');
@@ -1320,33 +1321,15 @@ export class AccountSecureStorage {
   }
 
   /**
-   * Persist the throttle, but never block unlock for longer than
-   * THROTTLE_PERSIST_TIMEOUT_MS. `saveThrottle` never rejects (it swallows write
-   * errors), so the normal path resolves as soon as the write completes — making
-   * the increment durable before verifyPin returns. If SecureStore hangs, the
-   * timeout wins and we proceed; the in-memory mirror still enforces the count.
+   * Clear the throttle on a verified PIN. Clears the in-memory mirror
+   * SYNCHRONOUSLY so the session resets immediately, then fires the persisted
+   * delete FIRE-AND-FORGET — a correct PIN must never hang on the delete. A
+   * slow/failed delete just leaves a stale persisted counter, which fails safe
+   * (worst case the user is nearer a lockout, never further from one).
    */
-  private static saveThrottleBounded(record: PinThrottleRecord): Promise<void> {
-    return new Promise<void>((resolve) => {
-      let settled = false;
-      const finish = () => {
-        if (!settled) {
-          settled = true;
-          resolve();
-        }
-      };
-      const timer = setTimeout(finish, THROTTLE_PERSIST_TIMEOUT_MS);
-      void this.saveThrottle(record).finally(() => {
-        clearTimeout(timer);
-        finish();
-      });
-    });
-  }
-
-  private static async resetThrottle(): Promise<void> {
-    // Clear BOTH the session mirror and the persisted record on a verified PIN.
+  private static resetThrottle(): void {
     this.throttleMirror = { failCount: 0, lockoutUntil: null, lastFailAt: 0 };
-    await secureStorage.deleteItem(this.PIN_THROTTLE_KEY).catch(() => {});
+    void secureStorage.deleteItem(this.PIN_THROTTLE_KEY).catch(() => {});
   }
 
   /**

--- a/src/services/secure/AccountSecureStorage.ts
+++ b/src/services/secure/AccountSecureStorage.ts
@@ -38,6 +38,39 @@ import {
   decryptKeyEnvelopeV2,
   MAX_KEY_BLOBS,
 } from './envelopeV2';
+import { SECURITY_CONFIG } from '../../config/security';
+
+// Persistent PIN throttle (DOC-137 §8 / TASK-26). PIN_ATTEMPT_LIMIT = fails per
+// window before a lockout; PIN_LOCKOUT_DURATION = base lockout, doubled each
+// window (see pinLockoutBackoff). Wired from the previously-dead security config.
+const { PIN_ATTEMPT_LIMIT, PIN_LOCKOUT_DURATION } = SECURITY_CONFIG;
+const THROTTLE_BACKOFF_CAP_MS = 24 * 60 * 60 * 1000; // hard cap: 24h
+
+/**
+ * Persisted PIN-throttle record. Lives in SecureStore under
+ * `voi_pin_throttle` so the lockout SURVIVES an app relaunch (killing the app
+ * no longer resets the guess counter).
+ */
+interface PinThrottleRecord {
+  /** Consecutive failed PIN attempts since the last success. */
+  failCount: number;
+  /** Epoch ms until which PIN entry is refused, or null when not locked. */
+  lockoutUntil: number | null;
+  /** Epoch ms of the most recent failure (diagnostics / future windowing). */
+  lastFailAt: number;
+}
+
+/**
+ * Lockout state surfaced to the UI (LockScreen) via `getPinThrottleState`. This
+ * is intentionally a SEPARATE read from `verifyPin` — `verifyPin` keeps its
+ * `boolean` return so no caller can mistake a truthy result object for success.
+ */
+export interface PinThrottleState {
+  /** Epoch ms the lockout ends, or null when the PIN can be entered now. */
+  lockedUntil: number | null;
+  /** Attempts left before the next lockout: max(0, LIMIT - failCount). */
+  attemptsRemaining: number;
+}
 
 type PersistedAccountMetadata = Omit<
   SecureAccountStorage,
@@ -99,6 +132,12 @@ export class AccountSecureStorage {
   private static readonly BIOMETRIC_ENABLED_KEY = 'voi_biometric_enabled';
   private static readonly DEVICE_ID_KEY = 'voi_device_installation_id';
   private static readonly PIN_TIMEOUT_KEY = 'voi_pin_timeout_setting';
+  private static readonly PIN_THROTTLE_KEY = 'voi_pin_throttle';
+
+  // In-memory promise-chain mutex serializing the throttle read-modify-write so
+  // concurrent verifyPin calls (e.g. batch signing) can never lose an
+  // increment. Modeled on the inFlightRequests dedup below.
+  private static throttleChain: Promise<unknown> = Promise.resolve();
 
   // Private key cache for batch signing performance (keeps keys secure within this module)
   private static privateKeyCache: Map<
@@ -999,66 +1038,205 @@ export class AccountSecureStorage {
     }
   }
 
+  /**
+   * Verify a PIN, enforcing the PERSISTENT throttle (DOC-137 §8 / TASK-26).
+   *
+   * IMPORTANT — return type stays `boolean` by design. DOC-137 §8.4 originally
+   * proposed returning a result object; Codex flagged that as dangerous because
+   * `if (result)` on a truthy object reads a WRONG pin as success at every
+   * un-converted caller (AuthContext, UnifiedAuthModal, SignerAuthModal,
+   * ChangePinScreen, transactionAuthController, getPrivateKey, changePin). So
+   * the throttle is enforced INTERNALLY here and lockout details are exposed to
+   * the UI through the separate `getPinThrottleState()` read — no caller changes.
+   *
+   * The whole load-check-hash-update-save sequence runs under an in-memory
+   * mutex so concurrent calls (batch signing) cannot lose an increment.
+   */
   static async verifyPin(pin: string): Promise<boolean> {
-    try {
-      if (!pin || pin.length !== 6 || !/^\d{6}$/.test(pin)) {
-        return false;
-      }
-
-      const storedData = await this.getStoredPinData();
-      if (!storedData) {
-        return false;
-      }
-
-      const salt = await this.getOrCreateSalt();
-
-      if (storedData.format === 'json') {
-        this.legacyCheckRequired = false;
-        const candidateHash = this.hashPin(pin, salt, storedData.iterations);
-        if (storedData.hash === candidateHash) {
-          if (storedData.iterations !== this.PIN_ITERATIONS) {
-            try {
-              const upgradedHash = this.hashPin(pin, salt, this.PIN_ITERATIONS);
-              await this.persistPinHash(upgradedHash, salt);
-            } catch (error) {
-              console.warn('Failed to upgrade stored PIN metadata', error);
-            }
-          }
-          return true;
-        }
-        return false;
-      }
-
-      const iterationCandidates = this.getIterationCandidates();
-
-      for (const iterations of iterationCandidates) {
-        const candidateHash = this.hashPin(pin, salt, iterations);
-        if (storedData.hash === candidateHash) {
-          if (iterations !== this.PIN_ITERATIONS) {
-            try {
-              const upgradedHash = this.hashPin(pin, salt, this.PIN_ITERATIONS);
-              await this.persistPinHash(upgradedHash, salt);
-              this.legacyCheckRequired = false;
-            } catch (error) {
-              console.warn(
-                'Failed to upgrade PIN hash to latest iteration count',
-                error
-              );
-            }
-          }
-          return true;
-        }
-      }
-
-      if (this.legacyCheckRequired === undefined) {
-        this.legacyCheckRequired = true;
-      }
-
-      return false;
-    } catch (error) {
-      console.warn('PIN verification failed');
+    // Malformed input never reaches the throttle: it can't unlock the wallet and
+    // is not produced by the UI (which only submits 6 digits), so it is not
+    // counted as an attempt.
+    if (!pin || pin.length !== 6 || !/^\d{6}$/.test(pin)) {
       return false;
     }
+
+    return this.runThrottleExclusive(async () => {
+      try {
+        const now = Date.now();
+        const throttle = await this.loadThrottle();
+
+        // Already locked out: refuse WITHOUT running the hash (saves the PBKDF2
+        // work, no timing leak) and WITHOUT incrementing (already penalized).
+        if (throttle.lockoutUntil !== null && now < throttle.lockoutUntil) {
+          return false;
+        }
+
+        const matched = await this.checkPinHash(pin);
+
+        if (matched) {
+          // Success — clear the throttle so the user starts from a clean slate.
+          if (throttle.failCount !== 0 || throttle.lockoutUntil !== null) {
+            await this.resetThrottle();
+          }
+          return true;
+        }
+
+        // Failure — increment and, at the limit, arm an escalating lockout.
+        const failCount = throttle.failCount + 1;
+        let lockoutUntil = throttle.lockoutUntil;
+        if (failCount >= PIN_ATTEMPT_LIMIT) {
+          lockoutUntil = now + this.pinLockoutBackoff(failCount);
+        }
+
+        // TODO(wave2): opt-in wipe-after-N — when the user enables the
+        // "erase wallet after N failed attempts" setting (deferred to a later
+        // PR with its own settings toggle), hook the destructive wipe here,
+        // e.g. `if (wipeAfterNEnabled && failCount >= wipeAfterN) await this.clearAll();`.
+
+        await this.saveThrottle({ failCount, lockoutUntil, lastFailAt: now });
+        return false;
+      } catch (error) {
+        console.warn('PIN verification failed');
+        return false;
+      }
+    });
+  }
+
+  /**
+   * Lockout state for the UI. SEPARATE from `verifyPin` so the boolean contract
+   * of `verifyPin` is preserved (see the note on `verifyPin`).
+   */
+  static async getPinThrottleState(): Promise<PinThrottleState> {
+    const throttle = await this.loadThrottle();
+    const now = Date.now();
+    const lockedUntil =
+      throttle.lockoutUntil !== null && now < throttle.lockoutUntil
+        ? throttle.lockoutUntil
+        : null;
+    return {
+      lockedUntil,
+      attemptsRemaining: Math.max(0, PIN_ATTEMPT_LIMIT - throttle.failCount),
+    };
+  }
+
+  /**
+   * Escalating lockout duration. Doubles every `PIN_ATTEMPT_LIMIT` failures,
+   * capped at 24h: 5 fails -> 5m, 10 -> 10m, 15 -> 20m, ... cap 24h.
+   */
+  private static pinLockoutBackoff(failCount: number): number {
+    const step = Math.floor(failCount / PIN_ATTEMPT_LIMIT) - 1;
+    const duration = PIN_LOCKOUT_DURATION * Math.pow(2, step);
+    return Math.min(duration, THROTTLE_BACKOFF_CAP_MS);
+  }
+
+  /**
+   * Serialize a throttle read-modify-write. The chain never rejects (outcomes
+   * are swallowed) so one failing task can't poison later ones.
+   */
+  private static runThrottleExclusive<T>(task: () => Promise<T>): Promise<T> {
+    const result = this.throttleChain.then(task, task);
+    this.throttleChain = result.then(
+      () => undefined,
+      () => undefined
+    );
+    return result;
+  }
+
+  private static async loadThrottle(): Promise<PinThrottleRecord> {
+    try {
+      const raw = await secureStorage.getItem(this.PIN_THROTTLE_KEY);
+      if (raw) {
+        const parsed = JSON.parse(raw) as Partial<PinThrottleRecord>;
+        return {
+          failCount:
+            typeof parsed.failCount === 'number' && parsed.failCount >= 0
+              ? parsed.failCount
+              : 0,
+          lockoutUntil:
+            typeof parsed.lockoutUntil === 'number'
+              ? parsed.lockoutUntil
+              : null,
+          lastFailAt:
+            typeof parsed.lastFailAt === 'number' ? parsed.lastFailAt : 0,
+        };
+      }
+    } catch (error) {
+      console.warn('Failed to load PIN throttle record', error);
+    }
+    return { failCount: 0, lockoutUntil: null, lastFailAt: 0 };
+  }
+
+  private static async saveThrottle(record: PinThrottleRecord): Promise<void> {
+    try {
+      await secureStorage.setItem(
+        this.PIN_THROTTLE_KEY,
+        JSON.stringify(record)
+      );
+    } catch (error) {
+      console.warn('Failed to persist PIN throttle record', error);
+    }
+  }
+
+  private static async resetThrottle(): Promise<void> {
+    await secureStorage.deleteItem(this.PIN_THROTTLE_KEY).catch(() => {});
+  }
+
+  /**
+   * Extracted PIN-hash verification (formerly inline in verifyPin). Returns
+   * whether the supplied PIN matches the stored hash. Runs the PBKDF2 hash, so
+   * verifyPin skips it entirely while locked out.
+   */
+  private static async checkPinHash(pin: string): Promise<boolean> {
+    const storedData = await this.getStoredPinData();
+    if (!storedData) {
+      return false;
+    }
+
+    const salt = await this.getOrCreateSalt();
+
+    if (storedData.format === 'json') {
+      this.legacyCheckRequired = false;
+      const candidateHash = this.hashPin(pin, salt, storedData.iterations);
+      if (storedData.hash === candidateHash) {
+        if (storedData.iterations !== this.PIN_ITERATIONS) {
+          try {
+            const upgradedHash = this.hashPin(pin, salt, this.PIN_ITERATIONS);
+            await this.persistPinHash(upgradedHash, salt);
+          } catch (error) {
+            console.warn('Failed to upgrade stored PIN metadata', error);
+          }
+        }
+        return true;
+      }
+      return false;
+    }
+
+    const iterationCandidates = this.getIterationCandidates();
+
+    for (const iterations of iterationCandidates) {
+      const candidateHash = this.hashPin(pin, salt, iterations);
+      if (storedData.hash === candidateHash) {
+        if (iterations !== this.PIN_ITERATIONS) {
+          try {
+            const upgradedHash = this.hashPin(pin, salt, this.PIN_ITERATIONS);
+            await this.persistPinHash(upgradedHash, salt);
+            this.legacyCheckRequired = false;
+          } catch (error) {
+            console.warn(
+              'Failed to upgrade PIN hash to latest iteration count',
+              error
+            );
+          }
+        }
+        return true;
+      }
+    }
+
+    if (this.legacyCheckRequired === undefined) {
+      this.legacyCheckRequired = true;
+    }
+
+    return false;
   }
 
   static async hasPin(): Promise<boolean> {
@@ -1341,6 +1519,7 @@ export class AccountSecureStorage {
         this.BIOMETRIC_ENABLED_KEY,
         this.METADATA_LIST_KEY,
         this.PIN_TIMEOUT_KEY,
+        this.PIN_THROTTLE_KEY,
       ]);
       // Clear from secure storage
       await Promise.all([
@@ -1349,6 +1528,8 @@ export class AccountSecureStorage {
         secureStorage.deleteItem(this.BIOMETRIC_ENABLED_KEY).catch(() => {}),
         secureStorage.deleteItem(this.METADATA_LIST_KEY).catch(() => {}),
         secureStorage.deleteItem(this.PIN_TIMEOUT_KEY).catch(() => {}),
+        // Reset the persistent PIN throttle so a fresh wallet starts unlocked.
+        secureStorage.deleteItem(this.PIN_THROTTLE_KEY).catch(() => {}),
       ]);
     } catch (error) {
       throw new AccountStorageError('Failed to clear all secure storage');

--- a/src/services/secure/AccountSecureStorage.ts
+++ b/src/services/secure/AccountSecureStorage.ts
@@ -139,6 +139,14 @@ export class AccountSecureStorage {
   // increment. Modeled on the inFlightRequests dedup below.
   private static throttleChain: Promise<unknown> = Promise.resolve();
 
+  // In-memory mirror of the throttle state (DOC-137 §8 / TASK-26, Codex P1).
+  // The EFFECTIVE throttle enforced by verifyPin is the MORE RESTRICTIVE of the
+  // persisted record and this mirror, so a swallowed write failure or a
+  // mid-session tamper of the persisted record can't grant free guesses within
+  // the session. null = nothing observed yet this process. Cleared on success
+  // (resetThrottle) and on clearAll.
+  private static throttleMirror: PinThrottleRecord | null = null;
+
   // Private key cache for batch signing performance (keeps keys secure within this module)
   private static privateKeyCache: Map<
     string,
@@ -1063,7 +1071,10 @@ export class AccountSecureStorage {
     return this.runThrottleExclusive(async () => {
       try {
         const now = Date.now();
-        const throttle = await this.loadThrottle();
+        // Effective = MORE RESTRICTIVE of the (fail-closed) persisted record and
+        // the in-memory mirror. This also raises the mirror to the persisted
+        // level so the session never forgets a lockout.
+        const throttle = await this.loadEffectiveThrottle(now);
 
         // Already locked out: refuse WITHOUT running the hash (saves the PBKDF2
         // work, no timing leak) and WITHOUT incrementing (already penalized).
@@ -1075,9 +1086,7 @@ export class AccountSecureStorage {
 
         if (matched) {
           // Success — clear the throttle so the user starts from a clean slate.
-          if (throttle.failCount !== 0 || throttle.lockoutUntil !== null) {
-            await this.resetThrottle();
-          }
+          await this.resetThrottle();
           return true;
         }
 
@@ -1093,7 +1102,15 @@ export class AccountSecureStorage {
         // PR with its own settings toggle), hook the destructive wipe here,
         // e.g. `if (wipeAfterNEnabled && failCount >= wipeAfterN) await this.clearAll();`.
 
-        await this.saveThrottle({ failCount, lockoutUntil, lastFailAt: now });
+        const updated: PinThrottleRecord = {
+          failCount,
+          lockoutUntil,
+          lastFailAt: now,
+        };
+        // Update the mirror FIRST so the session keeps enforcing the increment
+        // even if the persisted write below fails (write fails CLOSED).
+        this.throttleMirror = updated;
+        await this.saveThrottle(updated);
         return false;
       } catch (error) {
         console.warn('PIN verification failed');
@@ -1104,19 +1121,24 @@ export class AccountSecureStorage {
 
   /**
    * Lockout state for the UI. SEPARATE from `verifyPin` so the boolean contract
-   * of `verifyPin` is preserved (see the note on `verifyPin`).
+   * of `verifyPin` is preserved (see the note on `verifyPin`). Runs under the
+   * throttle mutex and reports the same fail-closed effective state verifyPin
+   * enforces (persisted ⊔ mirror), so the UI can't show "unlocked" while the
+   * session is actually locked out from a corrupt/tampered persisted record.
    */
   static async getPinThrottleState(): Promise<PinThrottleState> {
-    const throttle = await this.loadThrottle();
-    const now = Date.now();
-    const lockedUntil =
-      throttle.lockoutUntil !== null && now < throttle.lockoutUntil
-        ? throttle.lockoutUntil
-        : null;
-    return {
-      lockedUntil,
-      attemptsRemaining: Math.max(0, PIN_ATTEMPT_LIMIT - throttle.failCount),
-    };
+    return this.runThrottleExclusive(async () => {
+      const now = Date.now();
+      const throttle = await this.loadEffectiveThrottle(now);
+      const lockedUntil =
+        throttle.lockoutUntil !== null && now < throttle.lockoutUntil
+          ? throttle.lockoutUntil
+          : null;
+      return {
+        lockedUntil,
+        attemptsRemaining: Math.max(0, PIN_ATTEMPT_LIMIT - throttle.failCount),
+      };
+    });
   }
 
   /**
@@ -1142,42 +1164,134 @@ export class AccountSecureStorage {
     return result;
   }
 
-  private static async loadThrottle(): Promise<PinThrottleRecord> {
-    try {
-      const raw = await secureStorage.getItem(this.PIN_THROTTLE_KEY);
-      if (raw) {
-        const parsed = JSON.parse(raw) as Partial<PinThrottleRecord>;
-        return {
-          failCount:
-            typeof parsed.failCount === 'number' && parsed.failCount >= 0
-              ? parsed.failCount
-              : 0,
-          lockoutUntil:
-            typeof parsed.lockoutUntil === 'number'
-              ? parsed.lockoutUntil
-              : null,
-          lastFailAt:
-            typeof parsed.lastFailAt === 'number' ? parsed.lastFailAt : 0,
-        };
-      }
-    } catch (error) {
-      console.warn('Failed to load PIN throttle record', error);
+  /**
+   * A bounded fail-closed lockout used when the persisted throttle can't be
+   * trusted (corrupt value or read error). One lockout window, NOT permanent —
+   * a rare genuine corruption costs the user a single wait, never a wipe.
+   */
+  private static failClosedRecord(now: number): PinThrottleRecord {
+    return {
+      failCount: PIN_ATTEMPT_LIMIT,
+      lockoutUntil: now + PIN_LOCKOUT_DURATION,
+      lastFailAt: now,
+    };
+  }
+
+  private static isValidThrottleRecord(
+    value: unknown
+  ): value is PinThrottleRecord {
+    if (typeof value !== 'object' || value === null) {
+      return false;
     }
-    return { failCount: 0, lockoutUntil: null, lastFailAt: 0 };
+    const v = value as Record<string, unknown>;
+    const failOk =
+      typeof v.failCount === 'number' &&
+      Number.isFinite(v.failCount) &&
+      v.failCount >= 0;
+    const lockOk =
+      v.lockoutUntil === null ||
+      (typeof v.lockoutUntil === 'number' && Number.isFinite(v.lockoutUntil));
+    const lastOk =
+      typeof v.lastFailAt === 'number' && Number.isFinite(v.lastFailAt);
+    return failOk && lockOk && lastOk;
+  }
+
+  /**
+   * Load the PERSISTED throttle record, failing CLOSED on anything untrusted
+   * (Codex P1). ONLY a genuinely-absent key (fresh install / post-reset /
+   * post-success) yields a clean record:
+   *   - getItem throws (read/IO error, e.g. tampered device)  -> fail closed
+   *   - value present but unparseable / wrong shape (corrupt) -> fail closed
+   *     (+ best-effort overwrite so it re-persists as a valid record)
+   *   - getItem returns null (absent)                          -> clean
+   */
+  private static async loadPersistedThrottle(
+    now: number
+  ): Promise<PinThrottleRecord> {
+    let raw: string | null;
+    try {
+      raw = await secureStorage.getItem(this.PIN_THROTTLE_KEY);
+    } catch {
+      // Read/IO error — do NOT assume clean. Enforce a bounded lockout.
+      console.warn('PIN throttle read failed; enforcing lockout');
+      return this.failClosedRecord(now);
+    }
+
+    if (raw === null) {
+      // Key genuinely absent — clean slate.
+      return { failCount: 0, lockoutUntil: null, lastFailAt: 0 };
+    }
+
+    let parsed: unknown;
+    try {
+      parsed = JSON.parse(raw);
+    } catch {
+      parsed = undefined;
+    }
+
+    if (this.isValidThrottleRecord(parsed)) {
+      return {
+        failCount: parsed.failCount,
+        lockoutUntil: parsed.lockoutUntil,
+        lastFailAt: parsed.lastFailAt,
+      };
+    }
+
+    // Present but corrupt (bad JSON or wrong shape) — fail closed, and
+    // best-effort re-persist a valid fail-closed record over the garbage.
+    console.warn('PIN throttle record corrupt; enforcing lockout');
+    const failClosed = this.failClosedRecord(now);
+    await this.saveThrottle(failClosed);
+    return failClosed;
+  }
+
+  /** Return the more-restrictive of two throttle records. */
+  private static combineThrottle(
+    a: PinThrottleRecord,
+    b: PinThrottleRecord
+  ): PinThrottleRecord {
+    const lock = Math.max(a.lockoutUntil ?? 0, b.lockoutUntil ?? 0);
+    return {
+      failCount: Math.max(a.failCount, b.failCount),
+      lockoutUntil: lock > 0 ? lock : null,
+      lastFailAt: Math.max(a.lastFailAt, b.lastFailAt),
+    };
+  }
+
+  /**
+   * Effective throttle = MORE RESTRICTIVE of the (fail-closed) persisted record
+   * and the in-memory mirror. Raises the mirror to the combined value so the
+   * session never forgets a lockout. MUST be called under the throttle mutex.
+   */
+  private static async loadEffectiveThrottle(
+    now: number
+  ): Promise<PinThrottleRecord> {
+    const persisted = await this.loadPersistedThrottle(now);
+    const effective = this.throttleMirror
+      ? this.combineThrottle(persisted, this.throttleMirror)
+      : persisted;
+    this.throttleMirror = effective;
+    return effective;
   }
 
   private static async saveThrottle(record: PinThrottleRecord): Promise<void> {
+    // Best-effort persist. A failure here does NOT reset the counter: the
+    // in-memory mirror (updated by the caller BEFORE this call) keeps enforcing
+    // for the session, and the persisted record — if it survives — remains at
+    // its prior (>=) value. We never write a weaker state on failure.
     try {
       await secureStorage.setItem(
         this.PIN_THROTTLE_KEY,
         JSON.stringify(record)
       );
-    } catch (error) {
-      console.warn('Failed to persist PIN throttle record', error);
+    } catch {
+      console.warn('Failed to persist PIN throttle record');
     }
   }
 
   private static async resetThrottle(): Promise<void> {
+    // Clear BOTH the session mirror and the persisted record on a verified PIN.
+    this.throttleMirror = { failCount: 0, lockoutUntil: null, lastFailAt: 0 };
     await secureStorage.deleteItem(this.PIN_THROTTLE_KEY).catch(() => {});
   }
 
@@ -1531,6 +1645,9 @@ export class AccountSecureStorage {
         // Reset the persistent PIN throttle so a fresh wallet starts unlocked.
         secureStorage.deleteItem(this.PIN_THROTTLE_KEY).catch(() => {}),
       ]);
+      // Also clear the in-memory throttle mirror so the fresh wallet isn't
+      // held under a prior session's lockout.
+      this.throttleMirror = null;
     } catch (error) {
       throw new AccountStorageError('Failed to clear all secure storage');
     }

--- a/src/services/secure/__tests__/pinThrottle.test.ts
+++ b/src/services/secure/__tests__/pinThrottle.test.ts
@@ -246,6 +246,17 @@ describe('verifyPin throttle behavior', () => {
     expect(await AccountSecureStorage.verifyPin(CORRECT_PIN)).toBe(false);
   });
 
+  it('durably persists a single increment before verifyPin resolves (force-kill race)', async () => {
+    // verifyPin awaits the persist, so once it resolves false the record is
+    // already on disk. Clearing the mirror (fresh process after a force-kill)
+    // must still show the increment purely from the persisted record.
+    expect(await failOnce()).toBe(false);
+    expect(mockPlatform.__secure.has(THROTTLE_KEY)).toBe(true); // persisted, not fire-and-forget
+
+    resetThrottleMirror();
+    expect((await getState()).attemptsRemaining).toBe(PIN_ATTEMPT_LIMIT - 1);
+  });
+
   it('does not lose increments under concurrent verifyPin (mutex)', async () => {
     // Fire (LIMIT - 1) wrong PINs in parallel — all should count (stays under
     // the lockout threshold). Without the mutex, concurrent read-modify-write

--- a/src/services/secure/__tests__/pinThrottle.test.ts
+++ b/src/services/secure/__tests__/pinThrottle.test.ts
@@ -238,6 +238,34 @@ describe('verifyPin throttle behavior', () => {
     await pendingDelete;
   });
 
+  it('orders the reset-delete before a later increment (no clobber)', async () => {
+    // Defer the persisted delete so an UNORDERED delete would land AFTER the
+    // later increment and erase it. Because resetThrottle enqueues the delete on
+    // the same serialization chain as increments, the order is delete -> then
+    // increment, so the increment's record is the final on-disk state.
+    jest.spyOn(platform.secureStorage, 'deleteItem').mockImplementation(
+      (k: string) =>
+        new Promise<void>((resolve) => {
+          setTimeout(() => {
+            mockPlatform.__secure.delete(k);
+            resolve();
+          }, 0);
+        })
+    );
+
+    // Correct PIN (triggers reset+delete) immediately followed by a wrong PIN.
+    expect(await AccountSecureStorage.verifyPin(CORRECT_PIN)).toBe(true);
+    expect(await AccountSecureStorage.verifyPin(WRONG_PIN)).toBe(false);
+
+    // Let any deferred delete settle (it must have run BEFORE the increment).
+    await new Promise((resolve) => setTimeout(resolve, 20));
+
+    const raw = mockPlatform.__secure.get(THROTTLE_KEY);
+    expect(raw).toBeDefined(); // increment NOT erased by a late delete
+    expect(JSON.parse(raw as string).failCount).toBe(1);
+    expect((await getState()).attemptsRemaining).toBe(PIN_ATTEMPT_LIMIT - 1);
+  });
+
   it('clears the lockout once the window elapses, then allows a retry', async () => {
     for (let i = 0; i < PIN_ATTEMPT_LIMIT; i++) {
       await failOnce();

--- a/src/services/secure/__tests__/pinThrottle.test.ts
+++ b/src/services/secure/__tests__/pinThrottle.test.ts
@@ -1,0 +1,272 @@
+// Unit tests for the PERSISTENT PIN throttle (DOC-137 §8 / TASK-26).
+//
+// Proves that AccountSecureStorage.verifyPin (which KEEPS its boolean return):
+//   - counts wrong PINs and locks out at PIN_ATTEMPT_LIMIT,
+//   - while locked, refuses WITHOUT running the PBKDF2 hash (even a correct PIN),
+//   - resets on success,
+//   - persists the lockout across a simulated relaunch (record lives in
+//     SecureStore, not in-memory state),
+//   - never loses an increment under concurrent calls (promise-chain mutex),
+//   - and that the escalating backoff math + getPinThrottleState values are correct.
+//
+// SECURITY NOTE: PINs here are throwaway test strings; no secret or hash is logged.
+
+// In-memory platform mock (SecureStore/AsyncStorage/crypto). getRandomBytes is
+// backed by Node so salt generation runs; hashing uses the real crypto-js PBKDF2.
+jest.mock('@/platform', () => {
+  const nodeCrypto = require('crypto');
+  const secure = new Map<string, string>();
+  const kv = new Map<string, string>();
+  return {
+    __secure: secure,
+    __kv: kv,
+    __reset: () => {
+      secure.clear();
+      kv.clear();
+    },
+    crypto: {
+      getRandomBytes: async (n: number): Promise<Uint8Array> =>
+        Uint8Array.from(nodeCrypto.randomBytes(n)),
+      sha256: async (input: string): Promise<string> =>
+        nodeCrypto.createHash('sha256').update(input).digest('hex'),
+      randomUUID: () => nodeCrypto.randomUUID(),
+    },
+    secureStorage: {
+      getItem: async (k: string) => (secure.has(k) ? secure.get(k)! : null),
+      setItem: async (k: string, v: string) => {
+        secure.set(k, v);
+      },
+      deleteItem: async (k: string) => {
+        secure.delete(k);
+      },
+      getItemWithAuth: async (k: string) =>
+        secure.has(k) ? secure.get(k)! : null,
+    },
+    storage: {
+      getItem: async (k: string) => (kv.has(k) ? kv.get(k)! : null),
+      setItem: async (k: string, v: string) => {
+        kv.set(k, v);
+      },
+      removeItem: async (k: string) => {
+        kv.delete(k);
+      },
+      multiRemove: async (keys: string[]) => {
+        keys.forEach((k) => kv.delete(k));
+      },
+    },
+    biometrics: {
+      isAvailable: async () => false,
+      isEnrolled: async () => false,
+    },
+    deviceId: {
+      getDeviceId: async () => 'throttle-test-device-idfv',
+    },
+  };
+});
+
+import 'crypto-js/pbkdf2';
+import * as platform from '@/platform';
+import { AccountSecureStorage } from '../AccountSecureStorage';
+import { SECURITY_CONFIG } from '../../../config/security';
+
+const { PIN_ATTEMPT_LIMIT, PIN_LOCKOUT_DURATION } = SECURITY_CONFIG;
+const DAY_MS = 24 * 60 * 60 * 1000;
+const CORRECT_PIN = '123456';
+const WRONG_PIN = '000000';
+const THROTTLE_KEY = 'voi_pin_throttle';
+
+const mockPlatform = platform as unknown as {
+  __secure: Map<string, string>;
+  __reset: () => void;
+};
+
+// Deterministic clock so lockout math is exact.
+let mockNow = 1_700_000_000_000;
+
+const getState = () => AccountSecureStorage.getPinThrottleState();
+const failOnce = () => AccountSecureStorage.verifyPin(WRONG_PIN);
+
+/** Fail once, first jumping the clock past any active lockout. */
+async function failPastLockout(): Promise<void> {
+  const state = await getState();
+  if (state.lockedUntil !== null) {
+    mockNow = state.lockedUntil + 1;
+  }
+  await failOnce();
+}
+
+beforeEach(async () => {
+  mockPlatform.__reset();
+  mockNow = 1_700_000_000_000;
+  jest.spyOn(Date, 'now').mockImplementation(() => mockNow);
+  await AccountSecureStorage.storePin(CORRECT_PIN);
+});
+
+afterEach(() => {
+  jest.restoreAllMocks();
+});
+
+describe('PIN throttle backoff math (pinLockoutBackoff)', () => {
+  const backoff = (n: number): number =>
+    (
+      AccountSecureStorage as unknown as {
+        pinLockoutBackoff: (n: number) => number;
+      }
+    ).pinLockoutBackoff(n);
+
+  it('doubles the lockout every PIN_ATTEMPT_LIMIT failures', () => {
+    expect(backoff(5)).toBe(PIN_LOCKOUT_DURATION); // 5 min
+    expect(backoff(9)).toBe(PIN_LOCKOUT_DURATION); // still tier 1
+    expect(backoff(10)).toBe(PIN_LOCKOUT_DURATION * 2); // 10 min
+    expect(backoff(15)).toBe(PIN_LOCKOUT_DURATION * 4); // 20 min
+    expect(backoff(20)).toBe(PIN_LOCKOUT_DURATION * 8); // 40 min
+  });
+
+  it('caps the escalation at 24h', () => {
+    expect(backoff(50)).toBe(DAY_MS);
+    expect(backoff(200)).toBe(DAY_MS);
+  });
+});
+
+describe('verifyPin throttle behavior', () => {
+  it('starts with a clean throttle state', async () => {
+    const state = await getState();
+    expect(state).toEqual({
+      lockedUntil: null,
+      attemptsRemaining: PIN_ATTEMPT_LIMIT,
+    });
+  });
+
+  it('increments on wrong PIN and locks out at the limit', async () => {
+    for (let i = 1; i < PIN_ATTEMPT_LIMIT; i++) {
+      expect(await failOnce()).toBe(false);
+      const state = await getState();
+      expect(state.attemptsRemaining).toBe(PIN_ATTEMPT_LIMIT - i);
+      expect(state.lockedUntil).toBeNull();
+    }
+
+    // The PIN_ATTEMPT_LIMIT-th failure arms the first-tier (5 min) lockout.
+    expect(await failOnce()).toBe(false);
+    const locked = await getState();
+    expect(locked.attemptsRemaining).toBe(0);
+    expect(locked.lockedUntil).toBe(mockNow + PIN_LOCKOUT_DURATION);
+  });
+
+  it('escalates the lockout at each PIN_ATTEMPT_LIMIT multiple', async () => {
+    const expectations: [number, number][] = [
+      [5, PIN_LOCKOUT_DURATION], // 5 min
+      [10, PIN_LOCKOUT_DURATION * 2], // 10 min
+      [15, PIN_LOCKOUT_DURATION * 4], // 20 min
+    ];
+    let idx = 0;
+    for (let failCount = 1; failCount <= 15; failCount++) {
+      await failPastLockout();
+      if (idx < expectations.length && failCount === expectations[idx][0]) {
+        const state = await getState();
+        expect(state.lockedUntil).not.toBeNull();
+        expect((state.lockedUntil ?? 0) - mockNow).toBe(expectations[idx][1]);
+        idx++;
+      }
+    }
+    expect(idx).toBe(expectations.length);
+  });
+
+  it('refuses WITHOUT running the hash while locked out', async () => {
+    for (let i = 0; i < PIN_ATTEMPT_LIMIT; i++) {
+      await failOnce();
+    }
+    expect((await getState()).lockedUntil).not.toBeNull();
+
+    // Spy AFTER lockout is armed: a call during the window must not hash — and
+    // even the CORRECT pin is refused.
+    const hashSpy = jest.spyOn(
+      AccountSecureStorage as unknown as {
+        hashPin: (...a: unknown[]) => string;
+      },
+      'hashPin'
+    );
+    expect(await AccountSecureStorage.verifyPin(CORRECT_PIN)).toBe(false);
+    expect(hashSpy).not.toHaveBeenCalled();
+  });
+
+  it('resets the throttle on a successful verify', async () => {
+    await failOnce();
+    await failOnce();
+    expect((await getState()).attemptsRemaining).toBe(PIN_ATTEMPT_LIMIT - 2);
+
+    expect(await AccountSecureStorage.verifyPin(CORRECT_PIN)).toBe(true);
+
+    const state = await getState();
+    expect(state.attemptsRemaining).toBe(PIN_ATTEMPT_LIMIT);
+    expect(state.lockedUntil).toBeNull();
+    expect(mockPlatform.__secure.has(THROTTLE_KEY)).toBe(false);
+  });
+
+  it('clears the lockout once the window elapses, then allows a retry', async () => {
+    for (let i = 0; i < PIN_ATTEMPT_LIMIT; i++) {
+      await failOnce();
+    }
+    const locked = await getState();
+    expect(locked.lockedUntil).not.toBeNull();
+
+    // Jump past the lockout window.
+    mockNow = (locked.lockedUntil ?? 0) + 1;
+    expect((await getState()).lockedUntil).toBeNull();
+
+    // A correct PIN now succeeds and wipes the record.
+    expect(await AccountSecureStorage.verifyPin(CORRECT_PIN)).toBe(true);
+    expect((await getState()).attemptsRemaining).toBe(PIN_ATTEMPT_LIMIT);
+  });
+
+  it('persists the lockout across a simulated relaunch', async () => {
+    for (let i = 0; i < PIN_ATTEMPT_LIMIT; i++) {
+      await failOnce();
+    }
+    const before = await getState();
+    expect(before.lockedUntil).not.toBeNull();
+
+    // Simulate a relaunch: the ONLY app-level state that resets is in-memory
+    // (there is no in-memory throttle cache). The record lives in SecureStore,
+    // so a fresh read still reports the lockout.
+    AccountSecureStorage.clearPrivateKeyCache();
+    expect(mockPlatform.__secure.has(THROTTLE_KEY)).toBe(true);
+
+    const after = await getState();
+    expect(after.lockedUntil).toBe(before.lockedUntil);
+    // Still within the window -> even the correct PIN is refused.
+    expect(await AccountSecureStorage.verifyPin(CORRECT_PIN)).toBe(false);
+  });
+
+  it('does not lose increments under concurrent verifyPin (mutex)', async () => {
+    // Fire (LIMIT - 1) wrong PINs in parallel — all should count (stays under
+    // the lockout threshold). Without the mutex, concurrent read-modify-write
+    // would lose increments and attemptsRemaining would be too high.
+    const n = PIN_ATTEMPT_LIMIT - 1;
+    await Promise.all(Array.from({ length: n }, () => failOnce()));
+
+    const state = await getState();
+    expect(state.attemptsRemaining).toBe(PIN_ATTEMPT_LIMIT - n);
+    expect(state.lockedUntil).toBeNull();
+  });
+
+  it('does not count malformed input as an attempt', async () => {
+    expect(await AccountSecureStorage.verifyPin('12')).toBe(false);
+    expect(await AccountSecureStorage.verifyPin('abcdef')).toBe(false);
+    expect(await AccountSecureStorage.verifyPin('')).toBe(false);
+    expect((await getState()).attemptsRemaining).toBe(PIN_ATTEMPT_LIMIT);
+  });
+
+  it('clearAll wipes the persisted throttle record', async () => {
+    for (let i = 0; i < PIN_ATTEMPT_LIMIT; i++) {
+      await failOnce();
+    }
+    expect(mockPlatform.__secure.has(THROTTLE_KEY)).toBe(true);
+
+    await AccountSecureStorage.clearAll();
+    expect(mockPlatform.__secure.has(THROTTLE_KEY)).toBe(false);
+    expect(await getState()).toEqual({
+      lockedUntil: null,
+      attemptsRemaining: PIN_ATTEMPT_LIMIT,
+    });
+  });
+});

--- a/src/services/secure/__tests__/pinThrottle.test.ts
+++ b/src/services/secure/__tests__/pinThrottle.test.ts
@@ -86,6 +86,13 @@ let mockNow = 1_700_000_000_000;
 const getState = () => AccountSecureStorage.getPinThrottleState();
 const failOnce = () => AccountSecureStorage.verifyPin(WRONG_PIN);
 
+// Reset the private in-memory throttle mirror to simulate a fresh process.
+const resetThrottleMirror = () => {
+  (
+    AccountSecureStorage as unknown as { throttleMirror: unknown }
+  ).throttleMirror = null;
+};
+
 /** Fail once, first jumping the clock past any active lockout. */
 async function failPastLockout(): Promise<void> {
   const state = await getState();
@@ -97,6 +104,7 @@ async function failPastLockout(): Promise<void> {
 
 beforeEach(async () => {
   mockPlatform.__reset();
+  resetThrottleMirror();
   mockNow = 1_700_000_000_000;
   jest.spyOn(Date, 'now').mockImplementation(() => mockNow);
   await AccountSecureStorage.storePin(CORRECT_PIN);
@@ -225,10 +233,11 @@ describe('verifyPin throttle behavior', () => {
     const before = await getState();
     expect(before.lockedUntil).not.toBeNull();
 
-    // Simulate a relaunch: the ONLY app-level state that resets is in-memory
-    // (there is no in-memory throttle cache). The record lives in SecureStore,
-    // so a fresh read still reports the lockout.
+    // Simulate a relaunch: a fresh process starts with an EMPTY in-memory
+    // mirror; only the SecureStore record survives. Clearing the mirror proves
+    // the persisted record alone still enforces the lockout.
     AccountSecureStorage.clearPrivateKeyCache();
+    resetThrottleMirror();
     expect(mockPlatform.__secure.has(THROTTLE_KEY)).toBe(true);
 
     const after = await getState();
@@ -268,5 +277,108 @@ describe('verifyPin throttle behavior', () => {
       lockedUntil: null,
       attemptsRemaining: PIN_ATTEMPT_LIMIT,
     });
+  });
+});
+
+// Codex P1: the throttle must fail CLOSED. A corrupt record, a read/IO error,
+// or a swallowed write failure must NOT reset the counter and let an attacker
+// keep guessing. Only a genuinely-absent record (fresh install) is clean.
+describe('PIN throttle fails closed (Codex P1)', () => {
+  it('treats a corrupt/unparseable stored record as locked, without hashing', async () => {
+    // A rooted/tampered device overwrites the record with garbage to reset it.
+    mockPlatform.__secure.set(THROTTLE_KEY, 'not-json-{{{');
+    resetThrottleMirror(); // fresh process re-reads the tampered persisted value
+
+    const hashSpy = jest.spyOn(
+      AccountSecureStorage as unknown as {
+        hashPin: (...a: unknown[]) => string;
+      },
+      'hashPin'
+    );
+
+    // Even the correct PIN is refused while fail-closed, and no hash is run.
+    expect(await AccountSecureStorage.verifyPin(CORRECT_PIN)).toBe(false);
+    expect(hashSpy).not.toHaveBeenCalled();
+
+    const state = await getState();
+    expect(state.lockedUntil).toBe(mockNow + PIN_LOCKOUT_DURATION);
+    expect(state.attemptsRemaining).toBe(0);
+  });
+
+  it('best-effort repairs a corrupt record into a valid fail-closed record', async () => {
+    mockPlatform.__secure.set(THROTTLE_KEY, '{ broken');
+    resetThrottleMirror();
+
+    await getState(); // triggers the corrupt-detection + repair write
+
+    const repaired = mockPlatform.__secure.get(THROTTLE_KEY);
+    expect(repaired).toBeDefined();
+    const parsed = JSON.parse(repaired as string);
+    expect(parsed.failCount).toBe(PIN_ATTEMPT_LIMIT);
+    expect(parsed.lockoutUntil).toBe(mockNow + PIN_LOCKOUT_DURATION);
+  });
+
+  it('treats a read/IO error as locked, without hashing', async () => {
+    resetThrottleMirror();
+    jest
+      .spyOn(platform.secureStorage, 'getItem')
+      .mockImplementation(async (k: string) => {
+        if (k === THROTTLE_KEY) {
+          throw new Error('secure read failure');
+        }
+        return mockPlatform.__secure.has(k)
+          ? (mockPlatform.__secure.get(k) as string)
+          : null;
+      });
+
+    const hashSpy = jest.spyOn(
+      AccountSecureStorage as unknown as {
+        hashPin: (...a: unknown[]) => string;
+      },
+      'hashPin'
+    );
+
+    expect(await AccountSecureStorage.verifyPin(CORRECT_PIN)).toBe(false);
+    expect(hashSpy).not.toHaveBeenCalled();
+
+    const state = await getState();
+    expect(state.lockedUntil).not.toBeNull();
+    expect(state.attemptsRemaining).toBe(0);
+  });
+
+  it('enforces via the in-memory mirror when the persisted write fails', async () => {
+    // SecureStore writes fail (e.g. disk/IO error): the persisted record never
+    // updates, but the mirror must still count the failures within the session.
+    jest
+      .spyOn(platform.secureStorage, 'setItem')
+      .mockRejectedValue(new Error('secure write failure'));
+
+    // Two wrong attempts: the mirror tracks them even though nothing persisted.
+    await failOnce();
+    await failOnce();
+    expect(mockPlatform.__secure.has(THROTTLE_KEY)).toBe(false); // never written
+    expect((await getState()).attemptsRemaining).toBe(PIN_ATTEMPT_LIMIT - 2);
+
+    // Continue to the limit: the mirror locks out even with no persistence.
+    for (let i = 2; i < PIN_ATTEMPT_LIMIT; i++) {
+      await failOnce();
+    }
+    const locked = await getState();
+    expect(locked.attemptsRemaining).toBe(0);
+    expect(locked.lockedUntil).not.toBeNull();
+    // A locked session refuses even the correct PIN — purely via the mirror.
+    expect(await AccountSecureStorage.verifyPin(CORRECT_PIN)).toBe(false);
+  });
+
+  it('a genuinely-absent record stays clean (does not fail closed)', async () => {
+    // No throttle key present (fresh install) — must be unlocked, LIMIT attempts.
+    resetThrottleMirror();
+    expect(mockPlatform.__secure.has(THROTTLE_KEY)).toBe(false);
+    expect(await getState()).toEqual({
+      lockedUntil: null,
+      attemptsRemaining: PIN_ATTEMPT_LIMIT,
+    });
+    // And a correct PIN still verifies normally.
+    expect(await AccountSecureStorage.verifyPin(CORRECT_PIN)).toBe(true);
   });
 });

--- a/src/services/secure/__tests__/pinThrottle.test.ts
+++ b/src/services/secure/__tests__/pinThrottle.test.ts
@@ -317,6 +317,22 @@ describe('verifyPin throttle behavior', () => {
       attemptsRemaining: PIN_ATTEMPT_LIMIT,
     });
   });
+
+  it('serializes the throttle wipe with an in-flight verifyPin (no phantom lockout)', async () => {
+    // Race an in-flight wrong-PIN increment against a wallet reset. Because
+    // clearAll wipes the throttle through the SAME mutex, the increment is
+    // serialized ahead of the wipe and persists FIRST, then the wipe removes it —
+    // it can never land after the wipe and leave a stale lockout behind.
+    const verify = AccountSecureStorage.verifyPin(WRONG_PIN);
+    const reset = AccountSecureStorage.clearAll();
+    await Promise.all([verify, reset]);
+
+    // No stale increment survives the reset.
+    expect(mockPlatform.__secure.has(THROTTLE_KEY)).toBe(false);
+    const state = await getState();
+    expect(state.attemptsRemaining).toBe(PIN_ATTEMPT_LIMIT);
+    expect(state.lockedUntil).toBeNull();
+  });
 });
 
 // Codex P1: the throttle must fail CLOSED. A corrupt record, a read/IO error,

--- a/src/services/secure/__tests__/pinThrottle.test.ts
+++ b/src/services/secure/__tests__/pinThrottle.test.ts
@@ -210,58 +210,16 @@ describe('verifyPin throttle behavior', () => {
     expect(mockPlatform.__secure.has(THROTTLE_KEY)).toBe(false);
   });
 
-  it('resolves a correct PIN without awaiting the persisted reset delete', async () => {
-    // Prime a non-clean throttle so the reset has something to delete.
-    await failOnce();
-    await failOnce();
-    expect(mockPlatform.__secure.has(THROTTLE_KEY)).toBe(true);
-
-    // Make the persisted delete hang indefinitely — a correct PIN must NOT wait
-    // on it (the reset clears the mirror synchronously + fires the delete).
-    let releaseDelete: () => void = () => {};
-    const pendingDelete = new Promise<void>((resolve) => {
-      releaseDelete = resolve;
-    });
-    jest
-      .spyOn(platform.secureStorage, 'deleteItem')
-      .mockReturnValue(pendingDelete);
-
-    // Resolves promptly (if it awaited the delete, this would time out)…
-    expect(await AccountSecureStorage.verifyPin(CORRECT_PIN)).toBe(true);
-    // …and the in-memory mirror is already clean, synchronously.
-    expect(
-      (AccountSecureStorage as unknown as { throttleMirror: unknown })
-        .throttleMirror
-    ).toEqual({ failCount: 0, lockoutUntil: null, lastFailAt: 0 });
-
-    releaseDelete(); // clean up the pending promise
-    await pendingDelete;
-  });
-
-  it('orders the reset-delete before a later increment (no clobber)', async () => {
-    // Defer the persisted delete so an UNORDERED delete would land AFTER the
-    // later increment and erase it. Because resetThrottle enqueues the delete on
-    // the same serialization chain as increments, the order is delete -> then
-    // increment, so the increment's record is the final on-disk state.
-    jest.spyOn(platform.secureStorage, 'deleteItem').mockImplementation(
-      (k: string) =>
-        new Promise<void>((resolve) => {
-          setTimeout(() => {
-            mockPlatform.__secure.delete(k);
-            resolve();
-          }, 0);
-        })
-    );
-
-    // Correct PIN (triggers reset+delete) immediately followed by a wrong PIN.
-    expect(await AccountSecureStorage.verifyPin(CORRECT_PIN)).toBe(true);
-    expect(await AccountSecureStorage.verifyPin(WRONG_PIN)).toBe(false);
-
-    // Let any deferred delete settle (it must have run BEFORE the increment).
-    await new Promise((resolve) => setTimeout(resolve, 20));
+  it('a reset then a later increment persists the increment, ordered in-mutex', async () => {
+    // Both the reset (delete) and the increment (save) are plain awaited writes
+    // in the same mutex, so they serialize: reset clears the counter, then the
+    // later increment reads clean and persists 1 — never clobbered or doubled.
+    await failOnce(); // failCount 1
+    expect(await AccountSecureStorage.verifyPin(CORRECT_PIN)).toBe(true); // reset -> clean
+    expect(await AccountSecureStorage.verifyPin(WRONG_PIN)).toBe(false); // reads clean -> 1
 
     const raw = mockPlatform.__secure.get(THROTTLE_KEY);
-    expect(raw).toBeDefined(); // increment NOT erased by a late delete
+    expect(raw).toBeDefined(); // increment persisted, not erased by the reset
     expect(JSON.parse(raw as string).failCount).toBe(1);
     expect((await getState()).attemptsRemaining).toBe(PIN_ATTEMPT_LIMIT - 1);
   });

--- a/src/services/secure/__tests__/pinThrottle.test.ts
+++ b/src/services/secure/__tests__/pinThrottle.test.ts
@@ -210,6 +210,34 @@ describe('verifyPin throttle behavior', () => {
     expect(mockPlatform.__secure.has(THROTTLE_KEY)).toBe(false);
   });
 
+  it('resolves a correct PIN without awaiting the persisted reset delete', async () => {
+    // Prime a non-clean throttle so the reset has something to delete.
+    await failOnce();
+    await failOnce();
+    expect(mockPlatform.__secure.has(THROTTLE_KEY)).toBe(true);
+
+    // Make the persisted delete hang indefinitely — a correct PIN must NOT wait
+    // on it (the reset clears the mirror synchronously + fires the delete).
+    let releaseDelete: () => void = () => {};
+    const pendingDelete = new Promise<void>((resolve) => {
+      releaseDelete = resolve;
+    });
+    jest
+      .spyOn(platform.secureStorage, 'deleteItem')
+      .mockReturnValue(pendingDelete);
+
+    // Resolves promptly (if it awaited the delete, this would time out)…
+    expect(await AccountSecureStorage.verifyPin(CORRECT_PIN)).toBe(true);
+    // …and the in-memory mirror is already clean, synchronously.
+    expect(
+      (AccountSecureStorage as unknown as { throttleMirror: unknown })
+        .throttleMirror
+    ).toEqual({ failCount: 0, lockoutUntil: null, lastFailAt: 0 });
+
+    releaseDelete(); // clean up the pending promise
+    await pendingDelete;
+  });
+
   it('clears the lockout once the window elapses, then allows a retry', async () => {
     for (let i = 0; i < PIN_ATTEMPT_LIMIT; i++) {
       await failOnce();
@@ -255,6 +283,20 @@ describe('verifyPin throttle behavior', () => {
 
     resetThrottleMirror();
     expect((await getState()).attemptsRemaining).toBe(PIN_ATTEMPT_LIMIT - 1);
+  });
+
+  it('persists sequential increments in order (no out-of-order clobber)', async () => {
+    // Two awaited increments through the mutex land 1 then 2 in order — there is
+    // no timed-out write that could complete late and overwrite a newer counter.
+    await failOnce();
+    expect(
+      JSON.parse(mockPlatform.__secure.get(THROTTLE_KEY) as string).failCount
+    ).toBe(1);
+    await failOnce();
+    expect(
+      JSON.parse(mockPlatform.__secure.get(THROTTLE_KEY) as string).failCount
+    ).toBe(2);
+    expect((await getState()).attemptsRemaining).toBe(PIN_ATTEMPT_LIMIT - 2);
   });
 
   it('does not lose increments under concurrent verifyPin (mutex)', async () => {

--- a/src/services/secure/index.ts
+++ b/src/services/secure/index.ts
@@ -1,5 +1,6 @@
 // Core secure storage for multi-account wallet
 export { AccountSecureStorage } from './AccountSecureStorage';
+export type { PinThrottleState } from './AccountSecureStorage';
 
 // Re-export existing secure services
 export * from './keyManager';


### PR DESCRIPTION
## PR2 — Persistent PIN throttle (TASK-26, DOC-137 §8)

Moves PIN rate-limiting out of `LockScreen` React state (which **reset on app relaunch** → unlimited guessing after a kill, and only covered the LockScreen path) into a **persisted throttle enforced inside `AccountSecureStorage.verifyPin`**, so every PIN path (unlock, `getPrivateKey`, `changePin`, messaging/WC step-up) is covered and the lockout **survives restart**.

Independent of the key-migration PRs (no key wrapping/migration here).

### Boolean-preserving design (improves on DOC-137 §8.4 — and why)
Codex flagged that changing `verifyPin`/`unlock` from `boolean` to a result object is dangerous: `if (result)` on a truthy object would read a **wrong PIN as success** at every un-converted caller (`UnifiedAuthModal`, `SignerAuthModal`, `ChangePinScreen`, `transactionAuthController`, `AuthContext.unlock`, `getPrivateKey`, `changePin`). So:

- **`verifyPin` and `AuthContext.unlock` keep returning `boolean`** — every existing caller stays correct and **untouched** (confirmed by grep; `git diff` touches only 3 source files, `AuthContext.tsx` is not among them).
- The throttle is enforced **inside** `verifyPin`: it returns `false` when locked out (without running the hash), and `true`/`false` for the real check otherwise.
- Lockout details for the UI come from a **new separate read** `getPinThrottleState(): Promise<{ lockedUntil, attemptsRemaining }>`, sidestepping the truthy-object footgun entirely.

### What changed
- **`AccountSecureStorage.ts`**
  - Persisted record in SecureStore: `voi_pin_throttle` → `{ failCount, lockoutUntil, lastFailAt }` with `loadThrottle`/`saveThrottle`/`resetThrottle` helpers.
  - `verifyPin` (boolean): load throttle → if `lockoutUntil && now < lockoutUntil` return `false` immediately (no hash, no increment) → else run the extracted `checkPinHash` → on success reset throttle → on failure `failCount++`, arm lockout at the limit.
  - `pinLockoutBackoff(n) = min(PIN_LOCKOUT_DURATION * 2^(floor(n/PIN_ATTEMPT_LIMIT) − 1), 24h)`: **5 fails → 5 min, 10 → 10 min, 15 → 20 min, … cap 24h**.
  - Wires the previously-dead constants `PIN_ATTEMPT_LIMIT` / `PIN_LOCKOUT_DURATION` from `config/security.ts`.
  - `getPinThrottleState()` (new public read) → `{ lockedUntil, attemptsRemaining: max(0, PIN_ATTEMPT_LIMIT − failCount) }`.
  - `clearAll()` now also wipes the throttle record.
  - `// TODO(wave2): opt-in wipe-after-N` placeholder left where it would hook in (deferred to a later PR with its settings toggle).
- **`LockScreen.tsx`** — deletes the local `attempts`/`isLocked`/`MAX_ATTEMPTS`/`LOCKOUT_TIME` state and the `setTimeout` reset. Reads `getPinThrottleState()` on mount + after each failed attempt, shows remaining attempts and a **live M:SS countdown** to `lockedUntil`, and surfaces `SECURITY_MESSAGES.PIN_ATTEMPTS_EXCEEDED`. The lockout now **survives relaunch** (mount read of the persisted record). `verifyPin`'s boolean usage is unchanged.
- **`secure/index.ts`** — re-exports the `PinThrottleState` type for the UI.

### Concurrency
Concurrent `verifyPin` calls (e.g. batch signing) run the whole load-check-hash-update-save under an in-memory **promise-chain mutex** (`runThrottleExclusive`, modeled on the existing `inFlightRequests` dedup): each task chains off the previous, so read-modify-write is serialized and **no increment is lost**. The chain swallows outcomes so a failing task can't poison later ones; no re-entrancy (nothing inside the critical section calls `verifyPin`).

### Tests (`src/services/secure/__tests__/pinThrottle.test.ts`, 12 cases, all green)
Backoff math incl. 24h cap; wrong PIN increments and locks at the limit; **locked-out call returns `false` without invoking the hash** (spy on `hashPin`); success resets; lockout **clears once the window elapses**; **persistence across a simulated relaunch**; **concurrent `verifyPin` loses no increments** (mutex); malformed input isn't counted; `clearAll` wipes the record; `getPinThrottleState` values. No secrets logged.

### Gates
- `npm run typecheck` → **0 errors**
- `npm run lint` → **0 errors** (net +1 warning: an unavoidable `require()` in the test's `jest.mock` factory, identical to the existing `getPrivateKey.reader.test.ts` pattern)
- `npm test -- --ci` → **25 suites / 360 tests pass**

Wipe-after-N intentionally **deferred** to a later PR.
