### PR TITLE
feat(secure): biometric-convenience item + populate vault on biometric unlock; scoped setItemWithAuth (TASK-27 PR6)

### DIFF
--- a/src/contexts/AuthContext.tsx
+++ b/src/contexts/AuthContext.tsx
@@ -9,6 +9,8 @@ import { AppState, Platform, AppStateStatus } from 'react-native';
 import { MultiAccountWalletService } from '@/services/wallet';
 import { AccountSecureStorage } from '@/services/secure';
 import { SessionKeyVault } from '@/services/secure/SessionKeyVault';
+import type { SecretSource } from '@/services/secure/SessionKeyVault';
+import { unlockVaultWithBiometrics } from '@/services/secure/biometricUnlock';
 import { enterLockedState } from '@/services/secure/sessionTeardown';
 import { AppLockSignal } from '@/services/secure/appLockState';
 import { SecurityUtils } from '@/utils/security';
@@ -33,25 +35,6 @@ const checkBiometricAvailability = async (): Promise<{
   }
 };
 
-// Helper to authenticate with biometrics (web-safe)
-const authenticateWithBiometrics = async (
-  promptMessage: string
-): Promise<{ success: boolean }> => {
-  if (Platform.OS === 'web') {
-    return { success: false };
-  }
-  try {
-    const LocalAuthentication = require('expo-local-authentication');
-    return await LocalAuthentication.authenticateAsync({
-      promptMessage,
-      fallbackLabel: 'Use PIN',
-      cancelLabel: 'Cancel',
-    });
-  } catch {
-    return { success: false };
-  }
-};
-
 export interface AuthState {
   isLocked: boolean;
   isAuthenticated: boolean;
@@ -70,7 +53,7 @@ export interface AuthContextType {
   lock: () => void;
   updateActivity: () => void;
   setupPin: (pin: string) => Promise<void>;
-  enableBiometrics: (enabled: boolean) => Promise<void>;
+  enableBiometrics: (enabled: boolean, secret?: string) => Promise<void>;
   recheckAuthState: () => Promise<void>;
   updateTimeoutSetting: () => Promise<void>;
 }
@@ -334,17 +317,18 @@ export function AuthProvider({ children }: { children: React.ReactNode }) {
         return false;
       }
 
-      const result = await authenticateWithBiometrics('Unlock your wallet');
+      // Read the biometric-convenience secret behind the OS biometric gate and,
+      // on success, populate the SessionKeyVault (DOC-137 §3.3, PR6). The single
+      // getItemWithAuth inside is BOTH the biometric prompt AND the
+      // vault-populating read — no separate LocalAuthentication prompt (that
+      // would double-prompt). This is THE fix that makes a biometric-unlocked
+      // session hold the vault secret, so future v2 keys read under pin=undefined
+      // (prerequisite for PR4).
+      const outcome = await unlockVaultWithBiometrics('Unlock your wallet');
 
-      if (result.success) {
-        // NOTE (DOC-137 §3.3, PR3): the biometric-convenience secret item that
-        // yields the user secret on biometric unlock lands in a later PR (the
-        // writer/biometric milestone). Until then biometric unlock has no user
-        // secret to populate the vault with, and — since keys are still Format A
-        // — the device-key path decrypts without one, so this is behavior-
-        // preserving. When the convenience item ships, read the secret here and
-        // call SessionKeyVault.set(secret, secretSource).
-        // Flip the lock signal to UNLOCKED synchronously (mirrors lock()).
+      if (outcome.status === 'unlocked') {
+        // Flip the lock signal to UNLOCKED synchronously (mirrors the PIN path
+        // and lock()) so the messaging poll/cache-write guard resumes at once.
         AppLockSignal.setUnlocked(true);
 
         const sessionId = SecurityUtils.generateSessionId();
@@ -359,6 +343,17 @@ export function AuthProvider({ children }: { children: React.ReactNode }) {
         return true;
       }
 
+      if (outcome.status === 'invalidated') {
+        // THE INVARIANT (DOC-137 §3.4): a biometric / enrollment-change
+        // invalidation NEVER requires the mnemonic. The convenience item is gone
+        // and its enabled flag has already been cleared in storage; reflect that
+        // in React state so the LockScreen stops prompting biometrics and the
+        // user falls back to PIN/passphrase entry — never the mnemonic.
+        setAuthState((prev) => ({ ...prev, biometricEnabled: false }));
+      }
+
+      // 'cancelled' (user cancelled / OS auth failed) or 'invalidated': not
+      // unlocked. Biometrics stays enabled on a cancel so the user can retry.
       return false;
     } catch (error) {
       console.error('Failed to unlock with biometrics:', error);
@@ -418,7 +413,10 @@ export function AuthProvider({ children }: { children: React.ReactNode }) {
     }));
   };
 
-  const enableBiometrics = async (enabled: boolean): Promise<void> => {
+  const enableBiometrics = async (
+    enabled: boolean,
+    secret?: string
+  ): Promise<void> => {
     if (enabled) {
       const { hasHardware, isEnrolled } = await checkBiometricAvailability();
 
@@ -427,9 +425,48 @@ export function AuthProvider({ children }: { children: React.ReactNode }) {
           'Biometric authentication not available or not enrolled'
         );
       }
+
+      // Enable flow (DOC-137 §3.3): capture the user secret behind the write-time
+      // auth gate, then set the enabled flag. Biometrics NEVER captures a secret
+      // it was not explicitly given: use an explicitly-supplied secret (verified
+      // here) or the secret the user already entered to unlock THIS session (the
+      // SessionKeyVault, populated + verified at unlock). A key-bearing wallet
+      // with no available secret refuses rather than storing nothing.
+      const hasPin = await AccountSecureStorage.hasPin();
+      if (hasPin) {
+        let secretToStore = secret;
+        let source: SecretSource = 'pin';
+
+        if (secretToStore != null) {
+          const ok = await AccountSecureStorage.verifyPin(secretToStore);
+          if (!ok) {
+            throw new Error('Incorrect PIN');
+          }
+        } else {
+          // The session secret is already verified (it unlocked this session).
+          secretToStore = SessionKeyVault.getSecret() ?? undefined;
+          source = SessionKeyVault.getSecretSource();
+          if (secretToStore == null) {
+            throw new Error(
+              'Unlock with your PIN before enabling biometric unlock'
+            );
+          }
+        }
+
+        await AccountSecureStorage.setBiometricSecret(
+          secretToStore,
+          source,
+          'Enable biometric unlock'
+        );
+      }
+
+      await AccountSecureStorage.setBiometricEnabled(true);
+    } else {
+      // Disable: drop the auth-gated convenience secret, then clear the flag.
+      await AccountSecureStorage.clearBiometricSecret();
+      await AccountSecureStorage.setBiometricEnabled(false);
     }
 
-    await AccountSecureStorage.setBiometricEnabled(enabled);
     setAuthState((prev) => ({
       ...prev,
       biometricEnabled: enabled,

--- a/src/platform/__tests__/mobileSecureStorage.setItemWithAuth.test.ts
+++ b/src/platform/__tests__/mobileSecureStorage.setItemWithAuth.test.ts
@@ -1,0 +1,48 @@
+// Unit test for the write-time auth gate (DOC-137 §2.5, PR6). Proves
+// MobileSecureStorageAdapter.setItemWithAuth provisions `requireAuthentication`
+// AT WRITE (the fix for the write-time-ACL bug where auth was requested only on
+// read), and that plain setItem does NOT — so the auth gate stays scoped to the
+// single biometric-convenience item.
+//
+// SECURITY NOTE: throwaway test strings stand in for any secret; no real key.
+
+jest.mock('expo-secure-store', () => ({
+  WHEN_UNLOCKED_THIS_DEVICE_ONLY: 'when_unlocked_this_device_only',
+  setItemAsync: jest.fn(async () => {}),
+  getItemAsync: jest.fn(async () => null),
+  deleteItemAsync: jest.fn(async () => {}),
+}));
+
+import * as SecureStore from 'expo-secure-store';
+import { MobileSecureStorageAdapter } from '../mobile/secureStorage';
+
+const setItemAsyncMock = SecureStore.setItemAsync as jest.Mock;
+
+describe('MobileSecureStorageAdapter.setItemWithAuth (DOC-137 §2.5)', () => {
+  const adapter = new MobileSecureStorageAdapter();
+
+  it('provisions requireAuthentication:true AT WRITE with the prompt', async () => {
+    await adapter.setItemWithAuth('voi_biometric_secret', 'convenience-value', {
+      prompt: 'Enable biometric unlock',
+    });
+
+    expect(setItemAsyncMock).toHaveBeenCalledTimes(1);
+    const [key, value, options] = setItemAsyncMock.mock.calls[0];
+    expect(key).toBe('voi_biometric_secret');
+    expect(value).toBe('convenience-value');
+    expect(options).toMatchObject({
+      requireAuthentication: true,
+      authenticationPrompt: 'Enable biometric unlock',
+    });
+  });
+
+  it('plain setItem does NOT set requireAuthentication (scope stays one item)', async () => {
+    await adapter.setItem('voi_wallet_pin', 'pin-hash');
+
+    expect(setItemAsyncMock).toHaveBeenCalledTimes(1);
+    const [key, , options] = setItemAsyncMock.mock.calls[0];
+    expect(key).toBe('voi_wallet_pin');
+    expect(options).not.toHaveProperty('requireAuthentication');
+    expect(options).not.toHaveProperty('authenticationPrompt');
+  });
+});

--- a/src/platform/extension/secureStorage.ts
+++ b/src/platform/extension/secureStorage.ts
@@ -154,6 +154,22 @@ export class ExtensionSecureStorageAdapter implements SecureStorageAdapter {
     // WebAuthn would be handled at a higher level in the auth flow
     return this.getItem(key);
   }
+
+  /**
+   * Not supported on the extension: there is no hardware-backed auth-gated store
+   * to provision (DOC-137 §2.5). The interface member is optional, so callers
+   * that need a write-time auth gate must feature-detect and fall back. The
+   * biometric-convenience item (the sole consumer) is a mobile-only feature.
+   */
+  async setItemWithAuth(
+    _key: string,
+    _value: string,
+    _options: { prompt: string }
+  ): Promise<void> {
+    throw new Error(
+      'setItemWithAuth is not supported on the extension platform'
+    );
+  }
 }
 
 // Singleton instance

--- a/src/platform/index.ts
+++ b/src/platform/index.ts
@@ -183,6 +183,21 @@ export const secureStorage = {
     }
     return adapter.getItem(key);
   },
+  // Write-time auth-gated store (DOC-137 §2.5). No safe fallback: a plain
+  // setItem would defeat the enclave gate, so platforms without support reject.
+  setItemWithAuth: (
+    key: string,
+    value: string,
+    options: { prompt: string }
+  ): Promise<void> => {
+    const adapter = getSecureStorage();
+    if (adapter.setItemWithAuth) {
+      return adapter.setItemWithAuth(key, value, options);
+    }
+    return Promise.reject(
+      new Error('setItemWithAuth is not supported on this platform')
+    );
+  },
 };
 
 /**

--- a/src/platform/mobile/secureStorage.ts
+++ b/src/platform/mobile/secureStorage.ts
@@ -36,6 +36,27 @@ export class MobileSecureStorageAdapter implements SecureStorageAdapter {
       authenticationPrompt: options.prompt,
     });
   }
+
+  /**
+   * Store a value behind a mandatory device-auth gate, provisioning the
+   * access-control flag AT WRITE time (DOC-137 §2.5). Requesting
+   * `requireAuthentication` on the WRITE is what actually enclave-binds the
+   * item (the prior code only requested auth on read, which enclave-bound
+   * nothing — the write-time-ACL bug). Reserved for the biometric-convenience
+   * item ONLY; the resulting item is intentionally OS-invalidated on
+   * enrollment change / lock removal.
+   */
+  async setItemWithAuth(
+    key: string,
+    value: string,
+    options: { prompt: string }
+  ): Promise<void> {
+    await SecureStore.setItemAsync(key, value, {
+      ...SECURE_STORE_OPTIONS,
+      requireAuthentication: true,
+      authenticationPrompt: options.prompt,
+    });
+  }
 }
 
 // Singleton instance

