### PR TITLE
feat(secure): v2 key-migration engine — lazy + post-unlock sweep, dual-blob verify-before-delete (TASK-27 PR5)

### DIFF
--- a/src/contexts/AuthContext.tsx
+++ b/src/contexts/AuthContext.tsx
@@ -301,6 +301,11 @@ export function AuthProvider({ children }: { children: React.ReactNode }) {
           lastActivity: Date.now(),
         }));
         updateActivity();
+        // Fire-and-forget post-unlock migration sweep (DOC-137 §4.5 trigger 2,
+        // PR5): upgrade idle device-key (Format A) accounts to the user-secret
+        // v2 wrap under the just-verified secret. Sequential + vault-fresh per
+        // account; NEVER blocks the unlock, all failures swallowed internally.
+        void AccountSecureStorage.migrateAllAccountsToV2();
         return true;
       }
 
@@ -340,6 +345,11 @@ export function AuthProvider({ children }: { children: React.ReactNode }) {
           lastActivity: Date.now(),
         }));
         updateActivity();
+        // Fire-and-forget post-unlock migration sweep (DOC-137 §4.5 trigger 2,
+        // PR5): the vault was just populated from the biometric-convenience
+        // secret, so idle Format-A accounts can be upgraded to v2 under it. NEVER
+        // blocks the unlock; failures swallowed internally.
+        void AccountSecureStorage.migrateAllAccountsToV2();
         return true;
       }
 

--- a/src/services/secure/AccountSecureStorage.ts
+++ b/src/services/secure/AccountSecureStorage.ts
@@ -134,6 +134,18 @@ interface AccountSecretPayload {
   blobs?: KeyEnvelopeV2[];
 }
 
