### PR TITLE
feat(secure): v2 key writer + atomic changePin/setupPin rewrap (verify-before-delete, global key-mutation lock, salt-in-credential) — TASK-27 PR4

### DIFF
--- a/src/contexts/AuthContext.tsx
+++ b/src/contexts/AuthContext.tsx
@@ -406,7 +406,10 @@ export function AuthProvider({ children }: { children: React.ReactNode }) {
       throw new Error('PIN must be 6 digits');
     }
 
-    await AccountSecureStorage.storePin(pin);
+    // Use the atomic first-secret setup flow (DOC-137 §5.4), NOT a bare hash
+    // persist: it re-wraps any pre-existing device-key accounts under the new PIN
+    // (verify-before-delete) so first-time PIN setup can never strand keys.
+    await AccountSecureStorage.setupPin(pin, 'pin');
     setAuthState((prev) => ({
       ...prev,
       hasPin: true,

--- a/src/screens/onboarding/SecuritySetupScreen.tsx
+++ b/src/screens/onboarding/SecuritySetupScreen.tsx
@@ -103,9 +103,11 @@ export default function SecuritySetupScreen({ navigation, route }: Props) {
     try {
       setSubmitting(true);
 
-      // Store PIN first
+      // Store PIN first — atomic first-secret setup (DOC-137 §5.4). Re-wraps any
+      // pre-existing device-key accounts under the new PIN before committing the
+      // credential (verify-before-delete), so onboarding never strands keys.
       setSetupStep('Setting up PIN...');
-      await AccountSecureStorage.storePin(pin);
+      await AccountSecureStorage.setupPin(pin, 'pin');
 
       // Store biometric preference. When the user opts into biometrics at
       // onboarding, capture the just-set PIN behind the write-time auth gate

--- a/src/screens/settings/ChangePinScreen.tsx
+++ b/src/screens/settings/ChangePinScreen.tsx
@@ -165,8 +165,10 @@ export default function ChangePinScreen() {
       setIsSubmitting(true);
       try {
         if (isInitialSetup) {
-          // Initial PIN setup - use storePin
-          await AccountSecureStorage.storePin(newPin);
+          // Initial PIN setup - atomic first-secret rewrap (DOC-137 §5.4), which
+          // migrates any pre-existing device-key accounts to the PIN-wrapped v2
+          // envelope before committing the credential.
+          await AccountSecureStorage.setupPin(newPin, 'pin');
         } else {
           // Changing existing PIN - use changePin
           await AccountSecureStorage.changePin(currentPin, newPin);

--- a/src/services/secure/AccountSecureStorage.ts
+++ b/src/services/secure/AccountSecureStorage.ts
@@ -37,6 +37,9 @@ import {
   KeyEnvelopeV2,
   decryptKeyEnvelopeV2,
   decryptKeyEnvelopeV2WithWrapKey,
+  encryptKeyEnvelopeV2,
+  assertPayloadSizeWithinLimit,
+  AT_REST_KDF_PARAMS,
   MAX_KEY_BLOBS,
 } from './envelopeV2';
 import { SessionKeyVault, VaultLockedError } from './SessionKeyVault';
@@ -152,6 +155,19 @@ const customPBKDF2 = (
 interface StoredPinData {
   hash: string;
   iterations: number;
+  /**
+   * Per-credential verification salt, FOLDED into the PIN credential (DOC-137
+   * §5.2). Present on Wave-2 (folded) credentials; ABSENT on pre-Wave-2 shapes
+   * that kept the salt in the separate `SALT_KEY` item (back-compat: readers
+   * fall back to `getOrCreateSalt()` when this is undefined).
+   */
+  salt?: string;
+  /**
+   * Which kind of user secret this credential verifies (DOC-137 §5.2 / R3). UX
+   * hint only — never a decryption gate. Absent on pre-Wave-2 shapes (treated as
+   * 'pin').
+   */
+  secretSource?: SecretSource;
   format: 'json' | 'legacy';
 }
 
@@ -175,6 +191,37 @@ export class AccountSecureStorage {
   // concurrent verifyPin calls (e.g. batch signing) can never lose an
   // increment. Modeled on the inFlightRequests dedup below.
   private static throttleChain: Promise<unknown> = Promise.resolve();
+
+  // ───────────────────────────────────────────────────────────────────────────
+  // GLOBAL KEY-MUTATION MUTEX (DOC-137 §0 P1-B). READ BEFORE CHANGING.
+  //
+  // A SINGLE process-wide exclusive lock that serializes EVERY writer of account
+  // key material against EVERY PIN-lifecycle credential change, so the two can
+  // never interleave:
+  //   - storeAccount (and import/restore, which funnel through it)
+  //   - setupPin / changePin (the atomic rewrap-all → verify-all → flip-credential
+  //     transaction of §5)
+  //
+  // WHY (the real lockout vector, P1-B): changePin/setupPin enumerate the account
+  // list, re-wrap every account under the NEW secret, then flip the PIN
+  // credential. If a NEW account were stored (under the OLD session secret, as a
+  // v2 blob) AFTER that enumeration snapshot but BEFORE the credential commit, it
+  // would be wrapped under the OLD secret and become unreadable once the new
+  // credential lands — a permanent strand recoverable only by the mnemonic. This
+  // mutex forces such a concurrent storeAccount to run EITHER fully before the
+  // enumeration (so it is included in the rewrap) OR fully after the commit + the
+  // vault rotate (so it wraps under the NEW secret). It is acquired BEFORE
+  // enumerating accounts and released only AFTER the credential commit and the
+  // SessionKeyVault rotation.
+  //
+  // NEVER roll a failed rewrap back by writing a stale full-payload snapshot (it
+  // could clobber a legitimate concurrent write) — roll back by dropping only the
+  // specific unproven blob (dropBlob). The chain never rejects (outcomes are
+  // swallowed) so one failing task cannot poison later ones. verifyPin is called
+  // BEFORE acquiring this lock (it takes the SEPARATE throttle mutex), so the two
+  // mutexes never nest and cannot deadlock.
+  // ───────────────────────────────────────────────────────────────────────────
+  private static keyMutationChain: Promise<unknown> = Promise.resolve();
 
   // In-memory mirror of the throttle state (DOC-137 §8 / TASK-26, Codex P1).
   // The EFFECTIVE throttle enforced by verifyPin is the MORE RESTRICTIVE of the
@@ -280,6 +327,244 @@ export class AccountSecureStorage {
     );
   }
 
+  // ───────────────────────────────────────────────────────────────────────────
+  // V2 AT-REST WRITER (DOC-137 §2, PR4). READ BEFORE CHANGING.
+  //
+  // Wraps the FULL stored key bytes (the 64-byte algosdk `sk`, or whatever length
+  // is stored — NEVER hardcode 32; §0 P1-A) under a USER-SECRET-derived scrypt
+  // envelope (KeyEnvelopeV2). Every persist of a v2 payload goes through
+  // saveSecretV2Checked, which enforces the multi-blob budget (≤2 blobs, <2048
+  // bytes serialized) BEFORE writing. NEVER logs the secret or key bytes.
+  // ───────────────────────────────────────────────────────────────────────────
+
+  /**
+   * Run a task under the GLOBAL key-mutation mutex (P1-B). Every account-secret
+   * writer and every PIN-lifecycle credential change acquires this before
+   * enumerating/mutating, so a store/import can never interleave with a
+   * setupPin/changePin rewrap. The chain never rejects (each outcome is
+   * swallowed onto the chain) so a failing task cannot poison later ones; the
+   * task's own result/rejection is still returned to its caller.
+   */
+  private static runKeyMutationExclusive<T>(
+    task: () => Promise<T>
+  ): Promise<T> {
+    const result = this.keyMutationChain.then(task, task);
+    this.keyMutationChain = result.then(
+      () => undefined,
+      () => undefined
+    );
+    return result;
+  }
+
+  /**
+   * Encrypt raw key bytes into a KeyEnvelopeV2 under a user secret (scrypt +
+   * AES-256-CTR + encrypt-then-MAC). Round-trips the EXACT input bytes (§0
+   * P1-A). When `deviceBound` is true the wrap key gets the device post-mix (a
+   * cheap HMAC over the device id — mild defense-in-depth, §2.2). Uses the at-rest
+   * unlock KDF params (2^14). The caller owns `keyBytes` and must scrub it.
+   */
+  private static async encryptPrivateKeyV2(
+    keyBytes: Uint8Array,
+    secret: string,
+    secretSource: SecretSource,
+    options: { deviceBound: boolean }
+  ): Promise<KeyEnvelopeV2> {
+    const deviceSecret = options.deviceBound
+      ? await this.getStableDeviceId()
+      : undefined;
+    return encryptKeyEnvelopeV2({
+      plaintext: keyBytes,
+      secret,
+      secretSource,
+      deviceSecret,
+      kdfParams: AT_REST_KDF_PARAMS,
+    });
+  }
+
+  /**
+   * Serialize + budget-check + persist a v2 payload in ONE atomic SecureStore
+   * write. Enforces the PR1 carry-forward (§2.4): hard-cap MAX_KEY_BLOBS blobs
+   * and the expo-secure-store 2048-byte value limit, BEFORE the write, so an
+   * over-budget payload throws instead of being persisted (or silently rejected
+   * by SecureStore). A single setItem is atomic per item on both platforms, which
+   * is what makes add-blob → verify → drop-old crash-safe.
+   */
+  private static async saveSecretV2Checked(
+    accountId: string,
+    payload: AccountSecretPayload
+  ): Promise<void> {
+    const serialized = JSON.stringify(payload);
+    assertPayloadSizeWithinLimit(serialized, payload.blobs?.length ?? 0);
+    await secureStorage.setItem(this.secretKey(accountId), serialized);
+  }
+
+  /**
+   * Append (or set) a KeyEnvelopeV2 blob in `AccountSecretPayload.blobs` and
+   * persist it budget-checked (DOC-137 §2, the writeSecretV2 primitive). Reads
+   * the current payload, appends the blob, and writes via saveSecretV2Checked so
+   * the 2-blob / 2048-byte cap is enforced. Legacy `encryptedPrivateKey` is
+   * retained (dual-readable) — cleanup happens in the atomic rewrap flow, never
+   * here. NOTE: general-purpose primitive; the changePin/setupPin rewrap uses the
+   * lower-level appendBlob + saveSecretV2Checked directly for keeper-blob control.
+   */
+  static async writeSecretV2(
+    accountId: string,
+    blob: KeyEnvelopeV2
+  ): Promise<void> {
+    const existing = await this.readSecret(accountId);
+    const base: AccountSecretPayload = existing ?? {
+      accountId,
+      encryptedPrivateKey: '',
+      authMethod: 'pin',
+    };
+    await this.saveSecretV2Checked(accountId, this.appendBlob(base, blob));
+  }
+
+  /**
+   * Pure helper: return a copy of `payload` with `blob` appended to `blobs` and
+   * version:2 set. Retains `encryptedPrivateKey` (dual-readable during a rewrap).
+   * The budget cap is enforced at persist time (saveSecretV2Checked).
+   */
+  private static appendBlob(
+    payload: AccountSecretPayload,
+    blob: KeyEnvelopeV2
+  ): AccountSecretPayload {
+    return {
+      accountId: payload.accountId,
+      encryptedPrivateKey: payload.encryptedPrivateKey,
+      authMethod: payload.authMethod,
+      version: 2,
+      blobs: [...(payload.blobs ?? []), blob],
+    };
+  }
+
+  /**
+   * Pure helper: return a copy of `payload` with the specific `blob` removed,
+   * matched by its unique MAC (identity match is unusable after a JSON round-trip
+   * on re-read; the HMAC binds the random salt/iv so it is a collision-free id).
+   * Used for verify-before-delete ROLLBACK — drop ONLY the specific unproven
+   * blob, NEVER write a stale full-payload snapshot (P1-B). If no blobs remain,
+   * the payload reverts to its legacy (Format-A) shape.
+   */
+  private static dropBlob(
+    payload: AccountSecretPayload,
+    blob: KeyEnvelopeV2
+  ): AccountSecretPayload {
+    const remaining = (payload.blobs ?? []).filter((b) => b.mac !== blob.mac);
+    if (remaining.length === 0) {
+      return {
+        accountId: payload.accountId,
+        encryptedPrivateKey: payload.encryptedPrivateKey,
+        authMethod: payload.authMethod,
+      };
+    }
+    return {
+      accountId: payload.accountId,
+      encryptedPrivateKey: payload.encryptedPrivateKey,
+      authMethod: payload.authMethod,
+      version: 2,
+      blobs: remaining,
+    };
+  }
+
+  /**
+   * Pure helper: the FINAL committed shape for an account — a single v2 blob,
+   * legacy `encryptedPrivateKey` cleared, so the ONLY at-rest copy is the
+   * user-secret-wrapped envelope (this is the whole point of DR-2: dropping the
+   * device-key copy that needed no user secret). Used in the post-commit cleanup.
+   */
+  private static finalizePayload(
+    payload: AccountSecretPayload,
+    keepBlob: KeyEnvelopeV2
+  ): AccountSecretPayload {
+    return {
+      accountId: payload.accountId,
+      encryptedPrivateKey: '',
+      authMethod: payload.authMethod,
+      version: 2,
+      blobs: [keepBlob],
+    };
+  }
+
+  /**
+   * Constant-time byte-equality (verify-before-delete byte-exact round-trip
+   * check). Length-independent early return is safe (length is not secret).
+   */
+  private static constantTimeEqualBytes(a: Uint8Array, b: Uint8Array): boolean {
+    if (a.length !== b.length) {
+      return false;
+    }
+    let diff = 0;
+    for (let i = 0; i < a.length; i++) {
+      diff |= a[i] ^ b[i];
+    }
+    return diff === 0;
+  }
+
+  /**
+   * Trial-decrypt an account's key material for a REWRAP (DOC-137 §4.3/§5.3),
+   * returning the in-memory key bytes plus the v2 blob that verified (the
+   * "keeper" to retain during the dual-blob transition), or null if nothing
+   * decrypts under `currentSecret`/the device key.
+   *
+   * Ladder (MAC-anchored — a wrong key can never forge the MAC, so a bad
+   * candidate simply falls through):
+   *   1. v2 blobs under `currentSecret` (if a secret is provided) → keeperBlob set;
+   *   2. Format A (device-key, PIN-independent) → keeperBlob undefined;
+   *   3. Format C (legacy PIN-mixed, needs `currentSecret`) → keeperBlob undefined.
+   *
+   * `currentSecret === undefined` is the setupPin (first-secret) case: only the
+   * device-key path (2) applies, migrating pre-existing Format-A accounts.
+   */
+  private static async unwrapKeyForRewrap(
+    payload: AccountSecretPayload,
+    currentSecret: string | undefined,
+    deviceSecret: string
+  ): Promise<{ plaintext: Uint8Array; keeperBlob?: KeyEnvelopeV2 } | null> {
+    // 1. Existing v2 blobs under the current secret.
+    if (currentSecret !== undefined && Array.isArray(payload.blobs)) {
+      for (const blob of payload.blobs.slice(0, MAX_KEY_BLOBS)) {
+        try {
+          const pt = await decryptKeyEnvelopeV2(
+            blob,
+            currentSecret,
+            deviceSecret
+          );
+          if (pt) {
+            return { plaintext: pt, keeperBlob: blob };
+          }
+        } catch {
+          // Structurally invalid/out-of-cap blob — try the next candidate.
+        }
+      }
+    }
+
+    // 2. Format A (device key — PIN-independent).
+    if (payload.encryptedPrivateKey) {
+      try {
+        const pt = await this.decryptPrivateKey(payload.encryptedPrivateKey);
+        return { plaintext: pt };
+      } catch {
+        // Not a device-key blob — fall through to Format C.
+      }
+
+      // 3. Format C (legacy PIN-mixed) — only when a PIN-shaped secret is present.
+      if (currentSecret !== undefined) {
+        try {
+          const pt = await this.decryptPrivateKeyWithPin(
+            payload.encryptedPrivateKey,
+            currentSecret
+          );
+          return { plaintext: pt };
+        } catch {
+          // Not Format C either.
+        }
+      }
+    }
+
+    return null;
+  }
+
   private static async migrateLegacyAccountData(
     accountId: string
   ): Promise<PersistedAccountMetadata | null> {
@@ -328,46 +613,97 @@ export class AccountSecureStorage {
     account: AccountMetadata,
     privateKey?: Uint8Array
   ): Promise<void> {
-    try {
-      const hasPin = await this.hasPin();
-      const lastAccessed = new Date().toISOString();
+    // Acquire the GLOBAL key-mutation mutex (P1-B) around the WHOLE write — the
+    // secret payload AND the account-list mutation — so a store can never
+    // interleave with a setupPin/changePin rewrap enumeration+commit. See the
+    // keyMutationChain comment above.
+    return this.runKeyMutationExclusive(async () => {
+      try {
+        const hasPin = await this.hasPin();
+        const lastAccessed = new Date().toISOString();
 
-      const metadata: PersistedAccountMetadata = {
-        accountId: account.id,
-        address: account.address,
-        type: account.type,
-        publicData: {
-          publicKey: account.publicKey,
-          label: account.label || '',
-          color: account.color || '#000000',
-          createdAt: account.createdAt,
-          importedAt: account.importedAt,
-          avatarUrl: account.avatarUrl,
-          avatarUpdatedAt: account.avatarUpdatedAt,
-        },
-        authMethod: hasPin ? 'pin' : 'biometric',
-        lastAccessed,
-      };
-
-      // Encrypt and store private key for Standard accounts
-      if (account.type === AccountType.STANDARD && privateKey) {
-        const encryptedPrivateKey = await this.encryptPrivateKey(privateKey);
-        await this.saveSecret(account.id, {
+        const metadata: PersistedAccountMetadata = {
           accountId: account.id,
-          encryptedPrivateKey,
-          authMethod: metadata.authMethod,
-        });
-      } else {
-        await this.saveSecret(account.id, null);
-      }
+          address: account.address,
+          type: account.type,
+          publicData: {
+            publicKey: account.publicKey,
+            label: account.label || '',
+            color: account.color || '#000000',
+            createdAt: account.createdAt,
+            importedAt: account.importedAt,
+            avatarUrl: account.avatarUrl,
+            avatarUpdatedAt: account.avatarUpdatedAt,
+          },
+          authMethod: hasPin ? 'pin' : 'biometric',
+          lastAccessed,
+        };
 
-      // Store metadata for quick access
-      await this.storeAccountMetadata(metadata);
-    } catch (error) {
-      throw new AccountStorageError(
-        `Failed to store account: ${error instanceof Error ? error.message : 'Unknown error'}`
-      );
-    }
+        // Encrypt and store private key for Standard accounts.
+        if (account.type === AccountType.STANDARD && privateKey) {
+          // WRITE V2 DIRECTLY when a durable user secret is available — i.e. a
+          // PIN credential EXISTS *and* the unlocked SessionKeyVault holds the
+          // verified session secret — so new accounts created during an active
+          // session are wrapped under the user secret from the start
+          // (DOC-137 §5.4). Because this runs under the global mutex, the vault
+          // secret it reads is guaranteed NOT to be mid-rotated by a concurrent
+          // changePin: the store is fully ordered before that change's
+          // enumeration or fully after its commit + vault rotate (P1-B).
+          //
+          // The `hasPin` gate is load-bearing safety: a v2 blob is re-derivable
+          // ONLY via a secret that a PIN credential can verify. Without a PIN
+          // credential the session secret is ephemeral (and cannot be verified
+          // after the vault clears), so wrapping under it could strand the key —
+          // AND setupPin's device-key unwrap could not later migrate it. So when
+          // no PIN exists we ALWAYS write the legacy device-key (Format A) blob;
+          // setupPin upgrades it to v2 on first-secret setup.
+          if (hasPin && SessionKeyVault.isUnlocked()) {
+            const secret = SessionKeyVault.getSecret();
+            const source = SessionKeyVault.getSecretSource();
+            if (secret !== null) {
+              const blob = await this.encryptPrivateKeyV2(
+                privateKey,
+                secret,
+                source,
+                { deviceBound: true }
+              );
+              await this.saveSecretV2Checked(account.id, {
+                accountId: account.id,
+                encryptedPrivateKey: '',
+                authMethod: metadata.authMethod,
+                version: 2,
+                blobs: [blob],
+              });
+            } else {
+              const encryptedPrivateKey =
+                await this.encryptPrivateKey(privateKey);
+              await this.saveSecret(account.id, {
+                accountId: account.id,
+                encryptedPrivateKey,
+                authMethod: metadata.authMethod,
+              });
+            }
+          } else {
+            const encryptedPrivateKey =
+              await this.encryptPrivateKey(privateKey);
+            await this.saveSecret(account.id, {
+              accountId: account.id,
+              encryptedPrivateKey,
+              authMethod: metadata.authMethod,
+            });
+          }
+        } else {
+          await this.saveSecret(account.id, null);
+        }
+
+        // Store metadata for quick access
+        await this.storeAccountMetadata(metadata);
+      } catch (error) {
+        throw new AccountStorageError(
+          `Failed to store account: ${error instanceof Error ? error.message : 'Unknown error'}`
+        );
+      }
+    });
   }
 
   static async retrieveAccount(accountId: string): Promise<AccountMetadata> {
@@ -1162,20 +1498,63 @@ export class AccountSecureStorage {
   }
 
   // PIN Management Methods
-  static async storePin(pin: string): Promise<void> {
-    try {
-      if (!pin || pin.length !== 6 || !/^\d{6}$/.test(pin)) {
-        throw new Error('PIN must be 6 digits');
+
+  /**
+   * Validate a user secret for its kind. PIN is the enforced 6-digit default;
+   * passphrase policy (min length / entropy meter) is finalized in PR7 — here we
+   * only reject an empty passphrase so a blank secret can never commit.
+   */
+  private static validateSecret(
+    secret: string,
+    secretSource: SecretSource
+  ): void {
+    if (secretSource === 'passphrase') {
+      if (!secret || secret.length === 0) {
+        throw new Error('Passphrase must not be empty');
       }
+      return;
+    }
+    if (!secret || secret.length !== 6 || !/^\d{6}$/.test(secret)) {
+      throw new Error('PIN must be 6 digits');
+    }
+  }
 
-      const salt = await this.getOrCreateSalt(true);
-      const hashedPin = this.hashPin(pin, salt, this.PIN_ITERATIONS);
+  /**
+   * First-secret setup. Back-compat alias that DELEGATES to setupPin so the
+   * credential commit ALWAYS re-wraps any pre-existing device-key accounts under
+   * the new secret (DOC-137 §5.4). Persisting a bare hash without re-wrapping
+   * would brick v2 keys on the next unlock — never do that.
+   */
+  static async storePin(pin: string): Promise<void> {
+    await this.setupPin(pin, 'pin');
+  }
 
-      await this.persistPinHash(hashedPin, salt);
+  /**
+   * First-secret setup / device→v2 migration (DOC-137 §5.4).
+   *
+   * Establishes the FIRST PIN credential and atomically re-wraps every
+   * pre-existing (Format-A, device-key) standard account under the new secret,
+   * using the SAME dual-blob verify-before-delete transaction as changePin with
+   * `currentSecret` = the device key (Format A needs no user secret to unwrap).
+   * Fund-risking: verify-before-delete + crash-safety are enforced by
+   * rewrapAndCommitCredential (crash before commit → no credential, device-key
+   * copies intact; crash after commit → v2 copies valid, cleanup idempotent).
+   */
+  static async setupPin(
+    newSecret: string,
+    secretSource: SecretSource = 'pin'
+  ): Promise<void> {
+    try {
+      this.validateSecret(newSecret, secretSource);
+      await this.rewrapAndCommitCredential({
+        currentSecret: undefined,
+        newSecret,
+        newSource: secretSource,
+      });
       this.legacyCheckRequired = false;
     } catch (error) {
       throw new AccountStorageError(
-        `Failed to store PIN: ${error instanceof Error ? error.message : 'Unknown error'}`
+        `Failed to set up PIN: ${error instanceof Error ? error.message : 'Unknown error'}`
       );
     }
   }
@@ -1459,16 +1838,27 @@ export class AccountSecureStorage {
       return false;
     }
 
-    const salt = await this.getOrCreateSalt();
+    // Prefer the salt FOLDED into the credential (§5.2); fall back to the
+    // standalone SALT_KEY only for pre-Wave-2 credentials that lack it.
+    const salt = storedData.salt ?? (await this.getOrCreateSalt());
+    const secretSource: SecretSource = storedData.secretSource ?? 'pin';
 
     if (storedData.format === 'json') {
       this.legacyCheckRequired = false;
       const candidateHash = this.hashPin(pin, salt, storedData.iterations);
       if (storedData.hash === candidateHash) {
-        if (storedData.iterations !== this.PIN_ITERATIONS) {
+        if (
+          storedData.iterations !== this.PIN_ITERATIONS ||
+          storedData.salt === undefined
+        ) {
           try {
             const upgradedHash = this.hashPin(pin, salt, this.PIN_ITERATIONS);
-            await this.persistPinHash(upgradedHash, salt);
+            await this.persistPinCredential({
+              hash: upgradedHash,
+              iterations: this.PIN_ITERATIONS,
+              salt,
+              secretSource,
+            });
           } catch (error) {
             console.warn('Failed to upgrade stored PIN metadata', error);
           }
@@ -1483,17 +1873,20 @@ export class AccountSecureStorage {
     for (const iterations of iterationCandidates) {
       const candidateHash = this.hashPin(pin, salt, iterations);
       if (storedData.hash === candidateHash) {
-        if (iterations !== this.PIN_ITERATIONS) {
-          try {
-            const upgradedHash = this.hashPin(pin, salt, this.PIN_ITERATIONS);
-            await this.persistPinHash(upgradedHash, salt);
-            this.legacyCheckRequired = false;
-          } catch (error) {
-            console.warn(
-              'Failed to upgrade PIN hash to latest iteration count',
-              error
-            );
-          }
+        try {
+          const upgradedHash = this.hashPin(pin, salt, this.PIN_ITERATIONS);
+          await this.persistPinCredential({
+            hash: upgradedHash,
+            iterations: this.PIN_ITERATIONS,
+            salt,
+            secretSource,
+          });
+          this.legacyCheckRequired = false;
+        } catch (error) {
+          console.warn(
+            'Failed to upgrade PIN hash to latest iteration count',
+            error
+          );
         }
         return true;
       }
@@ -1532,41 +1925,247 @@ export class AccountSecureStorage {
         throw new Error('New PIN must be different from current PIN');
       }
 
-      // Verify current PIN first
+      // Verify current PIN FIRST (throttle-aware, §8) — OUTSIDE the global
+      // key-mutation mutex. verifyPin takes the SEPARATE throttle mutex; the two
+      // must never nest (would deadlock / serialize unnecessarily).
       const isCurrentValid = await this.verifyPin(currentPin);
       if (!isCurrentValid) {
         throw new Error('Current PIN is incorrect');
       }
 
-      // Generate a fresh salt for the new PIN
-      const salt = await this.getOrCreateSalt(true);
-      const hashedNewPin = this.hashPin(newPin, salt, this.PIN_ITERATIONS);
-
-      await this.persistPinHash(hashedNewPin, salt);
+      // Atomic rewrap-all → verify-all → flip-credential (DOC-137 §5.3), under
+      // the global key-mutation mutex. This re-wraps EVERY standard account from
+      // the OLD secret to the NEW one before the credential flips, so a bare hash
+      // rotation can never brick v2 keys. Preserves PR6's biometric-item refresh
+      // and the SessionKeyVault rotation (both done post-commit, inside the
+      // mutex).
+      await this.rewrapAndCommitCredential({
+        currentSecret: currentPin,
+        newSecret: newPin,
+        newSource: 'pin',
+      });
       this.legacyCheckRequired = false;
-
-      // COMMIT POINT passed — the new PIN hash is persisted. Keep the biometric-
-      // convenience item and the live session in sync with the NEW secret
-      // (DOC-137 §5.3 / Codex P2). Without this, a biometric unlock after a PIN
-      // change would load the OLD PIN into the vault — harmless for Format-A
-      // keys today, but a real break once PR4 wraps v2 keys under the new PIN.
-      // changePin here handles PINs only, so secretSource is 'pin'. This never
-      // throws (it disables biometrics on a failed refresh) so a post-commit
-      // failure can't misreport the (successful) PIN change.
-      await this.refreshBiometricSecretAfterSecretChange(newPin, 'pin');
-
-      // Rotate the live session so an unlocked session holds the new secret
-      // WITHOUT re-locking (SessionKeyVault.rotate, PR3). Only when currently
-      // unlocked — a locked session has nothing to rotate and will populate the
-      // vault fresh on its next unlock.
-      if (SessionKeyVault.isUnlocked()) {
-        SessionKeyVault.rotate(newPin, 'pin');
-      }
     } catch (error) {
       throw new AccountStorageError(
         `Failed to change PIN: ${error instanceof Error ? error.message : 'Unknown error'}`
       );
     }
+  }
+
+  /**
+   * The shared atomic PIN-lifecycle rewrap+commit transaction (DOC-137 §5.3/§5.4)
+   * — the fund-risking core of both changePin and setupPin. READ CAREFULLY.
+   *
+   * Runs under the GLOBAL key-mutation mutex (P1-B), acquired BEFORE enumerating
+   * accounts, so no store/import can interleave and strand a new account under
+   * the old secret. Phases:
+   *
+   *   1. UNWRAP every key-bearing account under the OLD secret (or the device key
+   *      when `currentSecret` is undefined = first-secret setup) into an
+   *      in-memory buffer. ALL-OR-NOTHING: if any account cannot be unwrapped,
+   *      abort before touching storage (old credential + copies stay intact).
+   *   2. ADD a NEW-secret v2 blob to each account (dual-blob). The old readable
+   *      copy — the "keeper" v2 blob or the Format-A field — is preserved, so the
+   *      account decrypts under EITHER secret at every instant. Reduces to the
+   *      keeper first so the payload never exceeds 2 blobs.
+   *   3. VERIFY every new blob byte-exactly under the NEW secret via a FULL
+   *      independent decrypt (its own scrypt) — verify-before-delete. Any
+   *      mismatch → rollback.
+   *   4. COMMIT the PIN credential in ONE folded write (§5.2). POINT OF NO RETURN.
+   *   5. CLEANUP (best-effort, post-commit): keep ONLY the new blob and clear the
+   *      legacy device-key copy (the DR-2 goal — no copy readable without the
+   *      user secret). Then resync the biometric item + rotate the vault.
+   *
+   * CRASH SAFETY (commit = step 4's single atomic write):
+   *   - crash BEFORE 4 → credential still verifies the OLD secret; old copies
+   *     decrypt; the unproven new blobs are inert (wrong-secret trial-decrypt
+   *     MAC-fails); nothing stranded; retried on the next attempt.
+   *   - crash AFTER 4 → credential verifies the NEW secret; new blobs decrypt;
+   *     stale old copies are inert; cleanup is idempotent.
+   * At NO crash point does an account have zero readable copies.
+   *
+   * ROLLBACK on a pre-commit error drops ONLY the specific unproven new blob
+   * (by MAC), never a stale full-payload snapshot (P1-B). All plaintext buffers
+   * are scrubbed in `finally`. Never logs the secret or key bytes.
+   */
+  private static async rewrapAndCommitCredential(opts: {
+    /** OLD secret to unwrap under; undefined = first-secret setup (device key). */
+    currentSecret?: string;
+    /** NEW secret to wrap every account (and the new credential) under. */
+    newSecret: string;
+    /** Kind of the new secret (folded into the credential + each blob). */
+    newSource: SecretSource;
+  }): Promise<void> {
+    const { currentSecret, newSecret, newSource } = opts;
+
+    await this.runKeyMutationExclusive(async () => {
+      const deviceSecret = await this.getStableDeviceId();
+      const ids = await this.getAllAccountIds();
+
+      interface RewrapCtx {
+        payload: AccountSecretPayload; // as read in phase 1 (stable under mutex)
+        plaintext: Uint8Array;
+        keeperBlob?: KeyEnvelopeV2; // old v2 blob that verified under currentSecret
+        newBlob?: KeyEnvelopeV2; // the unproven new-secret blob (set in phase 2)
+        appended: boolean; // true once the new blob has been persisted
+      }
+      const ctxs = new Map<string, RewrapCtx>();
+      let committed = false;
+
+      try {
+        // PHASE 1 — UNWRAP every key-bearing account under the OLD secret.
+        for (const id of ids) {
+          const payload = await this.readSecret(id);
+          if (!payload) {
+            continue; // watch-only / already deleted — nothing to re-wrap
+          }
+          const hasKeyMaterial =
+            (Array.isArray(payload.blobs) && payload.blobs.length > 0) ||
+            !!payload.encryptedPrivateKey;
+          if (!hasKeyMaterial) {
+            continue; // watch-only payload
+          }
+          const unwrapped = await this.unwrapKeyForRewrap(
+            payload,
+            currentSecret,
+            deviceSecret
+          );
+          if (!unwrapped) {
+            // ALL-OR-NOTHING: an account unreadable under the current secret must
+            // NOT be left behind by a committed new credential. Abort BEFORE any
+            // write so the old credential + all copies stay intact.
+            throw new AccountStorageError(
+              `Cannot re-wrap account ${id}: no readable key copy under the current secret`
+            );
+          }
+          ctxs.set(id, {
+            payload,
+            plaintext: unwrapped.plaintext,
+            keeperBlob: unwrapped.keeperBlob,
+            appended: false,
+          });
+        }
+
+        // PHASE 2 — ADD a NEW-secret v2 blob to each account (dual-blob).
+        for (const [id, ctx] of ctxs) {
+          const newBlob = await this.encryptPrivateKeyV2(
+            ctx.plaintext,
+            newSecret,
+            newSource,
+            { deviceBound: true }
+          );
+          // Reduce to the keeper (drop any OTHER stale blobs) then append the new
+          // blob, so the payload holds at most 2 blobs (keeper + new). This
+          // self-heals a stray blob left by a previously-interrupted rewrap.
+          const base: AccountSecretPayload = ctx.keeperBlob
+            ? {
+                accountId: ctx.payload.accountId,
+                encryptedPrivateKey: ctx.payload.encryptedPrivateKey,
+                authMethod: ctx.payload.authMethod,
+                version: 2,
+                blobs: [ctx.keeperBlob],
+              }
+            : {
+                accountId: ctx.payload.accountId,
+                encryptedPrivateKey: ctx.payload.encryptedPrivateKey,
+                authMethod: ctx.payload.authMethod,
+              };
+          await this.saveSecretV2Checked(id, this.appendBlob(base, newBlob));
+          ctx.newBlob = newBlob;
+          ctx.appended = true;
+        }
+
+        // PHASE 3 — VERIFY every new blob byte-exactly under the NEW secret via a
+        // FULL independent decrypt, BEFORE any old copy is removed or the
+        // credential flips (verify-before-delete).
+        for (const [, ctx] of ctxs) {
+          const check = await decryptKeyEnvelopeV2(
+            ctx.newBlob!,
+            newSecret,
+            deviceSecret
+          );
+          try {
+            if (!check || !this.constantTimeEqualBytes(check, ctx.plaintext)) {
+              throw new AccountStorageError('Re-wrap verification failed');
+            }
+          } finally {
+            check?.fill(0);
+          }
+        }
+
+        // PHASE 4 — COMMIT: flip the PIN credential in ONE folded write (§5.2).
+        // POINT OF NO RETURN.
+        const newSalt = await this.generateRandomHex(32);
+        const hash = this.hashPin(newSecret, newSalt, this.PIN_ITERATIONS);
+        await this.persistPinCredential({
+          hash,
+          iterations: this.PIN_ITERATIONS,
+          salt: newSalt,
+          secretSource: newSource,
+        });
+        committed = true;
+        this.legacyCheckRequired = false;
+
+        // ── Everything below runs AFTER the commit and MUST NOT throw upward:
+        // the PIN change already succeeded. Stale old copies are inert (a
+        // wrong-secret trial-decrypt MAC-fails), so cleanup is best-effort.
+
+        // PHASE 5 — CLEANUP: keep ONLY the new blob; clear the legacy device-key
+        // copy so no at-rest copy is readable without the user secret.
+        for (const [id, ctx] of ctxs) {
+          try {
+            await this.saveSecretV2Checked(
+              id,
+              this.finalizePayload(ctx.payload, ctx.newBlob!)
+            );
+          } catch {
+            // Best-effort; a surviving old copy is inert under the new secret.
+          }
+        }
+
+        // Post-commit session sync (PR6): resync the biometric-convenience item
+        // to the NEW secret, then rotate the live vault so the session stays
+        // unlocked WITHOUT re-locking. Neither throws upward.
+        await this.refreshBiometricSecretAfterSecretChange(
+          newSecret,
+          newSource
+        );
+        if (SessionKeyVault.isUnlocked()) {
+          SessionKeyVault.rotate(newSecret, newSource);
+        }
+      } catch (error) {
+        // ROLLBACK — only reachable PRE-commit (post-commit code above swallows).
+        // Drop ONLY the specific unproven new blob (by MAC) from each account we
+        // appended to; never write a stale snapshot (P1-B). Old credential + old
+        // copies remain intact → nothing stranded → retried on the next attempt.
+        if (!committed) {
+          for (const [id, ctx] of ctxs) {
+            if (!ctx.appended || !ctx.newBlob) {
+              continue;
+            }
+            try {
+              const current = await this.readSecret(id);
+              if (!current) {
+                continue;
+              }
+              await this.saveSecretV2Checked(
+                id,
+                this.dropBlob(current, ctx.newBlob)
+              );
+            } catch {
+              // Best-effort; the unproven new blob is inert under the OLD secret.
+            }
+          }
+        }
+        throw error;
+      } finally {
+        // Scrub every in-memory plaintext buffer.
+        for (const ctx of ctxs.values()) {
+          ctx.plaintext.fill(0);
+        }
+        ctxs.clear();
+      }
+    });
   }
 
   /**
@@ -1651,16 +2250,49 @@ export class AccountSecureStorage {
     await this.clearBiometricSecret().catch(() => {});
   }
 
+  /**
+   * Remove the PIN — but ONLY when no wallet holds standard-account keys
+   * (DOC-137 §5.5 / Dave's decision: NO no-user-secret resting state for
+   * key-bearing wallets). Removing the PIN would leave only the device secret to
+   * wrap keys — the exact zero-offline-resistance state DR-2 eliminates — so on a
+   * key-bearing wallet this THROWS. The genuine "no PIN" escape hatch is the
+   * explicit, mnemonic-required destructive Reset Wallet, never a silent
+   * downgrade. Watch-only wallets (no key material) may still remove the PIN.
+   *
+   * The enumerate-then-delete runs under the global key-mutation mutex so a
+   * concurrent storeAccount can't add a key between the check and the delete
+   * (which would leave a key-bearing wallet with no PIN).
+   */
   static async deletePin(): Promise<void> {
-    try {
-      await storage.removeItem(this.PIN_KEY);
-      await secureStorage.deleteItem(this.PIN_KEY).catch(() => {});
-      await storage.removeItem(this.SALT_KEY).catch(() => {});
-      await secureStorage.deleteItem(this.SALT_KEY).catch(() => {});
-      this.legacyCheckRequired = undefined;
-    } catch (error) {
-      throw new AccountStorageError('Failed to delete PIN');
-    }
+    return this.runKeyMutationExclusive(async () => {
+      try {
+        const ids = await this.getAllAccountIds();
+        for (const id of ids) {
+          const payload = await this.readSecret(id);
+          const holdsKey =
+            !!payload &&
+            (!!payload.encryptedPrivateKey ||
+              (Array.isArray(payload.blobs) && payload.blobs.length > 0));
+          if (holdsKey) {
+            throw new AccountStorageError(
+              'Cannot remove PIN while accounts hold keys — use Change PIN or Reset Wallet'
+            );
+          }
+        }
+
+        // Watch-only (no key material) — safe to remove the credential.
+        await storage.removeItem(this.PIN_KEY);
+        await secureStorage.deleteItem(this.PIN_KEY).catch(() => {});
+        await storage.removeItem(this.SALT_KEY).catch(() => {});
+        await secureStorage.deleteItem(this.SALT_KEY).catch(() => {});
+        this.legacyCheckRequired = undefined;
+      } catch (error) {
+        if (error instanceof AccountStorageError) {
+          throw error;
+        }
+        throw new AccountStorageError('Failed to delete PIN');
+      }
+    });
   }
 
   // Biometric Settings
@@ -1924,11 +2556,25 @@ export class AccountSecureStorage {
         const parsed = JSON.parse(value) as {
           hash?: string;
           iterations?: number;
+          salt?: unknown;
+          secretSource?: unknown;
         };
         if (parsed.hash && typeof parsed.iterations === 'number') {
+          // Back-compat: the folded salt + secretSource (§5.2) are present on
+          // Wave-2 credentials and ABSENT on the older {hash, iterations} shape.
+          const salt =
+            typeof parsed.salt === 'string' ? parsed.salt : undefined;
+          const secretSource =
+            parsed.secretSource === 'passphrase'
+              ? 'passphrase'
+              : parsed.secretSource === 'pin'
+                ? 'pin'
+                : undefined;
           return {
             hash: parsed.hash,
             iterations: parsed.iterations,
+            salt,
+            secretSource,
             format: 'json',
           };
         }
@@ -1944,16 +2590,35 @@ export class AccountSecureStorage {
     };
   }
 
-  private static async persistPinHash(
-    hash: string,
-    salt: string,
-    iterations: number = this.PIN_ITERATIONS
-  ): Promise<void> {
-    const payload = JSON.stringify({ hash, iterations });
+  /**
+   * Commit the PIN credential in ONE atomic write (DOC-137 §5.2). Folds the
+   * verification salt (and the secretSource UX hint) INTO the PIN_KEY value —
+   * `{ hash, iterations, salt, secretSource }` — so the credential flip is a
+   * single JSON write, eliminating the former two-write micro-window where
+   * PIN_KEY and a separate SALT_KEY could momentarily disagree. The standalone
+   * SALT_KEY is dropped best-effort since the salt now lives in the credential;
+   * a later getOrCreateSalt() read is only reached by pre-Wave-2 credentials that
+   * never folded the salt. Never logs the hash or salt.
+   */
+  private static async persistPinCredential(data: {
+    hash: string;
+    iterations: number;
+    salt: string;
+    secretSource: SecretSource;
+  }): Promise<void> {
+    const payload = JSON.stringify({
+      hash: data.hash,
+      iterations: data.iterations,
+      salt: data.salt,
+      secretSource: data.secretSource,
+    });
 
+    // SINGLE atomic write of the whole credential.
     await secureStorage.setItem(this.PIN_KEY, payload);
-    await secureStorage.setItem(this.SALT_KEY, salt);
 
+    // The salt is now inside the credential — drop stale standalone copies so a
+    // fallback getOrCreateSalt() can never return a mismatched salt.
+    await secureStorage.deleteItem(this.SALT_KEY).catch(() => {});
     await storage.removeItem(this.PIN_KEY).catch(() => {});
     await storage.removeItem(this.SALT_KEY).catch(() => {});
   }

--- a/src/services/secure/AccountSecureStorage.ts
+++ b/src/services/secure/AccountSecureStorage.ts
@@ -286,7 +286,17 @@ export class AccountSecureStorage {
     );
   }
 
-  private static async readSecret(
+  /**
+   * Read a secret payload. `Locked`: the caller ALREADY holds the key-mutation
+   * mutex (every internal reader — rewrap / deletePin / writeSecretV2 — is inside
+   * it), so a needed legacy fold uses the RAW migrateLegacyAccountDataLocked and
+   * never re-acquires the promise-chain lock (which would deadlock). The two
+   * OTHER read entry points that can trigger a legacy fold — readMetadata and
+   * getPrivateKey — run OUTSIDE the mutex and call the MUTEX-GUARDED
+   * migrateLegacyAccountData directly, so no secret write ever bypasses the lock
+   * (P1-1a).
+   */
+  private static async readSecretLocked(
     accountId: string
   ): Promise<AccountSecretPayload | null> {
     try {
@@ -295,8 +305,8 @@ export class AccountSecureStorage {
         return JSON.parse(stored) as AccountSecretPayload;
       }
 
-      // Fall back to legacy storage for migration
-      const migrated = await this.migrateLegacyAccountData(accountId);
+      // Fall back to legacy storage for migration (RAW — already inside the lock)
+      const migrated = await this.migrateLegacyAccountDataLocked(accountId);
       if (!migrated) {
         return null;
       }
@@ -411,7 +421,19 @@ export class AccountSecureStorage {
     accountId: string,
     blob: KeyEnvelopeV2
   ): Promise<void> {
-    const existing = await this.readSecret(accountId);
+    // Acquire the GLOBAL key-mutation mutex (P1-1a): this is a secret writer, so
+    // it must serialize against every rewrap/store/delete.
+    return this.runKeyMutationExclusive(() =>
+      this.writeSecretV2Locked(accountId, blob)
+    );
+  }
+
+  /** RAW writeSecretV2 (no mutex acquire) — for callers already holding it. */
+  private static async writeSecretV2Locked(
+    accountId: string,
+    blob: KeyEnvelopeV2
+  ): Promise<void> {
+    const existing = await this.readSecretLocked(accountId);
     const base: AccountSecretPayload = existing ?? {
       accountId,
       encryptedPrivateKey: '',
@@ -565,7 +587,23 @@ export class AccountSecureStorage {
     return null;
   }
 
+  /**
+   * Public read-path legacy fold (Format B → Format A). Acquires the GLOBAL
+   * key-mutation mutex so its secret write can never bypass the lock (P1-1a).
+   * Reached ONLY outside the mutex (readMetadata / getPrivateKey); in-mutex
+   * readers use readSecretLocked → migrateLegacyAccountDataLocked to avoid
+   * nesting the promise-chain lock on itself (which would deadlock).
+   */
   private static async migrateLegacyAccountData(
+    accountId: string
+  ): Promise<PersistedAccountMetadata | null> {
+    return this.runKeyMutationExclusive(() =>
+      this.migrateLegacyAccountDataLocked(accountId)
+    );
+  }
+
+  /** RAW legacy fold (no mutex acquire) — for callers already holding it. */
+  private static async migrateLegacyAccountDataLocked(
     accountId: string
   ): Promise<PersistedAccountMetadata | null> {
     try {
@@ -640,58 +678,26 @@ export class AccountSecureStorage {
         };
 
         // Encrypt and store private key for Standard accounts.
+        //
+        // ALWAYS write the legacy device-key (Format A) envelope — NEVER v2 here
+        // (Codex P1-2). A device-key blob is PIN-independent and can be read back
+        // regardless of the PIN/vault state, so a newly-stored account can never
+        // be stranded under an obsolete/mismatched vault secret (the entire
+        // "wrapped under a secret the credential can't reproduce" class). New
+        // accounts are upgraded to the user-secret v2 envelope by setupPin /
+        // changePin (which enumerate + re-wrap them) or by the PR5 migration
+        // engine. The global key-mutation mutex (held here) still serializes this
+        // write against any concurrent rewrap, so a store during a changePin is
+        // ordered either fully before the enumeration (→ re-wrapped) or fully
+        // after the commit (→ stays device-readable, upgraded on the next
+        // enumerate). Either way the key is readable — never lost (P1-B).
         if (account.type === AccountType.STANDARD && privateKey) {
-          // WRITE V2 DIRECTLY when a durable user secret is available — i.e. a
-          // PIN credential EXISTS *and* the unlocked SessionKeyVault holds the
-          // verified session secret — so new accounts created during an active
-          // session are wrapped under the user secret from the start
-          // (DOC-137 §5.4). Because this runs under the global mutex, the vault
-          // secret it reads is guaranteed NOT to be mid-rotated by a concurrent
-          // changePin: the store is fully ordered before that change's
-          // enumeration or fully after its commit + vault rotate (P1-B).
-          //
-          // The `hasPin` gate is load-bearing safety: a v2 blob is re-derivable
-          // ONLY via a secret that a PIN credential can verify. Without a PIN
-          // credential the session secret is ephemeral (and cannot be verified
-          // after the vault clears), so wrapping under it could strand the key —
-          // AND setupPin's device-key unwrap could not later migrate it. So when
-          // no PIN exists we ALWAYS write the legacy device-key (Format A) blob;
-          // setupPin upgrades it to v2 on first-secret setup.
-          if (hasPin && SessionKeyVault.isUnlocked()) {
-            const secret = SessionKeyVault.getSecret();
-            const source = SessionKeyVault.getSecretSource();
-            if (secret !== null) {
-              const blob = await this.encryptPrivateKeyV2(
-                privateKey,
-                secret,
-                source,
-                { deviceBound: true }
-              );
-              await this.saveSecretV2Checked(account.id, {
-                accountId: account.id,
-                encryptedPrivateKey: '',
-                authMethod: metadata.authMethod,
-                version: 2,
-                blobs: [blob],
-              });
-            } else {
-              const encryptedPrivateKey =
-                await this.encryptPrivateKey(privateKey);
-              await this.saveSecret(account.id, {
-                accountId: account.id,
-                encryptedPrivateKey,
-                authMethod: metadata.authMethod,
-              });
-            }
-          } else {
-            const encryptedPrivateKey =
-              await this.encryptPrivateKey(privateKey);
-            await this.saveSecret(account.id, {
-              accountId: account.id,
-              encryptedPrivateKey,
-              authMethod: metadata.authMethod,
-            });
-          }
+          const encryptedPrivateKey = await this.encryptPrivateKey(privateKey);
+          await this.saveSecret(account.id, {
+            accountId: account.id,
+            encryptedPrivateKey,
+            authMethod: metadata.authMethod,
+          });
         } else {
           await this.saveSecret(account.id, null);
         }
@@ -1111,6 +1117,16 @@ export class AccountSecureStorage {
   }
 
   static async deleteAccount(accountId: string): Promise<void> {
+    // Secret writer → acquire the GLOBAL key-mutation mutex (P1-1a) so a delete
+    // can never interleave with a rewrap enumeration+commit.
+    return this.runKeyMutationExclusive(() =>
+      this.deleteAccountLocked(accountId)
+    );
+  }
+
+  /** RAW deleteAccount (no mutex acquire) — for callers already holding it
+   *  (e.g. clearAll). */
+  private static async deleteAccountLocked(accountId: string): Promise<void> {
     try {
       // Remove from secure storage
       await this.saveSecret(accountId, null);
@@ -1537,20 +1553,37 @@ export class AccountSecureStorage {
    * using the SAME dual-blob verify-before-delete transaction as changePin with
    * `currentSecret` = the device key (Format A needs no user secret to unwrap).
    * Fund-risking: verify-before-delete + crash-safety are enforced by
-   * rewrapAndCommitCredential (crash before commit → no credential, device-key
-   * copies intact; crash after commit → v2 copies valid, cleanup idempotent).
+   * rewrapAndCommitCredentialLocked (crash before commit → no credential,
+   * device-key copies intact; crash after commit → v2 copies valid, cleanup
+   * idempotent).
+   *
+   * TODO(PR7): allow `secretSource: 'passphrase'` once verifyPin supports a
+   * non-6-digit secret. Until then a passphrase credential would be
+   * UNRECOVERABLE — verifyPin rejects any non-6-digit input BEFORE the hash
+   * check — so passphrase is REFUSED here (Codex P1-4).
    */
   static async setupPin(
     newSecret: string,
     secretSource: SecretSource = 'pin'
   ): Promise<void> {
     try {
+      if (secretSource !== 'pin') {
+        // TODO(PR7): remove once verifyPin can unlock a passphrase credential.
+        throw new Error(
+          'Passphrase credentials are not supported yet (PR7); only a 6-digit PIN can be set'
+        );
+      }
       this.validateSecret(newSecret, secretSource);
-      await this.rewrapAndCommitCredential({
-        currentSecret: undefined,
-        newSecret,
-        newSource: secretSource,
-      });
+      // Acquire the GLOBAL key-mutation mutex, then run the atomic rewrap+commit
+      // under it (P1-3: no verify/commit races). setupPin has no current secret
+      // to verify (first-secret setup).
+      await this.runKeyMutationExclusive(() =>
+        this.rewrapAndCommitCredentialLocked({
+          currentSecret: undefined,
+          newSecret,
+          newSource: secretSource,
+        })
+      );
       this.legacyCheckRequired = false;
     } catch (error) {
       throw new AccountStorageError(
@@ -1925,24 +1958,29 @@ export class AccountSecureStorage {
         throw new Error('New PIN must be different from current PIN');
       }
 
-      // Verify current PIN FIRST (throttle-aware, §8) — OUTSIDE the global
-      // key-mutation mutex. verifyPin takes the SEPARATE throttle mutex; the two
-      // must never nest (would deadlock / serialize unnecessarily).
-      const isCurrentValid = await this.verifyPin(currentPin);
-      if (!isCurrentValid) {
-        throw new Error('Current PIN is incorrect');
-      }
-
-      // Atomic rewrap-all → verify-all → flip-credential (DOC-137 §5.3), under
-      // the global key-mutation mutex. This re-wraps EVERY standard account from
-      // the OLD secret to the NEW one before the credential flips, so a bare hash
-      // rotation can never brick v2 keys. Preserves PR6's biometric-item refresh
-      // and the SessionKeyVault rotation (both done post-commit, inside the
-      // mutex).
-      await this.rewrapAndCommitCredential({
-        currentSecret: currentPin,
-        newSecret: newPin,
-        newSource: 'pin',
+      // Acquire the GLOBAL key-mutation mutex FIRST, THEN verify the current PIN
+      // and run the atomic rewrap+commit ALL under the one lock (Codex P1-3 —
+      // verify-inside-mutex closes an authorization TOCTOU: two concurrent
+      // changePins can no longer both pass verification against the OLD credential
+      // and clobber each other; the second acquires the lock only after the first
+      // has committed, so its verifyPin against the now-NEW credential fails).
+      // verifyPin takes the SEPARATE throttle mutex; key→throttle never deadlocks
+      // (nothing acquires the key mutex inside the throttle path).
+      //
+      // The rewrap re-wraps EVERY standard account from the OLD secret to the NEW
+      // one before the credential flips (so a bare hash rotation can never brick
+      // v2 keys), and preserves PR6's biometric-item refresh + SessionKeyVault
+      // rotation (both post-commit, inside the mutex).
+      await this.runKeyMutationExclusive(async () => {
+        const isCurrentValid = await this.verifyPin(currentPin);
+        if (!isCurrentValid) {
+          throw new Error('Current PIN is incorrect');
+        }
+        await this.rewrapAndCommitCredentialLocked({
+          currentSecret: currentPin,
+          newSecret: newPin,
+          newSource: 'pin',
+        });
       });
       this.legacyCheckRequired = false;
     } catch (error) {
@@ -1956,21 +1994,26 @@ export class AccountSecureStorage {
    * The shared atomic PIN-lifecycle rewrap+commit transaction (DOC-137 §5.3/§5.4)
    * — the fund-risking core of both changePin and setupPin. READ CAREFULLY.
    *
-   * Runs under the GLOBAL key-mutation mutex (P1-B), acquired BEFORE enumerating
-   * accounts, so no store/import can interleave and strand a new account under
-   * the old secret. Phases:
+   * `Locked`: the CALLER already holds the GLOBAL key-mutation mutex (Codex P1-3:
+   * changePin verifies the current PIN inside that same lock, before this runs).
+   * Because the mutex is held across the whole transaction AND every secret
+   * writer acquires it (P1-1a), no store/import/migration/delete can interleave
+   * and strand an account. Phases:
    *
    *   1. UNWRAP every key-bearing account under the OLD secret (or the device key
    *      when `currentSecret` is undefined = first-secret setup) into an
    *      in-memory buffer. ALL-OR-NOTHING: if any account cannot be unwrapped,
    *      abort before touching storage (old credential + copies stay intact).
-   *   2. ADD a NEW-secret v2 blob to each account (dual-blob). The old readable
-   *      copy — the "keeper" v2 blob or the Format-A field — is preserved, so the
-   *      account decrypts under EITHER secret at every instant. Reduces to the
-   *      keeper first so the payload never exceeds 2 blobs.
-   *   3. VERIFY every new blob byte-exactly under the NEW secret via a FULL
-   *      independent decrypt (its own scrypt) — verify-before-delete. Any
-   *      mismatch → rollback.
+   *   2. ADD a NEW-secret v2 blob to each account (dual-blob). ALL readable old
+   *      copies are preserved through commit (the old v2 blob(s) AND the Format-A
+   *      field) — nothing is removed pre-commit (Codex P2-5). Blobs are trimmed
+   *      only to respect the 2-blob cap, and only the non-current-secret copy is
+   *      dropped in that case, so the account decrypts under EITHER secret at
+   *      every instant.
+   *   3. VERIFY every new blob byte-exactly under the NEW secret, reading the
+   *      PERSISTED bytes back from storage (NOT the in-memory object) so a
+   *      clobbered/torn write is caught before the credential flips (Codex
+   *      P1-1b). Missing/invalid persisted new blob → abort.
    *   4. COMMIT the PIN credential in ONE folded write (§5.2). POINT OF NO RETURN.
    *   5. CLEANUP (best-effort, post-commit): keep ONLY the new blob and clear the
    *      legacy device-key copy (the DR-2 goal — no copy readable without the
@@ -1988,7 +2031,7 @@ export class AccountSecureStorage {
    * (by MAC), never a stale full-payload snapshot (P1-B). All plaintext buffers
    * are scrubbed in `finally`. Never logs the secret or key bytes.
    */
-  private static async rewrapAndCommitCredential(opts: {
+  private static async rewrapAndCommitCredentialLocked(opts: {
     /** OLD secret to unwrap under; undefined = first-secret setup (device key). */
     currentSecret?: string;
     /** NEW secret to wrap every account (and the new credential) under. */
@@ -1998,174 +2041,205 @@ export class AccountSecureStorage {
   }): Promise<void> {
     const { currentSecret, newSecret, newSource } = opts;
 
-    await this.runKeyMutationExclusive(async () => {
-      const deviceSecret = await this.getStableDeviceId();
-      const ids = await this.getAllAccountIds();
+    // TODO(PR7): a passphrase credential is UNRECOVERABLE today (verifyPin rejects
+    // any non-6-digit input before the hash check), so refuse to CREATE one until
+    // PR7 wires the passphrase verify/unlock path (Codex P1-4). Defense-in-depth:
+    // setupPin also rejects passphrase up front; changePin only ever passes 'pin'.
+    if (newSource !== 'pin') {
+      throw new AccountStorageError(
+        'Passphrase credentials are not supported yet (PR7)'
+      );
+    }
 
-      interface RewrapCtx {
-        payload: AccountSecretPayload; // as read in phase 1 (stable under mutex)
-        plaintext: Uint8Array;
-        keeperBlob?: KeyEnvelopeV2; // old v2 blob that verified under currentSecret
-        newBlob?: KeyEnvelopeV2; // the unproven new-secret blob (set in phase 2)
-        appended: boolean; // true once the new blob has been persisted
-      }
-      const ctxs = new Map<string, RewrapCtx>();
-      let committed = false;
+    const deviceSecret = await this.getStableDeviceId();
+    const ids = await this.getAllAccountIds();
 
-      try {
-        // PHASE 1 — UNWRAP every key-bearing account under the OLD secret.
-        for (const id of ids) {
-          const payload = await this.readSecret(id);
-          if (!payload) {
-            continue; // watch-only / already deleted — nothing to re-wrap
-          }
-          const hasKeyMaterial =
-            (Array.isArray(payload.blobs) && payload.blobs.length > 0) ||
-            !!payload.encryptedPrivateKey;
-          if (!hasKeyMaterial) {
-            continue; // watch-only payload
-          }
-          const unwrapped = await this.unwrapKeyForRewrap(
-            payload,
-            currentSecret,
-            deviceSecret
-          );
-          if (!unwrapped) {
-            // ALL-OR-NOTHING: an account unreadable under the current secret must
-            // NOT be left behind by a committed new credential. Abort BEFORE any
-            // write so the old credential + all copies stay intact.
-            throw new AccountStorageError(
-              `Cannot re-wrap account ${id}: no readable key copy under the current secret`
-            );
-          }
-          ctxs.set(id, {
-            payload,
-            plaintext: unwrapped.plaintext,
-            keeperBlob: unwrapped.keeperBlob,
-            appended: false,
-          });
+    interface RewrapCtx {
+      payload: AccountSecretPayload; // as read in phase 1 (stable under the lock)
+      plaintext: Uint8Array;
+      keeperBlob?: KeyEnvelopeV2; // old v2 blob that verified under currentSecret
+      newBlob?: KeyEnvelopeV2; // the unproven new-secret blob (set in phase 2)
+      appended: boolean; // true once the new blob has been persisted
+    }
+    const ctxs = new Map<string, RewrapCtx>();
+    let committed = false;
+
+    try {
+      // PHASE 1 — UNWRAP every key-bearing account under the OLD secret. Uses the
+      // RAW readSecretLocked (we already hold the key mutex).
+      for (const id of ids) {
+        const payload = await this.readSecretLocked(id);
+        if (!payload) {
+          continue; // watch-only / already deleted — nothing to re-wrap
         }
-
-        // PHASE 2 — ADD a NEW-secret v2 blob to each account (dual-blob).
-        for (const [id, ctx] of ctxs) {
-          const newBlob = await this.encryptPrivateKeyV2(
-            ctx.plaintext,
-            newSecret,
-            newSource,
-            { deviceBound: true }
-          );
-          // Reduce to the keeper (drop any OTHER stale blobs) then append the new
-          // blob, so the payload holds at most 2 blobs (keeper + new). This
-          // self-heals a stray blob left by a previously-interrupted rewrap.
-          const base: AccountSecretPayload = ctx.keeperBlob
-            ? {
-                accountId: ctx.payload.accountId,
-                encryptedPrivateKey: ctx.payload.encryptedPrivateKey,
-                authMethod: ctx.payload.authMethod,
-                version: 2,
-                blobs: [ctx.keeperBlob],
-              }
-            : {
-                accountId: ctx.payload.accountId,
-                encryptedPrivateKey: ctx.payload.encryptedPrivateKey,
-                authMethod: ctx.payload.authMethod,
-              };
-          await this.saveSecretV2Checked(id, this.appendBlob(base, newBlob));
-          ctx.newBlob = newBlob;
-          ctx.appended = true;
+        const hasKeyMaterial =
+          (Array.isArray(payload.blobs) && payload.blobs.length > 0) ||
+          !!payload.encryptedPrivateKey;
+        if (!hasKeyMaterial) {
+          continue; // watch-only payload
         }
-
-        // PHASE 3 — VERIFY every new blob byte-exactly under the NEW secret via a
-        // FULL independent decrypt, BEFORE any old copy is removed or the
-        // credential flips (verify-before-delete).
-        for (const [, ctx] of ctxs) {
-          const check = await decryptKeyEnvelopeV2(
-            ctx.newBlob!,
-            newSecret,
-            deviceSecret
+        const unwrapped = await this.unwrapKeyForRewrap(
+          payload,
+          currentSecret,
+          deviceSecret
+        );
+        if (!unwrapped) {
+          // ALL-OR-NOTHING: an account unreadable under the current secret must
+          // NOT be left behind by a committed new credential. Abort BEFORE any
+          // write so the old credential + all copies stay intact.
+          throw new AccountStorageError(
+            `Cannot re-wrap account ${id}: no readable key copy under the current secret`
           );
-          try {
-            if (!check || !this.constantTimeEqualBytes(check, ctx.plaintext)) {
-              throw new AccountStorageError('Re-wrap verification failed');
-            }
-          } finally {
-            check?.fill(0);
-          }
         }
-
-        // PHASE 4 — COMMIT: flip the PIN credential in ONE folded write (§5.2).
-        // POINT OF NO RETURN.
-        const newSalt = await this.generateRandomHex(32);
-        const hash = this.hashPin(newSecret, newSalt, this.PIN_ITERATIONS);
-        await this.persistPinCredential({
-          hash,
-          iterations: this.PIN_ITERATIONS,
-          salt: newSalt,
-          secretSource: newSource,
+        ctxs.set(id, {
+          payload,
+          plaintext: unwrapped.plaintext,
+          keeperBlob: unwrapped.keeperBlob,
+          appended: false,
         });
-        committed = true;
-        this.legacyCheckRequired = false;
+      }
 
-        // ── Everything below runs AFTER the commit and MUST NOT throw upward:
-        // the PIN change already succeeded. Stale old copies are inert (a
-        // wrong-secret trial-decrypt MAC-fails), so cleanup is best-effort.
+      // PHASE 2 — ADD a NEW-secret v2 blob to each account (dual-blob), KEEPING
+      // all readable old copies through commit (Codex P2-5).
+      for (const [id, ctx] of ctxs) {
+        const newBlob = await this.encryptPrivateKeyV2(
+          ctx.plaintext,
+          newSecret,
+          newSource,
+          { deviceBound: true }
+        );
+        // Keep EVERY existing old blob plus the Format-A field, and only trim to
+        // respect the 2-blob cap: if adding the new blob would exceed MAX_KEY_BLOBS
+        // (i.e. there are already 2 old blobs — only reachable from a prior
+        // interrupted rewrap), keep the ONE that decrypts under the current secret
+        // (the keeper) and drop the other (which is NOT readable under the current
+        // credential). Never drop a copy readable under the current secret.
+        const existingBlobs = ctx.payload.blobs ?? [];
+        const keptOldBlobs =
+          existingBlobs.length + 1 <= MAX_KEY_BLOBS
+            ? existingBlobs
+            : ctx.keeperBlob
+              ? [ctx.keeperBlob]
+              : [];
+        const base: AccountSecretPayload = {
+          accountId: ctx.payload.accountId,
+          encryptedPrivateKey: ctx.payload.encryptedPrivateKey,
+          authMethod: ctx.payload.authMethod,
+          ...(keptOldBlobs.length > 0
+            ? { version: 2 as const, blobs: keptOldBlobs }
+            : {}),
+        };
+        await this.saveSecretV2Checked(id, this.appendBlob(base, newBlob));
+        ctx.newBlob = newBlob;
+        ctx.appended = true;
+      }
 
-        // PHASE 5 — CLEANUP: keep ONLY the new blob; clear the legacy device-key
-        // copy so no at-rest copy is readable without the user secret.
-        for (const [id, ctx] of ctxs) {
+      // PHASE 3 — VERIFY every new blob byte-exactly under the NEW secret from the
+      // PERSISTED bytes (Codex P1-1b): re-read what is actually on disk, confirm
+      // the new blob is present, and decrypt IT (not the in-memory object) so a
+      // torn/clobbered write is caught BEFORE the credential flips. Any account's
+      // persisted new blob missing/invalid → throw → rollback, no commit.
+      for (const [id, ctx] of ctxs) {
+        const raw = await secureStorage.getItem(this.secretKey(id));
+        let persistedNewBlob: KeyEnvelopeV2 | undefined;
+        if (raw) {
           try {
-            await this.saveSecretV2Checked(
-              id,
-              this.finalizePayload(ctx.payload, ctx.newBlob!)
+            const persisted = JSON.parse(raw) as AccountSecretPayload;
+            persistedNewBlob = persisted.blobs?.find(
+              (b) => b.mac === ctx.newBlob!.mac
             );
           } catch {
-            // Best-effort; a surviving old copy is inert under the new secret.
+            persistedNewBlob = undefined;
           }
         }
-
-        // Post-commit session sync (PR6): resync the biometric-convenience item
-        // to the NEW secret, then rotate the live vault so the session stays
-        // unlocked WITHOUT re-locking. Neither throws upward.
-        await this.refreshBiometricSecretAfterSecretChange(
-          newSecret,
-          newSource
-        );
-        if (SessionKeyVault.isUnlocked()) {
-          SessionKeyVault.rotate(newSecret, newSource);
+        if (!persistedNewBlob) {
+          throw new AccountStorageError(
+            `Re-wrap verification failed: new blob for ${id} is not present in storage`
+          );
         }
-      } catch (error) {
-        // ROLLBACK — only reachable PRE-commit (post-commit code above swallows).
-        // Drop ONLY the specific unproven new blob (by MAC) from each account we
-        // appended to; never write a stale snapshot (P1-B). Old credential + old
-        // copies remain intact → nothing stranded → retried on the next attempt.
-        if (!committed) {
-          for (const [id, ctx] of ctxs) {
-            if (!ctx.appended || !ctx.newBlob) {
+        const check = await decryptKeyEnvelopeV2(
+          persistedNewBlob,
+          newSecret,
+          deviceSecret
+        );
+        try {
+          if (!check || !this.constantTimeEqualBytes(check, ctx.plaintext)) {
+            throw new AccountStorageError('Re-wrap verification failed');
+          }
+        } finally {
+          check?.fill(0);
+        }
+      }
+
+      // PHASE 4 — COMMIT: flip the PIN credential in ONE folded write (§5.2).
+      // POINT OF NO RETURN.
+      const newSalt = await this.generateRandomHex(32);
+      const hash = this.hashPin(newSecret, newSalt, this.PIN_ITERATIONS);
+      await this.persistPinCredential({
+        hash,
+        iterations: this.PIN_ITERATIONS,
+        salt: newSalt,
+        secretSource: newSource,
+      });
+      committed = true;
+      this.legacyCheckRequired = false;
+
+      // ── Everything below runs AFTER the commit and MUST NOT throw upward:
+      // the PIN change already succeeded. Stale old copies are inert (a
+      // wrong-secret trial-decrypt MAC-fails), so cleanup is best-effort.
+
+      // PHASE 5 — CLEANUP: keep ONLY the new blob; clear the legacy device-key
+      // copy so no at-rest copy is readable without the user secret.
+      for (const [id, ctx] of ctxs) {
+        try {
+          await this.saveSecretV2Checked(
+            id,
+            this.finalizePayload(ctx.payload, ctx.newBlob!)
+          );
+        } catch {
+          // Best-effort; a surviving old copy is inert under the new secret.
+        }
+      }
+
+      // Post-commit session sync (PR6): resync the biometric-convenience item
+      // to the NEW secret, then rotate the live vault so the session stays
+      // unlocked WITHOUT re-locking. Neither throws upward.
+      await this.refreshBiometricSecretAfterSecretChange(newSecret, newSource);
+      if (SessionKeyVault.isUnlocked()) {
+        SessionKeyVault.rotate(newSecret, newSource);
+      }
+    } catch (error) {
+      // ROLLBACK — only reachable PRE-commit (post-commit code above swallows).
+      // Drop ONLY the specific unproven new blob (by MAC) from each account we
+      // appended to; never write a stale snapshot (P1-B). Old credential + old
+      // copies remain intact → nothing stranded → retried on the next attempt.
+      if (!committed) {
+        for (const [id, ctx] of ctxs) {
+          if (!ctx.appended || !ctx.newBlob) {
+            continue;
+          }
+          try {
+            const current = await this.readSecretLocked(id);
+            if (!current) {
               continue;
             }
-            try {
-              const current = await this.readSecret(id);
-              if (!current) {
-                continue;
-              }
-              await this.saveSecretV2Checked(
-                id,
-                this.dropBlob(current, ctx.newBlob)
-              );
-            } catch {
-              // Best-effort; the unproven new blob is inert under the OLD secret.
-            }
+            await this.saveSecretV2Checked(
+              id,
+              this.dropBlob(current, ctx.newBlob)
+            );
+          } catch {
+            // Best-effort; the unproven new blob is inert under the OLD secret.
           }
         }
-        throw error;
-      } finally {
-        // Scrub every in-memory plaintext buffer.
-        for (const ctx of ctxs.values()) {
-          ctx.plaintext.fill(0);
-        }
-        ctxs.clear();
       }
-    });
+      throw error;
+    } finally {
+      // Scrub every in-memory plaintext buffer.
+      for (const ctx of ctxs.values()) {
+        ctx.plaintext.fill(0);
+      }
+      ctxs.clear();
+    }
   }
 
   /**
@@ -2268,7 +2342,8 @@ export class AccountSecureStorage {
       try {
         const ids = await this.getAllAccountIds();
         for (const id of ids) {
-          const payload = await this.readSecret(id);
+          // readSecretLocked: we already hold the key mutex (no nesting).
+          const payload = await this.readSecretLocked(id);
           const holdsKey =
             !!payload &&
             (!!payload.encryptedPrivateKey ||
@@ -2642,45 +2717,53 @@ export class AccountSecureStorage {
   }
 
   static async clearAll(): Promise<void> {
-    try {
-      const accountIds = await this.getAllAccountIds();
+    // Full wipe deletes account key material → hold the GLOBAL key-mutation
+    // mutex across the whole thing (P1-1a) so it can't interleave with a rewrap
+    // or a store. Uses deleteAccountLocked (already inside the mutex — never
+    // re-acquire, which would deadlock the promise-chain lock).
+    return this.runKeyMutationExclusive(async () => {
+      try {
+        const accountIds = await this.getAllAccountIds();
 
-      // Delete all accounts
-      for (const accountId of accountIds) {
-        await this.deleteAccount(accountId);
+        // Delete all accounts
+        for (const accountId of accountIds) {
+          await this.deleteAccountLocked(accountId);
+        }
+
+        // Clear PIN and settings from general storage
+        // NOTE: DEVICE_ID_KEY is intentionally NOT cleared - it's used for key derivation
+        // and must remain consistent across restore operations to decrypt private keys
+        await storage.multiRemove([
+          this.PIN_KEY,
+          this.SALT_KEY,
+          this.BIOMETRIC_ENABLED_KEY,
+          this.METADATA_LIST_KEY,
+          this.PIN_TIMEOUT_KEY,
+        ]);
+        // Clear from secure storage
+        await Promise.all([
+          secureStorage.deleteItem(this.PIN_KEY).catch(() => {}),
+          secureStorage.deleteItem(this.SALT_KEY).catch(() => {}),
+          secureStorage.deleteItem(this.BIOMETRIC_ENABLED_KEY).catch(() => {}),
+          // Drop the auth-gated biometric-convenience secret on a full wipe.
+          secureStorage.deleteItem(this.BIOMETRIC_SECRET_KEY).catch(() => {}),
+          secureStorage.deleteItem(this.METADATA_LIST_KEY).catch(() => {}),
+          secureStorage.deleteItem(this.PIN_TIMEOUT_KEY).catch(() => {}),
+        ]);
+        // Wipe the persistent PIN throttle THROUGH the throttle serialization
+        // mutex verifyPin uses (a SEPARATE mutex from the key-mutation lock; the
+        // two never deadlock because nothing acquires the key mutex inside the
+        // throttle path), as the FINAL throttle mutation. Any in-flight verifyPin
+        // increment is serialized ahead of this block, so it persists FIRST and
+        // is then wiped here — it can never land AFTER the wipe and leave a stale
+        // lockout (which would phantom-lock the freshly reset/restored wallet).
+        await this.runThrottleExclusive(async () => {
+          await secureStorage.deleteItem(this.PIN_THROTTLE_KEY).catch(() => {});
+          this.throttleMirror = null;
+        });
+      } catch (error) {
+        throw new AccountStorageError('Failed to clear all secure storage');
       }
-
-      // Clear PIN and settings from general storage
-      // NOTE: DEVICE_ID_KEY is intentionally NOT cleared - it's used for key derivation
-      // and must remain consistent across restore operations to decrypt private keys
-      await storage.multiRemove([
-        this.PIN_KEY,
-        this.SALT_KEY,
-        this.BIOMETRIC_ENABLED_KEY,
-        this.METADATA_LIST_KEY,
-        this.PIN_TIMEOUT_KEY,
-      ]);
-      // Clear from secure storage
-      await Promise.all([
-        secureStorage.deleteItem(this.PIN_KEY).catch(() => {}),
-        secureStorage.deleteItem(this.SALT_KEY).catch(() => {}),
-        secureStorage.deleteItem(this.BIOMETRIC_ENABLED_KEY).catch(() => {}),
-        // Drop the auth-gated biometric-convenience secret on a full wipe.
-        secureStorage.deleteItem(this.BIOMETRIC_SECRET_KEY).catch(() => {}),
-        secureStorage.deleteItem(this.METADATA_LIST_KEY).catch(() => {}),
-        secureStorage.deleteItem(this.PIN_TIMEOUT_KEY).catch(() => {}),
-      ]);
-      // Wipe the persistent PIN throttle THROUGH the same serialization mutex
-      // verifyPin uses, as the FINAL throttle mutation. Any in-flight verifyPin
-      // increment is serialized ahead of this block, so it persists FIRST and is
-      // then wiped here — it can never land AFTER the wipe and leave a stale
-      // lockout (which would phantom-lock the freshly reset/restored wallet).
-      await this.runThrottleExclusive(async () => {
-        await secureStorage.deleteItem(this.PIN_THROTTLE_KEY).catch(() => {});
-        this.throttleMirror = null;
-      });
-    } catch (error) {
-      throw new AccountStorageError('Failed to clear all secure storage');
-    }
+    });
   }
 }

--- a/src/services/secure/__tests__/keyWriterChangePin.test.ts
+++ b/src/services/secure/__tests__/keyWriterChangePin.test.ts
@@ -279,12 +279,49 @@ function useFastWriter(): void {
     );
 }
 
+/** Persist a folded PIN credential directly (skips the rewrap flow). */
+async function seedCredential(pin: string): Promise<void> {
+  const salt = 'a'.repeat(64);
+  await asPriv.persistPinCredential({
+    hash: asPriv.hashPin(pin, salt, PIN_ITERATIONS),
+    iterations: PIN_ITERATIONS,
+    salt,
+    secretSource: 'pin',
+  });
+}
+
+/** Minimal STANDARD account metadata for storeAccount. */
+function makeStandardMeta(
+  id: string,
+  k: ReturnType<typeof makeAlgoKey>
+): StandardAccountMetadata {
+  return {
+    id,
+    address: k.address,
+    publicKey: hex(k.pubkey),
+    type: AccountType.STANDARD,
+    label: '',
+    color: '#000000',
+    isHidden: false,
+    createdAt: new Date().toISOString(),
+    lastUsed: new Date().toISOString(),
+    mnemonic: '',
+    hasBackup: false,
+  };
+}
+
 beforeEach(() => {
   mockPlatform.__reset();
   AccountSecureStorage.clearPrivateKeyCache();
   SessionKeyVault.clear();
   asPriv.throttleMirror = null;
   asPriv.legacyCheckRequired = undefined;
+  // clearMocks clears CALLS but not IMPLEMENTATIONS, so restore the default
+  // passthrough for any test that overrode secureStorage.getItem (the clobber
+  // test) — otherwise the override would leak into later tests.
+  mockPlatform.secureStorage.getItem.mockImplementation(async (k: string) =>
+    mockPlatform.__secure.has(k) ? mockPlatform.__secure.get(k)! : null
+  );
 });
 
 afterEach(() => {
@@ -554,9 +591,24 @@ describe('changePin crash-injection — verify-before-delete, never strands (§4
     expect(await AccountSecureStorage.verifyPin('222222')).toBe(true);
     expect(await AccountSecureStorage.verifyPin('111111')).toBe(false);
     await assertReadable('222222', { 'acct-a': a, 'acct-b': b });
-    // Cleanup didn't run, so the account still carries the (now inert) old blob
-    // alongside the new one — but it remains readable under the new secret.
-    expect(readPayload('acct-a').blobs!.length).toBeGreaterThanOrEqual(1);
+
+    // Cleanup (phase 5) was skipped, so the account still carries BOTH copies:
+    // the OLD blob (kept through commit — Codex P2-5) and the proven NEW blob.
+    // This proves old readable copies survive until the post-commit cleanup.
+    const blobs = readPayload('acct-a').blobs!;
+    expect(blobs).toHaveLength(2);
+    const oldDecrypts = await decryptKeyEnvelopeV2(
+      blobs[0],
+      '111111',
+      DEVICE_ID
+    );
+    const newDecrypts = await decryptKeyEnvelopeV2(
+      blobs[1],
+      '222222',
+      DEVICE_ID
+    );
+    expect(oldDecrypts && hex(oldDecrypts)).toBe(hex(a.sk)); // OLD copy present
+    expect(newDecrypts && hex(newDecrypts)).toBe(hex(a.sk)); // NEW copy present
   }, 20000);
 });
 
@@ -602,61 +654,153 @@ describe('deletePin policy (§5.5)', () => {
 });
 
 // ─────────────────────────────────────────────────────────────────────────────
-describe('global key-mutation mutex (P1-B) — storeAccount vs changePin', () => {
-  it('serializes a concurrent store + change so the new account is never stranded', async () => {
+describe('storeAccount ALWAYS writes Format-A (Codex P1-2)', () => {
+  it('writes a device-key (Format A) blob, NEVER v2 — even with a PIN set + vault unlocked', async () => {
+    await seedCredential('111111');
+    SessionKeyVault.set('111111', 'pin'); // pre-Codex, this would trigger a v2 write
+    const k = makeAlgoKey();
+
+    await AccountSecureStorage.storeAccount(
+      makeStandardMeta('acct-fa', k),
+      k.sk
+    );
+
+    const p = readPayload('acct-fa');
+    expect(p.blobs).toBeUndefined(); // NO v2 blob without a changePin/setupPin
+    expect(p.version).toBeUndefined();
+    expect(p.encryptedPrivateKey.split(':')).toHaveLength(4); // 4-colon Format A
+    // Device-readable regardless of PIN/vault.
+    const out = await AccountSecureStorage.getPrivateKey('acct-fa', '111111');
+    expect(hex(out)).toBe(hex(k.sk));
+  }, 20000);
+});
+
+describe('global key-mutation mutex (P1-B / P1-1a) — writers serialize with rewrap', () => {
+  it('a Format-A account stored concurrently with changePin is NOT lost (device-readable, rewrapped on enumerate)', async () => {
     useFastWriter();
     const existing = makeAlgoKey();
     await seedV2('acct-existing', existing.sk, '111111');
-    await asPriv.persistPinCredential({
-      hash: asPriv.hashPin('111111', 'a'.repeat(64), PIN_ITERATIONS),
-      iterations: PIN_ITERATIONS,
-      salt: 'a'.repeat(64),
-      secretSource: 'pin',
-    });
-    // Unlocked session holding the OLD secret (so storeAccount writes v2).
+    await seedCredential('111111');
     SessionKeyVault.set('111111', 'pin');
 
     const fresh = makeAlgoKey();
-    const newAccount: StandardAccountMetadata = {
-      id: 'acct-new',
-      address: fresh.address,
-      publicKey: hex(fresh.pubkey),
-      type: AccountType.STANDARD,
-      label: '',
-      color: '#000000',
-      isHidden: false,
-      createdAt: new Date().toISOString(),
-      lastUsed: new Date().toISOString(),
-      mnemonic: '',
-      hasBackup: false,
-    };
-
-    // Fire BOTH concurrently. The global mutex must serialize them so the new
-    // account is either included in the change's enumeration (wrapped NEW) or
-    // stored after the vault rotates to NEW — never wrapped under OLD and left
-    // behind by the committed new credential.
+    // Fire BOTH concurrently. The global mutex serializes them: the store (now
+    // always Format-A) runs either fully before the change's enumeration (→ it
+    // is re-wrapped to v2 under NEW) or fully after the commit (→ it stays
+    // Format-A, device-readable). Either way the key is never lost.
     await Promise.all([
       AccountSecureStorage.changePin('111111', '222222'),
-      AccountSecureStorage.storeAccount(newAccount, fresh.sk),
+      AccountSecureStorage.storeAccount(
+        makeStandardMeta('acct-new', fresh),
+        fresh.sk
+      ),
     ]);
 
-    // Credential is NEW.
     expect(await AccountSecureStorage.verifyPin('222222')).toBe(true);
     expect(await AccountSecureStorage.verifyPin('111111')).toBe(false);
 
-    // BOTH accounts are readable under the NEW secret — the new one is NOT
-    // stranded under the old secret.
-    const existingOut = await AccountSecureStorage.getPrivateKey(
-      'acct-existing',
-      '222222'
-    );
-    expect(hex(existingOut)).toBe(hex(existing.sk));
-    const newOut = await AccountSecureStorage.getPrivateKey(
-      'acct-new',
-      '222222'
-    );
-    expect(hex(newOut)).toBe(hex(fresh.sk));
+    // Both accounts readable under the NEW secret (getPrivateKey falls back to
+    // the device key for a still-Format-A new account after verifying the PIN).
+    expect(
+      hex(await AccountSecureStorage.getPrivateKey('acct-existing', '222222'))
+    ).toBe(hex(existing.sk));
+    expect(
+      hex(await AccountSecureStorage.getPrivateKey('acct-new', '222222'))
+    ).toBe(hex(fresh.sk));
   }, 20000);
+
+  it('a concurrent deleteAccount + changePin serialize cleanly; remaining account intact', async () => {
+    useFastWriter();
+    const a = makeAlgoKey();
+    const b = makeAlgoKey();
+    await seedV2('acct-a', a.sk, '111111');
+    await seedV2('acct-b', b.sk, '111111');
+    await seedCredential('111111');
+
+    // deleteAccount (a secret writer) must go through the mutex, so it can't
+    // interleave with the rewrap enumeration+commit.
+    await Promise.all([
+      AccountSecureStorage.changePin('111111', '222222'),
+      AccountSecureStorage.deleteAccount('acct-b'),
+    ]);
+
+    expect(await AccountSecureStorage.verifyPin('222222')).toBe(true);
+    // acct-a survived and is readable under NEW; acct-b is gone.
+    expect(
+      hex(await AccountSecureStorage.getPrivateKey('acct-a', '222222'))
+    ).toBe(hex(a.sk));
+    expect(mockPlatform.__secure.has(secretKey('acct-b'))).toBe(false);
+  }, 20000);
+
+  it('two concurrent changePins do NOT clobber each other (verify-inside-mutex, Codex P1-3)', async () => {
+    useFastWriter();
+    const a = makeAlgoKey();
+    await seedV2('acct-a', a.sk, '111111');
+    await seedCredential('111111');
+
+    // Both verify OLD; without verify-inside-mutex both would pass and clobber.
+    // With it, the 2nd acquires the lock only AFTER the 1st commits, so its
+    // verifyPin against the now-NEW credential fails.
+    const [r1, r2] = await Promise.allSettled([
+      AccountSecureStorage.changePin('111111', '222222'),
+      AccountSecureStorage.changePin('111111', '333333'),
+    ]);
+    const fulfilled = [r1, r2].filter((r) => r.status === 'fulfilled');
+    const rejected = [r1, r2].filter((r) => r.status === 'rejected');
+    expect(fulfilled).toHaveLength(1);
+    expect(rejected).toHaveLength(1);
+    expect((rejected[0] as PromiseRejectedResult).reason).toMatchObject({
+      message: expect.stringMatching(/Current PIN is incorrect/),
+    });
+
+    // The first changePin (acquires the lock first) wins → 222222.
+    expect(await AccountSecureStorage.verifyPin('222222')).toBe(true);
+    expect(
+      hex(await AccountSecureStorage.getPrivateKey('acct-a', '222222'))
+    ).toBe(hex(a.sk));
+  }, 20000);
+
+  it('re-read-before-commit catches a clobbered persisted new blob → aborts, no strand (Codex P1-1b)', async () => {
+    useFastWriter();
+    const a = makeAlgoKey();
+    await seedV2('acct-a', a.sk, '111111');
+    await seedCredential('111111');
+
+    // Simulate a clobber/torn write: during changePin, every read of the account
+    // secret returns the OLD (pre-append) payload, so phase-3's re-read never
+    // sees the new blob it just wrote → verification aborts BEFORE the commit.
+    const oldRaw = mockPlatform.__secure.get(secretKey('acct-a'))!;
+    mockPlatform.secureStorage.getItem.mockImplementation(async (k: string) => {
+      if (k === secretKey('acct-a')) return oldRaw;
+      return mockPlatform.__secure.has(k)
+        ? mockPlatform.__secure.get(k)!
+        : null;
+    });
+
+    await expect(
+      AccountSecureStorage.changePin('111111', '222222')
+    ).rejects.toThrow();
+
+    // Restore normal reads and confirm NO strand: OLD credential still verifies,
+    // account still readable under OLD.
+    mockPlatform.secureStorage.getItem.mockImplementation(async (k: string) =>
+      mockPlatform.__secure.has(k) ? mockPlatform.__secure.get(k)! : null
+    );
+    expect(await AccountSecureStorage.verifyPin('111111')).toBe(true);
+    expect(
+      hex(await AccountSecureStorage.getPrivateKey('acct-a', '111111'))
+    ).toBe(hex(a.sk));
+  }, 20000);
+});
+
+describe('passphrase credential rejected until PR7 (Codex P1-4)', () => {
+  it('setupPin with secretSource=passphrase throws (verifyPin cannot unlock it yet)', async () => {
+    await expect(
+      AccountSecureStorage.setupPin('correct horse battery', 'passphrase')
+    ).rejects.toThrow(/not supported yet|PR7/i);
+    // No credential was created.
+    expect(await AccountSecureStorage.hasPin()).toBe(false);
+  });
 });
 
 // ─────────────────────────────────────────────────────────────────────────────

--- a/src/services/secure/__tests__/keyWriterChangePin.test.ts
+++ b/src/services/secure/__tests__/keyWriterChangePin.test.ts
@@ -1,0 +1,769 @@
+// PR4 (TASK-27, DOC-137 §2/§4.4/§5) — the FUND-RISKING core:
+//   - the v2 at-rest key writer (encryptPrivateKeyV2 / writeSecretV2);
+//   - atomic setupPin/changePin re-wrap (dual-blob verify-before-delete);
+//   - the global key-mutation mutex (P1-B);
+//   - deletePin policy; salt-in-credential; the 2-blob/2048-byte budget.
+//
+// SAFETY FOCUS. These tests prove:
+//   * a 64-byte algosdk `sk` round-trips BYTE-IDENTICALLY through a Format-A→v2
+//     re-wrap, with the derived public address unchanged and a real Ed25519
+//     (Pera-style) sign still verifying (§0 P1-A / AC8);
+//   * changePin re-wraps EVERY account atomically and each new blob verifies;
+//   * an injected failure at each re-wrap step (after add-blob, after
+//     partial-verify, before/after commit) leaves ≥1 readable copy and NEVER
+//     strands an account (§4.4 / AC3/AC5);
+//   * deletePin throws for a key-bearing wallet, allowed for watch-only;
+//   * setupPin migrates device-key (Format A) accounts to v2;
+//   * the global mutex serializes a concurrent storeAccount vs changePin so a
+//     new account is never wrapped under the old secret and stranded (P1-B);
+//   * the payload budget is enforced on write; the credential folds the salt.
+//
+// SECURITY NOTE: key material is a throwaway Ed25519 keypair; PINs are throwaway
+// test strings. Nothing real is used, and nothing is logged.
+
+jest.mock('@/platform', () => {
+  const nodeCrypto = require('crypto');
+  const secure = new Map<string, string>();
+  const kv = new Map<string, string>();
+  return {
+    __secure: secure,
+    __kv: kv,
+    __reset: () => {
+      secure.clear();
+      kv.clear();
+    },
+    crypto: {
+      getRandomBytes: async (n: number): Promise<Uint8Array> =>
+        Uint8Array.from(nodeCrypto.randomBytes(n)),
+      sha256: async (input: string): Promise<string> =>
+        nodeCrypto.createHash('sha256').update(input).digest('hex'),
+      randomUUID: () => nodeCrypto.randomUUID(),
+    },
+    secureStorage: {
+      getItem: jest.fn(async (k: string) =>
+        secure.has(k) ? secure.get(k)! : null
+      ),
+      setItem: jest.fn(async (k: string, v: string) => {
+        secure.set(k, v);
+      }),
+      deleteItem: jest.fn(async (k: string) => {
+        secure.delete(k);
+      }),
+      getItemWithAuth: jest.fn(async (k: string) =>
+        secure.has(k) ? secure.get(k)! : null
+      ),
+      setItemWithAuth: jest.fn(async (k: string, v: string) => {
+        secure.set(k, v);
+      }),
+    },
+    storage: {
+      getItem: jest.fn(async (k: string) => (kv.has(k) ? kv.get(k)! : null)),
+      setItem: jest.fn(async (k: string, v: string) => {
+        kv.set(k, v);
+      }),
+      removeItem: jest.fn(async (k: string) => {
+        kv.delete(k);
+      }),
+      multiRemove: jest.fn(async (keys: string[]) => {
+        keys.forEach((k) => kv.delete(k));
+      }),
+    },
+    biometrics: {
+      isAvailable: async () => false,
+      isEnrolled: async () => false,
+    },
+    deviceId: {
+      getDeviceId: async () => 'pr4-test-device-idfv',
+    },
+  };
+});
+
+import CryptoJS from 'crypto-js';
+import 'crypto-js/hmac-sha256';
+import 'crypto-js/sha256';
+import 'crypto-js/aes';
+import 'crypto-js/mode-ctr';
+import 'crypto-js/pad-nopadding';
+import 'crypto-js/enc-hex';
+import 'crypto-js/pbkdf2';
+import { createHash, randomBytes } from 'crypto';
+import nacl from 'tweetnacl';
+import algosdk from 'algosdk';
+import * as platform from '@/platform';
+import { AccountSecureStorage } from '../AccountSecureStorage';
+import { SessionKeyVault } from '../SessionKeyVault';
+import {
+  encryptKeyEnvelopeV2,
+  decryptKeyEnvelopeV2,
+  KeyEnvelopeV2,
+} from '../envelopeV2';
+import type { ScryptKdfParams } from '../../backup/types';
+import { AccountType } from '../../../types/wallet';
+import type { StandardAccountMetadata } from '../../../types/wallet';
+
+const DEVICE_ID = 'pr4-test-device-idfv';
+const PIN_ITERATIONS = 8000; // AccountSecureStorage.PIN_ITERATIONS
+// Small (power-of-two, within caps) scrypt params keep the multi-account
+// re-wrap suites fast. The DEFAULT (2^14) is exercised by the byte-identity
+// round-trip test below, which uses the real writer with no injection.
+const FAST_PARAMS: ScryptKdfParams = { N: 2 ** 12, r: 8, p: 1, dkLen: 32 };
+
+const mockPlatform = platform as unknown as {
+  __secure: Map<string, string>;
+  __kv: Map<string, string>;
+  __reset: () => void;
+  secureStorage: {
+    getItem: jest.Mock;
+    setItem: jest.Mock;
+    getItemWithAuth: jest.Mock;
+    setItemWithAuth: jest.Mock;
+    deleteItem: jest.Mock;
+  };
+};
+
+// Reach the private statics the way the merged suites do (cast, no `any`).
+const asPriv = AccountSecureStorage as unknown as {
+  encryptPrivateKeyV2: (
+    keyBytes: Uint8Array,
+    secret: string,
+    secretSource: 'pin' | 'passphrase',
+    options: { deviceBound: boolean }
+  ) => Promise<KeyEnvelopeV2>;
+  persistPinCredential: (data: {
+    hash: string;
+    iterations: number;
+    salt: string;
+    secretSource: 'pin' | 'passphrase';
+  }) => Promise<void>;
+  constantTimeEqualBytes: (a: Uint8Array, b: Uint8Array) => boolean;
+  finalizePayload: (payload: unknown, keepBlob: KeyEnvelopeV2) => unknown;
+  hashPin: (pin: string, salt: string, iterations: number) => string;
+  throttleMirror: unknown;
+  legacyCheckRequired: boolean | undefined;
+};
+
+function hex(bytes: Uint8Array): string {
+  return Buffer.from(bytes).toString('hex');
+}
+
+function nodeSha256Hex(input: string): string {
+  return createHash('sha256').update(input).digest('hex');
+}
+
+function customPBKDF2(
+  password: string,
+  saltHex: string,
+  iterations: number,
+  keyLength: number
+): string {
+  const saltWA = CryptoJS.enc.Hex.parse(saltHex);
+  const derived = CryptoJS.PBKDF2(password, saltWA, {
+    keySize: keyLength / 4,
+    iterations,
+    hasher: CryptoJS.algo.SHA256,
+  });
+  return derived.toString(CryptoJS.enc.Hex);
+}
+
+/** A real 64-byte Ed25519 secret key (seed‖pubkey), as algosdk stores. */
+function makeAlgoKey(): {
+  sk: Uint8Array;
+  pubkey: Uint8Array;
+  address: string;
+} {
+  const kp = nacl.sign.keyPair();
+  return {
+    sk: kp.secretKey, // 64 bytes
+    pubkey: kp.publicKey, // 32 bytes = sk.slice(32)
+    address: algosdk.encodeAddress(kp.publicKey),
+  };
+}
+
+/** Build a legacy Format-A (device-key) 4-colon blob, as encryptPrivateKey does. */
+function makeFormatA(privateKey: Uint8Array): string {
+  const saltHex = randomBytes(32).toString('hex');
+  const ivHex = randomBytes(16).toString('hex');
+  const baseEntropy = nodeSha256Hex(`voi_wallet_${DEVICE_ID}`);
+  const keyMaterial = customPBKDF2(baseEntropy, saltHex, 10000, 32);
+
+  const privateKeyHex = hex(privateKey);
+  const encrypted = CryptoJS.AES.encrypt(
+    privateKeyHex,
+    CryptoJS.enc.Hex.parse(keyMaterial),
+    {
+      iv: CryptoJS.enc.Hex.parse(ivHex),
+      mode: CryptoJS.mode.CTR,
+      padding: CryptoJS.pad.NoPadding,
+    }
+  );
+  const ct = encrypted.toString();
+  const hmacKey = CryptoJS.SHA256(keyMaterial + 'hmac_salt').toString();
+  const hmac = CryptoJS.HmacSHA256(ct, hmacKey).toString();
+  return `${saltHex}:${ivHex}:${ct}:${hmac}`;
+}
+
+function secretKey(id: string): string {
+  return `voi_account_secret_${id}`;
+}
+
+function addToList(id: string): void {
+  const raw = mockPlatform.__kv.get('voi_account_list');
+  const list: string[] = raw ? JSON.parse(raw) : [];
+  if (!list.includes(id)) {
+    list.push(id);
+  }
+  mockPlatform.__kv.set('voi_account_list', JSON.stringify(list));
+}
+
+function seedFormatA(id: string, sk: Uint8Array): void {
+  mockPlatform.__secure.set(
+    secretKey(id),
+    JSON.stringify({
+      accountId: id,
+      encryptedPrivateKey: makeFormatA(sk),
+      authMethod: 'pin',
+    })
+  );
+  addToList(id);
+}
+
+async function seedV2(
+  id: string,
+  sk: Uint8Array,
+  secret: string
+): Promise<void> {
+  const blob = await encryptKeyEnvelopeV2({
+    plaintext: sk,
+    secret,
+    secretSource: 'pin',
+    deviceSecret: DEVICE_ID,
+    kdfParams: FAST_PARAMS,
+  });
+  mockPlatform.__secure.set(
+    secretKey(id),
+    JSON.stringify({
+      accountId: id,
+      encryptedPrivateKey: '',
+      authMethod: 'pin',
+      version: 2,
+      blobs: [blob],
+    })
+  );
+  addToList(id);
+}
+
+function readPayload(id: string): {
+  accountId: string;
+  encryptedPrivateKey: string;
+  authMethod: string;
+  version?: number;
+  blobs?: KeyEnvelopeV2[];
+} {
+  return JSON.parse(mockPlatform.__secure.get(secretKey(id))!);
+}
+
+/** Force the WRITER path to use FAST_PARAMS so multi-account re-wraps stay fast
+ *  and deterministic. The stored blob still self-describes its kdfParams, so the
+ *  verify/read paths pick them up unchanged. */
+function useFastWriter(): void {
+  jest
+    .spyOn(asPriv, 'encryptPrivateKeyV2')
+    .mockImplementation(async (keyBytes, secret, secretSource, options) =>
+      encryptKeyEnvelopeV2({
+        plaintext: keyBytes,
+        secret,
+        secretSource,
+        deviceSecret: options.deviceBound ? DEVICE_ID : undefined,
+        kdfParams: FAST_PARAMS,
+      })
+    );
+}
+
+beforeEach(() => {
+  mockPlatform.__reset();
+  AccountSecureStorage.clearPrivateKeyCache();
+  SessionKeyVault.clear();
+  asPriv.throttleMirror = null;
+  asPriv.legacyCheckRequired = undefined;
+});
+
+afterEach(() => {
+  SessionKeyVault.clear();
+  jest.restoreAllMocks();
+});
+
+// ─────────────────────────────────────────────────────────────────────────────
+describe('v2 writer round-trip — 64-byte sk is byte-identical (§0 P1-A / AC8)', () => {
+  it('Format-A → v2 (via setupPin) preserves the EXACT 64-byte sk, address, and signing', async () => {
+    const { sk, pubkey, address } = makeAlgoKey();
+    expect(sk.length).toBe(64);
+    const id = 'acct-byte-identity';
+    seedFormatA(id, sk);
+
+    // Real writer (default 2^14 KDF) — no injection here.
+    await AccountSecureStorage.setupPin('123456', 'pin');
+
+    // Migrated to v2: the legacy device-key copy is gone, a single v2 blob remains.
+    const payload = readPayload(id);
+    expect(payload.encryptedPrivateKey).toBe('');
+    expect(payload.blobs).toHaveLength(1);
+    expect(payload.version).toBe(2);
+
+    // Round-trip the stored bytes — BYTE-IDENTICAL, whatever the length.
+    const out = await AccountSecureStorage.getPrivateKey(id, '123456');
+    expect(out.length).toBe(64);
+    expect(hex(out)).toBe(hex(sk));
+
+    // Public address unchanged (derived from sk.slice(32)).
+    expect(hex(out.slice(32))).toBe(hex(pubkey));
+    expect(algosdk.encodeAddress(out.slice(32))).toBe(address);
+
+    // A real (Pera-style) Ed25519 signature by the round-tripped key verifies.
+    const msg = Uint8Array.from(Buffer.from('voi pr4 sign check', 'utf8'));
+    const sig = nacl.sign.detached(msg, out);
+    expect(nacl.sign.detached.verify(msg, sig, pubkey)).toBe(true);
+  }, 20000);
+
+  it('encryptPrivateKeyV2 defaults to the at-rest 2^14 KDF params', async () => {
+    const { sk } = makeAlgoKey();
+    const blob = await asPriv.encryptPrivateKeyV2(sk, '123456', 'pin', {
+      deviceBound: true,
+    });
+    expect(blob.kdfParams.N).toBe(2 ** 14);
+    expect(blob.deviceBound).toBe(true);
+    // And it round-trips byte-exactly under the same secret + device id.
+    const back = await decryptKeyEnvelopeV2(blob, '123456', DEVICE_ID);
+    expect(back && hex(back)).toBe(hex(sk));
+  }, 20000);
+});
+
+// ─────────────────────────────────────────────────────────────────────────────
+describe('setupPin — first-secret device→v2 migration (§5.4)', () => {
+  it('migrates ALL pre-existing Format-A accounts to v2 under the new PIN', async () => {
+    useFastWriter();
+    const a = makeAlgoKey();
+    const b = makeAlgoKey();
+    seedFormatA('acct-a', a.sk);
+    seedFormatA('acct-b', b.sk);
+
+    await AccountSecureStorage.setupPin('123456', 'pin');
+
+    for (const [id, k] of [
+      ['acct-a', a],
+      ['acct-b', b],
+    ] as const) {
+      const payload = readPayload(id);
+      expect(payload.encryptedPrivateKey).toBe(''); // device-key copy dropped
+      expect(payload.blobs).toHaveLength(1);
+      const out = await AccountSecureStorage.getPrivateKey(id, '123456');
+      expect(hex(out)).toBe(hex(k.sk));
+    }
+
+    // The credential now verifies the new PIN.
+    expect(await AccountSecureStorage.verifyPin('123456')).toBe(true);
+  }, 20000);
+
+  it('leaves a watch-only account untouched', async () => {
+    useFastWriter();
+    // Watch-only = present in the list but no secret payload.
+    addToList('acct-watch');
+    await AccountSecureStorage.setupPin('123456', 'pin');
+    expect(mockPlatform.__secure.has(secretKey('acct-watch'))).toBe(false);
+    expect(await AccountSecureStorage.verifyPin('123456')).toBe(true);
+  });
+});
+
+// ─────────────────────────────────────────────────────────────────────────────
+describe('changePin — atomic re-wrap of every account (§5.3)', () => {
+  it('re-wraps ALL accounts from OLD→NEW; each new blob verifies; old copies dropped', async () => {
+    useFastWriter();
+    const a = makeAlgoKey();
+    const b = makeAlgoKey();
+    await seedV2('acct-a', a.sk, '111111');
+    await seedV2('acct-b', b.sk, '111111');
+    // Establish the OLD credential (no accounts unwrapped here since they are
+    // already v2 — persist the credential directly).
+    await asPriv.persistPinCredential({
+      hash: asPriv.hashPin('111111', 'a'.repeat(64), PIN_ITERATIONS),
+      iterations: PIN_ITERATIONS,
+      salt: 'a'.repeat(64),
+      secretSource: 'pin',
+    });
+
+    await AccountSecureStorage.changePin('111111', '222222');
+
+    // Both accounts now decrypt under the NEW secret, byte-exact, single blob.
+    for (const [id, k] of [
+      ['acct-a', a],
+      ['acct-b', b],
+    ] as const) {
+      const payload = readPayload(id);
+      expect(payload.blobs).toHaveLength(1);
+      const newBlob = payload.blobs![0];
+      const check = await decryptKeyEnvelopeV2(newBlob, '222222', DEVICE_ID);
+      expect(check && hex(check)).toBe(hex(k.sk));
+      // And the OLD secret no longer decrypts the surviving blob.
+      expect(
+        await decryptKeyEnvelopeV2(newBlob, '111111', DEVICE_ID)
+      ).toBeNull();
+    }
+    expect(await AccountSecureStorage.verifyPin('222222')).toBe(true);
+    expect(await AccountSecureStorage.verifyPin('111111')).toBe(false);
+  }, 20000);
+});
+
+// ─────────────────────────────────────────────────────────────────────────────
+describe('changePin crash-injection — verify-before-delete, never strands (§4.4/AC3/AC5)', () => {
+  async function setupTwoV2(oldPin: string): Promise<{
+    a: ReturnType<typeof makeAlgoKey>;
+    b: ReturnType<typeof makeAlgoKey>;
+  }> {
+    const a = makeAlgoKey();
+    const b = makeAlgoKey();
+    await seedV2('acct-a', a.sk, oldPin);
+    await seedV2('acct-b', b.sk, oldPin);
+    await asPriv.persistPinCredential({
+      hash: asPriv.hashPin(oldPin, 'a'.repeat(64), PIN_ITERATIONS),
+      iterations: PIN_ITERATIONS,
+      salt: 'a'.repeat(64),
+      secretSource: 'pin',
+    });
+    return { a, b };
+  }
+
+  /** Every account decrypts to its expected sk under `pin` (≥1 readable copy). */
+  async function assertReadable(
+    pin: string,
+    expected: Record<string, ReturnType<typeof makeAlgoKey>>
+  ): Promise<void> {
+    for (const [id, k] of Object.entries(expected)) {
+      const out = await AccountSecureStorage.getPrivateKey(id, pin);
+      expect(hex(out)).toBe(hex(k.sk));
+    }
+  }
+
+  it('after add-blob: a verify failure rolls back the new blobs; OLD copies stay readable', async () => {
+    useFastWriter();
+    const { a, b } = await setupTwoV2('111111');
+
+    // Verification fails for every account (as if the new blob wrote wrong).
+    jest.spyOn(asPriv, 'constantTimeEqualBytes').mockReturnValue(false);
+
+    await expect(
+      AccountSecureStorage.changePin('111111', '222222')
+    ).rejects.toThrow();
+
+    // Credential unchanged; both accounts still readable under the OLD secret;
+    // the unproven new blobs were dropped (single OLD blob remains).
+    expect(await AccountSecureStorage.verifyPin('111111')).toBe(true);
+    expect(await AccountSecureStorage.verifyPin('222222')).toBe(false);
+    await assertReadable('111111', { 'acct-a': a, 'acct-b': b });
+    expect(readPayload('acct-a').blobs).toHaveLength(1);
+    expect(readPayload('acct-b').blobs).toHaveLength(1);
+  }, 20000);
+
+  it('after partial-verify: acct-a verifies, acct-b fails → BOTH roll back, neither stranded', async () => {
+    useFastWriter();
+    const { a, b } = await setupTwoV2('111111');
+
+    // First verify passes, second fails (partial verify).
+    jest
+      .spyOn(asPriv, 'constantTimeEqualBytes')
+      .mockReturnValueOnce(true)
+      .mockReturnValue(false);
+
+    await expect(
+      AccountSecureStorage.changePin('111111', '222222')
+    ).rejects.toThrow();
+
+    expect(await AccountSecureStorage.verifyPin('111111')).toBe(true);
+    await assertReadable('111111', { 'acct-a': a, 'acct-b': b });
+    expect(readPayload('acct-a').blobs).toHaveLength(1);
+    expect(readPayload('acct-b').blobs).toHaveLength(1);
+  }, 20000);
+
+  it('during add-blob (before commit): a mid-phase write failure rolls back; nothing stranded', async () => {
+    useFastWriter();
+    const { a, b } = await setupTwoV2('111111');
+
+    // The SECOND account's new-blob encryption throws mid-phase-2. acct-a was
+    // already appended (dual-blob); rollback must drop it, leaving acct-a
+    // readable under OLD, acct-b never touched.
+    const spy = jest.spyOn(asPriv, 'encryptPrivateKeyV2');
+    let calls = 0;
+    spy.mockImplementation(async (keyBytes, secret, secretSource, options) => {
+      calls += 1;
+      if (calls === 2) {
+        throw new Error('injected add-blob failure');
+      }
+      return encryptKeyEnvelopeV2({
+        plaintext: keyBytes,
+        secret,
+        secretSource,
+        deviceSecret: options.deviceBound ? DEVICE_ID : undefined,
+        kdfParams: FAST_PARAMS,
+      });
+    });
+
+    await expect(
+      AccountSecureStorage.changePin('111111', '222222')
+    ).rejects.toThrow();
+
+    expect(await AccountSecureStorage.verifyPin('111111')).toBe(true);
+    expect(await AccountSecureStorage.verifyPin('222222')).toBe(false);
+    await assertReadable('111111', { 'acct-a': a, 'acct-b': b });
+    // acct-a rolled back to its single OLD blob; acct-b never appended.
+    expect(readPayload('acct-a').blobs).toHaveLength(1);
+    expect(readPayload('acct-b').blobs).toHaveLength(1);
+  }, 20000);
+
+  it('before commit: a credential-write failure rolls back; OLD credential + copies intact', async () => {
+    useFastWriter();
+    const { a, b } = await setupTwoV2('111111');
+
+    // The credential commit (phase 4) throws — committed stays false → rollback.
+    jest
+      .spyOn(asPriv, 'persistPinCredential')
+      .mockRejectedValueOnce(new Error('injected commit failure'));
+
+    await expect(
+      AccountSecureStorage.changePin('111111', '222222')
+    ).rejects.toThrow();
+
+    // OLD credential still verifies; NEW does not; both accounts readable under OLD.
+    expect(await AccountSecureStorage.verifyPin('111111')).toBe(true);
+    expect(await AccountSecureStorage.verifyPin('222222')).toBe(false);
+    await assertReadable('111111', { 'acct-a': a, 'acct-b': b });
+  }, 20000);
+
+  it('after commit: a cleanup failure does NOT fail changePin; keys readable under NEW', async () => {
+    useFastWriter();
+    const { a, b } = await setupTwoV2('111111');
+
+    // The post-commit cleanup (phase 5) throws for every account. The PIN change
+    // has already committed, so changePin must STILL resolve and the keys must be
+    // readable under the NEW secret (via the proven new blob).
+    jest.spyOn(asPriv, 'finalizePayload').mockImplementation(() => {
+      throw new Error('injected cleanup failure');
+    });
+
+    await expect(
+      AccountSecureStorage.changePin('111111', '222222')
+    ).resolves.toBeUndefined();
+
+    expect(await AccountSecureStorage.verifyPin('222222')).toBe(true);
+    expect(await AccountSecureStorage.verifyPin('111111')).toBe(false);
+    await assertReadable('222222', { 'acct-a': a, 'acct-b': b });
+    // Cleanup didn't run, so the account still carries the (now inert) old blob
+    // alongside the new one — but it remains readable under the new secret.
+    expect(readPayload('acct-a').blobs!.length).toBeGreaterThanOrEqual(1);
+  }, 20000);
+});
+
+// ─────────────────────────────────────────────────────────────────────────────
+describe('deletePin policy (§5.5)', () => {
+  it('THROWS on a wallet that holds standard-account keys (v2 blob)', async () => {
+    const a = makeAlgoKey();
+    await seedV2('acct-a', a.sk, '111111');
+    await asPriv.persistPinCredential({
+      hash: asPriv.hashPin('111111', 'a'.repeat(64), PIN_ITERATIONS),
+      iterations: PIN_ITERATIONS,
+      salt: 'a'.repeat(64),
+      secretSource: 'pin',
+    });
+
+    await expect(AccountSecureStorage.deletePin()).rejects.toThrow(
+      /Cannot remove PIN while accounts hold keys/
+    );
+    // The credential is untouched — the wallet is not left key-bearing-without-PIN.
+    expect(await AccountSecureStorage.verifyPin('111111')).toBe(true);
+  });
+
+  it('THROWS on a wallet holding a legacy Format-A (device-key) copy', async () => {
+    const a = makeAlgoKey();
+    seedFormatA('acct-a', a.sk);
+    await expect(AccountSecureStorage.deletePin()).rejects.toThrow(
+      /Cannot remove PIN/
+    );
+  });
+
+  it('ALLOWS removing the PIN on a watch-only wallet (no key material)', async () => {
+    addToList('acct-watch'); // no secret payload
+    await asPriv.persistPinCredential({
+      hash: asPriv.hashPin('111111', 'a'.repeat(64), PIN_ITERATIONS),
+      iterations: PIN_ITERATIONS,
+      salt: 'a'.repeat(64),
+      secretSource: 'pin',
+    });
+
+    await expect(AccountSecureStorage.deletePin()).resolves.toBeUndefined();
+    expect(await AccountSecureStorage.hasPin()).toBe(false);
+  });
+});
+
+// ─────────────────────────────────────────────────────────────────────────────
+describe('global key-mutation mutex (P1-B) — storeAccount vs changePin', () => {
+  it('serializes a concurrent store + change so the new account is never stranded', async () => {
+    useFastWriter();
+    const existing = makeAlgoKey();
+    await seedV2('acct-existing', existing.sk, '111111');
+    await asPriv.persistPinCredential({
+      hash: asPriv.hashPin('111111', 'a'.repeat(64), PIN_ITERATIONS),
+      iterations: PIN_ITERATIONS,
+      salt: 'a'.repeat(64),
+      secretSource: 'pin',
+    });
+    // Unlocked session holding the OLD secret (so storeAccount writes v2).
+    SessionKeyVault.set('111111', 'pin');
+
+    const fresh = makeAlgoKey();
+    const newAccount: StandardAccountMetadata = {
+      id: 'acct-new',
+      address: fresh.address,
+      publicKey: hex(fresh.pubkey),
+      type: AccountType.STANDARD,
+      label: '',
+      color: '#000000',
+      isHidden: false,
+      createdAt: new Date().toISOString(),
+      lastUsed: new Date().toISOString(),
+      mnemonic: '',
+      hasBackup: false,
+    };
+
+    // Fire BOTH concurrently. The global mutex must serialize them so the new
+    // account is either included in the change's enumeration (wrapped NEW) or
+    // stored after the vault rotates to NEW — never wrapped under OLD and left
+    // behind by the committed new credential.
+    await Promise.all([
+      AccountSecureStorage.changePin('111111', '222222'),
+      AccountSecureStorage.storeAccount(newAccount, fresh.sk),
+    ]);
+
+    // Credential is NEW.
+    expect(await AccountSecureStorage.verifyPin('222222')).toBe(true);
+    expect(await AccountSecureStorage.verifyPin('111111')).toBe(false);
+
+    // BOTH accounts are readable under the NEW secret — the new one is NOT
+    // stranded under the old secret.
+    const existingOut = await AccountSecureStorage.getPrivateKey(
+      'acct-existing',
+      '222222'
+    );
+    expect(hex(existingOut)).toBe(hex(existing.sk));
+    const newOut = await AccountSecureStorage.getPrivateKey(
+      'acct-new',
+      '222222'
+    );
+    expect(hex(newOut)).toBe(hex(fresh.sk));
+  }, 20000);
+});
+
+// ─────────────────────────────────────────────────────────────────────────────
+describe('payload budget enforced on write (§2.4 / PR1 carry-forward)', () => {
+  it('writeSecretV2 throws when appending would exceed MAX_KEY_BLOBS (2)', async () => {
+    const k = makeAlgoKey();
+    const blob1 = await encryptKeyEnvelopeV2({
+      plaintext: k.sk,
+      secret: '111111',
+      secretSource: 'pin',
+      kdfParams: FAST_PARAMS,
+    });
+    const blob2 = await encryptKeyEnvelopeV2({
+      plaintext: k.sk,
+      secret: '222222',
+      secretSource: 'pin',
+      kdfParams: FAST_PARAMS,
+    });
+    const blob3 = await encryptKeyEnvelopeV2({
+      plaintext: k.sk,
+      secret: '333333',
+      secretSource: 'pin',
+      kdfParams: FAST_PARAMS,
+    });
+    // Seed a payload already holding the 2-blob maximum.
+    mockPlatform.__secure.set(
+      secretKey('acct-full'),
+      JSON.stringify({
+        accountId: 'acct-full',
+        encryptedPrivateKey: '',
+        authMethod: 'pin',
+        version: 2,
+        blobs: [blob1, blob2],
+      })
+    );
+
+    await expect(
+      AccountSecureStorage.writeSecretV2('acct-full', blob3)
+    ).rejects.toThrow(/Too many key blobs/);
+    // Nothing was persisted over the existing 2-blob payload.
+    expect(readPayload('acct-full').blobs).toHaveLength(2);
+  }, 20000);
+});
+
+// ─────────────────────────────────────────────────────────────────────────────
+describe('changePin verify gate is throttle-aware (§8)', () => {
+  it('rejects a wrong current PIN and leaves every account untouched/readable', async () => {
+    useFastWriter();
+    const a = makeAlgoKey();
+    await seedV2('acct-a', a.sk, '111111');
+    await asPriv.persistPinCredential({
+      hash: asPriv.hashPin('111111', 'a'.repeat(64), PIN_ITERATIONS),
+      iterations: PIN_ITERATIONS,
+      salt: 'a'.repeat(64),
+      secretSource: 'pin',
+    });
+    const before = mockPlatform.__secure.get(secretKey('acct-a'));
+
+    // Wrong current PIN → verifyPin (throttle-aware) returns false → changePin
+    // aborts BEFORE any re-wrap.
+    await expect(
+      AccountSecureStorage.changePin('999999', '222222')
+    ).rejects.toThrow(/Current PIN is incorrect/);
+
+    // The secret payload is byte-for-byte unchanged; account still readable OLD.
+    expect(mockPlatform.__secure.get(secretKey('acct-a'))).toBe(before);
+    const out = await AccountSecureStorage.getPrivateKey('acct-a', '111111');
+    expect(hex(out)).toBe(hex(a.sk));
+    expect(await AccountSecureStorage.verifyPin('111111')).toBe(true);
+  }, 20000);
+});
+
+// ─────────────────────────────────────────────────────────────────────────────
+describe('salt-in-credential (§5.2)', () => {
+  it('setupPin folds {hash, iterations, salt, secretSource} into ONE PIN_KEY write', async () => {
+    await AccountSecureStorage.setupPin('123456', 'pin');
+
+    const raw = mockPlatform.__secure.get('voi_wallet_pin')!;
+    const parsed = JSON.parse(raw);
+    expect(typeof parsed.hash).toBe('string');
+    expect(parsed.iterations).toBe(PIN_ITERATIONS);
+    expect(typeof parsed.salt).toBe('string');
+    expect(parsed.salt.length).toBe(64); // 32 bytes hex
+    expect(parsed.secretSource).toBe('pin');
+    // No standalone SALT_KEY is relied upon.
+    expect(mockPlatform.__secure.has('voi_wallet_salt')).toBe(false);
+    // The folded salt verifies the PIN.
+    expect(await AccountSecureStorage.verifyPin('123456')).toBe(true);
+  });
+
+  it('back-compat: an OLD-shape {hash, iterations} + separate SALT_KEY still verifies, then self-heals to folded', async () => {
+    const oldSalt = 'b'.repeat(64);
+    const oldHash = customPBKDF2('123456', oldSalt, PIN_ITERATIONS, 32);
+    // Seed the PRE-Wave-2 shape: no folded salt; salt in the standalone key.
+    mockPlatform.__secure.set(
+      'voi_wallet_pin',
+      JSON.stringify({ hash: oldHash, iterations: PIN_ITERATIONS })
+    );
+    mockPlatform.__secure.set('voi_wallet_salt', oldSalt);
+
+    // Verifies via the SALT_KEY fallback.
+    expect(await AccountSecureStorage.verifyPin('123456')).toBe(true);
+
+    // ...and the credential self-heals to the folded shape (salt now inside).
+    const parsed = JSON.parse(mockPlatform.__secure.get('voi_wallet_pin')!);
+    expect(parsed.salt).toBe(oldSalt);
+    expect(parsed.secretSource).toBe('pin');
+    expect(await AccountSecureStorage.verifyPin('123456')).toBe(true);
+  });
+});


### PR DESCRIPTION
## PR4 of the Wave-2 key-migration (TASK-27, DOC-137) — the FUND-RISKING core

Adds the **v2 at-rest key writer** and makes `changePin`/`setupPin` **atomically re-wrap** every account's key under the user secret, with verify-before-delete crash-safety. Depends on PR1 (envelope/reader), PR3 (SessionKeyVault), PR6 (biometric refresh) — all merged. **Does NOT** do bulk/lazy migration of idle accounts (PR5).

A botched re-wrap locks users out of funds, so correctness + crash-safety are paramount. Every safety invariant from DOC-137 §0 is enforced and tested.

### The v2 writer (§2)
- `encryptPrivateKeyV2(keyBytes, secret, secretSource, {deviceBound})` → `KeyEnvelopeV2` via PR1's `encryptKeyEnvelopeV2` + scrypt `deriveWrapKey` (2^14 at-rest params, device post-mix).
- `writeSecretV2(accountId, blob)` + `saveSecretV2Checked` — every v2 persist calls `assertPayloadSizeWithinLimit` **before** writing (hard-cap 2 blobs, <2048 bytes).
- `storeAccount` now writes v2 directly when a **PIN credential exists AND** the `SessionKeyVault` is unlocked; otherwise the legacy device-key (Format A) path (setupPin upgrades it). The `hasPin` gate is load-bearing: a v2 blob is only re-derivable via a secret a credential can verify.

### Atomic `changePin`/`setupPin` re-wrap (§5.3/§5.4) — verify-before-delete
Shared core `rewrapAndCommitCredential`, under the global mutex:
1. **UNWRAP** every account under the OLD secret (or the device key for setup) into memory. All-or-nothing: if any account can't be read, abort before touching storage.
2. **ADD** a NEW-secret v2 blob to each (dual-blob); the old readable copy (keeper blob or Format-A field) is preserved → decryptable under **either** secret at every instant.
3. **VERIFY** each new blob byte-exactly under the NEW secret via a *full independent decrypt* (its own scrypt) — the verify-before-delete gate.
4. **COMMIT** the PIN credential in ONE folded write (point of no return).
5. **CLEANUP** (best-effort, post-commit): keep only the new blob, drop the device-key copy. Then resync the biometric item + rotate the vault (PR6 preserved).

**Crash-safety table** (commit = step 4's single atomic write):

| Interrupted | Old credential/copies | New v2 blobs | Reader result |
|---|---|---|---|
| before step 4 | intact (verify OLD) | present, inert (MAC-fail under OLD) | reads OLD; retried next attempt |
| after step 4 | stale, inert | proven under NEW | reads NEW; cleanup idempotent |

At **no** crash point does an account have zero readable copies. Pre-commit errors roll back by dropping **only the specific unproven blob** (matched by MAC), never a stale full-payload snapshot. All plaintext buffers scrubbed in `finally`.

### Global key-mutation mutex (§0 P1-B)
A single module-level promise-chain mutex serializes **all** secret writers (`storeAccount` + import/restore via it) AND `setupPin`/`changePin`/`deletePin`. Acquired **before** enumerating accounts and released only **after** the credential commit + vault rotate, so a new/imported account created mid-`changePin` cannot be wrapped under the old secret and stranded. `verifyPin` runs *before* the lock (it takes the separate throttle mutex) → the two never nest.

### 64-byte sk (§0 P1-A)
The writer round-trips the **exact stored bytes** (the full 64-byte algosdk `sk`), never hardcoding 32. Proven byte-identical before/after with public-address equality + a real Ed25519 (Pera-style) sign/verify.

### `deletePin` policy (§5.5)
**Throws** on any wallet holding standard-account keys ("Cannot remove PIN while accounts hold keys — use Change PIN or Reset Wallet"). Watch-only wallets may still remove it. Enumerate-then-delete runs under the mutex.

### Salt-in-credential (§5.2)
`StoredPinData` → `{hash, iterations, salt, secretSource}`; `persistPinCredential` commits it in one JSON write (eliminates the former PIN_KEY/SALT_KEY two-write micro-window). Old-shape `{hash, iterations}` + standalone `SALT_KEY` still parses and self-heals to the folded shape on first verify.

### Tests (18 new, `keyWriterChangePin.test.ts`)
- 64-byte-sk Format-A→v2 round-trip: **byte-identical** + address unchanged + Ed25519 sign verifies; writer defaults to 2^14.
- `setupPin` device→v2 migrates all Format-A accounts; watch-only untouched.
- `changePin` re-wraps ALL accounts atomically; each new blob verifies under NEW, none under OLD.
- **Crash-injection at each step** (after add-blob, after partial-verify, before commit, after commit) — each leaves ≥1 readable copy and never strands.
- `deletePin` throws for v2/Format-A key-bearing wallets, allowed for watch-only.
- **Global mutex** serializes concurrent `storeAccount` vs `changePin` → new account not stranded.
- `assertPayloadSizeWithinLimit` enforced (3rd blob rejected).
- `changePin` throttle-aware verify gate; salt-in-credential round-trip + old-shape back-compat.

### Gates
- `npm run typecheck` → 0
- `npm run lint` → 0 errors
- `npm test -- --ci` → **33 suites / 429 tests pass** (411 prior + 18 new)

### Gated / next
- **PR5** (bulk/lazy migration of idle accounts: `migrateAccountToV2` + post-unlock sweep + lazy `getPrivateKey` trigger + restore-writes-v2) is **not** in this PR and is gated on **§10 on-device testing** with real pre-existing keys.
- On-device migration/interruption/biometric-enrollment testing (§10.3) still required before PR5 merges.