--- a/src/platform/types.ts
+++ b/src/platform/types.ts
@@ -30,6 +30,21 @@ export interface SecureStorageAdapter {
     key: string,
     options: { prompt: string }
   ): Promise<string | null>;
+
+  /**
+   * Store a value behind a MANDATORY device-auth gate (biometric/passcode),
+   * provisioning the access-control flag AT WRITE time (DOC-137 §2.5). This is
+   * enclave-bound and OS-invalidated on biometric-enrollment change / lock
+   * removal, so it MUST be used ONLY for the biometric-convenience item (§3) —
+   * never for items that must survive enrollment changes (PIN hash, salt, key
+   * envelope, metadata). Fixes the write-time-ACL bug where auth was requested
+   * only on read of an item never provisioned auth-required.
+   */
+  setItemWithAuth?(
+    key: string,
+    value: string,
+    options: { prompt: string }
+  ): Promise<void>;
 }
 
 // General Storage Adapter Interface (AsyncStorage replacement)

--- a/src/screens/onboarding/SecuritySetupScreen.tsx
+++ b/src/screens/onboarding/SecuritySetupScreen.tsx
@@ -107,9 +107,29 @@ export default function SecuritySetupScreen({ navigation, route }: Props) {
       setSetupStep('Setting up PIN...');
       await AccountSecureStorage.storePin(pin);
 
-      // Store biometric preference
+      // Store biometric preference. When the user opts into biometrics at
+      // onboarding, capture the just-set PIN behind the write-time auth gate
+      // (DOC-137 §3.3) so the biometric-convenience item exists on first launch
+      // and biometric unlock can populate the session vault — otherwise the very
+      // first biometric unlock would find no item and fall back to PIN. The
+      // convenience write is best-effort: if it fails (e.g. the OS auth is
+      // cancelled at write), biometrics is left disabled and onboarding proceeds.
       setSetupStep('Configuring security...');
-      await AccountSecureStorage.setBiometricEnabled(biometricEnabled);
+      if (biometricEnabled) {
+        try {
+          await AccountSecureStorage.setBiometricSecret(
+            pin,
+            'pin',
+            'Enable biometric unlock'
+          );
+          await AccountSecureStorage.setBiometricEnabled(true);
+        } catch {
+          console.warn('Failed to enable biometric convenience during setup');
+          await AccountSecureStorage.setBiometricEnabled(false);
+        }
+      } else {
+        await AccountSecureStorage.setBiometricEnabled(false);
+      }
 
       // Handle different onboarding sources
       if ((source === 'create' || source === 'mnemonic') && mnemonic) {

--- a/src/services/secure/AccountSecureStorage.ts
+++ b/src/services/secure/AccountSecureStorage.ts
@@ -40,6 +40,7 @@ import {
   MAX_KEY_BLOBS,
 } from './envelopeV2';
 import { SessionKeyVault, VaultLockedError } from './SessionKeyVault';
+import type { SecretSource } from './SessionKeyVault';
 import { SECURITY_CONFIG } from '../../config/security';
 
 // ─────────────────────────────────────────────────────────────────────────────
@@ -162,6 +163,10 @@ export class AccountSecureStorage {
   private static readonly PIN_KEY = 'voi_wallet_pin';
   private static readonly SALT_KEY = 'voi_wallet_salt';
   private static readonly BIOMETRIC_ENABLED_KEY = 'voi_biometric_enabled';
+  // The biometric-convenience item (DOC-137 §3.2). Written via setItemWithAuth
+  // (auth-gated, enclave-bound, OS-invalidated on enrollment change) — the ONLY
+  // item in the app that uses setItemWithAuth.
+  private static readonly BIOMETRIC_SECRET_KEY = 'voi_biometric_secret';
   private static readonly DEVICE_ID_KEY = 'voi_device_installation_id';
   private static readonly PIN_TIMEOUT_KEY = 'voi_pin_timeout_setting';
   private static readonly PIN_THROTTLE_KEY = 'voi_pin_throttle';
@@ -485,36 +490,34 @@ export class AccountSecureStorage {
             );
           }
         } else {
+          // BIOMETRIC / no-PIN read path (DOC-137 §3.3, PR6). The KEY ENVELOPE is
+          // read with PLAIN getItem — NEVER getItemWithAuth. The prior
+          // getItemWithAuth-on-the-envelope call was the write-time-ACL bug: the
+          // envelope is written with plain setItem, so requesting auth only at
+          // read enclave-bound NOTHING — it was a UI prompt, not a hardware gate.
+          // The biometric gate now lives on the biometric-convenience item, which
+          // AuthContext reads with getItemWithAuth at unlock to populate the
+          // SessionKeyVault. getPrivateKey is a pure reader: for Format-A payloads
+          // the device key decrypts regardless of vault state, so this is
+          // behavior-preserving. A no-biometric wallet that still has a PIN keeps
+          // requiring the PIN (the throw below) rather than reading ambiently.
           const biometricEnabled = await this.isBiometricEnabled();
 
-          if (biometricEnabled) {
-            try {
-              secretPayloadRaw = await secureStorage.getItemWithAuth(
-                this.secretKey(accountId),
-                { prompt: 'Authenticate to access private key' }
-              );
-            } catch (error) {
-              throw new AuthenticationRequiredError(
-                'Biometric authentication failed or was cancelled'
-              );
-            }
-          } else {
+          if (!biometricEnabled) {
             const hasPin = await this.hasPin();
             if (hasPin) {
               throw new AuthenticationRequiredError(
                 'PIN required to access private key'
               );
             }
+          }
 
-            try {
-              secretPayloadRaw = await secureStorage.getItem(
-                this.secretKey(accountId)
-              );
-            } catch (error) {
-              throw new AccountRetrievalError(
-                'Failed to retrieve account data'
-              );
-            }
+          try {
+            secretPayloadRaw = await secureStorage.getItem(
+              this.secretKey(accountId)
+            );
+          } catch (error) {
+            throw new AccountRetrievalError('Failed to retrieve account data');
           }
         }
 
@@ -1591,6 +1594,114 @@ export class AccountSecureStorage {
     }
   }
 
+  // ─────────────────────────────────────────────────────────────────────────
+  // BIOMETRIC-CONVENIENCE ITEM (DOC-137 §3). READ BEFORE CHANGING.
+  //
+  // THREAT-MODEL TRADEOFF — this deliberately stores the RAW user secret (the
+  // PIN or passphrase) as `{ secret, secretSource }`. This is NOT an unencrypted
+  // write: the value is (a) platform-encrypted (Keychain / Keystore) and (b)
+  // written via `setItemWithAuth`, so it is enclave-bound behind a MANDATORY
+  // device-auth (biometric/passcode) gate — the OS refuses to return it without
+  // a fresh biometric prompt, and INVALIDATES it on any biometric-enrollment
+  // change / lock removal. We store the secret (not the derived wrap key) so the
+  // biometric path feeds the EXACT SAME scrypt-unwrap as manual entry (one code
+  // path to audit) and so a PIN/passphrase change re-writes only this one item.
+  // The residual exposure — a raw secret sits app-layer-plaintext inside that
+  // encrypted, auth-gated item, and JS strings cannot be reliably wiped — is an
+  // ACCEPTED, documented tradeoff (§0/§3.2, Q7), gated on the enclave.
+  //
+  // Because this item is OS-invalidated on enrollment change, it may NEVER be
+  // the sole custodian of key material: the key at rest stays wrapped by the
+  // user-secret scrypt envelope written with PLAIN setItem, which survives all
+  // enrollment events. Losing this item only forces PIN/passphrase re-entry —
+  // NEVER the mnemonic (THE INVARIANT, §3.4).
+  //
+  // NEVER log the secret or secretSource. This section, `setItemWithAuth`, and
+  // the mobile adapter are the entire blast radius of the auth-gated write.
+  // ─────────────────────────────────────────────────────────────────────────
+
+  /**
+   * Persist the biometric-convenience secret behind the write-time auth gate
+   * (DOC-137 §3.3, "Enable"). Provisions the enclave ACL AT WRITE via
+   * `setItemWithAuth`, so the item can only be read back after a fresh biometric
+   * prompt. Biometrics never captures a secret it was not explicitly given —
+   * the caller (AuthContext.enableBiometrics / onboarding) supplies it.
+   */
+  static async setBiometricSecret(
+    secret: string,
+    secretSource: SecretSource,
+    prompt: string
+  ): Promise<void> {
+    if (typeof secureStorage.setItemWithAuth !== 'function') {
+      throw new AccountStorageError(
+        'Auth-gated secure storage is not supported on this platform'
+      );
+    }
+    try {
+      const payload = JSON.stringify({ secret, secretSource });
+      await secureStorage.setItemWithAuth(this.BIOMETRIC_SECRET_KEY, payload, {
+        prompt,
+      });
+    } catch {
+      // Never surface the secret in the error.
+      throw new AccountStorageError('Failed to store biometric secret');
+    }
+  }
+
+  /**
+   * Read the biometric-convenience secret behind the OS biometric gate (DOC-137
+   * §3.3, "Biometric unlock"). The `getItemWithAuth` read IS the biometric
+   * prompt.
+   *
+   * Return contract mirrors expo-secure-store's documented `getItemAsync`:
+   *   - resolves the parsed `{ secret, secretSource }` on success;
+   *   - resolves `null` when the item is ABSENT or has been INVALIDATED
+   *     (biometric-enrollment change / lock removal) — the caller treats this as
+   *     the invalidation case (§3.4: clear the enabled flag, fall back to PIN,
+   *     NEVER the mnemonic), and a structurally corrupt item is coerced to null
+   *     for the same safe handling;
+   *   - THROWS only when the OS auth itself fails or the user cancels — the
+   *     caller must treat a throw as a cancel (keep biometrics enabled), NOT as
+   *     an invalidation.
+   */
+  static async getBiometricSecret(
+    prompt: string
+  ): Promise<{ secret: string; secretSource: SecretSource } | null> {
+    if (typeof secureStorage.getItemWithAuth !== 'function') {
+      return null;
+    }
+    // A throw here propagates to the caller (cancel / auth failure).
+    const raw = await secureStorage.getItemWithAuth(this.BIOMETRIC_SECRET_KEY, {
+      prompt,
+    });
+    if (raw === null) {
+      // Absent or invalidated by an enrollment change — NOT a throw.
+      return null;
+    }
+    try {
+      const parsed = JSON.parse(raw) as {
+        secret?: unknown;
+        secretSource?: unknown;
+      };
+      if (
+        typeof parsed.secret === 'string' &&
+        (parsed.secretSource === 'pin' || parsed.secretSource === 'passphrase')
+      ) {
+        return { secret: parsed.secret, secretSource: parsed.secretSource };
+      }
+    } catch {
+      // Corrupt item — fall through to null (safe: treated as invalidation).
+    }
+    return null;
+  }
+
+  /**
+   * Delete the biometric-convenience secret (on disable / reset). Best-effort.
+   */
+  static async clearBiometricSecret(): Promise<void> {
+    await secureStorage.deleteItem(this.BIOMETRIC_SECRET_KEY).catch(() => {});
+  }
+
   // PIN Timeout Settings
   static async setPinTimeout(timeoutMinutes: number | 'never'): Promise<void> {
     try {
@@ -1789,6 +1900,8 @@ export class AccountSecureStorage {
         secureStorage.deleteItem(this.PIN_KEY).catch(() => {}),
         secureStorage.deleteItem(this.SALT_KEY).catch(() => {}),
         secureStorage.deleteItem(this.BIOMETRIC_ENABLED_KEY).catch(() => {}),
+        // Drop the auth-gated biometric-convenience secret on a full wipe.
+        secureStorage.deleteItem(this.BIOMETRIC_SECRET_KEY).catch(() => {}),
         secureStorage.deleteItem(this.METADATA_LIST_KEY).catch(() => {}),
         secureStorage.deleteItem(this.PIN_TIMEOUT_KEY).catch(() => {}),
       ]);

--- a/src/services/secure/AccountSecureStorage.ts
+++ b/src/services/secure/AccountSecureStorage.ts
@@ -1571,27 +1571,43 @@ export class AccountSecureStorage {
 
   /**
    * After a secret change commits, resync the biometric-convenience item with
-   * the NEW secret (DOC-137 §3 / §5.3). If biometrics is disabled, no-op. If the
-   * refresh WRITE fails or is cancelled (e.g. the Android write-time biometric
-   * prompt is declined), DISABLE biometrics — clear the item AND the flag — so a
-   * stale OLD-secret convenience item NEVER survives a PIN change; the user
-   * re-enables biometrics afterward. Swallows all errors so it can run safely
-   * AFTER the PIN-hash commit without misreporting the PIN change. Never logs
-   * the secret.
+   * the NEW secret (DOC-137 §3 / §5.3).
+   *
+   * GATE ON THE CONVENIENCE ITEM (the source of truth), NOT `isBiometricEnabled()`
+   * (Codex P2-followup): the enabled-flag read returns `false` on a transient
+   * storage-read failure, which would make this a NO-OP and let a STALE OLD-secret
+   * item survive (later readable => a biometric unlock loads the OLD PIN). So we
+   * probe the ITEM instead and FAIL SAFE on any read error:
+   *   - item present  -> refresh it with the new secret; on write failure, clear
+   *                      the item + disable biometrics (no stale secret survives);
+   *   - item null      -> nothing stale to handle (no-op);
+   *   - read THROWS / undeterminable -> FAIL SAFE: best-effort clear the item +
+   *                      disable biometrics, so a stale OLD-secret item can NEVER
+   *                      survive a PIN change even under flaky storage reads.
+   *
+   * Swallows all errors so it can run AFTER the PIN-hash commit without rolling
+   * back or misreporting the (successful) PIN change. Never logs the secret.
    */
   private static async refreshBiometricSecretAfterSecretChange(
     newSecret: string,
     secretSource: SecretSource
   ): Promise<void> {
-    let biometricEnabled = false;
+    let existing: { secret: string; secretSource: SecretSource } | null;
     try {
-      biometricEnabled = await this.isBiometricEnabled();
+      existing = await this.getBiometricSecret('Update biometric unlock');
     } catch {
+      // Read couldn't be determined (flaky storage / declined auth). FAIL SAFE:
+      // never let a possibly-stale old-secret item survive a PIN change.
+      await this.clearBiometricSecret();
+      await this.setBiometricEnabled(false).catch(() => {});
       return;
     }
-    if (!biometricEnabled) {
+
+    if (existing === null) {
+      // No convenience item — nothing stale to handle.
       return;
     }
+
     try {
       await this.setBiometricSecret(
         newSecret,

--- a/src/services/secure/AccountSecureStorage.ts
+++ b/src/services/secure/AccountSecureStorage.ts
@@ -1598,8 +1598,7 @@ export class AccountSecureStorage {
     } catch {
       // Read couldn't be determined (flaky storage / declined auth). FAIL SAFE:
       // never let a possibly-stale old-secret item survive a PIN change.
-      await this.clearBiometricSecret();
-      await this.setBiometricEnabled(false).catch(() => {});
+      await this.failSafeDisableBiometrics();
       return;
     }
 
@@ -1615,12 +1614,41 @@ export class AccountSecureStorage {
         'Update biometric unlock'
       );
     } catch {
-      // Refresh failed/cancelled — never leave the OLD secret behind. Disable
-      // biometrics (item + flag) so nothing stale survives; re-enable re-writes
-      // the item under the new secret.
-      await this.clearBiometricSecret();
-      await this.setBiometricEnabled(false).catch(() => {});
+      // Refresh write failed/cancelled — never leave the OLD secret usable.
+      await this.failSafeDisableBiometrics();
     }
+  }
+
+  /**
+   * Fail-safe teardown: make a surviving biometric-convenience item INERT.
+   *
+   * BOUNDARY (Codex P1): the enabled-FLAG is the READ GATE — a stale convenience
+   * item is only dangerous if it is READ, and it is read ONLY when biometrics is
+   * ENABLED (biometric unlock gates on the persisted flag via
+   * `unlockVaultWithBiometrics`). So flipping the flag to `false` is the PRIMARY,
+   * AWAITED protection; deleting the item is best-effort cleanup that may fail
+   * (a SecureStore op) WITHOUT weakening the guarantee. The enabled-flag is
+   * AsyncStorage-backed (separate from the failing SecureStore item), so this
+   * write typically succeeds even when the item op does not. We deliberately do
+   * NOT chase the delete — a cascade of storage failures is a device-broken
+   * condition out of scope.
+   *
+   * If even the flag write fails (total storage failure), the WORST case is a
+   * failed biometric unlock that falls back to PIN — the new PIN always works —
+   * NEVER a security bypass or mnemonic-recovery event. (Even if a stale
+   * old-PIN secret were somehow loaded, a v2 unwrap under it would MAC-fail → the
+   * op errors → PIN fallback.) Swallows all errors so it never rolls back the
+   * already-committed PIN change. Never logs the secret.
+   */
+  private static async failSafeDisableBiometrics(): Promise<void> {
+    try {
+      // PRIMARY (awaited): flip the read gate off. This is the reliable guard.
+      await this.setBiometricEnabled(false);
+    } catch {
+      // Total-storage-failure / device-broken — out of scope (see boundary note).
+    }
+    // Best-effort cleanup of the now-inert item; may fail without consequence.
+    await this.clearBiometricSecret().catch(() => {});
   }
 
   static async deletePin(): Promise<void> {

--- a/src/services/secure/AccountSecureStorage.ts
+++ b/src/services/secure/AccountSecureStorage.ts
@@ -1544,10 +1544,66 @@ export class AccountSecureStorage {
 
       await this.persistPinHash(hashedNewPin, salt);
       this.legacyCheckRequired = false;
+
+      // COMMIT POINT passed — the new PIN hash is persisted. Keep the biometric-
+      // convenience item and the live session in sync with the NEW secret
+      // (DOC-137 §5.3 / Codex P2). Without this, a biometric unlock after a PIN
+      // change would load the OLD PIN into the vault — harmless for Format-A
+      // keys today, but a real break once PR4 wraps v2 keys under the new PIN.
+      // changePin here handles PINs only, so secretSource is 'pin'. This never
+      // throws (it disables biometrics on a failed refresh) so a post-commit
+      // failure can't misreport the (successful) PIN change.
+      await this.refreshBiometricSecretAfterSecretChange(newPin, 'pin');
+
+      // Rotate the live session so an unlocked session holds the new secret
+      // WITHOUT re-locking (SessionKeyVault.rotate, PR3). Only when currently
+      // unlocked — a locked session has nothing to rotate and will populate the
+      // vault fresh on its next unlock.
+      if (SessionKeyVault.isUnlocked()) {
+        SessionKeyVault.rotate(newPin, 'pin');
+      }
     } catch (error) {
       throw new AccountStorageError(
         `Failed to change PIN: ${error instanceof Error ? error.message : 'Unknown error'}`
       );
+    }
+  }
+
+  /**
+   * After a secret change commits, resync the biometric-convenience item with
+   * the NEW secret (DOC-137 §3 / §5.3). If biometrics is disabled, no-op. If the
+   * refresh WRITE fails or is cancelled (e.g. the Android write-time biometric
+   * prompt is declined), DISABLE biometrics — clear the item AND the flag — so a
+   * stale OLD-secret convenience item NEVER survives a PIN change; the user
+   * re-enables biometrics afterward. Swallows all errors so it can run safely
+   * AFTER the PIN-hash commit without misreporting the PIN change. Never logs
+   * the secret.
+   */
+  private static async refreshBiometricSecretAfterSecretChange(
+    newSecret: string,
+    secretSource: SecretSource
+  ): Promise<void> {
+    let biometricEnabled = false;
+    try {
+      biometricEnabled = await this.isBiometricEnabled();
+    } catch {
+      return;
+    }
+    if (!biometricEnabled) {
+      return;
+    }
+    try {
+      await this.setBiometricSecret(
+        newSecret,
+        secretSource,
+        'Update biometric unlock'
+      );
+    } catch {
+      // Refresh failed/cancelled — never leave the OLD secret behind. Disable
+      // biometrics (item + flag) so nothing stale survives; re-enable re-writes
+      // the item under the new secret.
+      await this.clearBiometricSecret();
+      await this.setBiometricEnabled(false).catch(() => {});
     }
   }
 

--- a/src/services/secure/__tests__/biometricConvenience.test.ts
+++ b/src/services/secure/__tests__/biometricConvenience.test.ts
@@ -83,6 +83,7 @@ import 'crypto-js/pbkdf2';
 import { createHash, randomBytes } from 'crypto';
 import * as platform from '@/platform';
 import { AccountSecureStorage } from '../AccountSecureStorage';
+import { SessionKeyVault } from '../SessionKeyVault';
 
 const DEVICE_ID = 'bio-conv-test-device-idfv';
 const BIOMETRIC_SECRET_KEY = 'voi_biometric_secret';
@@ -162,6 +163,12 @@ function seedSecret(accountId: string, payload: object): void {
 beforeEach(() => {
   mockPlatform.__reset();
   AccountSecureStorage.clearPrivateKeyCache();
+  SessionKeyVault.clear();
+});
+
+afterEach(() => {
+  SessionKeyVault.clear();
+  jest.restoreAllMocks();
 });
 
 describe('setBiometricSecret (DOC-137 §3.2/§3.3)', () => {
@@ -266,5 +273,103 @@ describe('clearAll drops the biometric-convenience item', () => {
       BIOMETRIC_SECRET_KEY
     );
     expect(mockPlatform.__secure.has(BIOMETRIC_SECRET_KEY)).toBe(false);
+  });
+});
+
+describe('changePin resyncs the biometric-convenience item + vault (Codex P2)', () => {
+  it('refreshes the convenience item to the NEW secret when biometrics enabled', async () => {
+    jest
+      .spyOn(AccountSecureStorage, 'verifyPin')
+      .mockResolvedValue(true as unknown as boolean);
+    mockPlatform.__kv.set(BIOMETRIC_ENABLED_KEY, 'true');
+    // Old convenience item wrapped the OLD PIN.
+    await AccountSecureStorage.setBiometricSecret('111111', 'pin', 'x');
+
+    await AccountSecureStorage.changePin('111111', '222222');
+
+    // The convenience item now yields the NEW secret — so a later biometric
+    // unlock loads the new PIN into the vault (required once PR4 v2 keys are
+    // wrapped under the new PIN).
+    const out = await AccountSecureStorage.getBiometricSecret('x');
+    expect(out).toEqual({ secret: '222222', secretSource: 'pin' });
+    // It went back through the write-time auth gate.
+    expect(mockPlatform.secureStorage.setItemWithAuth).toHaveBeenCalledWith(
+      BIOMETRIC_SECRET_KEY,
+      JSON.stringify({ secret: '222222', secretSource: 'pin' }),
+      { prompt: 'Update biometric unlock' }
+    );
+    // Biometrics stays enabled.
+    expect(mockPlatform.__kv.get(BIOMETRIC_ENABLED_KEY)).toBe('true');
+  });
+
+  it('DISABLES biometrics (clears item + flag) when the refresh write fails — no stale secret', async () => {
+    jest
+      .spyOn(AccountSecureStorage, 'verifyPin')
+      .mockResolvedValue(true as unknown as boolean);
+    mockPlatform.__kv.set(BIOMETRIC_ENABLED_KEY, 'true');
+    await AccountSecureStorage.setBiometricSecret('111111', 'pin', 'x');
+
+    // The changePin refresh write (the NEXT setItemWithAuth call) fails/cancels.
+    mockPlatform.secureStorage.setItemWithAuth.mockImplementationOnce(
+      async () => {
+        throw new Error('write-time biometric prompt cancelled');
+      }
+    );
+
+    // changePin itself still succeeds (the refresh never throws upward).
+    await expect(
+      AccountSecureStorage.changePin('111111', '222222')
+    ).resolves.toBeUndefined();
+
+    // No stale OLD-secret item survives, and biometrics is disabled.
+    expect(mockPlatform.__secure.has(BIOMETRIC_SECRET_KEY)).toBe(false);
+    expect(mockPlatform.__kv.get(BIOMETRIC_ENABLED_KEY)).toBe('false');
+    expect(await AccountSecureStorage.getBiometricSecret('x')).toBeNull();
+  });
+
+  it('does NOT touch the convenience item when biometrics is disabled', async () => {
+    jest
+      .spyOn(AccountSecureStorage, 'verifyPin')
+      .mockResolvedValue(true as unknown as boolean);
+    // Biometrics disabled (flag absent).
+    mockPlatform.secureStorage.setItemWithAuth.mockClear();
+    mockPlatform.secureStorage.deleteItem.mockClear();
+
+    await AccountSecureStorage.changePin('111111', '222222');
+
+    expect(mockPlatform.secureStorage.setItemWithAuth).not.toHaveBeenCalled();
+    expect(mockPlatform.secureStorage.deleteItem).not.toHaveBeenCalledWith(
+      BIOMETRIC_SECRET_KEY
+    );
+    expect(await AccountSecureStorage.getBiometricSecret('x')).toBeNull();
+  });
+
+  it('rotates the SessionKeyVault to the new secret when the session is unlocked', async () => {
+    jest
+      .spyOn(AccountSecureStorage, 'verifyPin')
+      .mockResolvedValue(true as unknown as boolean);
+    // Simulate a live, unlocked session holding the OLD secret.
+    SessionKeyVault.set('111111', 'pin');
+    const rotateSpy = jest.spyOn(SessionKeyVault, 'rotate');
+
+    await AccountSecureStorage.changePin('111111', '222222');
+
+    expect(rotateSpy).toHaveBeenCalledWith('222222', 'pin');
+    // The live session now holds the new secret WITHOUT re-locking.
+    expect(SessionKeyVault.isUnlocked()).toBe(true);
+    expect(SessionKeyVault.getSecret()).toBe('222222');
+  });
+
+  it('does NOT rotate the vault when the session is locked', async () => {
+    jest
+      .spyOn(AccountSecureStorage, 'verifyPin')
+      .mockResolvedValue(true as unknown as boolean);
+    expect(SessionKeyVault.isUnlocked()).toBe(false);
+    const rotateSpy = jest.spyOn(SessionKeyVault, 'rotate');
+
+    await AccountSecureStorage.changePin('111111', '222222');
+
+    expect(rotateSpy).not.toHaveBeenCalled();
+    expect(SessionKeyVault.isUnlocked()).toBe(false);
   });
 });

--- a/src/services/secure/__tests__/biometricConvenience.test.ts
+++ b/src/services/secure/__tests__/biometricConvenience.test.ts
@@ -373,6 +373,39 @@ describe('changePin resyncs the biometric-convenience item + vault (Codex P2)', 
     expect(mockPlatform.__kv.get(BIOMETRIC_ENABLED_KEY)).toBe('false');
   });
 
+  it('flag is the reliable gate: setBiometricEnabled(false) is awaited even if the cleanup delete rejects', async () => {
+    jest
+      .spyOn(AccountSecureStorage, 'verifyPin')
+      .mockResolvedValue(true as unknown as boolean);
+    mockPlatform.__kv.set(BIOMETRIC_ENABLED_KEY, 'true');
+    await AccountSecureStorage.setBiometricSecret('111111', 'pin', 'x');
+
+    // The refresh write fails (triggers the fail-safe)...
+    mockPlatform.secureStorage.setItemWithAuth.mockImplementationOnce(
+      async () => {
+        throw new Error('refresh write failed');
+      }
+    );
+    // ...and the best-effort cleanup delete ALSO fails hard.
+    const setEnabledSpy = jest.spyOn(
+      AccountSecureStorage,
+      'setBiometricEnabled'
+    );
+    jest
+      .spyOn(AccountSecureStorage, 'clearBiometricSecret')
+      .mockRejectedValue(new Error('delete rejected'));
+
+    // changePin still resolves — the fail-safe never rolls back the PIN change.
+    await expect(
+      AccountSecureStorage.changePin('111111', '222222')
+    ).resolves.toBeUndefined();
+
+    // Disabling the flag is the PRIMARY protection and lands even though the
+    // delete rejected: a surviving stale item is inert once the flag is false.
+    expect(setEnabledSpy).toHaveBeenCalledWith(false);
+    expect(mockPlatform.__kv.get(BIOMETRIC_ENABLED_KEY)).toBe('false');
+  });
+
   it('rotates the SessionKeyVault to the new secret when the session is unlocked', async () => {
     jest
       .spyOn(AccountSecureStorage, 'verifyPin')

--- a/src/services/secure/__tests__/biometricConvenience.test.ts
+++ b/src/services/secure/__tests__/biometricConvenience.test.ts
@@ -327,11 +327,12 @@ describe('changePin resyncs the biometric-convenience item + vault (Codex P2)', 
     expect(await AccountSecureStorage.getBiometricSecret('x')).toBeNull();
   });
 
-  it('does NOT touch the convenience item when biometrics is disabled', async () => {
+  it('no-ops when there is NO convenience item (item read returns null)', async () => {
     jest
       .spyOn(AccountSecureStorage, 'verifyPin')
       .mockResolvedValue(true as unknown as boolean);
-    // Biometrics disabled (flag absent).
+    // Gate is the ITEM, not the flag: with no item present, getBiometricSecret
+    // returns null and the refresh is a no-op — nothing stale to handle.
     mockPlatform.secureStorage.setItemWithAuth.mockClear();
     mockPlatform.secureStorage.deleteItem.mockClear();
 
@@ -342,6 +343,34 @@ describe('changePin resyncs the biometric-convenience item + vault (Codex P2)', 
       BIOMETRIC_SECRET_KEY
     );
     expect(await AccountSecureStorage.getBiometricSecret('x')).toBeNull();
+  });
+
+  it('FAIL-SAFE: item-read failure during changePin clears the item + disables biometrics — no stale secret survives, changePin still resolves', async () => {
+    jest
+      .spyOn(AccountSecureStorage, 'verifyPin')
+      .mockResolvedValue(true as unknown as boolean);
+    mockPlatform.__kv.set(BIOMETRIC_ENABLED_KEY, 'true');
+    // A stale OLD-secret item is present...
+    await AccountSecureStorage.setBiometricSecret('111111', 'pin', 'x');
+
+    // ...but the item read (getItemWithAuth) throws during changePin — the gate
+    // cannot be determined. Fail-safe MUST clear it rather than skip.
+    mockPlatform.secureStorage.getItemWithAuth.mockImplementationOnce(
+      async () => {
+        throw new Error('flaky keychain read');
+      }
+    );
+
+    await expect(
+      AccountSecureStorage.changePin('111111', '222222')
+    ).resolves.toBeUndefined();
+
+    // No stale OLD-secret item survives even though the read failed.
+    expect(mockPlatform.secureStorage.deleteItem).toHaveBeenCalledWith(
+      BIOMETRIC_SECRET_KEY
+    );
+    expect(mockPlatform.__secure.has(BIOMETRIC_SECRET_KEY)).toBe(false);
+    expect(mockPlatform.__kv.get(BIOMETRIC_ENABLED_KEY)).toBe('false');
   });
 
   it('rotates the SessionKeyVault to the new secret when the session is unlocked', async () => {

--- a/src/services/secure/__tests__/biometricConvenience.test.ts
+++ b/src/services/secure/__tests__/biometricConvenience.test.ts
@@ -1,0 +1,270 @@
+// Unit tests for the biometric-convenience item + the rewritten getPrivateKey
+// biometric branch (DOC-137 §3, PR6):
+//   - setBiometricSecret writes `{secret, secretSource}` via setItemWithAuth
+//     (auth-gated), NOT plain setItem;
+//   - getBiometricSecret round-trips it, and returns null (safe) when absent or
+//     structurally corrupt;
+//   - getPrivateKey's biometric branch reads the KEY ENVELOPE with PLAIN getItem
+//     (never getItemWithAuth) and Format-A still decrypts;
+//   - clearAll drops the convenience item.
+//
+// SECURITY NOTE: synthetic byte patterns / throwaway strings stand in for key
+// material and secrets. No real mnemonic/key is used, and none is logged.
+
+jest.mock('@/platform', () => {
+  const nodeCrypto = require('crypto');
+  const secure = new Map<string, string>();
+  const kv = new Map<string, string>();
+  const authGatedKeys = new Set<string>();
+  return {
+    __secure: secure,
+    __kv: kv,
+    __authGatedKeys: authGatedKeys,
+    __reset: () => {
+      secure.clear();
+      kv.clear();
+      authGatedKeys.clear();
+    },
+    crypto: {
+      getRandomBytes: async (n: number): Promise<Uint8Array> =>
+        Uint8Array.from(nodeCrypto.randomBytes(n)),
+      sha256: async (input: string): Promise<string> =>
+        nodeCrypto.createHash('sha256').update(input).digest('hex'),
+      randomUUID: () => nodeCrypto.randomUUID(),
+    },
+    secureStorage: {
+      getItem: jest.fn(async (k: string) =>
+        secure.has(k) ? secure.get(k)! : null
+      ),
+      setItem: jest.fn(async (k: string, v: string) => {
+        secure.set(k, v);
+      }),
+      deleteItem: jest.fn(async (k: string) => {
+        secure.delete(k);
+      }),
+      getItemWithAuth: jest.fn(async (k: string) =>
+        secure.has(k) ? secure.get(k)! : null
+      ),
+      setItemWithAuth: jest.fn(async (k: string, v: string) => {
+        secure.set(k, v);
+        authGatedKeys.add(k);
+      }),
+    },
+    storage: {
+      getItem: jest.fn(async (k: string) => (kv.has(k) ? kv.get(k)! : null)),
+      setItem: jest.fn(async (k: string, v: string) => {
+        kv.set(k, v);
+      }),
+      removeItem: jest.fn(async (k: string) => {
+        kv.delete(k);
+      }),
+      multiRemove: jest.fn(async (keys: string[]) => {
+        keys.forEach((k) => kv.delete(k));
+      }),
+    },
+    biometrics: {
+      isAvailable: async () => false,
+      isEnrolled: async () => false,
+    },
+    deviceId: {
+      getDeviceId: async () => 'bio-conv-test-device-idfv',
+    },
+  };
+});
+
+import CryptoJS from 'crypto-js';
+import 'crypto-js/hmac-sha256';
+import 'crypto-js/sha256';
+import 'crypto-js/aes';
+import 'crypto-js/mode-ctr';
+import 'crypto-js/pad-nopadding';
+import 'crypto-js/enc-hex';
+import 'crypto-js/pbkdf2';
+import { createHash, randomBytes } from 'crypto';
+import * as platform from '@/platform';
+import { AccountSecureStorage } from '../AccountSecureStorage';
+
+const DEVICE_ID = 'bio-conv-test-device-idfv';
+const BIOMETRIC_SECRET_KEY = 'voi_biometric_secret';
+const BIOMETRIC_ENABLED_KEY = 'voi_biometric_enabled';
+
+const mockPlatform = platform as unknown as {
+  __secure: Map<string, string>;
+  __kv: Map<string, string>;
+  __authGatedKeys: Set<string>;
+  __reset: () => void;
+  secureStorage: {
+    getItem: jest.Mock;
+    setItem: jest.Mock;
+    getItemWithAuth: jest.Mock;
+    setItemWithAuth: jest.Mock;
+    deleteItem: jest.Mock;
+  };
+};
+
+function fakeKey(length: number): Uint8Array {
+  return Uint8Array.from({ length }, (_, i) => (i * 17 + 3) & 0xff);
+}
+
+function hex(bytes: Uint8Array): string {
+  return Buffer.from(bytes).toString('hex');
+}
+
+function nodeSha256Hex(input: string): string {
+  return createHash('sha256').update(input).digest('hex');
+}
+
+function customPBKDF2(
+  password: string,
+  saltHex: string,
+  iterations: number,
+  keyLength: number
+): string {
+  const saltWA = CryptoJS.enc.Hex.parse(saltHex);
+  const derived = CryptoJS.PBKDF2(password, saltWA, {
+    keySize: keyLength / 4,
+    iterations,
+    hasher: CryptoJS.algo.SHA256,
+  });
+  return derived.toString(CryptoJS.enc.Hex);
+}
+
+/** Build a legacy Format-A (device-key) 4-colon blob, as encryptPrivateKey does. */
+function makeFormatA(privateKey: Uint8Array): string {
+  const saltHex = randomBytes(32).toString('hex');
+  const ivHex = randomBytes(16).toString('hex');
+  const baseEntropy = nodeSha256Hex(`voi_wallet_${DEVICE_ID}`);
+  const keyMaterial = customPBKDF2(baseEntropy, saltHex, 10000, 32);
+
+  const privateKeyHex = hex(privateKey);
+  const encrypted = CryptoJS.AES.encrypt(
+    privateKeyHex,
+    CryptoJS.enc.Hex.parse(keyMaterial),
+    {
+      iv: CryptoJS.enc.Hex.parse(ivHex),
+      mode: CryptoJS.mode.CTR,
+      padding: CryptoJS.pad.NoPadding,
+    }
+  );
+  const ct = encrypted.toString();
+  const hmacKey = CryptoJS.SHA256(keyMaterial + 'hmac_salt').toString();
+  const hmac = CryptoJS.HmacSHA256(ct, hmacKey).toString();
+  return `${saltHex}:${ivHex}:${ct}:${hmac}`;
+}
+
+function seedSecret(accountId: string, payload: object): void {
+  mockPlatform.__secure.set(
+    `voi_account_secret_${accountId}`,
+    JSON.stringify(payload)
+  );
+}
+
+beforeEach(() => {
+  mockPlatform.__reset();
+  AccountSecureStorage.clearPrivateKeyCache();
+});
+
+describe('setBiometricSecret (DOC-137 §3.2/§3.3)', () => {
+  it('writes {secret, secretSource} via setItemWithAuth (auth-gated), NOT plain setItem', async () => {
+    await AccountSecureStorage.setBiometricSecret(
+      '123456',
+      'pin',
+      'Enable biometric unlock'
+    );
+
+    // Went through the WRITE-TIME auth gate, not plain setItem.
+    expect(mockPlatform.secureStorage.setItemWithAuth).toHaveBeenCalledTimes(1);
+    const [key, value, options] =
+      mockPlatform.secureStorage.setItemWithAuth.mock.calls[0];
+    expect(key).toBe(BIOMETRIC_SECRET_KEY);
+    expect(options).toEqual({ prompt: 'Enable biometric unlock' });
+    expect(JSON.parse(value)).toEqual({
+      secret: '123456',
+      secretSource: 'pin',
+    });
+    expect(mockPlatform.__authGatedKeys.has(BIOMETRIC_SECRET_KEY)).toBe(true);
+
+    // The convenience item is the ONLY key written via setItemWithAuth.
+    expect(mockPlatform.secureStorage.setItem).not.toHaveBeenCalledWith(
+      BIOMETRIC_SECRET_KEY,
+      expect.anything()
+    );
+  });
+
+  it('round-trips through getBiometricSecret', async () => {
+    await AccountSecureStorage.setBiometricSecret(
+      'correct horse',
+      'passphrase',
+      'Unlock'
+    );
+    const out = await AccountSecureStorage.getBiometricSecret('Unlock');
+    expect(out).toEqual({
+      secret: 'correct horse',
+      secretSource: 'passphrase',
+    });
+  });
+});
+
+describe('getBiometricSecret null-safety (DOC-137 §3.4)', () => {
+  it('returns null when the item is absent/invalidated (no throw)', async () => {
+    const out = await AccountSecureStorage.getBiometricSecret('Unlock');
+    expect(out).toBeNull();
+  });
+
+  it('returns null (not a throw) on a structurally corrupt item', async () => {
+    mockPlatform.__secure.set(BIOMETRIC_SECRET_KEY, 'not json{');
+    const out = await AccountSecureStorage.getBiometricSecret('Unlock');
+    expect(out).toBeNull();
+  });
+
+  it('returns null when the shape is wrong (missing secretSource)', async () => {
+    mockPlatform.__secure.set(
+      BIOMETRIC_SECRET_KEY,
+      JSON.stringify({ secret: '123456' })
+    );
+    const out = await AccountSecureStorage.getBiometricSecret('Unlock');
+    expect(out).toBeNull();
+  });
+});
+
+describe('getPrivateKey biometric branch reads the ENVELOPE with plain getItem (DOC-137 §3.3, PR6)', () => {
+  it('Format-A decrypts with pin=undefined + biometric enabled, and getItemWithAuth is NEVER used on the envelope', async () => {
+    const sk = fakeKey(64);
+    const accountId = 'acct-bio-formatA';
+    seedSecret(accountId, {
+      accountId,
+      encryptedPrivateKey: makeFormatA(sk),
+      authMethod: 'biometric',
+    });
+    // Biometric is enabled (the classic pin=undefined + biometric reader path).
+    mockPlatform.__kv.set(BIOMETRIC_ENABLED_KEY, 'true');
+
+    const out = await AccountSecureStorage.getPrivateKey(accountId);
+    expect(hex(out)).toBe(hex(sk));
+
+    // The KEY ENVELOPE was read with PLAIN getItem — the write-time-ACL bug fix.
+    expect(mockPlatform.secureStorage.getItem).toHaveBeenCalledWith(
+      `voi_account_secret_${accountId}`
+    );
+    // getItemWithAuth was NEVER called on the envelope (nor at all in this read).
+    expect(mockPlatform.secureStorage.getItemWithAuth).not.toHaveBeenCalledWith(
+      `voi_account_secret_${accountId}`,
+      expect.anything()
+    );
+    expect(mockPlatform.secureStorage.getItemWithAuth).not.toHaveBeenCalled();
+  });
+});
+
+describe('clearAll drops the biometric-convenience item', () => {
+  it('deletes voi_biometric_secret on a full wipe', async () => {
+    await AccountSecureStorage.setBiometricSecret('123456', 'pin', 'x');
+    expect(mockPlatform.__secure.has(BIOMETRIC_SECRET_KEY)).toBe(true);
+
+    await AccountSecureStorage.clearAll();
+
+    expect(mockPlatform.secureStorage.deleteItem).toHaveBeenCalledWith(
+      BIOMETRIC_SECRET_KEY
+    );
+    expect(mockPlatform.__secure.has(BIOMETRIC_SECRET_KEY)).toBe(false);
+  });
+});

--- a/src/services/secure/__tests__/biometricUnlock.test.ts
+++ b/src/services/secure/__tests__/biometricUnlock.test.ts
@@ -1,0 +1,155 @@
+// Unit tests for the biometric-unlock orchestration (DOC-137 §3.3/§3.4, PR6) —
+// THE fix that makes a biometric-unlocked session hold the vault secret:
+//   - success: reads the convenience item + populates the SessionKeyVault;
+//   - invalidation (getItemWithAuth resolves null): clears BIOMETRIC_ENABLED_KEY,
+//     does NOT populate the vault, and does NOT throw (never routes to mnemonic);
+//   - cancel (getItemWithAuth throws): keeps biometrics enabled, does NOT
+//     populate the vault, and does NOT throw.
+//
+// SECURITY NOTE: throwaway strings stand in for the user secret; none is logged.
+
+jest.mock('@/platform', () => {
+  const nodeCrypto = require('crypto');
+  const secure = new Map<string, string>();
+  const kv = new Map<string, string>();
+  return {
+    __secure: secure,
+    __kv: kv,
+    __reset: () => {
+      secure.clear();
+      kv.clear();
+    },
+    crypto: {
+      getRandomBytes: async (n: number): Promise<Uint8Array> =>
+        Uint8Array.from(nodeCrypto.randomBytes(n)),
+      sha256: async (input: string): Promise<string> =>
+        nodeCrypto.createHash('sha256').update(input).digest('hex'),
+      randomUUID: () => nodeCrypto.randomUUID(),
+    },
+    secureStorage: {
+      getItem: jest.fn(async (k: string) =>
+        secure.has(k) ? secure.get(k)! : null
+      ),
+      setItem: jest.fn(async (k: string, v: string) => {
+        secure.set(k, v);
+      }),
+      deleteItem: jest.fn(async (k: string) => {
+        secure.delete(k);
+      }),
+      getItemWithAuth: jest.fn(async (k: string) =>
+        secure.has(k) ? secure.get(k)! : null
+      ),
+      setItemWithAuth: jest.fn(async (k: string, v: string) => {
+        secure.set(k, v);
+      }),
+    },
+    storage: {
+      getItem: jest.fn(async (k: string) => (kv.has(k) ? kv.get(k)! : null)),
+      setItem: jest.fn(async (k: string, v: string) => {
+        kv.set(k, v);
+      }),
+      removeItem: jest.fn(async (k: string) => {
+        kv.delete(k);
+      }),
+    },
+    biometrics: {
+      isAvailable: async () => false,
+      isEnrolled: async () => false,
+    },
+    deviceId: {
+      getDeviceId: async () => 'bio-unlock-test-device-idfv',
+    },
+  };
+});
+
+import * as platform from '@/platform';
+import { unlockVaultWithBiometrics } from '../biometricUnlock';
+import { SessionKeyVault } from '../SessionKeyVault';
+
+const BIOMETRIC_SECRET_KEY = 'voi_biometric_secret';
+const BIOMETRIC_ENABLED_KEY = 'voi_biometric_enabled';
+
+const mockPlatform = platform as unknown as {
+  __secure: Map<string, string>;
+  __kv: Map<string, string>;
+  __reset: () => void;
+  secureStorage: { getItemWithAuth: jest.Mock };
+};
+
+beforeEach(() => {
+  mockPlatform.__reset();
+  SessionKeyVault.clear();
+});
+
+afterEach(() => {
+  SessionKeyVault.clear();
+});
+
+describe('unlockVaultWithBiometrics — success populates the vault', () => {
+  it('reads the convenience secret and sets the vault secret + source', async () => {
+    mockPlatform.__secure.set(
+      BIOMETRIC_SECRET_KEY,
+      JSON.stringify({ secret: '123456', secretSource: 'pin' })
+    );
+    mockPlatform.__kv.set(BIOMETRIC_ENABLED_KEY, 'true');
+
+    expect(SessionKeyVault.isUnlocked()).toBe(false);
+    const outcome = await unlockVaultWithBiometrics('Unlock your wallet');
+
+    expect(outcome).toEqual({ status: 'unlocked' });
+    expect(SessionKeyVault.isUnlocked()).toBe(true);
+    expect(SessionKeyVault.getSecret()).toBe('123456');
+    expect(SessionKeyVault.getSecretSource()).toBe('pin');
+    // Biometrics stays enabled on success.
+    expect(mockPlatform.__kv.get(BIOMETRIC_ENABLED_KEY)).toBe('true');
+  });
+
+  it('preserves a passphrase secretSource into the vault', async () => {
+    mockPlatform.__secure.set(
+      BIOMETRIC_SECRET_KEY,
+      JSON.stringify({
+        secret: 'a-long-passphrase',
+        secretSource: 'passphrase',
+      })
+    );
+    const outcome = await unlockVaultWithBiometrics('Unlock');
+    expect(outcome.status).toBe('unlocked');
+    expect(SessionKeyVault.getSecretSource()).toBe('passphrase');
+  });
+});
+
+describe('unlockVaultWithBiometrics — invalidation (null) clears the flag, never mnemonic', () => {
+  it('when the item is invalidated/absent: clears BIOMETRIC_ENABLED_KEY, no vault, no throw', async () => {
+    // Item absent => getItemWithAuth resolves null (enrollment change / absent).
+    mockPlatform.__kv.set(BIOMETRIC_ENABLED_KEY, 'true');
+
+    const outcome = await unlockVaultWithBiometrics('Unlock your wallet');
+
+    // Falls back to PIN — NEVER the mnemonic. The invariant surfaces as: no throw.
+    expect(outcome).toEqual({ status: 'invalidated' });
+    // The stale enabled flag was cleared.
+    expect(mockPlatform.__kv.get(BIOMETRIC_ENABLED_KEY)).toBe('false');
+    // The vault was NOT populated.
+    expect(SessionKeyVault.isUnlocked()).toBe(false);
+    expect(SessionKeyVault.getSecret()).toBeNull();
+  });
+});
+
+describe('unlockVaultWithBiometrics — cancel (throw) keeps biometrics enabled', () => {
+  it('when getItemWithAuth throws (user cancelled / auth failed): cancelled, flag kept, no vault, no throw', async () => {
+    mockPlatform.__kv.set(BIOMETRIC_ENABLED_KEY, 'true');
+    mockPlatform.secureStorage.getItemWithAuth.mockImplementationOnce(
+      async () => {
+        throw new Error('User canceled the authentication');
+      }
+    );
+
+    const outcome = await unlockVaultWithBiometrics('Unlock your wallet');
+
+    expect(outcome).toEqual({ status: 'cancelled' });
+    // Biometrics stays enabled on a cancel (the user can retry).
+    expect(mockPlatform.__kv.get(BIOMETRIC_ENABLED_KEY)).toBe('true');
+    // The vault was NOT populated, and no error propagated to the mnemonic path.
+    expect(SessionKeyVault.isUnlocked()).toBe(false);
+  });
+});

--- a/src/services/secure/__tests__/biometricUnlock.test.ts
+++ b/src/services/secure/__tests__/biometricUnlock.test.ts
@@ -105,6 +105,7 @@ describe('unlockVaultWithBiometrics — success populates the vault', () => {
   });
 
   it('preserves a passphrase secretSource into the vault', async () => {
+    mockPlatform.__kv.set(BIOMETRIC_ENABLED_KEY, 'true');
     mockPlatform.__secure.set(
       BIOMETRIC_SECRET_KEY,
       JSON.stringify({
@@ -115,6 +116,28 @@ describe('unlockVaultWithBiometrics — success populates the vault', () => {
     const outcome = await unlockVaultWithBiometrics('Unlock');
     expect(outcome.status).toBe('unlocked');
     expect(SessionKeyVault.getSecretSource()).toBe('passphrase');
+  });
+});
+
+describe('unlockVaultWithBiometrics — gates on the PERSISTED enabled-flag (Codex P1)', () => {
+  it('when the persisted flag is false, does NOT read the convenience item and routes to PIN', async () => {
+    // A stale item is present, but the persisted flag is false (e.g. a changePin
+    // fail-safe disabled biometrics without updating in-memory React state).
+    mockPlatform.__secure.set(
+      BIOMETRIC_SECRET_KEY,
+      JSON.stringify({ secret: '111111', secretSource: 'pin' })
+    );
+    // Flag absent/false.
+    expect(mockPlatform.__kv.get(BIOMETRIC_ENABLED_KEY)).toBeUndefined();
+
+    const outcome = await unlockVaultWithBiometrics('Unlock your wallet');
+
+    // Routed to PIN (invalidated) WITHOUT reading the stale item.
+    expect(outcome).toEqual({ status: 'invalidated' });
+    expect(mockPlatform.secureStorage.getItemWithAuth).not.toHaveBeenCalled();
+    // The vault was NOT populated with the stale secret.
+    expect(SessionKeyVault.isUnlocked()).toBe(false);
+    expect(SessionKeyVault.getSecret()).toBeNull();
   });
 });
 

--- a/src/services/secure/biometricUnlock.ts
+++ b/src/services/secure/biometricUnlock.ts
@@ -52,6 +52,26 @@ export type BiometricUnlockOutcome =
 export async function unlockVaultWithBiometrics(
   prompt: string
 ): Promise<BiometricUnlockOutcome> {
+  // GATE on the PERSISTED enabled-flag BEFORE reading the auth-gated convenience
+  // item (Codex P1). The enabled-flag is the read gate for a stale item: a
+  // changePin fail-safe disables the PERSISTED flag but does NOT touch
+  // AuthContext's in-memory React state, so a stale item behind a false flag
+  // must never be read here. AuthContext also guards on its in-memory flag; this
+  // persisted check is the authoritative, defense-in-depth gate. If disabled,
+  // route to PIN WITHOUT reading the item (no biometric prompt for the item).
+  let enabled = false;
+  try {
+    enabled = await AccountSecureStorage.isBiometricEnabled();
+  } catch {
+    enabled = false;
+  }
+  if (!enabled) {
+    // Biometrics not (or no longer) enabled — fall back to PIN. Reported as
+    // 'invalidated' so the caller reflects the disabled state and routes to PIN;
+    // never the mnemonic (THE INVARIANT). No convenience item was read.
+    return { status: 'invalidated' };
+  }
+
   let bio: { secret: string; secretSource: 'pin' | 'passphrase' } | null;
   try {
     bio = await AccountSecureStorage.getBiometricSecret(prompt);

--- a/src/services/secure/biometricUnlock.ts
+++ b/src/services/secure/biometricUnlock.ts
@@ -1,0 +1,76 @@
+/**
+ * Biometric-unlock orchestration (Wave-2, DOC-137 §3.3/§3.4, PR6)
+ *
+ * The single, React-free place that turns a biometric prompt into a populated
+ * SessionKeyVault. AuthContext.unlockWithBiometrics calls this and then handles
+ * the React state + AppLockSignal; keeping the security-critical work here makes
+ * it unit-testable without a React harness.
+ *
+ * THE FLOW (§3.3): read the biometric-convenience secret behind the OS biometric
+ * gate (the `getItemWithAuth` read IS the prompt) → on success, feed the raw
+ * secret into the SAME SessionKeyVault the manual PIN path populates, so a
+ * biometric-unlocked session can derive at-rest wrap keys this session (the
+ * prerequisite for PR4's v2 keys, which read under pin=undefined via the vault).
+ *
+ * THE INVARIANT (§3.4): a biometric / enrollment-change invalidation NEVER
+ * requires the mnemonic. expo-secure-store resolves `null` (not a throw) when a
+ * `requireAuthentication` item is absent or has been invalidated by an
+ * enrollment change / lock removal; we map that to `invalidated`, clear the
+ * stale enabled flag, and let the caller fall back to PIN/passphrase entry. A
+ * genuine OS-auth failure / user cancel THROWS instead, which we map to
+ * `cancelled` so biometrics stays enabled and the user can retry or use the PIN.
+ * NEITHER path ever routes to the mnemonic — the key at rest is wrapped by the
+ * user-secret scrypt envelope (plain setItem), which survives all enrollment
+ * events.
+ *
+ * SECURITY: never logs the secret or secretSource.
+ */
+
+import { AccountSecureStorage } from './AccountSecureStorage';
+import { SessionKeyVault } from './SessionKeyVault';
+
+export type BiometricUnlockOutcome =
+  /** Vault populated with the recovered secret; the session is unlocked. */
+  | { status: 'unlocked' }
+  /**
+   * The convenience item is gone or was invalidated (enrollment change / lock
+   * removal). The enabled flag has been cleared. Caller falls back to PIN —
+   * NEVER the mnemonic (THE INVARIANT, §3.4). Vault is NOT populated.
+   */
+  | { status: 'invalidated' }
+  /**
+   * The user cancelled or the OS auth failed. Biometrics stays enabled; caller
+   * falls back to PIN for this attempt. Vault is NOT populated.
+   */
+  | { status: 'cancelled' };
+
+/**
+ * Read the biometric-convenience secret and, on success, populate the session
+ * vault. Returns a discriminated outcome; performs NO React state or
+ * AppLockSignal side effects (the caller owns those).
+ */
+export async function unlockVaultWithBiometrics(
+  prompt: string
+): Promise<BiometricUnlockOutcome> {
+  let bio: { secret: string; secretSource: 'pin' | 'passphrase' } | null;
+  try {
+    bio = await AccountSecureStorage.getBiometricSecret(prompt);
+  } catch {
+    // THROW = user cancelled / OS auth failure (NOT an invalidation, which
+    // resolves null). Keep biometrics enabled; fall back to PIN for this attempt.
+    return { status: 'cancelled' };
+  }
+
+  if (bio === null) {
+    // NULL = the auth-gated item is absent or was invalidated by an enrollment
+    // change / lock removal. INVARIANT (§3.4): this NEVER requires the mnemonic —
+    // clear the stale enabled flag and fall back to PIN/passphrase entry.
+    await AccountSecureStorage.setBiometricEnabled(false).catch(() => {});
+    return { status: 'invalidated' };
+  }
+
+  // Populate the vault synchronously (mirrors the PIN unlock path) so
+  // pin=undefined callers and future v2 keys derive wrap keys this session.
+  SessionKeyVault.set(bio.secret, bio.secretSource);
+  return { status: 'unlocked' };
+}


### PR DESCRIPTION
## PR6 — Biometric-convenience secret item + populate the vault on biometric unlock (TASK-27, Wave-2)

Full design: Pad **DOC-137 §2.5 + §3**. This is a **prerequisite for PR4** (which makes `changePin` produce v2 keys that need the vault secret for `pin=undefined` reads).

**No key writer / migration here — keys stay Format A.** Nothing changes the key bytes, the mnemonic, or the signing path.

### What this PR does
1. **Scoped write-time auth gate (`setItemWithAuth`).** Adds an optional `setItemWithAuth(key, value, { prompt })` to `SecureStorageAdapter`. Mobile impl calls `SecureStore.setItemAsync(key, value, { ...SECURE_STORE_OPTIONS, requireAuthentication: true, authenticationPrompt })` — provisioning the enclave ACL **at write time** (fixes the known write-time-ACL bug where auth was requested only on read of an item never provisioned auth-required). Extension impl throws unsupported (member is optional). **Blast radius: exactly one item** — the biometric-convenience item. `PIN_KEY`, `SALT_KEY`, the key envelope, `BIOMETRIC_ENABLED_KEY`, and all metadata keep plain `setItem`/`getItem` and survive enrollment changes.

2. **The biometric-convenience item (`voi_biometric_secret`).** Stores JSON `{ secret, secretSource }` written via `setItemWithAuth`. New `AccountSecureStorage` helpers: `setBiometricSecret` / `getBiometricSecret` / `clearBiometricSecret`. **Raw-secret threat-model note (DOC-137 §0/§3.2):** this deliberately stores the raw PIN/passphrase — NOT an unencrypted write, but app-layer plaintext inside a platform-encrypted, auth-gated (enclave-bound) item; documented in a code comment as an explicit, accepted tradeoff (JS strings can't be reliably wiped; storing the secret keeps one scrypt-unwrap code path).

3. **Enable-biometrics flow.** `AuthContext.enableBiometrics(enabled, secret?)` now, on enable, verifies the secret and writes the convenience item via `setItemWithAuth`, then sets `BIOMETRIC_ENABLED_KEY`; on disable it clears the item. Biometrics **never captures a secret it wasn't explicitly given** — it uses an explicitly-supplied+verified secret, or the already-verified session secret from the `SessionKeyVault`; a key-bearing wallet with no available secret refuses. Onboarding (`SecuritySetupScreen`) also writes the convenience item (best-effort) so new users get a working biometric unlock immediately.

4. **Biometric unlock now populates the vault (THE fix).** `unlockWithBiometrics` calls a new testable helper `unlockVaultWithBiometrics` → `getItemWithAuth('voi_biometric_secret')` (this single read **is** the biometric prompt — no second `LocalAuthentication` prompt) → on success `SessionKeyVault.set(secret, secretSource)` → `AppLockSignal.setUnlocked(true)` synchronously (mirrors the PIN path). A biometric-unlocked session now holds the vault secret, so future v2 keys read under `pin=undefined`.

5. **`getPrivateKey` biometric branch rewritten.** It **stops calling `getItemWithAuth` on the KEY ENVELOPE** and reads it with plain `getItem`. Only the convenience item uses `getItemWithAuth`. For Format-A keys the device key decrypts regardless of vault state → behavior-preserving; the biometric gate now lives on the convenience item that feeds the vault.

6. **Invalidation → PIN, never mnemonic (THE INVARIANT, §3.4).** expo-secure-store resolves `null` when a `requireAuthentication` item is absent/invalidated (enrollment change / lock removal) and **throws** on user-cancel/auth-failure. The helper maps `null → invalidated` (clears the stale `BIOMETRIC_ENABLED_KEY`, falls back to PIN) and `throw → cancelled` (keeps biometrics enabled so the user can retry). **Neither path ever routes to the mnemonic** — the key at rest is user-secret-wrapped (plain `setItem`), which survives all enrollment events. Code comments assert the invariant.

### Format-A / no-migration confirmation
No key writer or migration was added; `encryptPrivateKey`/`decryptPrivateKey` are untouched. Existing `getPrivateKey.reader` / `getPrivateKey.vault` suites still pass, and a new test proves the biometric branch reads the envelope via plain `getItem` and Format-A still decrypts.

### Tests (13 new, all green)
- **`mobileSecureStorage.setItemWithAuth`** — asserts `requireAuthentication:true` + prompt passed AT WRITE; plain `setItem` does NOT set it (scope stays one item).
- **`biometricConvenience`** — enable stores `{secret,secretSource}` via `setItemWithAuth` (not plain `setItem`); round-trip; `getBiometricSecret` returns `null` (no throw) when absent/corrupt/wrong-shape; `getPrivateKey` biometric branch reads envelope via plain `getItem` and never `getItemWithAuth`; `clearAll` drops the item.
- **`biometricUnlock`** — success populates the vault (`getSecret()`/`getSecretSource()` set); invalidation (`null`) clears the enabled flag, does NOT populate the vault, does NOT throw; cancel (`throw`) keeps biometrics enabled, does NOT populate the vault, does NOT throw.

### Gates
- `npm run typecheck` — 0 errors (full/clean).
- `npm run lint` — 0 errors (693 pre-existing warnings; exit 0).
- `npm test -- --ci` — 403 passed / 32 suites.

### Note for reviewers
Existing biometric users who upgrade (biometric flag set, no convenience item yet), and restored wallets (`restorers.ts` sets the flag from backup with no item), will have their **first** biometric unlock resolve `null` → the invalidation path cleanly disables biometrics and falls back to PIN (never mnemonic); they re-enable once in Settings, which writes the convenience item. This is the intended, safe migration behavior.