+/**
+ * Outcome of a single-account v2 migration attempt (DOC-137 §4.4, PR5).
+ *  - `MIGRATED`     — the account was re-wrapped to a user-secret v2 envelope and
+ *                     the legacy device-key copy dropped (point of no return passed).
+ *  - `ALREADY_V2`   — nothing to do: the sole at-rest copy is already a v2 blob
+ *                     readable under the current secret (idempotent no-op).
+ *  - `NOT_MIGRATED` — deferred, never fatal: no key material (watch-only), no
+ *                     copy readable under the supplied secret, or a caught
+ *                     failure left the OLD copy intact for a later retry.
+ */
+export type MigrationResult = 'MIGRATED' | 'ALREADY_V2' | 'NOT_MIGRATED';
+
 // PBKDF2 using CryptoJS with SHA256; returns hex string of keyLength bytes
 const customPBKDF2 = (
   password: string,
@@ -240,6 +252,15 @@ export class AccountSecureStorage {
 
   // In-flight request deduplication to prevent cache stampede
   private static inFlightRequests: Map<string, Promise<Uint8Array>> = new Map();
+
+  // Per-account in-flight guard for the PR5 migration engine (DOC-137 §4.4/§4.6
+  // `migrationLock`, modeled on inFlightRequests). The lazy getPrivateKey trigger
+  // and the post-unlock sweep can both target the same account; joining the
+  // in-flight promise avoids a redundant scrypt+rewrap queued behind the global
+  // key-mutation mutex (the mutex would serialize them anyway, but the second
+  // would waste a memory-hard derivation before finding the account ALREADY_V2).
+  private static migrationInFlight: Map<string, Promise<MigrationResult>> =
+    new Map();
 
   // Iteration counts optimized for mobile performance while maintaining security
   // SecureStore provides hardware-backed encryption, so lower iterations are acceptable
@@ -587,6 +608,272 @@ export class AccountSecureStorage {
     return null;
   }
 
+  // ───────────────────────────────────────────────────────────────────────────
+  // V2 MIGRATION ENGINE (DOC-137 §4, PR5). READ BEFORE CHANGING — FUND-RISKING.
+  //
+  // Upgrades a SINGLE existing account from a legacy device-key (Format A) or
+  // legacy PIN-mixed (Format C) wrap — or a stray old v2 blob — to the canonical
+  // user-secret v2 envelope, under the account's CURRENT verified secret. This is
+  // NOT a secret change (changePin/setupPin own the secret-change rewrap of §5);
+  // it re-wraps under the SAME secret and then drops the device-key copy. It is
+  // "the flip": once an account is finalized to v2-only, no at-rest copy is
+  // readable without the user secret, so the account requires the session vault
+  // (or an explicit step-up PIN) — the whole point of DR-2.
+  //
+  // SAFETY (identical contract to the changePin rewrap, §4.4): additive-then-
+  // verify-then-delete. The old readable copy (the Format-A field or an old v2
+  // blob) is dropped ONLY AFTER a fresh v2 blob has round-tripped byte-exactly
+  // under the same secret, read back from PERSISTED storage. At no crash point
+  // does the account have zero readable copies. Any failure is caught and
+  // downgraded to NOT_MIGRATED (never throws upward): the OLD copy is left intact
+  // and the unproven new blob dropped, so the account stays usable and migration
+  // retries on a later trigger.
+  //
+  // PRECONDITION (caller-guaranteed): `secret` is the account's CURRENT
+  // credential secret — an explicitly verified step-up PIN, or the
+  // SessionKeyVault secret (set at unlock AFTER verifyPin). Finalizing to
+  // v2-under-secret is only safe because the user can reproduce that exact
+  // secret. A WRONG secret can never pass the phase-3 verify, so it can only ever
+  // yield NOT_MIGRATED (never a strand) — but callers must still pass a real,
+  // current secret. Serialized against every other key writer by the GLOBAL
+  // key-mutation mutex, and deduped per-account by migrationInFlight.
+  // ───────────────────────────────────────────────────────────────────────────
+
+  /**
+   * Migrate ONE account to a user-secret v2 envelope (DOC-137 §4.4). Fire-and-
+   * forget safe: resolves to a MigrationResult and NEVER throws (every failure
+   * downgrades to NOT_MIGRATED). Deduped per-account so the lazy getPrivateKey
+   * trigger and the post-unlock sweep can't double-migrate the same account.
+   */
+  static async migrateAccountToV2(
+    accountId: string,
+    secret: string,
+    secretSource: SecretSource = 'pin'
+  ): Promise<MigrationResult> {
+    const existing = this.migrationInFlight.get(accountId);
+    if (existing) {
+      return existing;
+    }
+    // Acquire the GLOBAL key-mutation mutex (P1-B) so this can never interleave
+    // with a store/import/changePin/setupPin/delete. `.catch` makes the whole
+    // call non-throwing even if an unexpected error escapes the locked body.
+    const task = this.runKeyMutationExclusive(() =>
+      this.migrateAccountToV2Locked(accountId, secret, secretSource)
+    ).catch((): MigrationResult => 'NOT_MIGRATED');
+    this.migrationInFlight.set(accountId, task);
+    try {
+      return await task;
+    } finally {
+      // Guard on identity so a newer in-flight migration isn't evicted.
+      if (this.migrationInFlight.get(accountId) === task) {
+        this.migrationInFlight.delete(accountId);
+      }
+    }
+  }
+
+  /**
+   * RAW single-account migration (no mutex acquire — the caller holds the global
+   * key-mutation mutex). Returns a MigrationResult and NEVER throws upward. Reads
+   * with the RAW readSecretLocked (folds Format B → A first). All in-memory
+   * plaintext is scrubbed in `finally`. Never logs the secret or key bytes.
+   */
+  private static async migrateAccountToV2Locked(
+    accountId: string,
+    secret: string,
+    secretSource: SecretSource
+  ): Promise<MigrationResult> {
+    const deviceSecret = await this.getStableDeviceId();
+    const payload = await this.readSecretLocked(accountId);
+    if (!payload) {
+      return 'NOT_MIGRATED'; // watch-only / deleted — nothing to migrate
+    }
+    const hasKeyMaterial =
+      (Array.isArray(payload.blobs) && payload.blobs.length > 0) ||
+      !!payload.encryptedPrivateKey;
+    if (!hasKeyMaterial) {
+      return 'NOT_MIGRATED'; // watch-only payload (saveSecret(id, null))
+    }
+
+    // Fast idempotent exit: already finalized to v2-only (exactly one blob, no
+    // legacy field) AND that blob decrypts under `secret`. Avoids a needless
+    // re-wrap on every sweep pass once an account is done.
+    if (
+      !payload.encryptedPrivateKey &&
+      Array.isArray(payload.blobs) &&
+      payload.blobs.length === 1
+    ) {
+      try {
+        const pt = await decryptKeyEnvelopeV2(
+          payload.blobs[0],
+          secret,
+          deviceSecret
+        );
+        if (pt) {
+          pt.fill(0);
+          return 'ALREADY_V2';
+        }
+      } catch {
+        // Not readable under `secret` (wrapped under a different/old secret) —
+        // fall through; unwrapKeyForRewrap decides below.
+      }
+    }
+
+    // Unwrap under the CURRENT secret: an existing v2 blob, else Format A (device
+    // key), else Format C (legacy PIN-mixed). null => not readable under this
+    // secret → defer (never touch storage).
+    const unwrapped = await this.unwrapKeyForRewrap(
+      payload,
+      secret,
+      deviceSecret
+    );
+    if (!unwrapped) {
+      return 'NOT_MIGRATED';
+    }
+
+    let newBlob: KeyEnvelopeV2 | undefined;
+    let appended = false;
+    let finalized = false;
+    try {
+      // PHASE 2 — ADD a fresh v2 blob under `secret` (dual-blob), keeping the old
+      // readable copy through the point of no return. Respect the 2-blob cap the
+      // same way the changePin rewrap does: if two old blobs already exist (only
+      // reachable from a prior interrupted rewrap), keep ONLY the keeper (readable
+      // under `secret`) and drop the other before appending. Never drop a copy
+      // readable under the current secret.
+      newBlob = await this.encryptPrivateKeyV2(
+        unwrapped.plaintext,
+        secret,
+        secretSource,
+        { deviceBound: true }
+      );
+      const existingBlobs = payload.blobs ?? [];
+      const keptOldBlobs =
+        existingBlobs.length + 1 <= MAX_KEY_BLOBS
+          ? existingBlobs
+          : unwrapped.keeperBlob
+            ? [unwrapped.keeperBlob]
+            : [];
+      const base: AccountSecretPayload = {
+        accountId: payload.accountId,
+        encryptedPrivateKey: payload.encryptedPrivateKey,
+        authMethod: payload.authMethod,
+        ...(keptOldBlobs.length > 0
+          ? { version: 2 as const, blobs: keptOldBlobs }
+          : {}),
+      };
+      await this.saveSecretV2Checked(accountId, this.appendBlob(base, newBlob));
+      appended = true;
+
+      // PHASE 3 — VERIFY the new blob byte-exactly under `secret` from the
+      // PERSISTED bytes (re-read from storage, NOT the in-memory object), so a
+      // torn/clobbered write is caught BEFORE the legacy copy is dropped.
+      const raw = await secureStorage.getItem(this.secretKey(accountId));
+      let persistedNewBlob: KeyEnvelopeV2 | undefined;
+      if (raw) {
+        try {
+          const persisted = JSON.parse(raw) as AccountSecretPayload;
+          persistedNewBlob = persisted.blobs?.find(
+            (b) => b.mac === newBlob!.mac
+          );
+        } catch {
+          persistedNewBlob = undefined;
+        }
+      }
+      if (!persistedNewBlob) {
+        throw new AccountStorageError(
+          `Migration verify failed: new blob for ${accountId} not present in storage`
+        );
+      }
+      const check = await decryptKeyEnvelopeV2(
+        persistedNewBlob,
+        secret,
+        deviceSecret
+      );
+      try {
+        if (
+          !check ||
+          !this.constantTimeEqualBytes(check, unwrapped.plaintext)
+        ) {
+          throw new AccountStorageError('Migration verify failed');
+        }
+      } finally {
+        check?.fill(0);
+      }
+
+      // PHASE 5 — FINALIZE (POINT OF NO RETURN): keep ONLY the new blob and clear
+      // the legacy device-key field, so no at-rest copy is readable without the
+      // user secret (the DR-2 goal). One atomic write.
+      await this.saveSecretV2Checked(
+        accountId,
+        this.finalizePayload(payload, newBlob)
+      );
+      finalized = true;
+      this.legacyCheckRequired = false;
+      return 'MIGRATED';
+    } catch (error) {
+      // ROLLBACK (pre-finalize ONLY — never after the old copy is gone): drop the
+      // specific unproven new blob (by MAC), never a stale full-payload snapshot
+      // (P1-B). The OLD copy stays intact → nothing stranded → retried on a later
+      // trigger. `finalized` guards against a hypothetical future post-finalize
+      // throw dropping the ONLY remaining copy (mirrors changePin's `committed`).
+      if (!finalized && appended && newBlob) {
+        try {
+          const current = await this.readSecretLocked(accountId);
+          if (current) {
+            await this.saveSecretV2Checked(
+              accountId,
+              this.dropBlob(current, newBlob)
+            );
+          }
+        } catch {
+          // Best-effort; the unproven new blob is inert under `secret` (a
+          // wrong-secret trial-decrypt MAC-fails), so a surviving copy is harmless.
+        }
+      }
+      console.warn('v2 migration deferred', accountId, error);
+      return 'NOT_MIGRATED';
+    } finally {
+      unwrapped.plaintext.fill(0);
+    }
+  }
+
+  /**
+   * Background post-unlock sweep (DOC-137 §4.5 trigger 2, PR5): migrate every
+   * IDLE account to v2 under the CURRENT session secret. SEQUENTIAL (concurrency
+   * 1) — scrypt is memory-heavy and parallel derivations risk OOM on low-end
+   * Android. Reads the vault secret FRESH per account so a mid-sweep lock STOPS
+   * the sweep (no work under a dead session) and a mid-sweep changePin-rotate
+   * picks up the NEW secret. Per-account failures never abort the sweep
+   * (migrateAccountToV2 never throws). Fire-and-forget from AuthContext (unlock /
+   * unlockWithBiometrics) — NEVER blocks the unlock. Idempotent + resumable: an
+   * interrupted sweep re-runs on the next unlock (the proven v2 blob is the only
+   * truth — there is no trusted global "migration done" flag).
+   */
+  static async migrateAllAccountsToV2(): Promise<void> {
+    let ids: string[];
+    try {
+      ids = await this.getAllAccountIds();
+    } catch {
+      return;
+    }
+    for (const id of ids) {
+      const secret = SessionKeyVault.getSecret();
+      if (secret === null) {
+        return; // vault locked mid-sweep — stop; resumes on next unlock
+      }
+      try {
+        await this.migrateAccountToV2(
+          id,
+          secret,
+          SessionKeyVault.getSecretSource()
+        );
+      } catch {
+        // migrateAccountToV2 never throws; belt-and-suspenders so one account's
+        // failure can never abort the remaining sweep.
+      }
+    }
+  }
+
   /**
    * Public read-path legacy fold (Format B → Format A). Acquires the GLOBAL
    * key-mutation mutex so its secret write can never bypass the lock (P1-1a).
@@ -906,6 +1193,10 @@ export class AccountSecureStorage {
         // key came from the vault-independent device-key fallback (candidate 2),
         // so Format-A behavior is unchanged.
         let v2VaultEpoch = -1;
+        // Tracks whether the returned key came from a LEGACY tier (Format A/C),
+        // which is the lazy-migration trigger condition (DOC-137 §4.5.1, PR5). A
+        // v2-blob read leaves this false (already migrated).
+        let decryptedViaLegacy = false;
         if (
           Array.isArray(parsed.blobs) &&
           parsed.blobs.length > 0 &&
@@ -953,6 +1244,8 @@ export class AccountSecureStorage {
               throw error;
             }
           }
+          // Reached only via a Format A/C decrypt → eligible for lazy upgrade.
+          decryptedViaLegacy = true;
         }
 
         await this.updateLastAccessed(accountId);
@@ -974,6 +1267,29 @@ export class AccountSecureStorage {
           key: new Uint8Array(privateKey), // Store a copy
           timestamp: Date.now(),
         });
+
+        // LAZY MIGRATION TRIGGER (DOC-137 §4.5.1, PR5): a legacy-tier (Format
+        // A/C) decrypt just succeeded and a verified secret is available (an
+        // explicit step-up PIN, or the unlocked session vault) → opportunistically
+        // upgrade this account to a user-secret v2 wrap. Fire-and-forget: it
+        // NEVER blocks or affects the returned key, is deduped per-account, and
+        // swallows failures. Skipped for v2 reads (already migrated) and for a
+        // locked-device read with no secret available (migrates on the next
+        // unlock sweep instead).
+        if (decryptedViaLegacy) {
+          const migrationSecret =
+            pin ?? SessionKeyVault.getSecret() ?? undefined;
+          if (migrationSecret) {
+            const migrationSource: SecretSource = pin
+              ? 'pin'
+              : SessionKeyVault.getSecretSource();
+            void this.migrateAccountToV2(
+              accountId,
+              migrationSecret,
+              migrationSource
+            ).catch(() => {});
+          }
+        }
 
         return privateKey;
       } catch (error) {

--- a/src/services/secure/AccountSecureStorage.ts
+++ b/src/services/secure/AccountSecureStorage.ts
@@ -629,14 +629,22 @@ export class AccountSecureStorage {
   // and the unproven new blob dropped, so the account stays usable and migration
   // retries on a later trigger.
   //
-  // PRECONDITION (caller-guaranteed): `secret` is the account's CURRENT
-  // credential secret — an explicitly verified step-up PIN, or the
-  // SessionKeyVault secret (set at unlock AFTER verifyPin). Finalizing to
-  // v2-under-secret is only safe because the user can reproduce that exact
-  // secret. A WRONG secret can never pass the phase-3 verify, so it can only ever
-  // yield NOT_MIGRATED (never a strand) — but callers must still pass a real,
-  // current secret. Serialized against every other key writer by the GLOBAL
-  // key-mutation mutex, and deduped per-account by migrationInFlight.
+  // SECRET SAFETY — the strand vector (Codex/adversarial-review PR5 P1): finalizing
+  // to v2-under-`secret` is only safe because the user can reproduce that exact
+  // secret. It is NOT enough to rely on the phase-3 round-trip verify: for a
+  // Format-A account, unwrapKeyForRewrap decrypts via the DEVICE key regardless of
+  // `secret`, so phase-3 (which re-encrypts under `secret` then decrypts under the
+  // SAME `secret`) is SELF-REFERENTIAL — it proves the new blob is well-formed, NOT
+  // that `secret` is the credential. A stale/wrong secret (e.g. a biometric-
+  // convenience item left stale by a crash between a changePin commit and its
+  // refresh, loaded into the vault on a biometric unlock) would pass phase-3 and
+  // strand the account. So the FIRST thing migrateAccountToV2Locked does is
+  // checkPinHash(secret): finalize ONLY if `secret` verifies against the CURRENT
+  // PIN credential. That gate — not a caller precondition — is what makes the drop
+  // safe. Serialized against every other key writer by the GLOBAL key-mutation
+  // mutex, deduped per-account by migrationInFlight, and best-effort epoch-guarded
+  // so a lock mid-migration aborts before writing at each guard point (P2; an
+  // irreducible check-to-write race remains, but is benign given the gate above).
   // ───────────────────────────────────────────────────────────────────────────
 
   /**
@@ -648,7 +656,8 @@ export class AccountSecureStorage {
   static async migrateAccountToV2(
     accountId: string,
     secret: string,
-    secretSource: SecretSource = 'pin'
+    secretSource: SecretSource = 'pin',
+    vaultEpoch?: number
   ): Promise<MigrationResult> {
     const existing = this.migrationInFlight.get(accountId);
     if (existing) {
@@ -658,7 +667,7 @@ export class AccountSecureStorage {
     // with a store/import/changePin/setupPin/delete. `.catch` makes the whole
     // call non-throwing even if an unexpected error escapes the locked body.
     const task = this.runKeyMutationExclusive(() =>
-      this.migrateAccountToV2Locked(accountId, secret, secretSource)
+      this.migrateAccountToV2Locked(accountId, secret, secretSource, vaultEpoch)
     ).catch((): MigrationResult => 'NOT_MIGRATED');
     this.migrationInFlight.set(accountId, task);
     try {
@@ -680,8 +689,28 @@ export class AccountSecureStorage {
   private static async migrateAccountToV2Locked(
     accountId: string,
     secret: string,
-    secretSource: SecretSource
+    secretSource: SecretSource,
+    vaultEpoch?: number
   ): Promise<MigrationResult> {
+    // SECRET-IS-CURRENT-CREDENTIAL GATE (Codex PR5 P1 — FUND-CRITICAL). This
+    // migrator DROPS the device-key copy and finalizes to v2-under-`secret`. For
+    // a Format-A account, unwrapKeyForRewrap decrypts via the DEVICE key
+    // REGARDLESS of `secret`, and phase-3 verify only proves the new blob decrypts
+    // under that SAME supplied secret — NEITHER proves `secret` is a secret the
+    // user can reproduce. A stale/wrong secret (e.g. a biometric-convenience item
+    // left stale by a crash between a changePin commit and its refresh, then
+    // loaded into the vault on a biometric unlock) would otherwise finalize an
+    // account under a secret the current PIN can't reproduce → PERMANENT STRAND.
+    // So REFUSE to migrate unless `secret` verifies against the CURRENT PIN
+    // credential. Pure hash compare — NO throttle side effect (background op with
+    // an already-unlocked session, not a guess) and deadlock-safe inside the key
+    // mutex (persistPinCredential does not acquire it; changePin already calls
+    // this exact path in-mutex). No current credential (or a non-matching
+    // passphrase pre-PR7) → false → NOT_MIGRATED (fail-safe: never finalize).
+    if (!(await this.checkPinHash(secret))) {
+      return 'NOT_MIGRATED';
+    }
+
     const deviceSecret = await this.getStableDeviceId();
     const payload = await this.readSecretLocked(accountId);
     if (!payload) {
@@ -733,7 +762,27 @@ export class AccountSecureStorage {
     let newBlob: KeyEnvelopeV2 | undefined;
     let appended = false;
     let finalized = false;
+    // EPOCH GUARD (Codex PR5 P2 / P1-D): true once the SessionKeyVault epoch
+    // captured at the caller's secret-read (`vaultEpoch`) has changed — i.e. the
+    // session locked (`clear()`) or rotated. Re-checked after each awaited prep
+    // step so a vault-secret migration does not keep processing/writing key
+    // material under a session that no longer exists. This is BEST-EFFORT: an
+    // irreducible sub-await race remains between the final check and the native
+    // write completing — but that residual is BENIGN, not a strand. The hard
+    // fund-safety invariant is the checkPinHash gate above: whatever the lock
+    // timing, `secret` is the current credential, so any write that does land
+    // (dual-blob mid-transition, or a finalized v2-only blob) is correct and
+    // readable on the next unlock. Explicit-PIN step-up migrations pass no epoch
+    // (undefined) and are not gated — they are not vault-session-dependent.
+    const sessionEnded = (): boolean =>
+      vaultEpoch !== undefined && SessionKeyVault.currentEpoch() !== vaultEpoch;
     try {
+      // Abort before starting any work if the session already ended while this
+      // account waited behind the mutex.
+      if (sessionEnded()) {
+        return 'NOT_MIGRATED';
+      }
+
       // PHASE 2 — ADD a fresh v2 blob under `secret` (dual-blob), keeping the old
       // readable copy through the point of no return. Respect the 2-blob cap the
       // same way the changePin rewrap does: if two old blobs already exist (only
@@ -761,6 +810,11 @@ export class AccountSecureStorage {
           ? { version: 2 as const, blobs: keptOldBlobs }
           : {}),
       };
+      // Re-check after the scrypt await (encryptPrivateKeyV2) and before the FIRST
+      // write (Codex PR5 P2): a lock during the derivation must not land a write.
+      if (sessionEnded()) {
+        return 'NOT_MIGRATED';
+      }
       await this.saveSecretV2Checked(accountId, this.appendBlob(base, newBlob));
       appended = true;
 
@@ -798,6 +852,18 @@ export class AccountSecureStorage {
         }
       } finally {
         check?.fill(0);
+      }
+
+      // Re-check before the POINT OF NO RETURN: if a lock landed after the
+      // verified dual-blob write, do NOT drop the device-key copy under a dead
+      // session — leave the dual-blob state (Format A + proven v2 blob), which is
+      // fully readable under BOTH copies and converges on the next unlock's sweep.
+      // (Only a lock/clear can bump the epoch mid-migration — a changePin rotate
+      // can't, it holds this same mutex.) A benign check-to-write race remains,
+      // but per the checkPinHash invariant a finalize that slips through is still
+      // v2-under-current-credential and safe.
+      if (sessionEnded()) {
+        return 'NOT_MIGRATED';
       }
 
       // PHASE 5 — FINALIZE (POINT OF NO RETURN): keep ONLY the new blob and clear
@@ -861,11 +927,16 @@ export class AccountSecureStorage {
       if (secret === null) {
         return; // vault locked mid-sweep — stop; resumes on next unlock
       }
+      // Capture the epoch WITH the secret (both sync, no await between → a lock
+      // cannot slip in), so migrateAccountToV2 aborts this account if the session
+      // locks while it waits behind the mutex (P2 epoch guard).
+      const vaultEpoch = SessionKeyVault.currentEpoch();
       try {
         await this.migrateAccountToV2(
           id,
           secret,
-          SessionKeyVault.getSecretSource()
+          SessionKeyVault.getSecretSource(),
+          vaultEpoch
         );
       } catch {
         // migrateAccountToV2 never throws; belt-and-suspenders so one account's
@@ -1283,10 +1354,16 @@ export class AccountSecureStorage {
             const migrationSource: SecretSource = pin
               ? 'pin'
               : SessionKeyVault.getSecretSource();
+            // Vault-secret path carries the epoch (aborts if the session locks
+            // before the migration runs); an explicit step-up PIN passes none.
+            const migrationEpoch = pin
+              ? undefined
+              : SessionKeyVault.currentEpoch();
             void this.migrateAccountToV2(
               accountId,
               migrationSecret,
-              migrationSource
+              migrationSource,
+              migrationEpoch
             ).catch(() => {});
           }
         }

--- a/src/services/secure/__tests__/migrationEngine.test.ts
+++ b/src/services/secure/__tests__/migrationEngine.test.ts
@@ -1,0 +1,667 @@
+// PR5 (TASK-27, DOC-137 §4) — the V2 MIGRATION ENGINE. FUND-RISKING core.
+//
+// SAFETY FOCUS. These tests prove:
+//   * a 64-byte algosdk `sk` round-trips BYTE-IDENTICALLY through a Format-A→v2
+//     lazy migration, with the derived public address unchanged and a real
+//     Ed25519 (Pera-style) sign still verifying (§0 P1-A / AC8);
+//   * migrateAccountToV2 finalizes to a v2-ONLY payload (legacy device-key copy
+//     dropped) under the CURRENT secret, and is idempotent (ALREADY_V2);
+//   * an injected verify failure leaves the OLD copy readable, drops the unproven
+//     new blob, and returns NOT_MIGRATED (never throws, never strands — §4.4/AC3);
+//   * a wrong/absent secret (for a secret-gated account) is a NOT_MIGRATED no-op
+//     that never touches storage;
+//   * watch-only payloads are untouched;
+//   * per-account in-flight dedup coalesces the lazy trigger + the sweep onto ONE
+//     scrypt+rewrap;
+//   * the post-unlock sweep migrates every idle account, STOPS on a mid-sweep
+//     lock, and one account's failure never aborts the rest;
+//   * the getPrivateKey lazy trigger fires on a legacy-tier decrypt with a secret
+//     and NOT when the vault is locked with no PIN.
+//
+// SECURITY NOTE: key material is a throwaway Ed25519 keypair; PINs are throwaway
+// test strings. Nothing real is used, and nothing is logged.
+
+jest.mock('@/platform', () => {
+  const nodeCrypto = require('crypto');
+  const secure = new Map<string, string>();
+  const kv = new Map<string, string>();
+  return {
+    __secure: secure,
+    __kv: kv,
+    __reset: () => {
+      secure.clear();
+      kv.clear();
+    },
+    crypto: {
+      getRandomBytes: async (n: number): Promise<Uint8Array> =>
+        Uint8Array.from(nodeCrypto.randomBytes(n)),
+      sha256: async (input: string): Promise<string> =>
+        nodeCrypto.createHash('sha256').update(input).digest('hex'),
+      randomUUID: () => nodeCrypto.randomUUID(),
+    },
+    secureStorage: {
+      getItem: jest.fn(async (k: string) =>
+        secure.has(k) ? secure.get(k)! : null
+      ),
+      setItem: jest.fn(async (k: string, v: string) => {
+        secure.set(k, v);
+      }),
+      deleteItem: jest.fn(async (k: string) => {
+        secure.delete(k);
+      }),
+      getItemWithAuth: jest.fn(async (k: string) =>
+        secure.has(k) ? secure.get(k)! : null
+      ),
+      setItemWithAuth: jest.fn(async (k: string, v: string) => {
+        secure.set(k, v);
+      }),
+    },
+    storage: {
+      getItem: jest.fn(async (k: string) => (kv.has(k) ? kv.get(k)! : null)),
+      setItem: jest.fn(async (k: string, v: string) => {
+        kv.set(k, v);
+      }),
+      removeItem: jest.fn(async (k: string) => {
+        kv.delete(k);
+      }),
+      multiRemove: jest.fn(async (keys: string[]) => {
+        keys.forEach((k) => kv.delete(k));
+      }),
+    },
+    biometrics: {
+      isAvailable: async () => false,
+      isEnrolled: async () => false,
+    },
+    deviceId: {
+      getDeviceId: async () => 'pr5-test-device-idfv',
+    },
+  };
+});
+
+import CryptoJS from 'crypto-js';
+import 'crypto-js/hmac-sha256';
+import 'crypto-js/sha256';
+import 'crypto-js/aes';
+import 'crypto-js/mode-ctr';
+import 'crypto-js/pad-nopadding';
+import 'crypto-js/enc-hex';
+import 'crypto-js/pbkdf2';
+import { createHash, randomBytes } from 'crypto';
+import nacl from 'tweetnacl';
+import algosdk from 'algosdk';
+import * as platform from '@/platform';
+import { AccountSecureStorage } from '../AccountSecureStorage';
+import type { MigrationResult } from '../AccountSecureStorage';
+import { SessionKeyVault } from '../SessionKeyVault';
+import {
+  encryptKeyEnvelopeV2,
+  decryptKeyEnvelopeV2,
+  KeyEnvelopeV2,
+} from '../envelopeV2';
+import type { ScryptKdfParams } from '../../backup/types';
+
+const DEVICE_ID = 'pr5-test-device-idfv';
+const PIN_ITERATIONS = 8000; // AccountSecureStorage.PIN_ITERATIONS
+const ENCRYPTION_KEY_ITERATIONS = 10000; // AccountSecureStorage.ENCRYPTION_KEY_ITERATIONS
+// Small (power-of-two, within caps) scrypt params keep the suites fast. The
+// DEFAULT (2^14) is exercised by the byte-identity round-trip test, which uses
+// the real writer with no injection.
+const FAST_PARAMS: ScryptKdfParams = { N: 2 ** 12, r: 8, p: 1, dkLen: 32 };
+
+const mockPlatform = platform as unknown as {
+  __secure: Map<string, string>;
+  __kv: Map<string, string>;
+  __reset: () => void;
+  secureStorage: {
+    getItem: jest.Mock;
+    setItem: jest.Mock;
+    getItemWithAuth: jest.Mock;
+    setItemWithAuth: jest.Mock;
+    deleteItem: jest.Mock;
+  };
+};
+
+// Reach the private statics the way the merged suites do (cast, no `any`).
+const asPriv = AccountSecureStorage as unknown as {
+  encryptPrivateKeyV2: (
+    keyBytes: Uint8Array,
+    secret: string,
+    secretSource: 'pin' | 'passphrase',
+    options: { deviceBound: boolean }
+  ) => Promise<KeyEnvelopeV2>;
+  persistPinCredential: (data: {
+    hash: string;
+    iterations: number;
+    salt: string;
+    secretSource: 'pin' | 'passphrase';
+  }) => Promise<void>;
+  constantTimeEqualBytes: (a: Uint8Array, b: Uint8Array) => boolean;
+  hashPin: (pin: string, salt: string, iterations: number) => string;
+  throttleMirror: unknown;
+  legacyCheckRequired: boolean | undefined;
+};
+
+function hex(bytes: Uint8Array): string {
+  return Buffer.from(bytes).toString('hex');
+}
+
+function nodeSha256Hex(input: string): string {
+  return createHash('sha256').update(input).digest('hex');
+}
+
+function customPBKDF2(
+  password: string,
+  saltHex: string,
+  iterations: number,
+  keyLength: number
+): string {
+  const saltWA = CryptoJS.enc.Hex.parse(saltHex);
+  const derived = CryptoJS.PBKDF2(password, saltWA, {
+    keySize: keyLength / 4,
+    iterations,
+    hasher: CryptoJS.algo.SHA256,
+  });
+  return derived.toString(CryptoJS.enc.Hex);
+}
+
+/** A real 64-byte Ed25519 secret key (seed‖pubkey), as algosdk stores. */
+function makeAlgoKey(): {
+  sk: Uint8Array;
+  pubkey: Uint8Array;
+  address: string;
+} {
+  const kp = nacl.sign.keyPair();
+  return {
+    sk: kp.secretKey, // 64 bytes
+    pubkey: kp.publicKey, // 32 bytes = sk.slice(32)
+    address: algosdk.encodeAddress(kp.publicKey),
+  };
+}
+
+/** Build a legacy 4-colon blob under a given base-entropy string. */
+function makeLegacyBlob(privateKey: Uint8Array, entropyString: string): string {
+  const saltHex = randomBytes(32).toString('hex');
+  const ivHex = randomBytes(16).toString('hex');
+  const baseEntropy = nodeSha256Hex(entropyString);
+  const keyMaterial = customPBKDF2(
+    baseEntropy,
+    saltHex,
+    ENCRYPTION_KEY_ITERATIONS,
+    32
+  );
+  const privateKeyHex = hex(privateKey);
+  const encrypted = CryptoJS.AES.encrypt(
+    privateKeyHex,
+    CryptoJS.enc.Hex.parse(keyMaterial),
+    {
+      iv: CryptoJS.enc.Hex.parse(ivHex),
+      mode: CryptoJS.mode.CTR,
+      padding: CryptoJS.pad.NoPadding,
+    }
+  );
+  const ct = encrypted.toString();
+  const hmacKey = CryptoJS.SHA256(keyMaterial + 'hmac_salt').toString();
+  const hmac = CryptoJS.HmacSHA256(ct, hmacKey).toString();
+  return `${saltHex}:${ivHex}:${ct}:${hmac}`;
+}
+
+/** Format A: device-key wrap (voi_wallet_<deviceId>), PIN-independent. */
+function makeFormatA(privateKey: Uint8Array): string {
+  return makeLegacyBlob(privateKey, `voi_wallet_${DEVICE_ID}`);
+}
+
+/** Format C: legacy PIN-mixed wrap (voi_wallet_pin_<pin>_<deviceId>). */
+function makeFormatC(privateKey: Uint8Array, pin: string): string {
+  return makeLegacyBlob(privateKey, `voi_wallet_pin_${pin}_${DEVICE_ID}`);
+}
+
+function secretKey(id: string): string {
+  return `voi_account_secret_${id}`;
+}
+
+function addToList(id: string): void {
+  const raw = mockPlatform.__kv.get('voi_account_list');
+  const list: string[] = raw ? JSON.parse(raw) : [];
+  if (!list.includes(id)) {
+    list.push(id);
+  }
+  mockPlatform.__kv.set('voi_account_list', JSON.stringify(list));
+}
+
+function seedFormatA(id: string, sk: Uint8Array): void {
+  mockPlatform.__secure.set(
+    secretKey(id),
+    JSON.stringify({
+      accountId: id,
+      encryptedPrivateKey: makeFormatA(sk),
+      authMethod: 'pin',
+    })
+  );
+  addToList(id);
+}
+
+function seedFormatC(id: string, sk: Uint8Array, pin: string): void {
+  mockPlatform.__secure.set(
+    secretKey(id),
+    JSON.stringify({
+      accountId: id,
+      encryptedPrivateKey: makeFormatC(sk, pin),
+      authMethod: 'pin',
+    })
+  );
+  addToList(id);
+}
+
+/** Watch-only: exists in the list + metadata, but no secret payload. */
+function seedWatchOnly(id: string): void {
+  addToList(id);
+}
+
+async function seedV2(
+  id: string,
+  sk: Uint8Array,
+  secret: string
+): Promise<void> {
+  const blob = await encryptKeyEnvelopeV2({
+    plaintext: sk,
+    secret,
+    secretSource: 'pin',
+    deviceSecret: DEVICE_ID,
+    kdfParams: FAST_PARAMS,
+  });
+  mockPlatform.__secure.set(
+    secretKey(id),
+    JSON.stringify({
+      accountId: id,
+      encryptedPrivateKey: '',
+      authMethod: 'pin',
+      version: 2,
+      blobs: [blob],
+    })
+  );
+  addToList(id);
+}
+
+interface Payload {
+  accountId: string;
+  encryptedPrivateKey: string;
+  authMethod: string;
+  version?: number;
+  blobs?: KeyEnvelopeV2[];
+}
+
+function readPayload(id: string): Payload {
+  return JSON.parse(mockPlatform.__secure.get(secretKey(id))!);
+}
+
+/** Force the WRITER path to FAST_PARAMS so re-wraps stay fast + deterministic. */
+function useFastWriter(): void {
+  jest
+    .spyOn(asPriv, 'encryptPrivateKeyV2')
+    .mockImplementation(async (keyBytes, secret, secretSource, options) =>
+      encryptKeyEnvelopeV2({
+        plaintext: keyBytes,
+        secret,
+        secretSource,
+        deviceSecret: options.deviceBound ? DEVICE_ID : undefined,
+        kdfParams: FAST_PARAMS,
+      })
+    );
+}
+
+/** Persist a folded PIN credential directly (skips the rewrap flow). */
+async function seedCredential(pin: string): Promise<void> {
+  const salt = 'a'.repeat(64);
+  await asPriv.persistPinCredential({
+    hash: asPriv.hashPin(pin, salt, PIN_ITERATIONS),
+    iterations: PIN_ITERATIONS,
+    salt,
+    secretSource: 'pin',
+  });
+}
+
+const PIN = '135790';
+
+/** Enable biometrics so the `pin=undefined` reader branch passes its gate (the
+ *  realistic unlocked-vault read path — a PIN-only+no-biometric wallet still
+ *  requires an explicit PIN on that branch, unchanged by PR5). */
+function enableBiometrics(): void {
+  mockPlatform.__kv.set('voi_biometric_enabled', 'true');
+}
+
+beforeEach(() => {
+  mockPlatform.__reset();
+  AccountSecureStorage.clearPrivateKeyCache();
+  SessionKeyVault.clear();
+  asPriv.throttleMirror = null;
+  asPriv.legacyCheckRequired = undefined;
+  mockPlatform.secureStorage.getItem.mockImplementation(async (k: string) =>
+    mockPlatform.__secure.has(k) ? mockPlatform.__secure.get(k)! : null
+  );
+  mockPlatform.secureStorage.setItem.mockImplementation(
+    async (k: string, v: string) => {
+      mockPlatform.__secure.set(k, v);
+    }
+  );
+});
+
+afterEach(() => {
+  SessionKeyVault.clear();
+  jest.restoreAllMocks();
+});
+
+describe('migrateAccountToV2 — happy path', () => {
+  it('migrates a Format-A account to a v2-ONLY payload, byte-identically', async () => {
+    const k = makeAlgoKey();
+    seedFormatA('acct-A', k.sk);
+    await seedCredential(PIN);
+
+    // Real default-param writer here (no useFastWriter) — the byte-identity AC8
+    // proof runs the actual 2^14 KDF once.
+    const result: MigrationResult =
+      await AccountSecureStorage.migrateAccountToV2('acct-A', PIN, 'pin');
+    expect(result).toBe('MIGRATED');
+
+    const payload = readPayload('acct-A');
+    // v2-only: legacy device-key copy is gone; exactly one blob remains.
+    expect(payload.encryptedPrivateKey).toBe('');
+    expect(payload.version).toBe(2);
+    expect(payload.blobs).toHaveLength(1);
+
+    // The blob decrypts under the secret to the EXACT original 64-byte sk.
+    const recovered = await decryptKeyEnvelopeV2(
+      payload.blobs![0],
+      PIN,
+      DEVICE_ID
+    );
+    expect(recovered).not.toBeNull();
+    expect(hex(recovered!)).toBe(hex(k.sk));
+
+    // AC8: address unchanged + a real Ed25519 (Pera-style) sign verifies.
+    const derivedAddr = algosdk.encodeAddress(recovered!.slice(32));
+    expect(derivedAddr).toBe(k.address);
+    const msg = Uint8Array.from(randomBytes(48));
+    const sig = nacl.sign.detached(msg, recovered!);
+    expect(nacl.sign.detached.verify(msg, sig, k.pubkey)).toBe(true);
+  });
+
+  it('migrates a Format-C (legacy PIN-mixed) account under the correct PIN', async () => {
+    const k = makeAlgoKey();
+    seedFormatC('acct-C', k.sk, PIN);
+    await seedCredential(PIN);
+    useFastWriter();
+
+    const result = await AccountSecureStorage.migrateAccountToV2(
+      'acct-C',
+      PIN,
+      'pin'
+    );
+    expect(result).toBe('MIGRATED');
+
+    const payload = readPayload('acct-C');
+    expect(payload.encryptedPrivateKey).toBe('');
+    expect(payload.blobs).toHaveLength(1);
+    const recovered = await decryptKeyEnvelopeV2(
+      payload.blobs![0],
+      PIN,
+      DEVICE_ID
+    );
+    expect(hex(recovered!)).toBe(hex(k.sk));
+  });
+
+  it('is idempotent: a second migration returns ALREADY_V2 and re-wraps nothing', async () => {
+    const k = makeAlgoKey();
+    await seedV2('acct-V', k.sk, PIN);
+    await seedCredential(PIN);
+
+    const before = mockPlatform.__secure.get(secretKey('acct-V'));
+    const spy = jest.spyOn(asPriv, 'encryptPrivateKeyV2');
+
+    const result = await AccountSecureStorage.migrateAccountToV2('acct-V', PIN);
+    expect(result).toBe('ALREADY_V2');
+    // No re-wrap happened; payload bytes unchanged.
+    expect(spy).not.toHaveBeenCalled();
+    expect(mockPlatform.__secure.get(secretKey('acct-V'))).toBe(before);
+  });
+});
+
+describe('migrateAccountToV2 — safety / no-op paths', () => {
+  it('returns NOT_MIGRATED and touches nothing for a watch-only account', async () => {
+    seedWatchOnly('watch');
+    await seedCredential(PIN);
+    const setSpy = jest.spyOn(mockPlatform.secureStorage, 'setItem');
+
+    const result = await AccountSecureStorage.migrateAccountToV2('watch', PIN);
+    expect(result).toBe('NOT_MIGRATED');
+    // No secret payload was ever written for this id.
+    expect(setSpy.mock.calls.some((c) => c[0] === secretKey('watch'))).toBe(
+      false
+    );
+    expect(mockPlatform.__secure.has(secretKey('watch'))).toBe(false);
+  });
+
+  it('returns NOT_MIGRATED for a v2 account when the WRONG secret is supplied, leaving it intact', async () => {
+    const k = makeAlgoKey();
+    await seedV2('acct-V', k.sk, PIN); // wrapped under PIN
+    await seedCredential(PIN);
+    const before = mockPlatform.__secure.get(secretKey('acct-V'));
+
+    const result = await AccountSecureStorage.migrateAccountToV2(
+      'acct-V',
+      '000000' // wrong secret — cannot unwrap the v2 blob
+    );
+    expect(result).toBe('NOT_MIGRATED');
+    // Untouched: still decryptable under the ORIGINAL secret.
+    expect(mockPlatform.__secure.get(secretKey('acct-V'))).toBe(before);
+    const recovered = await decryptKeyEnvelopeV2(
+      readPayload('acct-V').blobs![0],
+      PIN,
+      DEVICE_ID
+    );
+    expect(hex(recovered!)).toBe(hex(k.sk));
+  });
+});
+
+describe('migrateAccountToV2 — verify-before-delete rollback', () => {
+  it('an injected verify failure keeps the OLD copy readable, drops the unproven blob, returns NOT_MIGRATED', async () => {
+    const k = makeAlgoKey();
+    seedFormatA('acct-A', k.sk);
+    await seedCredential(PIN);
+    useFastWriter();
+
+    // Force the phase-3 byte-equality verify to fail — simulating a torn write.
+    const eqSpy = jest
+      .spyOn(asPriv, 'constantTimeEqualBytes')
+      .mockReturnValue(false);
+
+    const result = await AccountSecureStorage.migrateAccountToV2(
+      'acct-A',
+      PIN,
+      'pin'
+    );
+    expect(result).toBe('NOT_MIGRATED');
+    expect(eqSpy).toHaveBeenCalled();
+
+    // Rollback: the Format-A field is intact and there is NO leftover unproven
+    // blob — the account is exactly as it started and still decrypts.
+    const payload = readPayload('acct-A');
+    expect(payload.encryptedPrivateKey).not.toBe('');
+    expect(payload.blobs ?? []).toHaveLength(0);
+    const recovered = await AccountSecureStorage.getPrivateKey('acct-A', PIN);
+    expect(hex(recovered)).toBe(hex(k.sk));
+  });
+});
+
+describe('migrateAccountToV2 — per-account in-flight dedup', () => {
+  it('coalesces two concurrent migrations onto ONE scrypt+rewrap', async () => {
+    const k = makeAlgoKey();
+    seedFormatA('acct-A', k.sk);
+    await seedCredential(PIN);
+    const spy = jest.fn(
+      async (
+        keyBytes: Uint8Array,
+        secret: string,
+        secretSource: 'pin' | 'passphrase',
+        options: { deviceBound: boolean }
+      ) =>
+        encryptKeyEnvelopeV2({
+          plaintext: keyBytes,
+          secret,
+          secretSource,
+          deviceSecret: options.deviceBound ? DEVICE_ID : undefined,
+          kdfParams: FAST_PARAMS,
+        })
+    );
+    jest.spyOn(asPriv, 'encryptPrivateKeyV2').mockImplementation(spy);
+
+    const [r1, r2] = await Promise.all([
+      AccountSecureStorage.migrateAccountToV2('acct-A', PIN, 'pin'),
+      AccountSecureStorage.migrateAccountToV2('acct-A', PIN, 'pin'),
+    ]);
+    // Both callers see the same (single) migration.
+    expect(r1).toBe('MIGRATED');
+    expect(r2).toBe('MIGRATED');
+    expect(spy).toHaveBeenCalledTimes(1);
+    expect(readPayload('acct-A').blobs).toHaveLength(1);
+  });
+});
+
+describe('migrateAllAccountsToV2 — post-unlock sweep', () => {
+  it('migrates every idle Format-A account under the vault secret', async () => {
+    const ks = [makeAlgoKey(), makeAlgoKey(), makeAlgoKey()];
+    ks.forEach((k, i) => seedFormatA(`sweep-${i}`, k.sk));
+    await seedCredential(PIN);
+    useFastWriter();
+    SessionKeyVault.set(PIN, 'pin');
+
+    await AccountSecureStorage.migrateAllAccountsToV2();
+
+    for (let i = 0; i < ks.length; i++) {
+      const payload = readPayload(`sweep-${i}`);
+      expect(payload.encryptedPrivateKey).toBe('');
+      expect(payload.blobs).toHaveLength(1);
+      const recovered = await decryptKeyEnvelopeV2(
+        payload.blobs![0],
+        PIN,
+        DEVICE_ID
+      );
+      expect(hex(recovered!)).toBe(hex(ks[i].sk));
+    }
+  });
+
+  it('does nothing when the vault is locked (no secret to migrate under)', async () => {
+    const k = makeAlgoKey();
+    seedFormatA('sweep-0', k.sk);
+    await seedCredential(PIN);
+    const before = mockPlatform.__secure.get(secretKey('sweep-0'));
+    // Vault deliberately NOT set (locked).
+
+    await AccountSecureStorage.migrateAllAccountsToV2();
+
+    expect(mockPlatform.__secure.get(secretKey('sweep-0'))).toBe(before);
+  });
+
+  it('stops mid-sweep when the vault locks, leaving later accounts on legacy', async () => {
+    const ks = [makeAlgoKey(), makeAlgoKey(), makeAlgoKey()];
+    ks.forEach((k, i) => seedFormatA(`sweep-${i}`, k.sk));
+    await seedCredential(PIN);
+    useFastWriter();
+    SessionKeyVault.set(PIN, 'pin');
+
+    // Lock the vault right after the first account migrates.
+    const origGetSecret = SessionKeyVault.getSecret.bind(SessionKeyVault);
+    let calls = 0;
+    jest.spyOn(SessionKeyVault, 'getSecret').mockImplementation(() => {
+      calls += 1;
+      if (calls > 1) {
+        return null; // vault locked before account #2
+      }
+      return origGetSecret();
+    });
+
+    await AccountSecureStorage.migrateAllAccountsToV2();
+
+    // Account 0 migrated; 1 and 2 left on legacy (sweep stopped).
+    expect(readPayload('sweep-0').encryptedPrivateKey).toBe('');
+    expect(readPayload('sweep-1').encryptedPrivateKey).not.toBe('');
+    expect(readPayload('sweep-2').encryptedPrivateKey).not.toBe('');
+  });
+
+  it('a non-migratable middle account never aborts the sweep of the others', async () => {
+    const k0 = makeAlgoKey();
+    const k1 = makeAlgoKey();
+    const k2 = makeAlgoKey();
+    seedFormatA('sweep-0', k0.sk);
+    // sweep-1 is a v2 blob under a DIFFERENT secret → unreadable under PIN →
+    // migrateAccountToV2 returns NOT_MIGRATED and leaves it untouched.
+    await seedV2('sweep-1', k1.sk, '999999');
+    seedFormatA('sweep-2', k2.sk);
+    await seedCredential(PIN);
+    useFastWriter();
+    SessionKeyVault.set(PIN, 'pin');
+
+    const before1 = mockPlatform.__secure.get(secretKey('sweep-1'));
+    await AccountSecureStorage.migrateAllAccountsToV2();
+
+    // 0 and 2 migrated to v2-only; the non-migratable 1 is byte-for-byte intact.
+    expect(readPayload('sweep-0').encryptedPrivateKey).toBe('');
+    expect(readPayload('sweep-2').encryptedPrivateKey).toBe('');
+    expect(mockPlatform.__secure.get(secretKey('sweep-1'))).toBe(before1);
+  });
+});
+
+describe('getPrivateKey — lazy migration trigger', () => {
+  it('fires migrateAccountToV2 after a Format-A decrypt with an explicit PIN', async () => {
+    const k = makeAlgoKey();
+    seedFormatA('acct-A', k.sk);
+    await seedCredential(PIN);
+    const migSpy = jest
+      .spyOn(AccountSecureStorage, 'migrateAccountToV2')
+      .mockResolvedValue('MIGRATED');
+
+    const recovered = await AccountSecureStorage.getPrivateKey('acct-A', PIN);
+    expect(hex(recovered)).toBe(hex(k.sk)); // read still correct
+    expect(migSpy).toHaveBeenCalledWith('acct-A', PIN, 'pin');
+  });
+
+  it('fires under an unlocked vault (pin=undefined, biometric read) using the vault secret', async () => {
+    const k = makeAlgoKey();
+    seedFormatA('acct-A', k.sk);
+    await seedCredential(PIN);
+    enableBiometrics(); // so the pin=undefined reader branch is allowed
+    SessionKeyVault.set(PIN, 'pin');
+    const migSpy = jest
+      .spyOn(AccountSecureStorage, 'migrateAccountToV2')
+      .mockResolvedValue('MIGRATED');
+
+    await AccountSecureStorage.getPrivateKey('acct-A');
+    expect(migSpy).toHaveBeenCalledWith('acct-A', PIN, 'pin');
+  });
+
+  it('does NOT fire when the vault is locked and no PIN is supplied (no secret)', async () => {
+    const k = makeAlgoKey();
+    seedFormatA('acct-A', k.sk);
+    // No PIN credential + no vault: biometric-less, key-less read path still
+    // decrypts Format A via the device key, but there is no secret to migrate under.
+    const migSpy = jest
+      .spyOn(AccountSecureStorage, 'migrateAccountToV2')
+      .mockResolvedValue('NOT_MIGRATED');
+
+    await AccountSecureStorage.getPrivateKey('acct-A');
+    expect(migSpy).not.toHaveBeenCalled();
+  });
+
+  it('does NOT fire for an already-v2 read (no legacy tier used)', async () => {
+    const k = makeAlgoKey();
+    await seedV2('acct-V', k.sk, PIN);
+    await seedCredential(PIN);
+    enableBiometrics(); // so the pin=undefined reader branch is allowed
+    SessionKeyVault.set(PIN, 'pin');
+    const migSpy = jest
+      .spyOn(AccountSecureStorage, 'migrateAccountToV2')
+      .mockResolvedValue('ALREADY_V2');
+
+    await AccountSecureStorage.getPrivateKey('acct-V');
+    expect(migSpy).not.toHaveBeenCalled();
+  });
+});

--- a/src/services/secure/__tests__/migrationEngine.test.ts
+++ b/src/services/secure/__tests__/migrationEngine.test.ts
@@ -137,6 +137,11 @@ const asPriv = AccountSecureStorage as unknown as {
   }) => Promise<void>;
   constantTimeEqualBytes: (a: Uint8Array, b: Uint8Array) => boolean;
   hashPin: (pin: string, salt: string, iterations: number) => string;
+  unwrapKeyForRewrap: (
+    payload: unknown,
+    currentSecret: string | undefined,
+    deviceSecret: string
+  ) => Promise<{ plaintext: Uint8Array; keeperBlob?: KeyEnvelopeV2 } | null>;
   throttleMirror: unknown;
   legacyCheckRequired: boolean | undefined;
 };
