### PR TITLE
feat(secure): SessionKeyVault + lock-lifecycle teardown, epoch-guarded (TASK-27 PR3)

### DIFF
--- a/src/contexts/AuthContext.tsx
+++ b/src/contexts/AuthContext.tsx
@@ -9,7 +9,7 @@ import { AppState, Platform, AppStateStatus } from 'react-native';
 import { MultiAccountWalletService } from '@/services/wallet';
 import { AccountSecureStorage } from '@/services/secure';
 import { SessionKeyVault } from '@/services/secure/SessionKeyVault';
-import { clearSessionSecurity } from '@/services/secure/sessionTeardown';
+import { enterLockedState } from '@/services/secure/sessionTeardown';
 import { AppLockSignal } from '@/services/secure/appLockState';
 import { SecurityUtils } from '@/utils/security';
 import { DeepLinkService } from '@/services/deeplink';
@@ -304,6 +304,10 @@ export function AuthProvider({ children }: { children: React.ReactNode }) {
         // for decryption (the device-key path handles it) — this establishes
         // the session secret the v2-blob path will use in PR4/PR5.
         SessionKeyVault.set(pin, 'pin');
+        // Flip the lock signal to UNLOCKED synchronously (mirrors lock()) so the
+        // messaging poll/cache-write guard resumes immediately, not only after
+        // the React effect below runs.
+        AppLockSignal.setUnlocked(true);
 
         const sessionId = SecurityUtils.generateSessionId();
         setAuthState((prev) => ({
@@ -340,6 +344,9 @@ export function AuthProvider({ children }: { children: React.ReactNode }) {
         // — the device-key path decrypts without one, so this is behavior-
         // preserving. When the convenience item ships, read the secret here and
         // call SessionKeyVault.set(secret, secretSource).
+        // Flip the lock signal to UNLOCKED synchronously (mirrors lock()).
+        AppLockSignal.setUnlocked(true);
+
         const sessionId = SecurityUtils.generateSessionId();
         setAuthState((prev) => ({
           ...prev,
@@ -360,6 +367,20 @@ export function AuthProvider({ children }: { children: React.ReactNode }) {
   };
 
   const lock = () => {
+    // A no-PIN wallet cannot lock (the user could not unlock again), so it is
+    // left untouched — including its always-unlocked AppLockSignal.
+    if (authStateRef.current.hasPin) {
+      // FIRST action, synchronous, before the React state update: flip the lock
+      // signal to LOCKED and run the SINGLE session-security teardown for EVERY
+      // lock path (explicit, inactivity-timeout, background-grace all route
+      // here) — session vault (epoch bump, Codex P1-D), the legacy 60 s cache,
+      // and the ~30 min messaging cache (Codex P1-E). Doing this synchronously
+      // (not via the effect below) closes the post-lock re-cache race: an
+      // in-flight key derivation resolving during teardown sees the locked
+      // signal and refuses to repopulate the messaging cache.
+      enterLockedState();
+    }
+
     setAuthState((prev) => {
       // Don't lock if user hasn't set up a PIN - they won't be able to unlock
       if (!prev.hasPin) {
@@ -383,13 +404,6 @@ export function AuthProvider({ children }: { children: React.ReactNode }) {
       clearTimeout(backgroundTimer.current);
       backgroundTimer.current = undefined;
     }
-
-    // The SINGLE session-security teardown for EVERY lock path (explicit,
-    // inactivity-timeout, and background-grace all route through here): clear
-    // the session vault (bumping its epoch — Codex P1-D), the legacy 60 s
-    // plaintext-key cache, and the ~30 min messaging key cache (Codex P1-E).
-    // Idempotent; safe to run even when no PIN is set (all caches are empty).
-    clearSessionSecurity();
   };
 
   const setupPin = async (pin: string): Promise<void> => {

--- a/src/contexts/AuthContext.tsx
+++ b/src/contexts/AuthContext.tsx
@@ -8,6 +8,9 @@ import React, {
 import { AppState, Platform, AppStateStatus } from 'react-native';
 import { MultiAccountWalletService } from '@/services/wallet';
 import { AccountSecureStorage } from '@/services/secure';
+import { SessionKeyVault } from '@/services/secure/SessionKeyVault';
+import { clearSessionSecurity } from '@/services/secure/sessionTeardown';
+import { AppLockSignal } from '@/services/secure/appLockState';
 import { SecurityUtils } from '@/utils/security';
 import { DeepLinkService } from '@/services/deeplink';
 
@@ -94,6 +97,12 @@ export function AuthProvider({ children }: { children: React.ReactNode }) {
   const sessionTimer = useRef<NodeJS.Timeout | undefined>(undefined);
   const backgroundTimer = useRef<NodeJS.Timeout | undefined>(undefined);
 
+  // Always-fresh mirror of authState so the inactivity interval can read the
+  // latest activity/auth flags and route through the single lock() (below)
+  // rather than mutating state inline (needed so lock's session teardown runs).
+  const authStateRef = useRef(authState);
+  authStateRef.current = authState;
+
   useEffect(() => {
     checkInitialAuthState();
     setupAppStateListener();
@@ -105,13 +114,16 @@ export function AuthProvider({ children }: { children: React.ReactNode }) {
     };
   }, []);
 
-  // Sync auth state to DeepLinkService for pending notification handling
+  // Sync auth state to DeepLinkService for pending notification handling, and to
+  // the AppLockSignal so non-React services (the messaging poll) can defer while
+  // locked (DOC-137 §6.5 / Codex P1-E).
   useEffect(() => {
     const isUnlocked = authState.isAuthenticated && !authState.isLocked;
     console.log(
       `[AuthContext] Syncing unlock state: isAuthenticated=${authState.isAuthenticated}, isLocked=${authState.isLocked}, isUnlocked=${isUnlocked}`
     );
     DeepLinkService.getInstance().setUnlockState(isUnlocked);
+    AppLockSignal.setUnlocked(isUnlocked);
   }, [authState.isAuthenticated, authState.isLocked]);
 
   useEffect(() => {
@@ -128,37 +140,20 @@ export function AuthProvider({ children }: { children: React.ReactNode }) {
     const timeoutMs = authState.timeoutMinutes * 60 * 1000;
 
     activityTimer.current = setInterval(() => {
-      setAuthState((currentState) => {
-        // Don't lock if no PIN is set - user won't be able to unlock
-        if (!currentState.hasPin) {
-          return currentState;
-        }
+      // Read the latest state from the ref (the interval closure is stale) and
+      // route inactivity locking through the single lock() so its session
+      // teardown (vault + 60 s cache + messaging cache) always runs.
+      const currentState = authStateRef.current;
 
-        const now = Date.now();
-        const timeSinceLastActivity = now - currentState.lastActivity;
+      // Don't lock if no PIN is set - user won't be able to unlock
+      if (!currentState.hasPin || !currentState.isAuthenticated) {
+        return;
+      }
 
-        if (timeSinceLastActivity > timeoutMs && currentState.isAuthenticated) {
-          // Clear timers when locking
-          if (sessionTimer.current) {
-            clearTimeout(sessionTimer.current);
-            sessionTimer.current = undefined;
-          }
-          if (backgroundTimer.current) {
-            clearTimeout(backgroundTimer.current);
-            backgroundTimer.current = undefined;
-          }
-
-          // Lock the app
-          return {
-            ...currentState,
-            isLocked: true,
-            isAuthenticated: false,
-            sessionId: null,
-            backgroundedAt: null,
-          };
-        }
-        return currentState;
-      });
+      const timeSinceLastActivity = Date.now() - currentState.lastActivity;
+      if (timeSinceLastActivity > timeoutMs) {
+        lock();
+      }
     }, ACTIVITY_CHECK_INTERVAL);
 
     return () => {
@@ -304,6 +299,12 @@ export function AuthProvider({ children }: { children: React.ReactNode }) {
       const isValid = await AccountSecureStorage.verifyPin(pin);
 
       if (isValid) {
+        // Populate the session vault with the verified secret (DOC-137 §6.3).
+        // In PR3 keys are still Format A, so the vault is not yet load-bearing
+        // for decryption (the device-key path handles it) — this establishes
+        // the session secret the v2-blob path will use in PR4/PR5.
+        SessionKeyVault.set(pin, 'pin');
+
         const sessionId = SecurityUtils.generateSessionId();
         setAuthState((prev) => ({
           ...prev,
@@ -332,6 +333,13 @@ export function AuthProvider({ children }: { children: React.ReactNode }) {
       const result = await authenticateWithBiometrics('Unlock your wallet');
 
       if (result.success) {
+        // NOTE (DOC-137 §3.3, PR3): the biometric-convenience secret item that
+        // yields the user secret on biometric unlock lands in a later PR (the
+        // writer/biometric milestone). Until then biometric unlock has no user
+        // secret to populate the vault with, and — since keys are still Format A
+        // — the device-key path decrypts without one, so this is behavior-
+        // preserving. When the convenience item ships, read the secret here and
+        // call SessionKeyVault.set(secret, secretSource).
         const sessionId = SecurityUtils.generateSessionId();
         setAuthState((prev) => ({
           ...prev,
@@ -375,6 +383,13 @@ export function AuthProvider({ children }: { children: React.ReactNode }) {
       clearTimeout(backgroundTimer.current);
       backgroundTimer.current = undefined;
     }
+
+    // The SINGLE session-security teardown for EVERY lock path (explicit,
+    // inactivity-timeout, and background-grace all route through here): clear
+    // the session vault (bumping its epoch — Codex P1-D), the legacy 60 s
+    // plaintext-key cache, and the ~30 min messaging key cache (Codex P1-E).
+    // Idempotent; safe to run even when no PIN is set (all caches are empty).
+    clearSessionSecurity();
   };
 
   const setupPin = async (pin: string): Promise<void> => {

--- a/src/services/messaging/__tests__/keyDerivation.lock.test.ts
+++ b/src/services/messaging/__tests__/keyDerivation.lock.test.ts
@@ -1,0 +1,54 @@
+// Unit test for the messaging cache-write lock guard (DOC-137 §6.5 / Codex
+// P1-E race fix). A messaging keypair derived while the app is LOCKED must NOT
+// be written to the ~30 min cache, and its freshly derived secret must be
+// zeroed — this closes the race where a derivation that started before a lock
+// resolves after it and repopulates the cache (poll AND direct thread-fetch
+// paths both funnel through the single cache-write site).
+//
+// SECURITY NOTE: a throwaway tweetnacl keypair stands in for the wallet secret
+// key; no real key material is used.
+
+import nacl from 'tweetnacl';
+import {
+  deriveMessagingKeyPairFromSecret,
+  getCachedKeyPair,
+  clearAllCachedKeys,
+} from '../keyDerivation';
+import { AppLockSignal } from '@/services/secure/appLockState';
+
+const ADDRESS = 'TESTADDRESS0000000000000000000000000000000000000000000';
+
+// A valid 64-byte Ed25519 secret key (throwaway).
+const ed25519SecretKey = nacl.sign.keyPair().secretKey;
+
+beforeEach(() => {
+  clearAllCachedKeys();
+  AppLockSignal.setUnlocked(true); // default to unlocked between tests
+});
+
+afterEach(() => {
+  clearAllCachedKeys();
+  AppLockSignal.setUnlocked(true);
+});
+
+describe('messaging key cache-write lock guard', () => {
+  it('caches the derived keypair when the app is UNLOCKED', () => {
+    AppLockSignal.setUnlocked(true);
+
+    const keyPair = deriveMessagingKeyPairFromSecret(ed25519SecretKey, ADDRESS);
+
+    expect(keyPair.secretKey.some((b) => b !== 0)).toBe(true);
+    expect(getCachedKeyPair(ADDRESS)).not.toBeNull();
+  });
+
+  it('does NOT cache (and zeroes the secret) when the app is LOCKED', () => {
+    AppLockSignal.setUnlocked(false);
+
+    const keyPair = deriveMessagingKeyPairFromSecret(ed25519SecretKey, ADDRESS);
+
+    // Cache stays empty — a locked device cannot hold a live messaging key.
+    expect(getCachedKeyPair(ADDRESS)).toBeNull();
+    // The freshly derived secret was scrubbed rather than returned live.
+    expect(Array.from(keyPair.secretKey).every((b) => b === 0)).toBe(true);
+  });
+});

--- a/src/services/messaging/index.ts
+++ b/src/services/messaging/index.ts
@@ -907,6 +907,7 @@ export {
   getCachedKeyPair,
   clearCachedKey,
   clearAllCachedKeys,
+  clearMessagingKeyCache,
 } from './keyDerivation';
 export {
   lookupMessagingKey,

--- a/src/services/messaging/keyDerivation.ts
+++ b/src/services/messaging/keyDerivation.ts
@@ -229,6 +229,17 @@ export function clearAllCachedKeys(): void {
 }
 
 /**
+ * Clear the derived messaging key cache on session lock (DOC-137 §6.5 / Codex
+ * P1-E). Named entry point invoked by AuthContext.lock() (via
+ * `clearSessionSecurity`) so a locked device stops holding — and stops being
+ * able to decrypt with — the ~30 min-cached X25519 secret key. Zeroes every
+ * cached secret key. Idempotent.
+ */
+export function clearMessagingKeyCache(): void {
+  clearAllCachedKeys();
+}
+
+/**
  * Get the base64-encoded messaging public key for an account.
  * Useful for key registration.
  *

--- a/src/services/messaging/keyDerivation.ts
+++ b/src/services/messaging/keyDerivation.ts
@@ -14,6 +14,7 @@
 
 import nacl from 'tweetnacl';
 import { encodeBase64 } from 'tweetnacl-util';
+import { AppLockSignal } from '@/services/secure/appLockState';
 import {
   createMessagingChallenge,
   KDF_DOMAIN_DECRYPTION_KEY,
@@ -27,6 +28,31 @@ import {
  * For Ledger wallets: calls the hardware wallet to sign
  */
 export type SignFunction = (message: Uint8Array) => Promise<Uint8Array>;
+
+/**
+ * Cache a freshly derived messaging keypair — UNLESS the app is locked (Codex
+ * P1-E race fix). A derivation can START while unlocked and RESOLVE after a lock
+ * (its `getPrivateKey` scrypt straddled the lock, or the poll raced the lock),
+ * and repopulating the ~30 min cache then would let a locked device keep
+ * decrypting messages. When locked, the freshly derived secret is zeroed and the
+ * cache is left untouched; the returned keypair carries a zeroed secret and is
+ * therefore unusable while locked. When unlocked, this replaces any stale entry
+ * and caches the new keypair. This guards ALL derive paths (poll and direct
+ * thread-fetch) at the single point where the cache is written.
+ */
+function cacheKeyPairUnlessLocked(
+  accountAddress: string,
+  keyPair: MessagingKeyPair
+): MessagingKeyPair {
+  if (!AppLockSignal.isUnlocked()) {
+    keyPair.secretKey.fill(0);
+    return keyPair;
+  }
+  // Clear old cache entry if exists, then cache the new keypair.
+  clearCachedKey(accountAddress);
+  keyCache.set(accountAddress, keyPair);
+  return keyPair;
+}
 
 /**
  * In-memory cache for derived messaging keypairs.
@@ -122,13 +148,8 @@ export function deriveMessagingKeyPairFromSecret(
     derivedAt: now,
   };
 
-  // Clear old cache entry if exists
-  clearCachedKey(accountAddress);
-
-  // Cache the new keypair
-  keyCache.set(accountAddress, keyPair);
-
-  return keyPair;
+  // Cache the new keypair — unless the app locked while we derived (P1-E).
+  return cacheKeyPairUnlessLocked(accountAddress, keyPair);
 }
 
 /**
@@ -173,13 +194,8 @@ export async function deriveMessagingKeyPairWithSign(
     derivedAt: now,
   };
 
-  // Clear old cache entry if exists
-  clearCachedKey(accountAddress);
-
-  // Cache the new keypair
-  keyCache.set(accountAddress, keyPair);
-
-  return keyPair;
+  // Cache the new keypair — unless the app locked while we derived (P1-E).
+  return cacheKeyPairUnlessLocked(accountAddress, keyPair);
 }
 
 /**

--- a/src/services/secure/AccountSecureStorage.ts
+++ b/src/services/secure/AccountSecureStorage.ts
@@ -36,9 +36,10 @@ import {
 import {
   KeyEnvelopeV2,
   decryptKeyEnvelopeV2,
+  decryptKeyEnvelopeV2WithWrapKey,
   MAX_KEY_BLOBS,
 } from './envelopeV2';
-import { SessionKeyVault } from './SessionKeyVault';
+import { SessionKeyVault, VaultLockedError } from './SessionKeyVault';
 import { SECURITY_CONFIG } from '../../config/security';
 
 // ─────────────────────────────────────────────────────────────────────────────
@@ -538,49 +539,36 @@ export class AccountSecureStorage {
 
         let privateKey: Uint8Array | undefined;
 
-        // Vault-aware secret selection (DOC-137 §6.4, PR3). An explicit `pin` is
-        // a step-up re-auth (already verified above). When no pin is supplied
-        // but the session vault is unlocked, the vault secret drives the v2-blob
-        // path — this is what lets the ~14 `pin=undefined` callers keep working
-        // once keys become v2 (PR4/PR5). RETAINED device-key fallback: keys are
-        // still Format A in PR3, so `parsed.blobs` is empty, this branch is
-        // inert, and decryption falls through to the Format A / C candidates
-        // below EXACTLY as today. The device-key path is NOT removed and a
-        // locked vault does NOT throw here (Format A never needs the secret).
-        const vaultSecret =
-          !pin && SessionKeyVault.isUnlocked()
-            ? (SessionKeyVault.getSecret() ?? undefined)
-            : undefined;
-        const v2Secret = pin ?? vaultSecret;
-
-        // Candidate 1 (v2 blobs) — tried FIRST when a verified user secret (or
-        // the unlocked-vault secret) is available. INERT today: no production
-        // writer emits blobs yet, so every existing payload (no `blobs`) skips
-        // this and behaves exactly as before. Security anchor: every accepted
-        // result MUST pass the envelope MAC — a wrong secret cannot forge it, so
-        // the ladder simply falls through.
+        // Candidate 1 (v2 blobs) — tried FIRST when a user secret is available,
+        // in one of two modes (DOC-137 §6.4):
+        //   - explicit `pin` (step-up re-auth): decrypt directly under that
+        //     secret (its own scrypt), independent of the vault.
+        //   - no pin + unlocked vault: derive the per-blob wrap key via the
+        //     memoized, epoch-guarded SessionKeyVault.getWrapKey — the
+        //     load-bearing path that lets the ~14 `pin=undefined` callers keep
+        //     working once keys become v2 (PR4/PR5).
+        // INERT today: no production writer emits blobs yet, so every existing
+        // payload (no `blobs`) skips this and behaves exactly as before —
+        // decryption falls through to the Format A / C candidates below EXACTLY
+        // as today (device-key path retained; a locked vault does NOT throw for
+        // Format A because this branch is never entered). Security anchor: every
+        // accepted result MUST pass the envelope MAC — a wrong key cannot forge
+        // it, so the ladder simply falls through.
         if (
-          v2Secret &&
           Array.isArray(parsed.blobs) &&
-          parsed.blobs.length > 0
+          parsed.blobs.length > 0 &&
+          (pin !== undefined || SessionKeyVault.isUnlocked())
         ) {
-          // Epoch guard (Codex P1-D): when the vault (not an explicit pin)
-          // supplied the secret, capture the vault epoch before the async
-          // scrypt/decrypt. If a lock (clear) or rotate bumps the epoch mid-
-          // flight, discard the derived material — do not use it and do not let
-          // it reach the 60 s cache — and fall through to the vault-independent
-          // device-key path (unchanged for Format A).
-          const usedVault = !pin;
-          const startEpoch = usedVault ? SessionKeyVault.currentEpoch() : -1;
-          const candidate = await this.tryDecryptV2Blobs(
+          // A VaultLockedError propagating out of here means a lock
+          // (clear/rotate) landed mid-derivation (Codex P1-D): ABORT the whole
+          // read — do NOT fall through and cache a device key under a session
+          // that no longer exists. tryDecryptV2Blobs re-checks the vault epoch
+          // after every await.
+          privateKey = await this.tryDecryptV2Blobs(
+            accountId,
             parsed.blobs,
-            v2Secret
+            pin
           );
-          if (usedVault && SessionKeyVault.currentEpoch() !== startEpoch) {
-            candidate?.fill(0);
-          } else {
-            privateKey = candidate;
-          }
         }
 
         // Candidates 2 & 3 (unchanged) — Format A (device key), then Format C
@@ -622,7 +610,10 @@ export class AccountSecureStorage {
           error instanceof AccountNotFoundError ||
           error instanceof AccountStorageError ||
           error instanceof AuthenticationRequiredError ||
-          error instanceof AccountRetrievalError
+          error instanceof AccountRetrievalError ||
+          // Vault locked mid-derivation (Codex P1-D): surface as-is so the caller
+          // re-auths rather than treating it as a generic retrieval failure.
+          error instanceof VaultLockedError
         ) {
           throw error;
         }
@@ -646,31 +637,78 @@ export class AccountSecureStorage {
   }
 
   /**
-   * Trial-decrypt the v2 blob candidates under a verified user secret
-   * (DOC-137 §4.3, candidate 1). Returns the first blob whose envelope MAC
-   * verifies, or `undefined` to fall through to the legacy formats.
+   * Trial-decrypt the v2 blob candidates (DOC-137 §4.3/§6.4, candidate 1).
+   * Returns the first blob whose envelope MAC verifies, or `undefined` to fall
+   * through to the legacy formats.
    *
-   * Only up to MAX_KEY_BLOBS blobs are attempted — each attempt runs a memory-
-   * hard scrypt, so capping the attempt count is itself a DoS guard. A wrong
-   * secret cannot forge the MAC, so a non-matching blob returns null and the
-   * ladder continues.
+   * Two modes:
+   *  - `explicitSecret` defined (step-up re-auth): decrypt each blob directly
+   *    under that secret (`decryptKeyEnvelopeV2` runs its own scrypt).
+   *  - `explicitSecret` undefined (session-vault path): derive the per-blob wrap
+   *    key via the memoized, epoch-guarded `SessionKeyVault.getWrapKey` so the
+   *    memory-hard scrypt runs at most once per (account, salt) per session, and
+   *    the cheap MAC-verify + AES-unwrap runs per read.
+   *
+   * Only up to MAX_KEY_BLOBS blobs are attempted (a DoS guard). A wrong key
+   * cannot forge the MAC, so a non-matching blob returns null and the ladder
+   * continues.
+   *
+   * EPOCH GUARD (Codex P1-D): in the vault path the vault epoch is captured
+   * before any await and RE-CHECKED after EVERY await (the device-id read, each
+   * getWrapKey scrypt — guarded inside getWrapKey — and each blob decrypt). If a
+   * lock (clear/rotate) bumps the epoch mid-flight, the freshly derived material
+   * is zeroed and `VaultLockedError` is thrown so no post-lock key material is
+   * ever returned or cached. `VaultLockedError` propagates (it is NOT swallowed
+   * as a "try next blob" error).
    */
   private static async tryDecryptV2Blobs(
+    accountId: string,
     blobs: KeyEnvelopeV2[],
-    secret: string
+    explicitSecret?: string
   ): Promise<Uint8Array | undefined> {
+    const useVault = explicitSecret === undefined;
+    const startEpoch = useVault ? SessionKeyVault.currentEpoch() : -1;
+
     const deviceSecret = await this.getStableDeviceId();
+    if (useVault && SessionKeyVault.currentEpoch() !== startEpoch) {
+      throw new VaultLockedError();
+    }
+
     for (const blob of blobs.slice(0, MAX_KEY_BLOBS)) {
       try {
-        const privateKey = await decryptKeyEnvelopeV2(
-          blob,
-          secret,
-          deviceSecret
-        );
+        let privateKey: Uint8Array | null;
+        if (explicitSecret !== undefined) {
+          privateKey = await decryptKeyEnvelopeV2(
+            blob,
+            explicitSecret,
+            deviceSecret
+          );
+        } else {
+          // getWrapKey memoizes per (account, salt) and throws VaultLockedError
+          // if its own scrypt straddles a lock.
+          const wrapKey = await SessionKeyVault.getWrapKey(
+            accountId,
+            blob.salt,
+            {
+              kdfParams: blob.kdfParams,
+              deviceSecret: blob.deviceBound ? deviceSecret : undefined,
+            }
+          );
+          privateKey = await decryptKeyEnvelopeV2WithWrapKey(blob, wrapKey);
+          // Re-check AFTER the decrypt await: a lock may have landed between
+          // getWrapKey returning and the unwrap completing.
+          if (SessionKeyVault.currentEpoch() !== startEpoch) {
+            privateKey?.fill(0);
+            throw new VaultLockedError();
+          }
+        }
         if (privateKey) {
           return privateKey;
         }
-      } catch {
+      } catch (error) {
+        if (error instanceof VaultLockedError) {
+          throw error; // abort: do NOT fall through / cache post-lock material
+        }
         // Structurally invalid / out-of-cap blob — try the next candidate.
       }
     }

--- a/src/services/secure/AccountSecureStorage.ts
+++ b/src/services/secure/AccountSecureStorage.ts
@@ -554,11 +554,20 @@ export class AccountSecureStorage {
         // Format A because this branch is never entered). Security anchor: every
         // accepted result MUST pass the envelope MAC — a wrong key cannot forge
         // it, so the ladder simply falls through.
+        // When a vault-derived v2 unwrap SUCCEEDS, `v2VaultEpoch` is armed with
+        // the epoch captured at unwrap time so EVERY later await — including
+        // updateLastAccessed below — can re-check it. It stays -1 (guard is a
+        // no-op) for an explicit-pin read, when no v2 blob matched, or when the
+        // key came from the vault-independent device-key fallback (candidate 2),
+        // so Format-A behavior is unchanged.
+        let v2VaultEpoch = -1;
         if (
           Array.isArray(parsed.blobs) &&
           parsed.blobs.length > 0 &&
           (pin !== undefined || SessionKeyVault.isUnlocked())
         ) {
+          const usedVault = pin === undefined;
+          const unwrapEpoch = usedVault ? SessionKeyVault.currentEpoch() : -1;
           // A VaultLockedError propagating out of here means a lock
           // (clear/rotate) landed mid-derivation (Codex P1-D): ABORT the whole
           // read — do NOT fall through and cache a device key under a session
@@ -569,6 +578,11 @@ export class AccountSecureStorage {
             parsed.blobs,
             pin
           );
+          // Arm the final-await guard only if the key actually came from the
+          // vault v2 path (not a Format-A fallthrough below).
+          if (usedVault && privateKey) {
+            v2VaultEpoch = unwrapEpoch;
+          }
         }
 
         // Candidates 2 & 3 (unchanged) — Format A (device key), then Format C
@@ -597,6 +611,18 @@ export class AccountSecureStorage {
         }
 
         await this.updateLastAccessed(accountId);
+
+        // Epoch guard (Codex P1-D), final await: a lock during
+        // updateLastAccessed clears the caches, so re-check BEFORE re-populating
+        // the 60 s cache. If the vault-derived read straddled a lock, zero the
+        // key and abort rather than caching/returning post-lock material.
+        if (
+          v2VaultEpoch !== -1 &&
+          SessionKeyVault.currentEpoch() !== v2VaultEpoch
+        ) {
+          privateKey.fill(0);
+          throw new VaultLockedError();
+        }
 
         // Cache the key for subsequent calls (60-second TTL)
         this.privateKeyCache.set(cacheKey, {

--- a/src/services/secure/AccountSecureStorage.ts
+++ b/src/services/secure/AccountSecureStorage.ts
@@ -38,6 +38,7 @@ import {
   decryptKeyEnvelopeV2,
   MAX_KEY_BLOBS,
 } from './envelopeV2';
+import { SessionKeyVault } from './SessionKeyVault';
 import { SECURITY_CONFIG } from '../../config/security';
 
 // ─────────────────────────────────────────────────────────────────────────────
@@ -537,13 +538,49 @@ export class AccountSecureStorage {
 
         let privateKey: Uint8Array | undefined;
 
-        // Candidate 1 (v2 blobs) — tried FIRST when a verified user secret is
-        // available. INERT today: no production writer emits blobs yet, so every
-        // existing payload (no `blobs`) skips this and behaves exactly as before.
-        // Security anchor: every accepted result MUST pass the envelope MAC — a
-        // wrong secret cannot forge it, so the ladder simply falls through.
-        if (pin && Array.isArray(parsed.blobs) && parsed.blobs.length > 0) {
-          privateKey = await this.tryDecryptV2Blobs(parsed.blobs, pin);
+        // Vault-aware secret selection (DOC-137 §6.4, PR3). An explicit `pin` is
+        // a step-up re-auth (already verified above). When no pin is supplied
+        // but the session vault is unlocked, the vault secret drives the v2-blob
+        // path — this is what lets the ~14 `pin=undefined` callers keep working
+        // once keys become v2 (PR4/PR5). RETAINED device-key fallback: keys are
+        // still Format A in PR3, so `parsed.blobs` is empty, this branch is
+        // inert, and decryption falls through to the Format A / C candidates
+        // below EXACTLY as today. The device-key path is NOT removed and a
+        // locked vault does NOT throw here (Format A never needs the secret).
+        const vaultSecret =
+          !pin && SessionKeyVault.isUnlocked()
+            ? (SessionKeyVault.getSecret() ?? undefined)
+            : undefined;
+        const v2Secret = pin ?? vaultSecret;
+
+        // Candidate 1 (v2 blobs) — tried FIRST when a verified user secret (or
+        // the unlocked-vault secret) is available. INERT today: no production
+        // writer emits blobs yet, so every existing payload (no `blobs`) skips
+        // this and behaves exactly as before. Security anchor: every accepted
+        // result MUST pass the envelope MAC — a wrong secret cannot forge it, so
+        // the ladder simply falls through.
+        if (
+          v2Secret &&
+          Array.isArray(parsed.blobs) &&
+          parsed.blobs.length > 0
+        ) {
+          // Epoch guard (Codex P1-D): when the vault (not an explicit pin)
+          // supplied the secret, capture the vault epoch before the async
+          // scrypt/decrypt. If a lock (clear) or rotate bumps the epoch mid-
+          // flight, discard the derived material — do not use it and do not let
+          // it reach the 60 s cache — and fall through to the vault-independent
+          // device-key path (unchanged for Format A).
+          const usedVault = !pin;
+          const startEpoch = usedVault ? SessionKeyVault.currentEpoch() : -1;
+          const candidate = await this.tryDecryptV2Blobs(
+            parsed.blobs,
+            v2Secret
+          );
+          if (usedVault && SessionKeyVault.currentEpoch() !== startEpoch) {
+            candidate?.fill(0);
+          } else {
+            privateKey = candidate;
+          }
         }
 
         // Candidates 2 & 3 (unchanged) — Format A (device key), then Format C

--- a/src/services/secure/SessionKeyVault.ts
+++ b/src/services/secure/SessionKeyVault.ts
@@ -141,7 +141,11 @@ class SessionKeyVaultImpl {
       throw new VaultLockedError();
     }
 
-    const memoized = this.wrapKeys.get(accountId);
+    // Memoize per (accountId, salt): a re-wrap transiently holds two blobs with
+    // DIFFERENT salts (the "dual slot"), so each blob must derive/cache its own
+    // wrap key rather than collide on accountId alone.
+    const cacheKey = this.wrapKeyCacheKey(accountId, saltHex);
+    const memoized = this.wrapKeys.get(cacheKey);
     if (memoized) {
       return memoized;
     }
@@ -163,16 +167,16 @@ class SessionKeyVaultImpl {
       );
     }
 
-    // A concurrent call for the same account may have populated the memo while
-    // we were deriving; prefer the existing entry and drop our duplicate so the
-    // cache holds exactly one buffer per account.
-    const raced = this.wrapKeys.get(accountId);
+    // A concurrent call for the same (account, salt) may have populated the memo
+    // while we were deriving; prefer the existing entry and drop our duplicate
+    // so the cache holds exactly one buffer per (account, salt).
+    const raced = this.wrapKeys.get(cacheKey);
     if (raced) {
       derived.fill(0);
       return raced;
     }
 
-    this.wrapKeys.set(accountId, derived);
+    this.wrapKeys.set(cacheKey, derived);
     return derived;
   }
 
@@ -184,6 +188,12 @@ class SessionKeyVaultImpl {
     this.zeroWrapKeys();
     this.secret = null;
     this.epoch++;
+  }
+
+  /** Composite memo key for the (accountId, salt) pair. The salt is a fixed-
+   *  length hex string, so joining with a separator is unambiguous. */
+  private wrapKeyCacheKey(accountId: string, saltHex: string): string {
+    return `${accountId}|${saltHex}`;
   }
 
   /** Zero and drop every memoized wrap key (defense-in-depth scrub). */

--- a/src/services/secure/SessionKeyVault.ts
+++ b/src/services/secure/SessionKeyVault.ts
@@ -62,8 +62,13 @@ class SessionKeyVaultImpl {
   private secret: string | null = null;
   /** UX hint mirroring the unlocking secret's kind. */
   private secretSource: SecretSource = 'pin';
-  /** Memoized deriveWrapKey() outputs keyed by accountId (the R2 cache). */
+  /** Memoized deriveWrapKey() outputs keyed by (accountId, salt) — the R2
+   *  cache. */
   private readonly wrapKeys: Map<string, Uint8Array> = new Map();
+  /** In-flight scrypt derivations keyed by (accountId, salt), so concurrent
+   *  first calls coalesce onto ONE scrypt (single-flight). */
+  private readonly pendingWrapKeys: Map<string, Promise<Uint8Array>> =
+    new Map();
   /** Monotonic epoch; bumped on every set / rotate / clear (Codex P1-D). */
   private epoch = 0;
 
@@ -118,16 +123,19 @@ class SessionKeyVaultImpl {
   }
 
   /**
-   * Lazily derive (and memoize) the per-account at-rest wrap key via scrypt.
-   * scrypt runs at most once per account per session; subsequent calls return
-   * the memoized buffer. The returned buffer is OWNED by the vault — callers
-   * MUST treat it as read-only and MUST NOT zero it (the vault zeroes it on
-   * clear/rotate).
+   * Lazily derive (and memoize) the per-account/salt at-rest wrap key via
+   * scrypt. scrypt runs at most ONCE per (account, salt) per session — even
+   * under concurrency (single-flight): the in-flight derivation PROMISE is
+   * cached, so concurrent first callers (e.g. batch signing right after unlock)
+   * await the same scrypt. Subsequent calls return the memoized buffer. The
+   * returned buffer is OWNED by the vault — callers MUST treat it as read-only
+   * and MUST NOT zero it (the vault zeroes it on clear/rotate).
    *
    * Epoch guard (Codex P1-D): the epoch is captured before the scrypt await; if
    * it changes during derivation (a concurrent set/rotate/clear — e.g. a lock),
    * the fresh key is zeroed, nothing is cached, and VaultLockedError is thrown so
-   * no post-lock key material is ever returned.
+   * no post-lock key material is ever returned. On any error the in-flight entry
+   * is dropped so a later call can retry.
    *
    * @throws VaultLockedError if locked at call time or if the epoch changed mid-derivation.
    */
@@ -150,34 +158,45 @@ class SessionKeyVaultImpl {
       return memoized;
     }
 
+    // Single-flight: join an in-flight derivation for the same (account, salt).
+    const pending = this.pendingWrapKeys.get(cacheKey);
+    if (pending) {
+      return pending;
+    }
+
     const startEpoch = this.epoch;
     const kdfParams = options?.kdfParams ?? AT_REST_KDF_PARAMS;
-    const derived = await deriveWrapKey(
-      secret,
-      saltHex,
-      kdfParams,
-      options?.deviceSecret
-    );
-
-    // Epoch guard: the session that requested this key no longer exists.
-    if (this.epoch !== startEpoch) {
-      derived.fill(0);
-      throw new VaultLockedError(
-        'SessionKeyVault epoch changed during derivation'
+    const derivePromise = (async (): Promise<Uint8Array> => {
+      const derived = await deriveWrapKey(
+        secret,
+        saltHex,
+        kdfParams,
+        options?.deviceSecret
       );
-    }
 
-    // A concurrent call for the same (account, salt) may have populated the memo
-    // while we were deriving; prefer the existing entry and drop our duplicate
-    // so the cache holds exactly one buffer per (account, salt).
-    const raced = this.wrapKeys.get(cacheKey);
-    if (raced) {
-      derived.fill(0);
-      return raced;
-    }
+      // Epoch guard: the session that requested this key no longer exists.
+      if (this.epoch !== startEpoch) {
+        derived.fill(0);
+        throw new VaultLockedError(
+          'SessionKeyVault epoch changed during derivation'
+        );
+      }
 
-    this.wrapKeys.set(cacheKey, derived);
-    return derived;
+      this.wrapKeys.set(cacheKey, derived);
+      return derived;
+    })();
+
+    this.pendingWrapKeys.set(cacheKey, derivePromise);
+    try {
+      return await derivePromise;
+    } finally {
+      // Drop the in-flight entry (success OR error) so a failed derive can be
+      // retried and the map never holds a stale/rejected promise. Guard on
+      // identity so a clear()+set() that started a NEW derivation isn't evicted.
+      if (this.pendingWrapKeys.get(cacheKey) === derivePromise) {
+        this.pendingWrapKeys.delete(cacheKey);
+      }
+    }
   }
 
   /**
@@ -196,10 +215,14 @@ class SessionKeyVaultImpl {
     return `${accountId}|${saltHex}`;
   }
 
-  /** Zero and drop every memoized wrap key (defense-in-depth scrub). */
+  /** Zero and drop every memoized wrap key (defense-in-depth scrub), and drop
+   *  references to any in-flight derivations from the prior epoch — they still
+   *  self-abort via the epoch guard when they resolve, and dropping them here
+   *  prevents a post-clear caller from joining a now-stale derivation. */
   private zeroWrapKeys(): void {
     this.wrapKeys.forEach((key) => key.fill(0));
     this.wrapKeys.clear();
+    this.pendingWrapKeys.clear();
   }
 }
 

--- a/src/services/secure/SessionKeyVault.ts
+++ b/src/services/secure/SessionKeyVault.ts
@@ -1,0 +1,197 @@
+/**
+ * SessionKeyVault (Wave-2, DR-2 / DOC-137 §6, PR3)
+ *
+ * An in-memory-ONLY singleton that holds the unlocked-session user secret and a
+ * memoized, per-account at-rest wrap key. It is the replacement custodian for
+ * the callers that today pass `pin=undefined` and rely on the ambient device-key
+ * wrap + the 60 s plaintext-key cache (DOC-137 §6.1). Under the future
+ * user-secret wrap (PR4/PR5) those callers derive the wrap key from the vault
+ * secret; in THIS PR keys are still Format A, so the vault is populated on unlock
+ * but the device-key path still performs decryption — no behavior change.
+ *
+ * NEVER PERSISTED: this state lives only for the process/session. It is cleared
+ * on every lock (explicit / inactivity / background-grace) via
+ * AuthContext.lock() (DOC-137 §6.3).
+ *
+ * WHY CACHE THE WRAP KEY, NOT THE PRIVATE KEY (DOC-137 §6.2): scrypt is
+ * deliberately expensive, so it must not run per signature; the cheap AES-CTR
+ * unwrap from a cached wrap key lets each getPrivateKey unwrap freshly (and the
+ * caller zeroes the seed). This is strictly LESS sensitive than the status quo
+ * 60 s full-private-key cache.
+ *
+ * VAULT EPOCH (Codex P1-D): a monotonic `epoch` is bumped on every secret-state
+ * transition (set / rotate / clear). Any async key op captures the epoch before
+ * its awaits and, after each await, ABORTS (returns no material, caches nothing)
+ * if the epoch changed — so an in-flight scrypt started before a lock cannot
+ * return or cache key material after the lock.
+ *
+ * SECURITY: this module never logs the secret, the derived wrap key, or any
+ * private key. Wrap-key buffers are zeroed (`fill(0)`) whenever they leave the
+ * cache (clear / rotate / re-set) or when an epoch-abort discards a fresh
+ * derivation. JS strings (the secret) cannot be reliably wiped; the vault holds
+ * exactly one reference and drops it on clear.
+ */
+
+import { deriveWrapKey, AT_REST_KDF_PARAMS } from './envelopeV2';
+import type { ScryptKdfParams } from '../backup/types';
+
+/** Which kind of user secret currently unlocks the session (UX hint only). */
+export type SecretSource = 'pin' | 'passphrase';
+
+/**
+ * Thrown by `getWrapKey` when no key material can be safely returned: the vault
+ * is locked at call time, or its epoch changed mid-derivation (Codex P1-D). It
+ * carries NO key material and never includes the secret in its message.
+ */
+export class VaultLockedError extends Error {
+  constructor(message = 'SessionKeyVault is locked') {
+    super(message);
+    this.name = 'VaultLockedError';
+  }
+}
+
+interface GetWrapKeyOptions {
+  /** scrypt params to derive with (defaults to AT_REST_KDF_PARAMS). */
+  kdfParams?: ScryptKdfParams;
+  /** Device id for the optional post-mix; omit for a non-device-bound key. */
+  deviceSecret?: string;
+}
+
+class SessionKeyVaultImpl {
+  /** The active session secret (PIN or passphrase). null => locked. */
+  private secret: string | null = null;
+  /** UX hint mirroring the unlocking secret's kind. */
+  private secretSource: SecretSource = 'pin';
+  /** Memoized deriveWrapKey() outputs keyed by accountId (the R2 cache). */
+  private readonly wrapKeys: Map<string, Uint8Array> = new Map();
+  /** Monotonic epoch; bumped on every set / rotate / clear (Codex P1-D). */
+  private epoch = 0;
+
+  /** True while a session secret is held. */
+  isUnlocked(): boolean {
+    return this.secret !== null;
+  }
+
+  /** The current monotonic epoch (Codex P1-D abort anchor). */
+  currentEpoch(): number {
+    return this.epoch;
+  }
+
+  /**
+   * The active session secret, or null when locked. Callers MUST NOT log it and
+   * MUST NOT retain it beyond the immediate derivation.
+   */
+  getSecret(): string | null {
+    return this.secret;
+  }
+
+  /** The active secret's kind (UX hint only — never a decryption gate). */
+  getSecretSource(): SecretSource {
+    return this.secretSource;
+  }
+
+  /**
+   * Populate the vault at unlock. Any previously memoized wrap keys are zeroed
+   * and dropped (a fresh unlock starts clean), and the epoch is bumped so an
+   * in-flight derivation from a prior session aborts.
+   */
+  set(secret: string, source: SecretSource): void {
+    this.zeroWrapKeys();
+    this.secret = secret;
+    this.secretSource = source;
+    this.epoch++;
+  }
+
+  /**
+   * Change the session secret WITHOUT re-locking (used by changePin/passphrase
+   * change so the session survives the rotation — DOC-137 §6.3). Memoized wrap
+   * keys were derived under the OLD secret, so they are zeroed + dropped and the
+   * epoch is bumped (an in-flight old-secret derivation must abort).
+   */
+  rotate(newSecret: string, newSource?: SecretSource): void {
+    this.zeroWrapKeys();
+    this.secret = newSecret;
+    if (newSource) {
+      this.secretSource = newSource;
+    }
+    this.epoch++;
+  }
+
+  /**
+   * Lazily derive (and memoize) the per-account at-rest wrap key via scrypt.
+   * scrypt runs at most once per account per session; subsequent calls return
+   * the memoized buffer. The returned buffer is OWNED by the vault — callers
+   * MUST treat it as read-only and MUST NOT zero it (the vault zeroes it on
+   * clear/rotate).
+   *
+   * Epoch guard (Codex P1-D): the epoch is captured before the scrypt await; if
+   * it changes during derivation (a concurrent set/rotate/clear — e.g. a lock),
+   * the fresh key is zeroed, nothing is cached, and VaultLockedError is thrown so
+   * no post-lock key material is ever returned.
+   *
+   * @throws VaultLockedError if locked at call time or if the epoch changed mid-derivation.
+   */
+  async getWrapKey(
+    accountId: string,
+    saltHex: string,
+    options?: GetWrapKeyOptions
+  ): Promise<Uint8Array> {
+    const secret = this.secret;
+    if (secret === null) {
+      throw new VaultLockedError();
+    }
+
+    const memoized = this.wrapKeys.get(accountId);
+    if (memoized) {
+      return memoized;
+    }
+
+    const startEpoch = this.epoch;
+    const kdfParams = options?.kdfParams ?? AT_REST_KDF_PARAMS;
+    const derived = await deriveWrapKey(
+      secret,
+      saltHex,
+      kdfParams,
+      options?.deviceSecret
+    );
+
+    // Epoch guard: the session that requested this key no longer exists.
+    if (this.epoch !== startEpoch) {
+      derived.fill(0);
+      throw new VaultLockedError(
+        'SessionKeyVault epoch changed during derivation'
+      );
+    }
+
+    // A concurrent call for the same account may have populated the memo while
+    // we were deriving; prefer the existing entry and drop our duplicate so the
+    // cache holds exactly one buffer per account.
+    const raced = this.wrapKeys.get(accountId);
+    if (raced) {
+      derived.fill(0);
+      return raced;
+    }
+
+    this.wrapKeys.set(accountId, derived);
+    return derived;
+  }
+
+  /**
+   * Lock the vault: zero every memoized wrap-key buffer, drop the secret, and
+   * bump the epoch so any in-flight derivation aborts (Codex P1-D). Idempotent.
+   */
+  clear(): void {
+    this.zeroWrapKeys();
+    this.secret = null;
+    this.epoch++;
+  }
+
+  /** Zero and drop every memoized wrap key (defense-in-depth scrub). */
+  private zeroWrapKeys(): void {
+    this.wrapKeys.forEach((key) => key.fill(0));
+    this.wrapKeys.clear();
+  }
+}
+
+/** The process-wide, in-memory-only session key vault singleton. */
+export const SessionKeyVault = new SessionKeyVaultImpl();

--- a/src/services/secure/__tests__/SessionKeyVault.test.ts
+++ b/src/services/secure/__tests__/SessionKeyVault.test.ts
@@ -53,7 +53,7 @@ describe('SessionKeyVault set / secret exposure', () => {
 });
 
 describe('SessionKeyVault getWrapKey (memoized scrypt)', () => {
-  it('runs scrypt at most ONCE per account and returns the memoized buffer', async () => {
+  it('runs scrypt at most ONCE per (account, salt) and returns the memoized buffer', async () => {
     SessionKeyVault.set('123456', 'pin');
 
     const k1 = await SessionKeyVault.getWrapKey('acct-1', SALT);
@@ -64,6 +64,20 @@ describe('SessionKeyVault getWrapKey (memoized scrypt)', () => {
 
     await SessionKeyVault.getWrapKey('acct-2', SALT);
     expect(mockDerive).toHaveBeenCalledTimes(2); // per-account derivation
+  });
+
+  it('memoizes per SALT too: the same account with a different salt derives again', async () => {
+    SessionKeyVault.set('123456', 'pin');
+    const otherSalt = 'cd'.repeat(32);
+
+    await SessionKeyVault.getWrapKey('acct-1', SALT);
+    await SessionKeyVault.getWrapKey('acct-1', SALT); // memoized
+    expect(mockDerive).toHaveBeenCalledTimes(1);
+
+    // A different blob salt for the SAME account (dual-slot) must derive its own
+    // wrap key, not collide on accountId.
+    await SessionKeyVault.getWrapKey('acct-1', otherSalt);
+    expect(mockDerive).toHaveBeenCalledTimes(2);
   });
 
   it('throws VaultLockedError (and never derives) when locked', async () => {

--- a/src/services/secure/__tests__/SessionKeyVault.test.ts
+++ b/src/services/secure/__tests__/SessionKeyVault.test.ts
@@ -87,6 +87,35 @@ describe('SessionKeyVault getWrapKey (memoized scrypt)', () => {
     ).rejects.toBeInstanceOf(VaultLockedError);
     expect(mockDerive).not.toHaveBeenCalled();
   });
+
+  it('is single-flight: concurrent first calls for the same (account, salt) run scrypt ONCE', async () => {
+    SessionKeyVault.set('123456', 'pin');
+
+    // Hold the derivation open so BOTH calls are in-flight before it resolves.
+    const derived = nonZeroKey(5);
+    let release!: () => void;
+    const gate = new Promise<void>((resolve) => {
+      release = resolve;
+    });
+    mockDerive.mockImplementationOnce(async () => {
+      await gate;
+      return derived;
+    });
+
+    const p1 = SessionKeyVault.getWrapKey('acct', SALT);
+    const p2 = SessionKeyVault.getWrapKey('acct', SALT); // joins the in-flight derive
+    release();
+
+    const [k1, k2] = await Promise.all([p1, p2]);
+
+    expect(mockDerive).toHaveBeenCalledTimes(1); // scrypt ran once
+    expect(k1).toBe(k2); // both resolve to the same memoized buffer
+
+    // A later call hits the resolved memo (still one derivation).
+    const k3 = await SessionKeyVault.getWrapKey('acct', SALT);
+    expect(k3).toBe(k1);
+    expect(mockDerive).toHaveBeenCalledTimes(1);
+  });
 });
 
 describe('SessionKeyVault clear (zeroes buffers + bumps epoch)', () => {

--- a/src/services/secure/__tests__/SessionKeyVault.test.ts
+++ b/src/services/secure/__tests__/SessionKeyVault.test.ts
@@ -1,0 +1,153 @@
+// Unit tests for the SessionKeyVault (DOC-137 §6.2 / Codex P1-D, PR3).
+//
+// Covers: set() unlock + epoch bump; getWrapKey memoization (scrypt runs ONCE
+// per account); getWrapKey locked-guard; clear() zeroing wrap-key buffers +
+// locking + epoch bump; rotate() secret swap without re-lock + wrap-key
+// invalidation; and the epoch-abort guard (a derivation whose epoch changes
+// mid-flight returns NO material, caches nothing, and zeroes the fresh key).
+//
+// SECURITY NOTE: `deriveWrapKey` (scrypt) is MOCKED so the suite is fast and so
+// call counts / timing are observable. No real secret or key material is used —
+// wrap keys are synthetic non-zero byte patterns.
+
+// Mock the scrypt KDF so we can count derivations and control their timing. The
+// vault imports exactly these two symbols from envelopeV2.
+jest.mock('../envelopeV2', () => ({
+  AT_REST_KDF_PARAMS: { N: 2 ** 12, r: 8, p: 1, dkLen: 32 },
+  deriveWrapKey: jest.fn(),
+}));
+
+import { SessionKeyVault, VaultLockedError } from '../SessionKeyVault';
+import { deriveWrapKey } from '../envelopeV2';
+
+const mockDerive = deriveWrapKey as jest.MockedFunction<typeof deriveWrapKey>;
+
+const SALT = 'ab'.repeat(32); // 32-byte hex salt (value irrelevant to the mock)
+
+/** A synthetic, all-`fill` non-zero 32-byte wrap key (NOT real key material). */
+function nonZeroKey(fill = 7): Uint8Array {
+  return Uint8Array.from({ length: 32 }, () => fill);
+}
+
+beforeEach(() => {
+  // The vault is a process singleton; reset it to a locked state each test.
+  SessionKeyVault.clear();
+  mockDerive.mockReset();
+  mockDerive.mockImplementation(async () => nonZeroKey());
+});
+
+describe('SessionKeyVault set / secret exposure', () => {
+  it('starts locked and exposes no secret', () => {
+    expect(SessionKeyVault.isUnlocked()).toBe(false);
+    expect(SessionKeyVault.getSecret()).toBeNull();
+  });
+
+  it('set() unlocks, records the secret + source, and bumps the epoch', () => {
+    const before = SessionKeyVault.currentEpoch();
+    SessionKeyVault.set('123456', 'pin');
+    expect(SessionKeyVault.isUnlocked()).toBe(true);
+    expect(SessionKeyVault.getSecret()).toBe('123456');
+    expect(SessionKeyVault.getSecretSource()).toBe('pin');
+    expect(SessionKeyVault.currentEpoch()).toBe(before + 1);
+  });
+});
+
+describe('SessionKeyVault getWrapKey (memoized scrypt)', () => {
+  it('runs scrypt at most ONCE per account and returns the memoized buffer', async () => {
+    SessionKeyVault.set('123456', 'pin');
+
+    const k1 = await SessionKeyVault.getWrapKey('acct-1', SALT);
+    const k2 = await SessionKeyVault.getWrapKey('acct-1', SALT);
+
+    expect(k2).toBe(k1); // same memoized instance
+    expect(mockDerive).toHaveBeenCalledTimes(1);
+
+    await SessionKeyVault.getWrapKey('acct-2', SALT);
+    expect(mockDerive).toHaveBeenCalledTimes(2); // per-account derivation
+  });
+
+  it('throws VaultLockedError (and never derives) when locked', async () => {
+    expect(SessionKeyVault.isUnlocked()).toBe(false);
+    await expect(
+      SessionKeyVault.getWrapKey('acct', SALT)
+    ).rejects.toBeInstanceOf(VaultLockedError);
+    expect(mockDerive).not.toHaveBeenCalled();
+  });
+});
+
+describe('SessionKeyVault clear (zeroes buffers + bumps epoch)', () => {
+  it('zeroes memoized wrap keys in place, locks, and bumps the epoch', async () => {
+    SessionKeyVault.set('123456', 'pin');
+    const key = await SessionKeyVault.getWrapKey('acct', SALT);
+    expect(key.some((b) => b !== 0)).toBe(true);
+
+    const before = SessionKeyVault.currentEpoch();
+    SessionKeyVault.clear();
+
+    // The exact buffer the caller holds is zeroed (defense-in-depth scrub).
+    expect(Array.from(key).every((b) => b === 0)).toBe(true);
+    expect(SessionKeyVault.isUnlocked()).toBe(false);
+    expect(SessionKeyVault.getSecret()).toBeNull();
+    expect(SessionKeyVault.currentEpoch()).toBe(before + 1);
+  });
+});
+
+describe('SessionKeyVault rotate (secret swap, no re-lock)', () => {
+  it('swaps the secret without locking, invalidates wrap keys, and bumps epoch', async () => {
+    SessionKeyVault.set('111111', 'pin');
+    const oldKey = await SessionKeyVault.getWrapKey('acct', SALT);
+    expect(mockDerive).toHaveBeenCalledTimes(1);
+
+    const before = SessionKeyVault.currentEpoch();
+    SessionKeyVault.rotate('222222');
+
+    expect(Array.from(oldKey).every((b) => b === 0)).toBe(true); // old key zeroed
+    expect(SessionKeyVault.isUnlocked()).toBe(true); // session stays alive
+    expect(SessionKeyVault.getSecret()).toBe('222222');
+    expect(SessionKeyVault.currentEpoch()).toBe(before + 1);
+
+    await SessionKeyVault.getWrapKey('acct', SALT);
+    expect(mockDerive).toHaveBeenCalledTimes(2); // re-derived under the new secret
+  });
+
+  it('can change the secret source when rotating', () => {
+    SessionKeyVault.set('111111', 'pin');
+    SessionKeyVault.rotate('a-long-passphrase', 'passphrase');
+    expect(SessionKeyVault.getSecretSource()).toBe('passphrase');
+    expect(SessionKeyVault.getSecret()).toBe('a-long-passphrase');
+  });
+});
+
+describe('SessionKeyVault epoch-abort guard (Codex P1-D)', () => {
+  it('aborts a derivation whose epoch changes mid-flight: no return, no cache, key zeroed', async () => {
+    SessionKeyVault.set('123456', 'pin');
+
+    // A derivation that resolves only AFTER we release the gate — long enough to
+    // clear() (bump the epoch) while the scrypt await is outstanding.
+    const derived = nonZeroKey(9);
+    let release!: () => void;
+    const gate = new Promise<void>((resolve) => {
+      release = resolve;
+    });
+    mockDerive.mockImplementationOnce(async () => {
+      await gate;
+      return derived;
+    });
+
+    const pending = SessionKeyVault.getWrapKey('acct', SALT);
+
+    // Lock mid-flight — this bumps the epoch the derivation captured.
+    SessionKeyVault.clear();
+    release();
+
+    await expect(pending).rejects.toBeInstanceOf(VaultLockedError);
+    // The freshly derived key was scrubbed rather than returned/cached.
+    expect(Array.from(derived).every((b) => b === 0)).toBe(true);
+
+    // Nothing was cached: re-unlocking and requesting the same account derives
+    // AGAIN (the aborted run left no memo behind).
+    SessionKeyVault.set('123456', 'pin');
+    await SessionKeyVault.getWrapKey('acct', SALT);
+    expect(mockDerive).toHaveBeenCalledTimes(2);
+  });
+});

--- a/src/services/secure/__tests__/getPrivateKey.vault.test.ts
+++ b/src/services/secure/__tests__/getPrivateKey.vault.test.ts
@@ -315,4 +315,47 @@ describe('getPrivateKey — v2 vault path aborts on a mid-flight lock (Codex P1-
     // The lock took effect and nothing lingers unlocked.
     expect(SessionKeyVault.isUnlocked()).toBe(false);
   });
+
+  it('throws VaultLockedError when the lock lands during the updateLastAccessed await (final await guard)', async () => {
+    const sk = fakeKey(64);
+    const accountId = 'acct-v2-abort-lastaccessed';
+    const blob = await encryptKeyEnvelopeV2({
+      plaintext: sk,
+      secret: PIN,
+      secretSource: 'pin',
+      kdfParams: FAST_PARAMS,
+    });
+    seedSecret(accountId, {
+      accountId,
+      encryptedPrivateKey: '',
+      authMethod: 'pin',
+      version: 2,
+      blobs: [blob],
+    });
+
+    SessionKeyVault.set(PIN, 'pin');
+
+    // The v2 unwrap SUCCEEDS; the lock lands during the LAST await
+    // (updateLastAccessed), after which the key must NOT be cached or returned.
+    jest
+      .spyOn(
+        AccountSecureStorage as unknown as {
+          updateLastAccessed: (id: string) => Promise<void>;
+        },
+        'updateLastAccessed'
+      )
+      .mockImplementation(async () => {
+        SessionKeyVault.clear();
+      });
+
+    await expect(
+      AccountSecureStorage.getPrivateKey(accountId)
+    ).rejects.toBeInstanceOf(VaultLockedError);
+
+    // The read aborted before caching: re-reading (still locked) fails rather
+    // than returning a stale cached key.
+    await expect(
+      AccountSecureStorage.getPrivateKey(accountId)
+    ).rejects.toBeTruthy();
+  });
 });

--- a/src/services/secure/__tests__/getPrivateKey.vault.test.ts
+++ b/src/services/secure/__tests__/getPrivateKey.vault.test.ts
@@ -68,10 +68,14 @@ import 'crypto-js/pbkdf2';
 import { createHash, randomBytes } from 'crypto';
 import * as platform from '@/platform';
 import { AccountSecureStorage } from '../AccountSecureStorage';
-import { SessionKeyVault } from '../SessionKeyVault';
+import { SessionKeyVault, VaultLockedError } from '../SessionKeyVault';
+import { encryptKeyEnvelopeV2 } from '../envelopeV2';
+import type { ScryptKdfParams } from '../../backup/types';
 
 const DEVICE_ID = 'vault-test-device-idfv';
 const PIN = '123456';
+// Small (power-of-two, within caps) scrypt params keep the suite fast.
+const FAST_PARAMS: ScryptKdfParams = { N: 2 ** 12, r: 8, p: 1, dkLen: 32 };
 
 const mockPlatform = platform as unknown as {
   __secure: Map<string, string>;
@@ -201,5 +205,114 @@ describe('getPrivateKey — Format A is unchanged with an UNLOCKED vault (v2 bra
 
     const out = await AccountSecureStorage.getPrivateKey(accountId);
     expect(hex(out)).toBe(hex(sk));
+  });
+});
+
+describe('getPrivateKey — v2 vault path derives via SessionKeyVault.getWrapKey (Codex P1-1)', () => {
+  it('decrypts a v2 blob via the memoized getWrapKey when pin=undefined + vault unlocked', async () => {
+    const sk = fakeKey(64);
+    const accountId = 'acct-v2-vaultpath';
+    const blob = await encryptKeyEnvelopeV2({
+      plaintext: sk,
+      secret: PIN,
+      secretSource: 'pin',
+      kdfParams: FAST_PARAMS, // non-device-bound
+    });
+    seedSecret(accountId, {
+      accountId,
+      encryptedPrivateKey: '',
+      authMethod: 'pin',
+      version: 2,
+      blobs: [blob],
+    });
+
+    SessionKeyVault.set(PIN, 'pin');
+    const getWrapKeySpy = jest.spyOn(SessionKeyVault, 'getWrapKey');
+
+    const out = await AccountSecureStorage.getPrivateKey(accountId);
+    expect(hex(out)).toBe(hex(sk));
+
+    // The derivation went through the vault (not decryptKeyEnvelopeV2's own
+    // scrypt): getWrapKey was the derivation path, keyed by (accountId, salt).
+    expect(getWrapKeySpy).toHaveBeenCalledWith(
+      accountId,
+      blob.salt,
+      expect.objectContaining({ deviceSecret: undefined })
+    );
+  });
+
+  it('passes the device id to getWrapKey for a device-bound v2 blob', async () => {
+    const sk = fakeKey(64);
+    const accountId = 'acct-v2-vaultpath-devicebound';
+    const blob = await encryptKeyEnvelopeV2({
+      plaintext: sk,
+      secret: PIN,
+      secretSource: 'pin',
+      deviceSecret: DEVICE_ID,
+      kdfParams: FAST_PARAMS,
+    });
+    expect(blob.deviceBound).toBe(true);
+    seedSecret(accountId, {
+      accountId,
+      encryptedPrivateKey: '',
+      authMethod: 'pin',
+      version: 2,
+      blobs: [blob],
+    });
+
+    SessionKeyVault.set(PIN, 'pin');
+    const getWrapKeySpy = jest.spyOn(SessionKeyVault, 'getWrapKey');
+
+    const out = await AccountSecureStorage.getPrivateKey(accountId);
+    expect(hex(out)).toBe(hex(sk));
+    expect(getWrapKeySpy).toHaveBeenCalledWith(
+      accountId,
+      blob.salt,
+      expect.objectContaining({ deviceSecret: DEVICE_ID })
+    );
+  });
+});
+
+describe('getPrivateKey — v2 vault path aborts on a mid-flight lock (Codex P1-D)', () => {
+  it('throws VaultLockedError (and caches nothing) when the vault epoch changes mid-decrypt', async () => {
+    const sk = fakeKey(64);
+    const accountId = 'acct-v2-abort';
+    const blob = await encryptKeyEnvelopeV2({
+      plaintext: sk,
+      secret: PIN,
+      secretSource: 'pin',
+      kdfParams: FAST_PARAMS,
+    });
+    seedSecret(accountId, {
+      accountId,
+      encryptedPrivateKey: '',
+      authMethod: 'pin',
+      version: 2,
+      blobs: [blob],
+    });
+
+    SessionKeyVault.set(PIN, 'pin');
+
+    // Simulate a lock landing DURING the first await inside tryDecryptV2Blobs
+    // (the device-id read): clearing the vault bumps the epoch, so the post-await
+    // re-check must abort before any key material is derived, returned, or cached.
+    jest
+      .spyOn(
+        AccountSecureStorage as unknown as {
+          getStableDeviceId: () => Promise<string>;
+        },
+        'getStableDeviceId'
+      )
+      .mockImplementation(async () => {
+        SessionKeyVault.clear();
+        return DEVICE_ID;
+      });
+
+    await expect(
+      AccountSecureStorage.getPrivateKey(accountId)
+    ).rejects.toBeInstanceOf(VaultLockedError);
+
+    // The lock took effect and nothing lingers unlocked.
+    expect(SessionKeyVault.isUnlocked()).toBe(false);
   });
 });

--- a/src/services/secure/__tests__/getPrivateKey.vault.test.ts
+++ b/src/services/secure/__tests__/getPrivateKey.vault.test.ts
@@ -1,0 +1,205 @@
+// Unit tests proving PR3 introduces NO behavior change to Format-A decryption
+// (DOC-137 §6.4). The SessionKeyVault is populated at unlock by AuthContext, but
+// getPrivateKey must decrypt existing device-key (Format A) payloads EXACTLY as
+// before whether the vault is empty (locked) or unlocked — because Format-A
+// payloads carry no `blobs` and therefore never enter the vault-aware v2 branch.
+//
+// SECURITY NOTE: synthetic byte patterns stand in for key material; secrets are
+// throwaway test strings. No real mnemonic/key is used.
+
+// In-memory platform mock (SecureStore/AsyncStorage/deviceId/crypto). Node backs
+// getRandomBytes/sha256 so the REAL device-key crypto path runs end-to-end.
+jest.mock('@/platform', () => {
+  const nodeCrypto = require('crypto');
+  const secure = new Map<string, string>();
+  const kv = new Map<string, string>();
+  return {
+    __secure: secure,
+    __kv: kv,
+    __reset: () => {
+      secure.clear();
+      kv.clear();
+    },
+    crypto: {
+      getRandomBytes: async (n: number): Promise<Uint8Array> =>
+        Uint8Array.from(nodeCrypto.randomBytes(n)),
+      sha256: async (input: string): Promise<string> =>
+        nodeCrypto.createHash('sha256').update(input).digest('hex'),
+      randomUUID: () => nodeCrypto.randomUUID(),
+    },
+    secureStorage: {
+      getItem: async (k: string) => (secure.has(k) ? secure.get(k)! : null),
+      setItem: async (k: string, v: string) => {
+        secure.set(k, v);
+      },
+      deleteItem: async (k: string) => {
+        secure.delete(k);
+      },
+      getItemWithAuth: async (k: string) =>
+        secure.has(k) ? secure.get(k)! : null,
+    },
+    storage: {
+      getItem: async (k: string) => (kv.has(k) ? kv.get(k)! : null),
+      setItem: async (k: string, v: string) => {
+        kv.set(k, v);
+      },
+      removeItem: async (k: string) => {
+        kv.delete(k);
+      },
+    },
+    biometrics: {
+      isAvailable: async () => false,
+      isEnrolled: async () => false,
+    },
+    deviceId: {
+      getDeviceId: async () => 'vault-test-device-idfv',
+    },
+  };
+});
+
+import CryptoJS from 'crypto-js';
+import 'crypto-js/hmac-sha256';
+import 'crypto-js/sha256';
+import 'crypto-js/aes';
+import 'crypto-js/mode-ctr';
+import 'crypto-js/pad-nopadding';
+import 'crypto-js/enc-hex';
+import 'crypto-js/pbkdf2';
+import { createHash, randomBytes } from 'crypto';
+import * as platform from '@/platform';
+import { AccountSecureStorage } from '../AccountSecureStorage';
+import { SessionKeyVault } from '../SessionKeyVault';
+
+const DEVICE_ID = 'vault-test-device-idfv';
+const PIN = '123456';
+
+const mockPlatform = platform as unknown as {
+  __secure: Map<string, string>;
+  __reset: () => void;
+};
+
+function fakeKey(length: number): Uint8Array {
+  return Uint8Array.from({ length }, (_, i) => (i * 13 + 7) & 0xff);
+}
+
+function hex(bytes: Uint8Array): string {
+  return Buffer.from(bytes).toString('hex');
+}
+
+function nodeSha256Hex(input: string): string {
+  return createHash('sha256').update(input).digest('hex');
+}
+
+function customPBKDF2(
+  password: string,
+  saltHex: string,
+  iterations: number,
+  keyLength: number
+): string {
+  const saltWA = CryptoJS.enc.Hex.parse(saltHex);
+  const derived = CryptoJS.PBKDF2(password, saltWA, {
+    keySize: keyLength / 4,
+    iterations,
+    hasher: CryptoJS.algo.SHA256,
+  });
+  return derived.toString(CryptoJS.enc.Hex);
+}
+
+/** Build a legacy Format-A (device-key) 4-colon blob (as encryptPrivateKey does). */
+function makeFormatA(privateKey: Uint8Array): string {
+  const saltHex = randomBytes(32).toString('hex');
+  const ivHex = randomBytes(16).toString('hex');
+  const baseEntropy = nodeSha256Hex(`voi_wallet_${DEVICE_ID}`);
+  const keyMaterial = customPBKDF2(baseEntropy, saltHex, 10000, 32);
+
+  const privateKeyHex = hex(privateKey);
+  const encrypted = CryptoJS.AES.encrypt(
+    privateKeyHex,
+    CryptoJS.enc.Hex.parse(keyMaterial),
+    {
+      iv: CryptoJS.enc.Hex.parse(ivHex),
+      mode: CryptoJS.mode.CTR,
+      padding: CryptoJS.pad.NoPadding,
+    }
+  );
+  const ct = encrypted.toString();
+  const hmacKey = CryptoJS.SHA256(keyMaterial + 'hmac_salt').toString();
+  const hmac = CryptoJS.HmacSHA256(ct, hmacKey).toString();
+  return `${saltHex}:${ivHex}:${ct}:${hmac}`;
+}
+
+function seedSecret(accountId: string, payload: object): void {
+  mockPlatform.__secure.set(
+    `voi_account_secret_${accountId}`,
+    JSON.stringify(payload)
+  );
+}
+
+beforeEach(() => {
+  mockPlatform.__reset();
+  AccountSecureStorage.clearPrivateKeyCache();
+  SessionKeyVault.clear(); // ensure an EMPTY (locked) vault
+});
+
+afterEach(() => {
+  SessionKeyVault.clear();
+  jest.restoreAllMocks();
+});
+
+describe('getPrivateKey — Format A is unchanged with an EMPTY vault', () => {
+  it('decrypts a Format-A blob via the device key (pin supplied) and does NOT touch the vault', async () => {
+    jest
+      .spyOn(AccountSecureStorage, 'verifyPin')
+      .mockResolvedValue(true as unknown as boolean);
+
+    const sk = fakeKey(64);
+    const accountId = 'acct-formatA-emptyvault';
+    seedSecret(accountId, {
+      accountId,
+      encryptedPrivateKey: makeFormatA(sk),
+      authMethod: 'pin',
+    });
+
+    expect(SessionKeyVault.isUnlocked()).toBe(false);
+    const out = await AccountSecureStorage.getPrivateKey(accountId, PIN);
+    expect(hex(out)).toBe(hex(sk));
+
+    // getPrivateKey is a pure reader: it never populates the vault.
+    expect(SessionKeyVault.isUnlocked()).toBe(false);
+  });
+
+  it('decrypts a Format-A blob with pin=undefined + empty vault (no PIN set) — no throw', async () => {
+    const sk = fakeKey(64);
+    const accountId = 'acct-formatA-nopin';
+    seedSecret(accountId, {
+      accountId,
+      encryptedPrivateKey: makeFormatA(sk),
+      authMethod: 'pin',
+    });
+
+    // No PIN, no biometric, empty vault: the device-key path succeeds exactly as
+    // before (the classic pin=undefined caller scenario).
+    const out = await AccountSecureStorage.getPrivateKey(accountId);
+    expect(hex(out)).toBe(hex(sk));
+  });
+});
+
+describe('getPrivateKey — Format A is unchanged with an UNLOCKED vault (v2 branch inert)', () => {
+  it('an unlocked vault does not change Format-A decryption (no blobs => device key)', async () => {
+    const sk = fakeKey(64);
+    const accountId = 'acct-formatA-vaultunlocked';
+    seedSecret(accountId, {
+      accountId,
+      encryptedPrivateKey: makeFormatA(sk),
+      authMethod: 'pin',
+    });
+
+    // Populate the vault (as AuthContext would at unlock). The Format-A payload
+    // carries no `blobs`, so the vault-aware v2 branch is skipped and decryption
+    // still flows through the device-key path.
+    SessionKeyVault.set(PIN, 'pin');
+
+    const out = await AccountSecureStorage.getPrivateKey(accountId);
+    expect(hex(out)).toBe(hex(sk));
+  });
+});

--- a/src/services/secure/__tests__/sessionTeardown.test.ts
+++ b/src/services/secure/__tests__/sessionTeardown.test.ts
@@ -1,0 +1,45 @@
+// Unit test for clearSessionSecurity (DOC-137 §6.3 / Codex P1-D + P1-E, PR3).
+//
+// This is the SINGLE teardown that AuthContext.lock() invokes on every lock path
+// (explicit / inactivity-timeout / background-grace). The test proves it fans
+// out to all THREE clears: the session vault, the legacy 60 s plaintext-key
+// cache, and the ~30 min messaging key cache — with each clear mocked/spied.
+
+// Minimal platform mock so importing AccountSecureStorage resolves under jest
+// (clearPrivateKeyCache itself touches none of these).
+jest.mock('@/platform', () => ({
+  crypto: {},
+  secureStorage: {},
+  storage: {},
+  biometrics: {},
+  deviceId: {},
+}));
+
+// Mock the messaging key cache clear so we assert the call without loading the
+// messaging module graph.
+jest.mock('../../messaging/keyDerivation', () => ({
+  clearMessagingKeyCache: jest.fn(),
+}));
+
+import { clearSessionSecurity } from '../sessionTeardown';
+import { AccountSecureStorage } from '../AccountSecureStorage';
+import { SessionKeyVault } from '../SessionKeyVault';
+import { clearMessagingKeyCache } from '../../messaging/keyDerivation';
+
+describe('clearSessionSecurity', () => {
+  it('clears the vault, the 60s key cache, and the messaging key cache', () => {
+    const vaultSpy = jest.spyOn(SessionKeyVault, 'clear');
+    const cacheSpy = jest
+      .spyOn(AccountSecureStorage, 'clearPrivateKeyCache')
+      .mockImplementation(() => {});
+
+    clearSessionSecurity();
+
+    expect(vaultSpy).toHaveBeenCalledTimes(1);
+    expect(cacheSpy).toHaveBeenCalledTimes(1);
+    expect(clearMessagingKeyCache).toHaveBeenCalledTimes(1);
+
+    vaultSpy.mockRestore();
+    cacheSpy.mockRestore();
+  });
+});

--- a/src/services/secure/__tests__/sessionTeardown.test.ts
+++ b/src/services/secure/__tests__/sessionTeardown.test.ts
@@ -21,9 +21,10 @@ jest.mock('../../messaging/keyDerivation', () => ({
   clearMessagingKeyCache: jest.fn(),
 }));
 
-import { clearSessionSecurity } from '../sessionTeardown';
+import { clearSessionSecurity, enterLockedState } from '../sessionTeardown';
 import { AccountSecureStorage } from '../AccountSecureStorage';
 import { SessionKeyVault } from '../SessionKeyVault';
+import { AppLockSignal } from '../appLockState';
 import { clearMessagingKeyCache } from '../../messaging/keyDerivation';
 
 describe('clearSessionSecurity', () => {
@@ -39,6 +40,35 @@ describe('clearSessionSecurity', () => {
     expect(cacheSpy).toHaveBeenCalledTimes(1);
     expect(clearMessagingKeyCache).toHaveBeenCalledTimes(1);
 
+    vaultSpy.mockRestore();
+    cacheSpy.mockRestore();
+  });
+});
+
+describe('enterLockedState (Codex P1-E: sync lock signal BEFORE teardown)', () => {
+  it('flips AppLockSignal to locked synchronously and BEFORE the cache teardown', () => {
+    AppLockSignal.setUnlocked(true);
+    const signalSpy = jest.spyOn(AppLockSignal, 'setUnlocked');
+    const vaultSpy = jest.spyOn(SessionKeyVault, 'clear');
+    const cacheSpy = jest
+      .spyOn(AccountSecureStorage, 'clearPrivateKeyCache')
+      .mockImplementation(() => {});
+
+    enterLockedState();
+
+    // The signal is now locked (set synchronously, not via a later effect)...
+    expect(AppLockSignal.isUnlocked()).toBe(false);
+    expect(signalSpy).toHaveBeenCalledWith(false);
+    // ...and it was flipped BEFORE the teardown ran (invocation order), so a
+    // racing derive that resolves during teardown already sees "locked".
+    expect(signalSpy.mock.invocationCallOrder[0]).toBeLessThan(
+      vaultSpy.mock.invocationCallOrder[0]
+    );
+    expect(signalSpy.mock.invocationCallOrder[0]).toBeLessThan(
+      (clearMessagingKeyCache as jest.Mock).mock.invocationCallOrder[0]
+    );
+
+    signalSpy.mockRestore();
     vaultSpy.mockRestore();
     cacheSpy.mockRestore();
   });

--- a/src/services/secure/appLockState.ts
+++ b/src/services/secure/appLockState.ts
@@ -1,0 +1,31 @@
+/**
+ * AppLockSignal (Wave-2, DOC-137 §6.5 row 9 / Codex P1-E, PR3)
+ *
+ * A minimal, module-level mirror of the app's unlock state so NON-React services
+ * (e.g. the background messaging poll) can cheaply check whether the app is
+ * currently unlocked WITHOUT importing React or AuthContext. AuthContext is the
+ * single writer (it already computes `isUnlocked` and pushes it to
+ * DeepLinkService); readers only observe.
+ *
+ * WHY NOT SessionKeyVault.isUnlocked(): in PR3 the vault is populated on PIN
+ * unlock but not on biometric unlock (the biometric-convenience secret item
+ * lands in a later PR), so the vault is not yet a reliable app-unlock signal for
+ * biometric users. This signal reflects the AuthContext lock state regardless of
+ * unlock method.
+ *
+ * Defaults to `false` (locked) so a poll that fires before AuthContext has
+ * synced defers rather than deriving keys while the lock state is unknown.
+ */
+
+let unlocked = false;
+
+export const AppLockSignal = {
+  /** AuthContext writes the current unlock state here on every transition. */
+  setUnlocked(value: boolean): void {
+    unlocked = value;
+  },
+  /** True when the app is unlocked (safe to derive keys). */
+  isUnlocked(): boolean {
+    return unlocked;
+  },
+};

--- a/src/services/secure/envelopeV2.ts
+++ b/src/services/secure/envelopeV2.ts
@@ -552,3 +552,55 @@ export async function decryptKeyEnvelopeV2(
     wipeWordArray(decryptedWA);
   }
 }
+
+/**
+ * Trial-decrypt a KeyEnvelopeV2 using a PRE-DERIVED 32-byte wrap key — e.g. the
+ * SessionKeyVault's memoized `getWrapKey` output (DOC-137 §6.4). This is the
+ * scrypt-free half of the reader: the caller (the vault) already paid the
+ * memory-hard cost once per account/salt, so per-signature reads only run the
+ * cheap MAC-verify + AES-CTR unwrap.
+ *
+ * Returns the exact wrapped key bytes on success, or `null` when the MAC does
+ * not verify (wrong wrap key / tampered header). THROWS only on a structurally
+ * invalid envelope or out-of-cap KDF params.
+ *
+ * CRITICAL: does NOT zero `wrapKey` — that buffer is OWNED by the vault (memoized
+ * and reused across reads; the vault zeroes it on clear/rotate). Only the
+ * derived AES/HMAC WordArrays created here are scrubbed.
+ */
+export async function decryptKeyEnvelopeV2WithWrapKey(
+  envelope: KeyEnvelopeV2,
+  wrapKey: Uint8Array
+): Promise<Uint8Array | null> {
+  // Structural + param-cap validation BEFORE any crypto work.
+  assertValidKeyEnvelopeV2(envelope);
+
+  let aesKeyWA: CryptoJS.lib.WordArray | null = null;
+  let hmacKeyWA: CryptoJS.lib.WordArray | null = null;
+  let decryptedWA: CryptoJS.lib.WordArray | null = null;
+
+  try {
+    ({ aesKeyWA, hmacKeyWA } = keyMaterialFromWrapKey(wrapKey));
+
+    const aad = canonicalAtRestAad(envelope);
+    const computedMac = CryptoJS.HmacSHA256(
+      aad + envelope.ct,
+      hmacKeyWA
+    ).toString();
+    if (!constantTimeEqualHex(computedMac, envelope.mac)) {
+      return null; // wrong wrap key / tampered header -> fall through
+    }
+
+    decryptedWA = CryptoJS.AES.decrypt(envelope.ct, aesKeyWA, {
+      iv: CryptoJS.enc.Hex.parse(envelope.iv),
+      mode: CryptoJS.mode.CTR,
+      padding: CryptoJS.pad.NoPadding,
+    });
+    return wordArrayToUint8Array(decryptedWA);
+  } finally {
+    // NOTE: `wrapKey` is intentionally NOT zeroed (vault-owned).
+    wipeWordArray(aesKeyWA);
+    wipeWordArray(hmacKeyWA);
+    wipeWordArray(decryptedWA);
+  }
+}

--- a/src/services/secure/sessionTeardown.ts
+++ b/src/services/secure/sessionTeardown.ts
@@ -20,6 +20,7 @@
 
 import { AccountSecureStorage } from './AccountSecureStorage';
 import { SessionKeyVault } from './SessionKeyVault';
+import { AppLockSignal } from './appLockState';
 import { clearMessagingKeyCache } from '../messaging/keyDerivation';
 
 /** Clear the session vault, the 60 s key cache, and the messaging key cache. */
@@ -27,4 +28,21 @@ export function clearSessionSecurity(): void {
   SessionKeyVault.clear();
   AccountSecureStorage.clearPrivateKeyCache();
   clearMessagingKeyCache();
+}
+
+/**
+ * Enter the locked state synchronously (Codex P1-E race fix). Order matters:
+ *   1. Flip AppLockSignal to LOCKED **first** — synchronously, before any
+ *      teardown — so non-React consumers (the messaging cache-write guard and
+ *      the poll) observe the lock immediately. A key derivation that started
+ *      before the lock and resolves during teardown then refuses to repopulate
+ *      the ~30 min messaging cache.
+ *   2. Run the cache teardown (vault + 60 s + messaging).
+ *
+ * AuthContext.lock() calls this on every real lock (i.e. only when a PIN is set;
+ * a no-PIN wallet never locks, so its always-unlocked signal is left untouched).
+ */
+export function enterLockedState(): void {
+  AppLockSignal.setUnlocked(false);
+  clearSessionSecurity();
 }

--- a/src/services/secure/sessionTeardown.ts
+++ b/src/services/secure/sessionTeardown.ts
@@ -1,0 +1,30 @@
+/**
+ * Session-security teardown (Wave-2, DOC-137 §6.3 / Codex P1-D + P1-E, PR3)
+ *
+ * The SINGLE place that drops every piece of in-memory session key material.
+ * AuthContext.lock() calls this on EVERY lock path (explicit, inactivity-timeout,
+ * and background-grace), so teardown lives in exactly one location:
+ *
+ *   1. SessionKeyVault.clear()            — zero memoized wrap keys + drop the
+ *                                           secret + bump the vault epoch (P1-D).
+ *   2. clearPrivateKeyCache()             — zero + drop the legacy 60 s
+ *                                           plaintext-key cache.
+ *   3. clearMessagingKeyCache()           — zero + drop the ~30 min derived
+ *                                           X25519 messaging keypair cache so a
+ *                                           locked device stops decrypting
+ *                                           messages (P1-E).
+ *
+ * Idempotent and safe to call when already locked. This module never logs any
+ * secret or key material.
+ */
+
+import { AccountSecureStorage } from './AccountSecureStorage';
+import { SessionKeyVault } from './SessionKeyVault';
+import { clearMessagingKeyCache } from '../messaging/keyDerivation';
+
+/** Clear the session vault, the 60 s key cache, and the messaging key cache. */
+export function clearSessionSecurity(): void {
+  SessionKeyVault.clear();
+  AccountSecureStorage.clearPrivateKeyCache();
+  clearMessagingKeyCache();
+}

--- a/src/store/messagesStore.ts
+++ b/src/store/messagesStore.ts
@@ -22,6 +22,7 @@ import {
 } from '@/services/messaging/types';
 import MessagingService from '@/services/messaging';
 import { computeSyncCursor } from '@/services/messaging/syncCursor';
+import { AppLockSignal } from '@/services/secure/appLockState';
 import { useFriendsStore } from './friendsStore';
 
 const STORAGE_KEY_PREFIX = '@messages/';
@@ -599,6 +600,15 @@ export const useMessagesStore = create<MessagesState>()(
      * Fetch all conversations from the blockchain
      */
     fetchAllThreads: async (userAddress, pin) => {
+      // Defer while the app is locked (DOC-137 §6.5 / Codex P1-E). This is the
+      // background poll path that reaches getPrivateKey; deriving the messaging
+      // key while locked would keep a locked device decrypting messages (and
+      // could pop a biometric prompt from the background). The next unlock
+      // re-triggers the poll, and fetchAllThreads drains from the durable sync
+      // cursor, so nothing is skipped.
+      if (!AppLockSignal.isUnlocked()) {
+        return;
+      }
       // Coalesce concurrent fetches for the same account so overlapping
       // bootstraps can't each commit a different window and skip the gap.
       if (inFlightThreadFetches.has(userAddress)) {


### PR DESCRIPTION
## PR3 of ~7 — SessionKeyVault + lock-lifecycle teardown (TASK-27, Wave-2 key migration)

Implements DOC-137 §6 (session vault + the ~14 `getPrivateKey` call sites) and the §0 Codex P1-D / P1-E must-fixes. **No key writer and no migration land here** — keys remain **Format A** (device-key wrapped). This PR introduces the in-memory session vault and routes every lock path through a single teardown, while **retaining the device-key fallback so existing wallets behave identically**.

### NO-behavior-change guarantee (Format-A keys)
- Existing payloads have **no `blobs`**, so the new vault-aware v2 candidate branch in `getPrivateKey` is **inert** — decryption falls through to the unchanged Format-A (device-key) / Format-C candidates exactly as today.
- A **locked vault does NOT throw** in `getPrivateKey` (Format A never needs the user secret). The 60 s plaintext-key cache is **kept**.
- Proven by tests: a Format-A blob decrypts byte-identically with the vault **empty** (pin and pin=undefined) and with the vault **unlocked**; `getPrivateKey` never populates the vault (it's a pure reader).

### SessionKeyVault (in-memory-only singleton, never persisted)
- Holds `secret`, `secretSource`, `wrapKeys: Map<accountId, Uint8Array>` (memoized `deriveWrapKey` outputs), and a monotonic `epoch`.
- `isUnlocked() / set() / rotate() / getWrapKey(accountId, salt) / getSecret() / currentEpoch() / clear()`.
- `getWrapKey` runs scrypt **at most once per account** (memoized); `clear()` **zeroes every wrap-key buffer + drops the secret + bumps the epoch**; `rotate()` swaps the secret **without re-locking** (for a future changePin) and invalidates stale wrap keys.

### Vault epoch (Codex P1-D)
`set()` / `rotate()` / `clear()` bump a monotonic `epoch`. `getWrapKey` captures the epoch before its scrypt await and, if the epoch changed mid-flight (a lock during derivation), **zeroes the fresh key, caches nothing, and throws `VaultLockedError`** — an in-flight scrypt started pre-lock can never return or cache key material post-lock. The same guard wraps the (inert) vault-derived v2 path in `getPrivateKey`.

### Unified lock() teardown
All three lock paths — **explicit lock, inactivity-timeout lock, and background-grace lock** — now route through the single `AuthContext.lock()`, which calls `clearSessionSecurity()`:
1. `SessionKeyVault.clear()` (vault + epoch bump),
2. `AccountSecureStorage.clearPrivateKeyCache()` (the legacy 60 s cache),
3. `clearMessagingKeyCache()` (the messaging key cache — P1-E).

The inactivity interval previously locked via an inline `setAuthState`; it now reads the latest state from a ref and calls `lock()`, so teardown runs on that path too. The vault is populated on PIN unlock (`set(pin, 'pin')`); the biometric path is documented to populate it once the biometric-convenience secret item lands (later PR) — until then, Format A decrypts via the device key with no secret, so it stays behavior-preserving.

### Messaging cache-on-lock + locked-poll defer (Codex P1-E)
- Added exported `clearMessagingKeyCache()` (wraps the existing `clearAllCachedKeys`, which zeroes each cached X25519 secret key); called on every lock.
- The background poll (`messagesStore.fetchAllThreads`, reached via `startPolling`) **early-returns while the app is locked**, checking a minimal `AppLockSignal` written by `AuthContext` (works for both PIN and biometric unlock, unlike `SessionKeyVault.isUnlocked()` which isn't yet populated on biometric unlock in PR3). The durable sync cursor recovers any skipped tick on the next unlock.

### Re-audited real `getPrivateKey` callers (Codex noted "~14" is approximate)
Direct, key-accessing call sites (all keep working unchanged via the centralized vault-aware read — **no call-site edits needed**):
- `keyManager.ts:53` (wrapper, passes pin) · `keyManager.ts:541` (mnemonic export, **pin=undefined**)
- `simplifiedKeyManager.ts:56` (wrapper, passes pin)
- `wallet/index.ts:889` (**pin=undefined**) · `wallet/rekeyManager.ts:196` (**pin=undefined**)
- `messaging/index.ts:146` (send, pin?) · `messaging/index.ts:810` (deriveMessagingKeyPair — **the poll path**, pin?)
- `remoteSigner/SignatureDisplayScreen.tsx:146` (pin?) · `remoteSigner/TransferToAirgapFlow.tsx:92` (**pin=undefined**)

Wrappers/self-calls (not direct): `keyManager.ts:172`, `simplifiedKeyManager.ts:137`.
Confirmed **not** a key access: `walletconnect/index.ts:527` only lists accounts; WC signing requires a `pin: string`.

### Files changed
- `src/services/secure/SessionKeyVault.ts` — new in-memory vault (epoch-guarded).
- `src/services/secure/appLockState.ts` — new minimal app-unlock signal for the messaging poll.
- `src/services/secure/sessionTeardown.ts` — new single teardown (vault + 60 s + messaging).
- `src/services/secure/AccountSecureStorage.ts` — vault-aware v2 candidate + epoch guard in `getPrivateKey` (inert for Format A).
- `src/contexts/AuthContext.tsx` — populate vault on unlock; route inactivity lock through `lock()`; teardown in `lock()`; push unlock state to `AppLockSignal`.
- `src/services/messaging/keyDerivation.ts` + `index.ts` — exported `clearMessagingKeyCache()`.
- `src/store/messagesStore.ts` — locked-poll defer.
- `src/services/secure/__tests__/{SessionKeyVault,sessionTeardown,getPrivateKey.vault}.test.ts` — 12 new tests.

### Tests & gates
- New tests: SessionKeyVault set/getWrapKey(memoized once per account)/clear(zeros+epoch)/rotate + epoch-abort guard; `clearSessionSecurity` fans out to all three clears; Format-A unchanged with empty **and** unlocked vault.
- `npm run typecheck` — 0 errors (full/clean). `npm run lint` — 0 errors, no new (2 introduced prettier errors fixed). `npm test -- --ci` — **28 suites / 381 tests pass**.

### Roadmap
PR3 of ~7. Writer = PR4, migration flip = PR5 (gated on on-device testing). The vault becomes load-bearing for decryption once keys become v2.