@@ -460,6 +465,69 @@ describe('migrateAccountToV2 — safety / no-op paths', () => {
     );
     expect(hex(recovered!)).toBe(hex(k.sk));
   });
+
+  // Codex PR5 P1 regression: a Format-A account decrypts via the DEVICE key
+  // regardless of the supplied secret, so without the checkPinHash gate a
+  // stale/wrong secret (e.g. a stale biometric-convenience item after a crash)
+  // would finalize it under a secret the current PIN can't reproduce → STRAND.
+  it('REFUSES to migrate a Format-A account under a non-credential secret (no strand)', async () => {
+    const k = makeAlgoKey();
+    seedFormatA('acct-A', k.sk);
+    await seedCredential(PIN); // the CURRENT credential is PIN
+    useFastWriter();
+
+    const before = mockPlatform.__secure.get(secretKey('acct-A'));
+    const result = await AccountSecureStorage.migrateAccountToV2(
+      'acct-A',
+      '000000', // NOT the current credential — a stale/wrong secret
+      'pin'
+    );
+    expect(result).toBe('NOT_MIGRATED');
+    // The device-key copy is INTACT (never dropped); the account is unchanged.
+    expect(mockPlatform.__secure.get(secretKey('acct-A'))).toBe(before);
+    const payload = readPayload('acct-A');
+    expect(payload.encryptedPrivateKey).not.toBe('');
+    expect(payload.blobs ?? []).toHaveLength(0);
+    // Still fully readable under the correct PIN.
+    const recovered = await AccountSecureStorage.getPrivateKey('acct-A', PIN);
+    expect(hex(recovered)).toBe(hex(k.sk));
+  });
+});
+
+describe('migrateAccountToV2 — epoch guard (lock mid-migration)', () => {
+  // Codex PR5 P2: a lock landing mid-migration must not keep processing/writing
+  // key material under a dead session.
+  it('aborts (NOT_MIGRATED) and writes nothing if the vault locks mid-unwrap', async () => {
+    const k = makeAlgoKey();
+    seedFormatA('acct-A', k.sk);
+    await seedCredential(PIN);
+    useFastWriter();
+    SessionKeyVault.set(PIN, 'pin');
+    const epoch = SessionKeyVault.currentEpoch();
+
+    // Simulate a lock DURING the migration: clear the vault right after the
+    // unwrap resolves (bumps the epoch), so epoch-guard #1 aborts before any
+    // write. checkPinHash (credential-based, vault-independent) already passed.
+    const origUnwrap = asPriv.unwrapKeyForRewrap.bind(AccountSecureStorage);
+    jest
+      .spyOn(asPriv, 'unwrapKeyForRewrap')
+      .mockImplementation(async (payload, currentSecret, deviceSecret) => {
+        const r = await origUnwrap(payload, currentSecret, deviceSecret);
+        SessionKeyVault.clear(); // lock mid-migration → epoch bumps
+        return r;
+      });
+
+    const before = mockPlatform.__secure.get(secretKey('acct-A'));
+    const result = await AccountSecureStorage.migrateAccountToV2(
+      'acct-A',
+      PIN,
+      'pin',
+      epoch
+    );
+    expect(result).toBe('NOT_MIGRATED');
+    // Nothing written — the Format-A copy is intact and still readable.
+    expect(mockPlatform.__secure.get(secretKey('acct-A'))).toBe(before);
+  });
 });
 
 describe('migrateAccountToV2 — verify-before-delete rollback', () => {
@@ -621,7 +689,8 @@ describe('getPrivateKey — lazy migration trigger', () => {
 
     const recovered = await AccountSecureStorage.getPrivateKey('acct-A', PIN);
     expect(hex(recovered)).toBe(hex(k.sk)); // read still correct
-    expect(migSpy).toHaveBeenCalledWith('acct-A', PIN, 'pin');
+    // Explicit step-up PIN → no vault epoch (undefined).
+    expect(migSpy).toHaveBeenCalledWith('acct-A', PIN, 'pin', undefined);
   });
 
   it('fires under an unlocked vault (pin=undefined, biometric read) using the vault secret', async () => {
@@ -635,7 +704,13 @@ describe('getPrivateKey — lazy migration trigger', () => {
       .mockResolvedValue('MIGRATED');
 
     await AccountSecureStorage.getPrivateKey('acct-A');
-    expect(migSpy).toHaveBeenCalledWith('acct-A', PIN, 'pin');
+    // Vault-secret path → carries the current epoch.
+    expect(migSpy).toHaveBeenCalledWith(
+      'acct-A',
+      PIN,
+      'pin',
+      expect.any(Number)
+    );
   });
 
   it('does NOT fire when the vault is locked and no PIN is supplied (no secret)', async () => {


### PR DESCRIPTION
## TASK-27 PR5 — v2 key-migration engine (the DR-2 flip)

Wave-2 PR5 of the key-at-rest hardening ([PLAN-10] / [DOC-137] §4). Migrates existing **idle** accounts from the legacy device-key wrap (Format A) or legacy PIN-mixed wrap (Format C) to the user-secret **v2** envelope, under the account's **current** verified secret, then drops the device-key copy — the flip that makes at-rest keys require a user secret.

Built entirely on PR4's already-merged primitives (`unwrapKeyForRewrap`, `encryptPrivateKeyV2`, `appendBlob`/`dropBlob`/`finalizePayload`, `saveSecretV2Checked`, the global key-mutation mutex, `SessionKeyVault`, `envelopeV2`).

### What it adds

- **`migrateAccountToV2(id, secret, source, vaultEpoch?)`** — single-account, same-secret, additive→verify→delete. Point of no return = dropping the legacy copy, and only after the new v2 blob round-trips **byte-exactly** under the secret, read back from **persisted** storage. Never throws (all failures → `NOT_MIGRATED`, old copy intact). `finalized` guard blocks any post-finalize rollback strand. Deduped per-account (`migrationInFlight`) + serialized by the global key-mutation mutex.
- **`migrateAllAccountsToV2()`** — sequential (concurrency-1, to avoid low-end-Android scrypt OOM) post-unlock sweep. Reads the vault secret **fresh per account** (stops on a mid-sweep lock; uses the new secret on a mid-sweep changePin-rotate). One account's failure never aborts the rest.
- **Lazy trigger** in `getPrivateKey` — fire-and-forget migrate after a legacy-tier decrypt with a verified secret (explicit step-up PIN, or the unlocked vault). Never blocks the read.
- **AuthContext** fires the sweep (fire-and-forget) on both unlock paths.

**Not implemented (deliberately):** DOC-137 trigger-4 (restore-writes-v2 directly). PR4's Codex-P1-2 already made `storeAccount` **always** write Format A; the sweep/lazy triggers upgrade it — strictly safer than a direct-v2 restore write.

### Adversarial review (Codex CLI oracle + independent 3-lens Claude workflow)

Two independent oracles **converged on the same fund-critical P1**, now fixed:

- **P1 (strand) — FIXED.** The migrator dropped the Format-A device-key copy and finalized under *whatever* secret it was handed. Format A decrypts via the device key regardless of the secret, and phase-3 verify is **self-referential** (re-encrypt then decrypt under the same secret), so it does *not* prove `secret` is the credential. Reachable via a **stale biometric-convenience secret** (crash between a `changePin` commit and its refresh → biometric unlock loads the old secret into the vault → the new sweep finalizes an imported Format-A account under it → permanent strand). **Fix:** a `checkPinHash(secret)` gate at the top of the migrator — refuse unless `secret` verifies against the **current PIN credential** (pure hash compare, no throttle side-effect, deadlock-safe inside the key mutex). The concurrency-review agent independently verified the fix closes the strand and is deadlock-safe.
- **P2 (post-lock work) — MITIGATED (best-effort).** A lock mid-migration could keep processing/writing key material. **Fix:** thread the `SessionKeyVault` epoch into the sweep + lazy trigger, re-check at every guard point (before work, after the scrypt await before the first write, before the finalize point-of-no-return). An irreducible sub-await check-to-native-write race remains, but it is **benign — not a strand**: the `checkPinHash` gate guarantees any write that lands is `v2-under-current-credential` (correct, readable on next unlock). Fully eliminating it would require a lock-vs-key-mutex serialization redesign (`AuthContext.lock` acquiring the key mutex), disproportionate to a gap that only ever writes correct data — flagged as an optional follow-up, not a blocker.

The other two review lenses (strand/crash-safety, key-leakage/byte-compat) returned **CLEAN**. Codex's final pass confirms P1 closed and no remaining strand / leak / byte-compat regression.

### Gates

- `npm run typecheck` — **0 errors**
- `npm run lint` — **0 errors**
- `npm test` — **467 pass** (+17 new PR5 tests: AC8 byte-identity + real Ed25519/Pera-style sign, Format-C, idempotency, watch-only no-op, wrong-secret no-op, **Format-A non-credential-secret refusal (P1 regression)**, injected-verify rollback, in-flight dedup, sweep migrate-all / stop-on-lock / fault-isolation, **lock-mid-unwrap epoch abort (P2)**, lazy-trigger fire/no-fire)

### ⛔ MERGE IS GATED — on-device migration test required (DOC-137 §10.3)

This is the fund-critical flip. Before merge it must be verified on a **dev-client build with real pre-existing keys** (real Format A, ideally a multi-account set): cold-open unlock, background-lock/resume, a send, a WC sign, a messaging poll — every address still resolves + Pera cross-signs; kill during the unlock sweep / a changePin / a lazy migration and confirm convergence with **no lockout and never a mnemonic prompt**; measure sweep latency on low-end Android (native scrypt makes each derivation tens of ms).

### Open question for Dave (pre-existing, not a PR5 regression)

A PIN-only, biometrics-off wallet's `getPrivateKey(pin=undefined)` throws at the reader's biometric gate **both before and after** migration — so DOC-137 §6.4's "the vault lets `pin=undefined` callers work once keys are v2" is unfulfilled for PIN-only wallets until the reader gate also honors `SessionKeyVault.isUnlocked()`. Deliberately kept out of PR5 (auth-flow change → your call). Without it, background signing (WC/messaging) for PIN-only-no-biometric wallets still needs an explicit PIN — same as today.

https://claude.ai/code/session_01FfbFvUJtj9hVCaYZ4MS4y3
