### PR TITLE
feat(secure): optional passphrase credential + §6.4 reader-gate (TASK-27 PR7)

### DIFF
--- a/src/components/UnifiedAuthModal.tsx
+++ b/src/components/UnifiedAuthModal.tsx
@@ -5,6 +5,7 @@ import {
   Text,
   StyleSheet,
   TouchableOpacity,
+  TextInput,
   ActivityIndicator,
   Platform,
 } from 'react-native';
@@ -14,6 +15,7 @@ import { useTheme } from '@/contexts/ThemeContext';
 import { Theme } from '@/constants/themes';
 import { useAuth } from '@/contexts/AuthContext';
 import { AccountSecureStorage } from '@/services/secure';
+import type { SecretSource } from '@/services/secure/SessionKeyVault';
 import { LedgerDeviceInfo } from '@/services/ledger/transport';
 import { hapticNotify } from '@/utils/haptics';
 
@@ -76,6 +78,12 @@ export default function UnifiedAuthModal({
   const styles = useThemedStyles(createStyles);
   const { authState } = useAuth();
   const [pin, setPin] = useState('');
+  // The stored credential kind decides the input: numeric keypad for a PIN, a
+  // masked text field for a passphrase (PR7). Defaults to 'pin' until the read
+  // resolves so existing PIN wallets show the keypad immediately.
+  const [credentialSource, setCredentialSource] = useState<SecretSource>('pin');
+  const isPassphrase = credentialSource === 'passphrase';
+  const secretNoun = isPassphrase ? 'passphrase' : 'PIN';
   const [attempts, setAttempts] = useState(0);
   const [isLocked, setIsLocked] = useState(false);
   const [isAuthenticating, setIsAuthenticating] = useState(false);
@@ -109,6 +117,24 @@ export default function UnifiedAuthModal({
       setBiometricAuthenticated(false);
     }
   }, [visible]);
+
+  // Read the stored credential kind once on mount so the correct input renders.
+  useEffect(() => {
+    let cancelled = false;
+    AccountSecureStorage.getCredentialSource()
+      .then((source) => {
+        if (!cancelled && source) {
+          setCredentialSource(source);
+        }
+      })
+      .catch(() => {
+        // Keep the default ('pin') — the keypad still works for a PIN wallet, and
+        // a passphrase wallet's verifyPin rejects a wrong-format entry safely.
+      });
+    return () => {
+      cancelled = true;
+    };
+  }, []);
 
   const getAuthMessage = (authPurpose: string): string => {
     switch (authPurpose) {
@@ -263,17 +289,24 @@ export default function UnifiedAuthModal({
           }, LOCKOUT_TIME);
         } else {
           showAlert(
-            'Incorrect PIN',
+            `Incorrect ${secretNoun}`,
             `${MAX_ATTEMPTS - newAttempts} attempts remaining`
           );
         }
       }
     } catch (error) {
-      console.error('PIN verification error:', error);
-      showAlert('Error', 'Failed to verify PIN');
+      console.error('Secret verification error:', error);
+      showAlert('Error', `Failed to verify ${secretNoun}`);
     } finally {
       setIsAuthenticating(false);
     }
+  };
+
+  // Passphrase submit — reuses the same verifyPin()/verify path as the keypad;
+  // it only differs in how the secret is entered (full string vs. 6 digits).
+  const handlePassphraseSubmit = () => {
+    if (isLocked || isAuthenticating || pin.length === 0) return;
+    verifyPin(pin);
   };
 
   const handleBiometricConfirm = () => {
@@ -317,6 +350,38 @@ export default function UnifiedAuthModal({
             ]}
           />
         ))}
+      </View>
+    );
+  };
+
+  const renderPassphraseInput = () => {
+    const submitDisabled = isLocked || isAuthenticating || pin.length === 0;
+    return (
+      <View style={styles.passphraseContainer}>
+        <TextInput
+          style={styles.passphraseInput}
+          value={pin}
+          onChangeText={setPin}
+          placeholder="Enter your passphrase"
+          placeholderTextColor={theme.colors.textMuted}
+          secureTextEntry
+          autoCapitalize="none"
+          autoCorrect={false}
+          editable={!isLocked && !isAuthenticating}
+          onSubmitEditing={handlePassphraseSubmit}
+          returnKeyType="go"
+          autoFocus
+        />
+        <TouchableOpacity
+          style={[
+            styles.passphraseSubmit,
+            submitDisabled && styles.passphraseSubmitDisabled,
+          ]}
+          onPress={handlePassphraseSubmit}
+          disabled={submitDisabled}
+        >
+          <Text style={styles.passphraseSubmitText}>Unlock</Text>
+        </TouchableOpacity>
       </View>
     );
   };
@@ -474,7 +539,7 @@ export default function UnifiedAuthModal({
             </View>
           ) : (
             <>
-              {renderPinDots()}
+              {!isPassphrase && renderPinDots()}
 
               {shouldUseBiometrics && !isLocked && (
                 <TouchableOpacity
@@ -491,7 +556,7 @@ export default function UnifiedAuthModal({
                 </TouchableOpacity>
               )}
 
-              {renderKeypad()}
+              {isPassphrase ? renderPassphraseInput() : renderKeypad()}
 
               {isLocked && (
                 <View style={styles.lockoutContainer}>
@@ -633,6 +698,34 @@ const createStyles = (theme: Theme) =>
     pinDotFilled: {
       backgroundColor: theme.colors.primary,
       borderColor: theme.colors.primary,
+    },
+    passphraseContainer: {
+      marginBottom: theme.spacing.lg,
+      gap: theme.spacing.md,
+    },
+    passphraseInput: {
+      borderWidth: 1,
+      borderColor: theme.colors.border,
+      borderRadius: theme.borderRadius.lg,
+      paddingHorizontal: theme.spacing.lg,
+      paddingVertical: theme.spacing.md,
+      fontSize: 18,
+      color: theme.colors.text,
+      backgroundColor: theme.colors.surface,
+    },
+    passphraseSubmit: {
+      backgroundColor: theme.colors.primary,
+      borderRadius: theme.borderRadius.lg,
+      paddingVertical: theme.spacing.md,
+      alignItems: 'center',
+    },
+    passphraseSubmitDisabled: {
+      opacity: 0.5,
+    },
+    passphraseSubmitText: {
+      color: theme.colors.buttonText,
+      fontSize: 16,
+      fontWeight: '600',
     },
     biometricButton: {
       alignItems: 'center',

--- a/src/components/common/PassphraseStrengthMeter.tsx
+++ b/src/components/common/PassphraseStrengthMeter.tsx
@@ -1,0 +1,104 @@
+/**
+ * PassphraseStrengthMeter (TASK-27 PR7)
+ *
+ * A small 4-segment strength bar + label for the passphrase setup/change flows.
+ * GUIDANCE ONLY — the hard gate on a passphrase is the min-length floor enforced
+ * by AccountSecureStorage.validateSecret. Never renders or logs the secret.
+ */
+
+import React, { useMemo } from 'react';
+import { View, Text, StyleSheet } from 'react-native';
+import { useTheme } from '@/contexts/ThemeContext';
+import { useThemedStyles } from '@/hooks/useThemedStyles';
+import { Theme } from '@/constants/themes';
+import {
+  estimatePassphraseStrength,
+  PassphraseStrengthScore,
+} from '@/utils/passphraseStrength';
+
+interface Props {
+  secret: string;
+  minLength: number;
+}
+
+const SEGMENTS = 4;
+
+export function PassphraseStrengthMeter({ secret, minLength }: Props) {
+  const { theme } = useTheme();
+  const styles = useThemedStyles(createStyles);
+
+  const strength = useMemo(
+    () => estimatePassphraseStrength(secret, minLength),
+    [secret, minLength]
+  );
+
+  // Empty field → no meter (avoids a red bar before the user has typed).
+  if (!secret) {
+    return null;
+  }
+
+  const colorForScore = (score: PassphraseStrengthScore): string => {
+    switch (score) {
+      case 0:
+      case 1:
+        return theme.colors.error;
+      case 2:
+        return theme.colors.warning ?? '#E0A100';
+      case 3:
+        return theme.colors.primary;
+      default:
+        return theme.colors.success ?? '#22A06B';
+    }
+  };
+
+  const activeColor = colorForScore(strength.score);
+  // Score 0 = "too short" (below the floor) → fill 1 segment red; else fill = score.
+  const filled = strength.score === 0 ? 1 : strength.score;
+
+  return (
+    <View style={styles.container} accessibilityRole="progressbar">
+      <View style={styles.bar}>
+        {Array.from({ length: SEGMENTS }).map((_, i) => (
+          <View
+            key={i}
+            style={[
+              styles.segment,
+              {
+                backgroundColor:
+                  i < filled ? activeColor : theme.colors.glassBorder,
+              },
+            ]}
+          />
+        ))}
+      </View>
+      <Text style={[styles.label, { color: activeColor }]}>
+        {strength.meetsMinLength
+          ? strength.label.charAt(0).toUpperCase() + strength.label.slice(1)
+          : `At least ${minLength} characters`}
+      </Text>
+    </View>
+  );
+}
+
+const createStyles = (theme: Theme) =>
+  StyleSheet.create({
+    container: {
+      marginTop: theme.spacing.xs,
+      gap: theme.spacing.xs,
+    },
+    bar: {
+      flexDirection: 'row',
+      gap: theme.spacing.xs,
+    },
+    segment: {
+      flex: 1,
+      height: 4,
+      borderRadius: 2,
+    },
+    label: {
+      fontSize: theme.typography.caption?.fontSize ?? 12,
+      fontWeight: '600',
+    },
+  });
+
+export default PassphraseStrengthMeter;

--- a/src/components/remoteSigner/SignerAuthModal.tsx
+++ b/src/components/remoteSigner/SignerAuthModal.tsx
@@ -6,13 +6,14 @@
  * The caller can then use this to retrieve private keys and sign transactions.
  */
 
-import React, { useEffect, useState, useCallback } from 'react';
+import React, { useEffect, useState } from 'react';
 import {
   Modal,
   View,
   Text,
   StyleSheet,
   TouchableOpacity,
+  TextInput,
   ActivityIndicator,
   Platform,
 } from 'react-native';
@@ -22,6 +23,7 @@ import { useThemedStyles } from '@/hooks/useThemedStyles';
 import { useTheme } from '@/contexts/ThemeContext';
 import { Theme } from '@/constants/themes';
 import { AccountSecureStorage } from '@/services/secure';
+import type { SecretSource } from '@/services/secure/SessionKeyVault';
 import { hapticNotify } from '@/utils/haptics';
 
 interface SignerAuthModalProps {
@@ -44,6 +46,12 @@ export default function SignerAuthModal({
   const styles = useThemedStyles(createStyles);
 
   const [pin, setPin] = useState('');
+  // The stored credential kind decides the input: numeric keypad for a PIN, a
+  // masked text field for a passphrase (PR7). Defaults to 'pin' until the read
+  // resolves so existing PIN wallets show the keypad immediately.
+  const [credentialSource, setCredentialSource] = useState<SecretSource>('pin');
+  const isPassphrase = credentialSource === 'passphrase';
+  const secretNoun = isPassphrase ? 'passphrase' : 'PIN';
   const [error, setError] = useState<string | null>(null);
   const [isVerifying, setIsVerifying] = useState(false);
   const [biometricAvailable, setBiometricAvailable] = useState(false);
@@ -77,6 +85,24 @@ export default function SignerAuthModal({
       setLockUntil(null);
     }
   }, [visible]);
+
+  // Read the stored credential kind once on mount so the correct input renders.
+  useEffect(() => {
+    let cancelled = false;
+    AccountSecureStorage.getCredentialSource()
+      .then((source) => {
+        if (!cancelled && source) {
+          setCredentialSource(source);
+        }
+      })
+      .catch(() => {
+        // Keep the default ('pin') — the keypad still works for a PIN wallet, and
+        // a passphrase wallet's verifyPin rejects a wrong-format entry safely.
+      });
+    return () => {
+      cancelled = true;
+    };
+  }, []);
 
   // Auto-prompt for biometric auth when modal opens
   useEffect(() => {
@@ -143,17 +169,24 @@ export default function SignerAuthModal({
           setError('Too many attempts. Try again in 30 seconds.');
         } else {
           setError(
-            `Incorrect PIN. ${MAX_ATTEMPTS - attempts} attempts remaining.`
+            `Incorrect ${secretNoun}. ${MAX_ATTEMPTS - attempts} attempts remaining.`
           );
         }
       }
     } catch (error) {
-      console.error('PIN verification error:', error);
-      setError('Failed to verify PIN');
+      console.error('Secret verification error:', error);
+      setError(`Failed to verify ${secretNoun}`);
       setPin('');
     } finally {
       setIsVerifying(false);
     }
+  };
+
+  // Passphrase submit — reuses the same handlePinSubmit()/verify path as the
+  // keypad; it only differs in how the secret is entered (full string vs. digits).
+  const handlePassphraseSubmit = () => {
+    if (isLocked || isVerifying || pin.length === 0) return;
+    handlePinSubmit(pin);
   };
 
   const handleBiometricAuth = async () => {
@@ -210,6 +243,41 @@ export default function SignerAuthModal({
       ))}
     </View>
   );
+
+  const renderPassphraseInput = () => {
+    const submitDisabled = isLocked || isVerifying || pin.length === 0;
+    return (
+      <View style={styles.passphraseContainer}>
+        <TextInput
+          style={styles.passphraseInput}
+          value={pin}
+          onChangeText={(text) => {
+            setPin(text);
+            setError(null);
+          }}
+          placeholder="Enter your passphrase"
+          placeholderTextColor={theme.colors.textMuted}
+          secureTextEntry
+          autoCapitalize="none"
+          autoCorrect={false}
+          editable={!isLocked && !isVerifying}
+          onSubmitEditing={handlePassphraseSubmit}
+          returnKeyType="go"
+          autoFocus
+        />
+        <TouchableOpacity
+          style={[
+            styles.passphraseSubmit,
+            submitDisabled && styles.passphraseSubmitDisabled,
+          ]}
+          onPress={handlePassphraseSubmit}
+          disabled={submitDisabled}
+        >
+          <Text style={styles.passphraseSubmitText}>Unlock</Text>
+        </TouchableOpacity>
+      </View>
+    );
+  };
 
   const renderNumberPad = () => (
     <View style={styles.numberPad}>
@@ -323,11 +391,11 @@ export default function SignerAuthModal({
               />
             )}
 
-            {renderPinDots()}
+            {!isPassphrase && renderPinDots()}
 
             {error && <Text style={styles.error}>{error}</Text>}
 
-            {renderNumberPad()}
+            {isPassphrase ? renderPassphraseInput() : renderNumberPad()}
           </View>
         </View>
       </View>
@@ -410,6 +478,36 @@ const createStyles = (theme: Theme) =>
     },
     pinDotFilled: {
       borderWidth: 0,
+    },
+    passphraseContainer: {
+      width: '100%',
+      maxWidth: 300,
+      marginBottom: 24,
+      gap: theme.spacing.md,
+    },
+    passphraseInput: {
+      borderWidth: 1,
+      borderColor: theme.colors.border,
+      borderRadius: theme.borderRadius.lg,
+      paddingHorizontal: theme.spacing.lg,
+      paddingVertical: theme.spacing.md,
+      fontSize: 18,
+      color: theme.colors.text,
+      backgroundColor: theme.colors.card,
+    },
+    passphraseSubmit: {
+      backgroundColor: theme.colors.primary,
+      borderRadius: theme.borderRadius.lg,
+      paddingVertical: theme.spacing.md,
+      alignItems: 'center',
+    },
+    passphraseSubmitDisabled: {
+      opacity: 0.5,
+    },
+    passphraseSubmitText: {
+      color: theme.colors.buttonText,
+      fontSize: 16,
+      fontWeight: '600',
     },
     error: {
       fontSize: 14,

--- a/src/contexts/AuthContext.tsx
+++ b/src/contexts/AuthContext.tsx
@@ -48,11 +48,11 @@ export interface AuthState {
 
 export interface AuthContextType {
   authState: AuthState;
-  unlock: (pin: string) => Promise<boolean>;
+  unlock: (secret: string) => Promise<boolean>;
   unlockWithBiometrics: () => Promise<boolean>;
   lock: () => void;
   updateActivity: () => void;
-  setupPin: (pin: string) => Promise<void>;
+  setupPin: (secret: string, source?: SecretSource) => Promise<void>;
   enableBiometrics: (enabled: boolean, secret?: string) => Promise<void>;
   recheckAuthState: () => Promise<void>;
   updateTimeoutSetting: () => Promise<void>;
@@ -273,20 +273,24 @@ export function AuthProvider({ children }: { children: React.ReactNode }) {
     }, timeoutMs);
   };
 
-  const unlock = async (pin: string): Promise<boolean> => {
+  const unlock = async (secret: string): Promise<boolean> => {
     try {
-      if (!pin || pin.length !== 6) {
+      // PR7: accept a PIN or a passphrase — verifyPin validates the format
+      // against the STORED credential kind, so no 6-digit gate here (that would
+      // reject a passphrase). An empty secret can never be valid.
+      if (!secret) {
         return false;
       }
 
-      const isValid = await AccountSecureStorage.verifyPin(pin);
+      const isValid = await AccountSecureStorage.verifyPin(secret);
 
       if (isValid) {
-        // Populate the session vault with the verified secret (DOC-137 §6.3).
-        // In PR3 keys are still Format A, so the vault is not yet load-bearing
-        // for decryption (the device-key path handles it) — this establishes
-        // the session secret the v2-blob path will use in PR4/PR5.
-        SessionKeyVault.set(pin, 'pin');
+        // Populate the session vault with the verified secret AND its kind
+        // (DOC-137 §6.3), read from the stored credential so a passphrase session
+        // is tagged 'passphrase'. The vault is load-bearing for v2 reads.
+        const source =
+          (await AccountSecureStorage.getCredentialSource()) ?? 'pin';
+        SessionKeyVault.set(secret, source);
         // Flip the lock signal to UNLOCKED synchronously (mirrors lock()) so the
         // messaging poll/cache-write guard resumes immediately, not only after
         // the React effect below runs.
@@ -411,15 +415,21 @@ export function AuthProvider({ children }: { children: React.ReactNode }) {
     }
   };
 
-  const setupPin = async (pin: string): Promise<void> => {
-    if (!pin || pin.length !== 6 || !/^\d{6}$/.test(pin)) {
-      throw new Error('PIN must be 6 digits');
+  const setupPin = async (
+    secret: string,
+    source: SecretSource = 'pin'
+  ): Promise<void> => {
+    // PR7: format is validated per-kind inside AccountSecureStorage.setupPin
+    // (validateSecret): PIN = 6 digits, passphrase = min length. Empty is never
+    // valid.
+    if (!secret) {
+      throw new Error('A PIN or passphrase is required');
     }
 
     // Use the atomic first-secret setup flow (DOC-137 §5.4), NOT a bare hash
-    // persist: it re-wraps any pre-existing device-key accounts under the new PIN
-    // (verify-before-delete) so first-time PIN setup can never strand keys.
-    await AccountSecureStorage.setupPin(pin, 'pin');
+    // persist: it re-wraps any pre-existing device-key accounts under the new
+    // secret (verify-before-delete) so first-time setup can never strand keys.
+    await AccountSecureStorage.setupPin(secret, source);
     setAuthState((prev) => ({
       ...prev,
       hasPin: true,

--- a/src/screens/auth/LockScreen.tsx
+++ b/src/screens/auth/LockScreen.tsx
@@ -4,6 +4,7 @@ import {
   Text,
   StyleSheet,
   TouchableOpacity,
+  TextInput,
   Platform,
 } from 'react-native';
 import { SafeAreaView } from 'react-native-safe-area-context';
@@ -14,6 +15,7 @@ import { Theme } from '@/constants/themes';
 import { useAuth } from '@/contexts/AuthContext';
 import { AccountSecureStorage } from '@/services/secure';
 import type { PinThrottleState } from '@/services/secure';
+import type { SecretSource } from '@/services/secure/SessionKeyVault';
 import { MultiAccountWalletService } from '@/services/wallet';
 import { hapticNotify } from '@/utils/haptics';
 import { SECURITY_CONFIG, SECURITY_MESSAGES } from '@/config/security';
@@ -57,6 +59,12 @@ export default function LockScreen() {
   const { authState, unlock, unlockWithBiometrics, recheckAuthState } =
     useAuth();
   const [pin, setPin] = useState('');
+  // The stored credential kind decides the input: numeric keypad for a PIN, a
+  // masked text field for a passphrase (PR7). Defaults to 'pin' until the read
+  // resolves so existing PIN wallets show the keypad immediately.
+  const [credentialSource, setCredentialSource] = useState<SecretSource>('pin');
+  const isPassphrase = credentialSource === 'passphrase';
+  const secretNoun = isPassphrase ? 'passphrase' : 'PIN';
 
   // Lockout state is now sourced from the PERSISTENT throttle in
   // AccountSecureStorage (DOC-137 §8 / TASK-26) instead of local React state, so
@@ -91,6 +99,24 @@ export default function LockScreen() {
       // fails closed, and we don't want to strand input disabled forever.
       setHydrated(true);
     }
+  }, []);
+
+  // Read the stored credential kind once on mount so the correct input renders.
+  useEffect(() => {
+    let cancelled = false;
+    AccountSecureStorage.getCredentialSource()
+      .then((source) => {
+        if (!cancelled && source) {
+          setCredentialSource(source);
+        }
+      })
+      .catch(() => {
+        // Keep the default ('pin') — the keypad still works for a PIN wallet, and
+        // a passphrase wallet's verifyPin rejects a wrong-format entry safely.
+      });
+    return () => {
+      cancelled = true;
+    };
   }, []);
 
   // Load persisted lockout on mount so a relaunch during a lockout stays locked.
@@ -186,19 +212,29 @@ export default function LockScreen() {
         showAlert('Too Many Attempts', SECURITY_MESSAGES.PIN_ATTEMPTS_EXCEEDED);
       } else if (state.attemptsRemaining > 0) {
         showAlert(
-          'Incorrect PIN',
+          `Incorrect ${secretNoun}`,
           `${state.attemptsRemaining} attempt${
             state.attemptsRemaining === 1 ? '' : 's'
           } remaining`
         );
       } else {
-        showAlert('Incorrect PIN', SECURITY_MESSAGES.PIN_ATTEMPTS_EXCEEDED);
+        showAlert(
+          `Incorrect ${secretNoun}`,
+          SECURITY_MESSAGES.PIN_ATTEMPTS_EXCEEDED
+        );
       }
     } catch (error) {
-      console.error('PIN verification error:', error);
+      console.error('Secret verification error:', error);
       hapticNotify('error');
-      showAlert('Error', 'Failed to verify PIN');
+      showAlert('Error', `Failed to verify ${secretNoun}`);
     }
+  };
+
+  // Passphrase submit — the local verifyPin() drives the same unlock/throttle path
+  // as the keypad; it only differs in how the secret is entered.
+  const handlePassphraseSubmit = () => {
+    if (inputDisabled || pin.length === 0) return;
+    verifyPin(pin);
   };
 
   const handleReset = () => {
@@ -286,6 +322,38 @@ export default function LockScreen() {
     );
   };
 
+  const renderPassphraseInput = () => {
+    return (
+      <View style={styles.passphraseContainer}>
+        <TextInput
+          style={styles.passphraseInput}
+          value={pin}
+          onChangeText={setPin}
+          placeholder="Enter your passphrase"
+          placeholderTextColor={theme.colors.textMuted}
+          secureTextEntry
+          autoCapitalize="none"
+          autoCorrect={false}
+          editable={!inputDisabled}
+          onSubmitEditing={handlePassphraseSubmit}
+          returnKeyType="go"
+          autoFocus
+        />
+        <TouchableOpacity
+          style={[
+            styles.passphraseSubmit,
+            (inputDisabled || pin.length === 0) &&
+              styles.passphraseSubmitDisabled,
+          ]}
+          onPress={handlePassphraseSubmit}
+          disabled={inputDisabled || pin.length === 0}
+        >
+          <Text style={styles.passphraseSubmitText}>Unlock</Text>
+        </TouchableOpacity>
+      </View>
+    );
+  };
+
   const renderKeypad = () => {
     const numbers = [
       ['1', '2', '3'],
@@ -344,11 +412,13 @@ export default function LockScreen() {
           <Ionicons name="lock-closed" size={48} color={theme.colors.primary} />
           <Text style={styles.title}>Wallet Locked</Text>
           <Text style={styles.subtitle}>
-            {hydrated ? 'Enter your PIN to unlock' : 'Checking status…'}
+            {hydrated
+              ? `Enter your ${secretNoun} to unlock`
+              : 'Checking status…'}
           </Text>
         </View>
 
-        {renderPinDots()}
+        {!isPassphrase && renderPinDots()}
 
         {authState.biometricEnabled && !isLocked && (
           <TouchableOpacity
@@ -364,7 +434,7 @@ export default function LockScreen() {
           </TouchableOpacity>
         )}
 
-        {renderKeypad()}
+        {isPassphrase ? renderPassphraseInput() : renderKeypad()}
 
         {isLocked ? (
           <View style={styles.lockoutContainer}>
@@ -453,6 +523,34 @@ const createStyles = (theme: Theme) =>
     pinDotFilled: {
       backgroundColor: theme.colors.primary,
       borderColor: theme.colors.primary,
+    },
+    passphraseContainer: {
+      marginBottom: theme.spacing.xxl,
+      gap: theme.spacing.md,
+    },
+    passphraseInput: {
+      borderWidth: 1,
+      borderColor: theme.colors.border,
+      borderRadius: theme.borderRadius.lg,
+      paddingHorizontal: theme.spacing.lg,
+      paddingVertical: theme.spacing.md,
+      fontSize: 18,
+      color: theme.colors.text,
+      backgroundColor: theme.colors.surface,
+    },
+    passphraseSubmit: {
+      backgroundColor: theme.colors.primary,
+      borderRadius: theme.borderRadius.lg,
+      paddingVertical: theme.spacing.md,
+      alignItems: 'center',
+    },
+    passphraseSubmitDisabled: {
+      opacity: 0.5,
+    },
+    passphraseSubmitText: {
+      color: theme.colors.buttonText,
+      fontSize: 16,
+      fontWeight: '600',
     },
     biometricButton: {
       alignItems: 'center',

--- a/src/screens/onboarding/SecuritySetupScreen.tsx
+++ b/src/screens/onboarding/SecuritySetupScreen.tsx
@@ -1,13 +1,5 @@
 import React, { useState } from 'react';
-import {
-  View,
-  Text,
-  StyleSheet,
-  TextInput,
-  Alert,
-  ActivityIndicator,
-  Switch,
-} from 'react-native';
+import { View, Text, StyleSheet, Pressable, Alert, Switch } from 'react-native';
 import { SafeAreaView } from 'react-native-safe-area-context';
 import { StackNavigationProp } from '@react-navigation/stack';
 import { RouteProp } from '@react-navigation/native';
@@ -28,7 +20,7 @@ import {
   clearAccountSecrets,
 } from '@/utils/accountQRParser';
 import { useTheme } from '@/contexts/ThemeContext';
-import { useThemeColors, useThemedStyles } from '@/hooks/useThemedStyles';
+import { useThemedStyles } from '@/hooks/useThemedStyles';
 import { Theme } from '@/constants/themes';
 import KeyboardAwareScrollView from '@/components/common/KeyboardAwareScrollView';
 import UniversalHeader from '@/components/common/UniversalHeader';
@@ -36,6 +28,10 @@ import { NFTBackground } from '@/components/common/NFTBackground';
 import { GlassCard } from '@/components/common/GlassCard';
 import { GlassButton } from '@/components/common/GlassButton';
 import { GlassInput } from '@/components/common/GlassInput';
+import { PassphraseStrengthMeter } from '@/components/common/PassphraseStrengthMeter';
+import type { SecretSource } from '@/services/secure/SessionKeyVault';
+
+const PASSPHRASE_MIN = AccountSecureStorage.PASSPHRASE_MIN_LENGTH;
 
 type SecuritySetupScreenNavigationProp = StackNavigationProp<
   RootStackParamList,
@@ -54,8 +50,8 @@ interface Props {
 
 export default function SecuritySetupScreen({ navigation, route }: Props) {
   const { theme } = useTheme();
-  const themeColors = useThemeColors();
   const styles = useThemedStyles(createStyles);
+  const [mode, setMode] = useState<SecretSource>('pin');
   const [pin, setPin] = useState('');
   const [confirmPin, setConfirmPin] = useState('');
   const [biometricAvailable, setBiometricAvailable] = useState(false);
@@ -88,26 +84,40 @@ export default function SecuritySetupScreen({ navigation, route }: Props) {
     setBiometricAvailable(available && enrolled);
   };
 
+  const isPassphrase = mode === 'passphrase';
+  const secretLabel = isPassphrase ? 'passphrase' : 'PIN';
+
   const handleComplete = async () => {
     if (submitting) return;
-    if (!pin || pin.length !== 6) {
+    if (isPassphrase) {
+      if (pin.length < PASSPHRASE_MIN) {
+        Alert.alert(
+          'Error',
+          `Passphrase must be at least ${PASSPHRASE_MIN} characters`
+        );
+        return;
+      }
+    } else if (!pin || pin.length !== 6) {
       Alert.alert('Error', 'PIN must be 6 digits');
       return;
     }
 
     if (pin !== confirmPin) {
-      Alert.alert('Error', 'PINs do not match');
+      Alert.alert(
+        'Error',
+        isPassphrase ? 'Passphrases do not match' : 'PINs do not match'
+      );
       return;
     }
 
     try {
       setSubmitting(true);
 
-      // Store PIN first — atomic first-secret setup (DOC-137 §5.4). Re-wraps any
-      // pre-existing device-key accounts under the new PIN before committing the
-      // credential (verify-before-delete), so onboarding never strands keys.
-      setSetupStep('Setting up PIN...');
-      await AccountSecureStorage.setupPin(pin, 'pin');
+      // Store the secret first — atomic first-secret setup (DOC-137 §5.4). Re-wraps
+      // any pre-existing device-key accounts under the new secret before committing
+      // the credential (verify-before-delete), so onboarding never strands keys.
+      setSetupStep(`Setting up ${secretLabel}...`);
+      await AccountSecureStorage.setupPin(pin, mode);
 
       // Store biometric preference. When the user opts into biometrics at
       // onboarding, capture the just-set PIN behind the write-time auth gate
@@ -121,7 +131,7 @@ export default function SecuritySetupScreen({ navigation, route }: Props) {
         try {
           await AccountSecureStorage.setBiometricSecret(
             pin,
-            'pin',
+            mode,
             'Enable biometric unlock'
           );
           await AccountSecureStorage.setBiometricEnabled(true);
@@ -261,27 +271,95 @@ export default function SecuritySetupScreen({ navigation, route }: Props) {
               />
             )}
 
-            <GlassInput
-              label="Create 6-digit PIN"
-              placeholder="Enter PIN"
-              value={pin}
-              onChangeText={setPin}
-              keyboardType="numeric"
-              maxLength={6}
-              secureTextEntry
-              leftIcon="lock-closed-outline"
-            />
+            {/* PIN vs passphrase mode toggle. Switching clears the fields so a
+                half-typed PIN can't leak into a passphrase submit (or vice-versa). */}
+            <View style={styles.modeToggle}>
+              {(['pin', 'passphrase'] as const).map((m) => {
+                const active = mode === m;
+                return (
+                  <Pressable
+                    key={m}
+                    onPress={() => {
+                      if (mode === m) return;
+                      setMode(m);
+                      setPin('');
+                      setConfirmPin('');
+                    }}
+                    style={[
+                      styles.modeOption,
+                      active && {
+                        backgroundColor: theme.colors.primary,
+                      },
+                    ]}
+                  >
+                    <Text
+                      style={[
+                        styles.modeOptionText,
+                        {
+                          color: active
+                            ? theme.colors.buttonText
+                            : theme.colors.text,
+                        },
+                      ]}
+                    >
+                      {m === 'pin' ? '6-digit PIN' : 'Passphrase'}
+                    </Text>
+                  </Pressable>
+                );
+              })}
+            </View>
 
-            <GlassInput
-              label="Confirm PIN"
-              placeholder="Confirm PIN"
-              value={confirmPin}
-              onChangeText={setConfirmPin}
-              keyboardType="numeric"
-              maxLength={6}
-              secureTextEntry
-              leftIcon="lock-closed-outline"
-            />
+            {isPassphrase ? (
+              <>
+                <GlassInput
+                  label={`Create passphrase (min ${PASSPHRASE_MIN} chars)`}
+                  placeholder="Enter passphrase"
+                  value={pin}
+                  onChangeText={setPin}
+                  autoCapitalize="none"
+                  autoCorrect={false}
+                  secureTextEntry
+                  leftIcon="key-outline"
+                />
+                <PassphraseStrengthMeter
+                  secret={pin}
+                  minLength={PASSPHRASE_MIN}
+                />
+                <GlassInput
+                  label="Confirm passphrase"
+                  placeholder="Confirm passphrase"
+                  value={confirmPin}
+                  onChangeText={setConfirmPin}
+                  autoCapitalize="none"
+                  autoCorrect={false}
+                  secureTextEntry
+                  leftIcon="key-outline"
+                />
+              </>
+            ) : (
+              <>
+                <GlassInput
+                  label="Create 6-digit PIN"
+                  placeholder="Enter PIN"
+                  value={pin}
+                  onChangeText={setPin}
+                  keyboardType="numeric"
+                  maxLength={6}
+                  secureTextEntry
+                  leftIcon="lock-closed-outline"
+                />
+                <GlassInput
+                  label="Confirm PIN"
+                  placeholder="Confirm PIN"
+                  value={confirmPin}
+                  onChangeText={setConfirmPin}
+                  keyboardType="numeric"
+                  maxLength={6}
+                  secureTextEntry
+                  leftIcon="lock-closed-outline"
+                />
+              </>
+            )}
 
             {biometricAvailable && (
               <View style={styles.biometricContainer}>
@@ -360,6 +438,23 @@ const createStyles = (theme: Theme) =>
       borderRadius: theme.borderRadius.xxl,
       marginBottom: theme.spacing.xl,
       gap: theme.spacing.md,
+    },
+    modeToggle: {
+      flexDirection: 'row',
+      gap: theme.spacing.xs,
+      backgroundColor: theme.colors.glassBorder,
+      borderRadius: theme.borderRadius.lg,
+      padding: theme.spacing.xs,
+    },
+    modeOption: {
+      flex: 1,
+      paddingVertical: theme.spacing.sm,
+      borderRadius: theme.borderRadius.md,
+      alignItems: 'center',
+    },
+    modeOptionText: {
+      fontSize: theme.typography.body.fontSize,
+      fontWeight: '600',
     },
     biometricContainer: {
       flexDirection: 'row',

--- a/src/screens/settings/ChangePinScreen.tsx
+++ b/src/screens/settings/ChangePinScreen.tsx
@@ -5,20 +5,34 @@ import {
   StyleSheet,
   TouchableOpacity,
   TextInput,
+  Pressable,
   Alert,
   ActivityIndicator,
 } from 'react-native';
 import { SafeAreaView } from 'react-native-safe-area-context';
 import { useNavigation } from '@react-navigation/native';
 import { AccountSecureStorage } from '@/services/secure';
+import type { SecretSource } from '@/services/secure/SessionKeyVault';
 import UniversalHeader from '@/components/common/UniversalHeader';
 import KeyboardAwareScrollView from '@/components/common/KeyboardAwareScrollView';
+import { PassphraseStrengthMeter } from '@/components/common/PassphraseStrengthMeter';
 import { useTheme } from '@/contexts/ThemeContext';
 import { useThemeColors, useThemedStyles } from '@/hooks/useThemedStyles';
 import { Theme } from '@/constants/themes';
 import { useAuth } from '@/contexts/AuthContext';
 
+const PASSPHRASE_MIN = AccountSecureStorage.PASSPHRASE_MIN_LENGTH;
+
 type PinStep = 'current' | 'new' | 'confirm';
+
+/** Format-valid for a kind: PIN = exactly 6 digits, passphrase = min length. */
+function isValidFor(source: SecretSource, value: string): boolean {
+  return source === 'passphrase'
+    ? value.length >= PASSPHRASE_MIN
+    : value.length === 6 && /^\d{6}$/.test(value);
+}
+
+const noun = (s: SecretSource) => (s === 'passphrase' ? 'passphrase' : 'PIN');
 
 export default function ChangePinScreen() {
   const navigation = useNavigation();
@@ -34,22 +48,34 @@ export default function ChangePinScreen() {
   const [attempts, setAttempts] = useState(0);
   const [isInitialSetup, setIsInitialSetup] = useState(false);
   const [isLoading, setIsLoading] = useState(true);
+  // The EXISTING credential kind (drives the 'current' step input) and the kind
+  // the user is switching TO (drives 'new'/'confirm'). Default both to 'pin'.
+  const [currentSource, setCurrentSource] = useState<SecretSource>('pin');
+  const [newSource, setNewSource] = useState<SecretSource>('pin');
 
-  // Check if this is initial PIN setup (no existing PIN) on mount
+  // On mount: is there a credential yet, and of what kind?
   useEffect(() => {
-    const checkPinExists = async () => {
+    const load = async () => {
       try {
-        const hasPin = await AccountSecureStorage.hasPin();
-        if (!hasPin) {
+        const source = await AccountSecureStorage.getCredentialSource();
+        if (!source) {
           setIsInitialSetup(true);
-          setCurrentStep('new'); // Skip 'current' step
+          setCurrentStep('new'); // Skip the 'current' step
+        } else {
+          setCurrentSource(source);
+          setNewSource(source); // default: keep the same kind
         }
       } finally {
         setIsLoading(false);
       }
     };
-    checkPinExists();
+    load();
   }, []);
+
+  // Which kind the ACTIVE step's input is for.
+  const stepSource: SecretSource =
+    currentStep === 'current' ? currentSource : newSource;
+  const isPassphraseStep = stepSource === 'passphrase';
 
   const getCurrentPinValue = () => {
     switch (currentStep) {
@@ -81,11 +107,13 @@ export default function ChangePinScreen() {
   const getStepTitle = () => {
     switch (currentStep) {
       case 'current':
-        return 'Enter Current PIN';
+        return `Enter Current ${noun(currentSource) === 'PIN' ? 'PIN' : 'Passphrase'}`;
       case 'new':
-        return isInitialSetup ? 'Create PIN' : 'Enter New PIN';
+        return isInitialSetup
+          ? `Create ${isPassphraseStep ? 'Passphrase' : 'PIN'}`
+          : `Enter New ${isPassphraseStep ? 'Passphrase' : 'PIN'}`;
       case 'confirm':
-        return isInitialSetup ? 'Confirm PIN' : 'Confirm New PIN';
+        return `Confirm ${isPassphraseStep ? 'Passphrase' : 'PIN'}`;
       default:
         return '';
     }
@@ -94,32 +122,35 @@ export default function ChangePinScreen() {
   const getStepMessage = () => {
     switch (currentStep) {
       case 'current':
-        return 'Please enter your current 6-digit PIN';
+        return `Enter your current ${noun(currentSource)} to verify your identity`;
       case 'new':
-        return isInitialSetup
-          ? 'Choose a 6-digit PIN to secure your wallet'
-          : 'Choose a new 6-digit PIN for your wallet';
+        return isPassphraseStep
+          ? `Choose a passphrase (at least ${PASSPHRASE_MIN} characters). Longer is stronger.`
+          : 'Choose a 6-digit PIN for your wallet';
       case 'confirm':
-        return isInitialSetup
-          ? 'Re-enter your PIN to confirm'
-          : 'Re-enter your new PIN to confirm';
+        return `Re-enter your ${isPassphraseStep ? 'passphrase' : 'PIN'} to confirm`;
       default:
         return '';
     }
   };
 
   const handleNext = async () => {
-    const pinValue = getCurrentPinValue();
+    const value = getCurrentPinValue();
 
-    if (pinValue.length !== 6) {
-      Alert.alert('Error', 'PIN must be 6 digits');
+    if (!isValidFor(stepSource, value)) {
+      Alert.alert(
+        'Error',
+        isPassphraseStep
+          ? `Passphrase must be at least ${PASSPHRASE_MIN} characters`
+          : 'PIN must be 6 digits'
+      );
       return;
     }
 
     if (currentStep === 'current') {
       setIsSubmitting(true);
       try {
-        const isValid = await AccountSecureStorage.verifyPin(pinValue);
+        const isValid = await AccountSecureStorage.verifyPin(value);
         if (isValid) {
           setCurrentStep('new');
           setAttempts(0);
@@ -127,37 +158,38 @@ export default function ChangePinScreen() {
           const newAttempts = attempts + 1;
           setAttempts(newAttempts);
           setCurrentPin('');
-
           if (newAttempts >= 5) {
             Alert.alert(
               'Too Many Attempts',
-              'Too many failed PIN attempts. Please try again later.',
+              'Too many failed attempts. Please try again later.',
               [{ text: 'OK', onPress: () => navigation.goBack() }]
             );
           } else {
             Alert.alert(
-              'Incorrect PIN',
-              `Incorrect PIN. ${5 - newAttempts} attempts remaining.`
+              `Incorrect ${noun(currentSource)}`,
+              `${5 - newAttempts} attempts remaining.`
             );
           }
         }
       } catch (error) {
-        Alert.alert('Error', 'Failed to verify PIN. Please try again.');
+        Alert.alert('Error', 'Failed to verify. Please try again.');
         setCurrentPin('');
       } finally {
         setIsSubmitting(false);
       }
     } else if (currentStep === 'new') {
-      // Only check against current PIN if changing (not initial setup)
-      if (!isInitialSetup && pinValue === currentPin) {
-        Alert.alert('Error', 'New PIN must be different from current PIN');
+      if (!isInitialSetup && value === currentPin) {
+        Alert.alert(
+          'Error',
+          `New ${noun(newSource)} must be different from the current one`
+        );
         setNewPin('');
         return;
       }
       setCurrentStep('confirm');
     } else if (currentStep === 'confirm') {
-      if (pinValue !== newPin) {
-        Alert.alert('Error', 'PINs do not match. Please try again.');
+      if (value !== newPin) {
+        Alert.alert('Error', 'Entries do not match. Please try again.');
         setConfirmPin('');
         return;
       }
@@ -165,34 +197,29 @@ export default function ChangePinScreen() {
       setIsSubmitting(true);
       try {
         if (isInitialSetup) {
-          // Initial PIN setup - atomic first-secret rewrap (DOC-137 §5.4), which
-          // migrates any pre-existing device-key accounts to the PIN-wrapped v2
-          // envelope before committing the credential.
-          await AccountSecureStorage.setupPin(newPin, 'pin');
+          // First-secret setup — atomic rewrap of any pre-existing device-key
+          // accounts under the new secret (DOC-137 §5.4).
+          await AccountSecureStorage.setupPin(newPin, newSource);
         } else {
-          // Changing existing PIN - use changePin
-          await AccountSecureStorage.changePin(currentPin, newPin);
+          // Change / convert — re-wraps every account from the OLD secret to the
+          // NEW secret+kind byte-identically (DOC-137 §5.3); a PIN↔passphrase
+          // switch keeps every account's key bytes (and Algorand address) intact.
+          await AccountSecureStorage.changePin(currentPin, newPin, newSource);
         }
 
-        // Update AuthContext to reflect new PIN state
         await recheckAuthState();
 
         Alert.alert(
-          isInitialSetup ? 'PIN Set Successfully' : 'PIN Changed Successfully',
+          isInitialSetup ? 'Security Set' : 'Updated',
           isInitialSetup
-            ? 'Your PIN has been set up successfully.'
-            : 'Your PIN has been updated successfully.',
-          [
-            {
-              text: 'OK',
-              onPress: () => navigation.goBack(),
-            },
-          ]
+            ? `Your ${noun(newSource)} has been set up.`
+            : `Your wallet is now secured with a ${noun(newSource)}.`,
+          [{ text: 'OK', onPress: () => navigation.goBack() }]
         );
       } catch (error) {
         Alert.alert(
           'Error',
-          `Failed to ${isInitialSetup ? 'set' : 'change'} PIN: ${error instanceof Error ? error.message : 'Unknown error'}`
+          `Failed to update: ${error instanceof Error ? error.message : 'Unknown error'}`
         );
       } finally {
         setIsSubmitting(false);
@@ -205,7 +232,6 @@ export default function ChangePinScreen() {
       navigation.goBack();
     } else if (currentStep === 'new') {
       if (isInitialSetup) {
-        // In initial setup, 'new' is the first step - go back to settings
         navigation.goBack();
       } else {
         setCurrentStep('current');
@@ -219,36 +245,32 @@ export default function ChangePinScreen() {
 
   const getProgress = () => {
     if (isInitialSetup) {
-      // 2-step flow for initial setup
-      switch (currentStep) {
-        case 'new':
-          return '1 of 2';
-        case 'confirm':
-          return '2 of 2';
-        default:
-          return '';
-      }
-    } else {
-      // 3-step flow for changing existing PIN
-      switch (currentStep) {
-        case 'current':
-          return '1 of 3';
-        case 'new':
-          return '2 of 3';
-        case 'confirm':
-          return '3 of 3';
-        default:
-          return '';
-      }
+      return currentStep === 'new'
+        ? '1 of 2'
+        : currentStep === 'confirm'
+          ? '2 of 2'
+          : '';
+    }
+    switch (currentStep) {
+      case 'current':
+        return '1 of 3';
+      case 'new':
+        return '2 of 3';
+      case 'confirm':
+        return '3 of 3';
+      default:
+        return '';
     }
   };
 
-  // Show loading state while checking if PIN exists
+  const value = getCurrentPinValue();
+  const canProceed = isValidFor(stepSource, value) && !isSubmitting;
+
   if (isLoading) {
     return (
       <SafeAreaView style={styles.container} edges={['top']}>
         <UniversalHeader
-          title="PIN"
+          title="Security"
           showBackButton
           onBackPress={() => navigation.goBack()}
         />
@@ -262,7 +284,7 @@ export default function ChangePinScreen() {
   return (
     <SafeAreaView style={styles.container} edges={['top']}>
       <UniversalHeader
-        title={isInitialSetup ? 'Set PIN' : 'Change PIN'}
+        title={isInitialSetup ? 'Set Up Security' : 'Change PIN / Passphrase'}
         showBackButton
         onBackPress={handleBack}
       />
@@ -280,31 +302,75 @@ export default function ChangePinScreen() {
           <Text style={styles.message}>{getStepMessage()}</Text>
         </View>
 
+        {/* Choose the NEW credential kind at the 'new' step. Switching clears the
+            in-progress entries so a half-typed PIN can't leak into a passphrase. */}
+        {currentStep === 'new' && (
+          <View style={styles.modeToggle}>
+            {(['pin', 'passphrase'] as const).map((m) => {
+              const active = newSource === m;
+              return (
+                <Pressable
+                  key={m}
+                  onPress={() => {
+                    if (newSource === m) return;
+                    setNewSource(m);
+                    setNewPin('');
+                    setConfirmPin('');
+                  }}
+                  style={[
+                    styles.modeOption,
+                    active && { backgroundColor: theme.colors.primary },
+                  ]}
+                >
+                  <Text
+                    style={[
+                      styles.modeOptionText,
+                      {
+                        color: active
+                          ? theme.colors.buttonText
+                          : theme.colors.text,
+                      },
+                    ]}
+                  >
+                    {m === 'pin' ? '6-digit PIN' : 'Passphrase'}
+                  </Text>
+                </Pressable>
+              );
+            })}
+          </View>
+        )}
+
         <View style={styles.inputContainer}>
           <TextInput
-            style={styles.pinInput}
-            value={getCurrentPinValue()}
+            style={isPassphraseStep ? styles.passphraseInput : styles.pinInput}
+            value={value}
             onChangeText={setCurrentPinValue}
-            keyboardType="numeric"
-            maxLength={6}
+            keyboardType={isPassphraseStep ? 'default' : 'numeric'}
+            maxLength={isPassphraseStep ? undefined : 6}
             secureTextEntry
-            placeholder="••••••"
+            autoCapitalize={isPassphraseStep ? 'none' : 'sentences'}
+            autoCorrect={false}
+            placeholder={isPassphraseStep ? 'Enter passphrase' : '••••••'}
             placeholderTextColor={themeColors.placeholder}
             editable={!isSubmitting}
+            onSubmitEditing={() => {
+              if (canProceed) handleNext();
+            }}
+            returnKeyType={currentStep === 'confirm' ? 'go' : 'next'}
             autoFocus
           />
+          {isPassphraseStep && currentStep === 'new' && (
+            <PassphraseStrengthMeter
+              secret={value}
+              minLength={PASSPHRASE_MIN}
+            />
+          )}
         </View>
 
         <TouchableOpacity
-          style={[
-            styles.nextButton,
-            {
-              opacity:
-                getCurrentPinValue().length === 6 && !isSubmitting ? 1 : 0.5,
-            },
-          ]}
+          style={[styles.nextButton, { opacity: canProceed ? 1 : 0.5 }]}
           onPress={handleNext}
-          disabled={getCurrentPinValue().length !== 6 || isSubmitting}
+          disabled={!canProceed}
         >
           {isSubmitting ? (
             <ActivityIndicator size="small" color="white" />
@@ -312,8 +378,8 @@ export default function ChangePinScreen() {
             <Text style={styles.nextButtonText}>
               {currentStep === 'confirm'
                 ? isInitialSetup
-                  ? 'Set PIN'
-                  : 'Change PIN'
+                  ? 'Set'
+                  : 'Update'
                 : 'Next'}
             </Text>
           )}
@@ -322,16 +388,6 @@ export default function ChangePinScreen() {
         {attempts > 0 && currentStep === 'current' && (
           <Text style={styles.attemptsText}>Failed attempts: {attempts}/5</Text>
         )}
-
-        <View style={styles.helpContainer}>
-          <Text style={styles.helpText}>
-            {currentStep === 'current' &&
-              'Enter your current PIN to verify your identity'}
-            {currentStep === 'new' &&
-              'Choose a secure 6-digit PIN that you can remember'}
-            {currentStep === 'confirm' && 'Make sure both PINs match exactly'}
-          </Text>
-        </View>
       </KeyboardAwareScrollView>
     </SafeAreaView>
   );
@@ -384,6 +440,26 @@ const createStyles = (theme: Theme) =>
       textAlign: 'center',
       lineHeight: 22,
     },
+    modeToggle: {
+      flexDirection: 'row',
+      gap: theme.spacing.xs,
+      backgroundColor: theme.colors.glassBorder,
+      borderRadius: theme.borderRadius.lg,
+      padding: theme.spacing.xs,
+      width: '100%',
+      maxWidth: 300,
+      marginBottom: theme.spacing.lg,
+    },
+    modeOption: {
+      flex: 1,
+      paddingVertical: theme.spacing.sm,
+      borderRadius: theme.borderRadius.md,
+      alignItems: 'center',
+    },
+    modeOptionText: {
+      fontSize: 15,
+      fontWeight: '600',
+    },
     inputContainer: {
       width: '100%',
       maxWidth: 300,
@@ -399,6 +475,16 @@ const createStyles = (theme: Theme) =>
       borderWidth: 2,
       borderColor: theme.colors.inputBorder,
       fontWeight: '600',
+      color: theme.colors.text,
+    },
+    passphraseInput: {
+      backgroundColor: theme.colors.inputBackground,
+      borderRadius: theme.borderRadius.xl,
+      padding: theme.spacing.lg,
+      fontSize: 18,
+      borderWidth: 2,
+      borderColor: theme.colors.inputBorder,
+      fontWeight: '500',
       color: theme.colors.text,
     },
     nextButton: {
@@ -420,15 +506,5 @@ const createStyles = (theme: Theme) =>
       color: theme.colors.error,
       textAlign: 'center',
       marginBottom: theme.spacing.lg,
-    },
-    helpContainer: {
-      marginTop: theme.spacing.lg,
-      paddingHorizontal: theme.spacing.lg,
-    },
-    helpText: {
-      fontSize: 14,
-      color: theme.colors.textMuted,
-      textAlign: 'center',
-      lineHeight: 20,
     },
   });

--- a/src/screens/settings/ChangePinScreen.tsx
+++ b/src/screens/settings/ChangePinScreen.tsx
@@ -45,7 +45,6 @@ export default function ChangePinScreen() {
   const [newPin, setNewPin] = useState('');
   const [confirmPin, setConfirmPin] = useState('');
   const [isSubmitting, setIsSubmitting] = useState(false);
-  const [attempts, setAttempts] = useState(0);
   const [isInitialSetup, setIsInitialSetup] = useState(false);
   const [isLoading, setIsLoading] = useState(true);
   // The EXISTING credential kind (drives the 'current' step input) and the kind
@@ -153,12 +152,17 @@ export default function ChangePinScreen() {
         const isValid = await AccountSecureStorage.verifyPin(value);
         if (isValid) {
           setCurrentStep('new');
-          setAttempts(0);
         } else {
-          const newAttempts = attempts + 1;
-          setAttempts(newAttempts);
           setCurrentPin('');
-          if (newAttempts >= 5) {
+          // verifyPin enforces the PERSISTENT throttle (TASK-26); read it so the
+          // lockout is real and survives reopening this screen (a local counter
+          // would reset and grant free guesses — Codex P2). The service is the
+          // source of truth for both the remaining-attempts copy and the lockout.
+          const throttle = await AccountSecureStorage.getPinThrottleState();
+          if (
+            throttle.lockedUntil !== null &&
+            Date.now() < throttle.lockedUntil
+          ) {
             Alert.alert(
               'Too Many Attempts',
               'Too many failed attempts. Please try again later.',
@@ -167,7 +171,9 @@ export default function ChangePinScreen() {
           } else {
             Alert.alert(
               `Incorrect ${noun(currentSource)}`,
-              `${5 - newAttempts} attempts remaining.`
+              `${throttle.attemptsRemaining} attempt${
+                throttle.attemptsRemaining === 1 ? '' : 's'
+              } remaining.`
             );
           }
         }
@@ -384,10 +390,6 @@ export default function ChangePinScreen() {
             </Text>
           )}
         </TouchableOpacity>
-
-        {attempts > 0 && currentStep === 'current' && (
-          <Text style={styles.attemptsText}>Failed attempts: {attempts}/5</Text>
-        )}
       </KeyboardAwareScrollView>
     </SafeAreaView>
   );

--- a/src/screens/settings/SecuritySettingsScreen.tsx
+++ b/src/screens/settings/SecuritySettingsScreen.tsx
@@ -253,7 +253,7 @@ export default function SecuritySettingsScreen() {
             style={styles.settingItem}
             onPress={handleChangePin}
           >
-            <Text style={styles.settingText}>Change PIN</Text>
+            <Text style={styles.settingText}>Change PIN or Passphrase</Text>
             <Text style={styles.arrow}>→</Text>
           </TouchableOpacity>
 

--- a/src/services/secure/AccountSecureStorage.ts
+++ b/src/services/secure/AccountSecureStorage.ts
@@ -1177,6 +1177,15 @@ export class AccountSecureStorage {
     const fetchPromise = (async () => {
       try {
         let unlockMethod: 'pin' | 'biometric' = 'biometric';
+        // Vault epoch captured when a pin=undefined read is authorized BY THE
+        // VAULT (§6.4 gate). It scopes the WHOLE read to that unlocked session so
+        // the final guard aborts an in-flight read that straddles a lock — even a
+        // device-key (Format-A) decrypt, which arms no v2 epoch (Codex PR7 P1
+        // lock-race: otherwise such a read could resolve post-lock, return the
+        // key, and re-populate the 60 s cache that lock had just cleared). Stays
+        // -1 for an explicit-pin step-up read (authorized independently of the
+        // session) and for a no-credential ambient read.
+        let gatedVaultEpoch = -1;
 
         if (pin) {
           const isValidPin = await this.verifyPin(pin);
@@ -1233,6 +1242,11 @@ export class AccountSecureStorage {
                 'PIN or passphrase required to access private key'
               );
             }
+          } else {
+            // Authorized by the unlocked vault → scope the read to this session
+            // epoch so a lock mid-read aborts it (final guard below), closing the
+            // Format-A lock-race.
+            gatedVaultEpoch = SessionKeyVault.currentEpoch();
           }
 
           try {
@@ -1344,13 +1358,18 @@ export class AccountSecureStorage {
 
         await this.updateLastAccessed(accountId);
 
-        // Epoch guard (Codex P1-D), final await: a lock during
-        // updateLastAccessed clears the caches, so re-check BEFORE re-populating
-        // the 60 s cache. If the vault-derived read straddled a lock, zero the
-        // key and abort rather than caching/returning post-lock material.
+        // Epoch guard (Codex P1-D + PR7 P1 lock-race), final await: a lock during
+        // any await clears the caches and bumps the vault epoch, so re-check
+        // BEFORE returning/re-populating the 60 s cache. Abort (zero + throw) if
+        // EITHER (a) a vault-v2 unwrap straddled a lock (`v2VaultEpoch`), OR (b)
+        // this pin=undefined read was authorized by the vault gate and the session
+        // has since locked (`gatedVaultEpoch`) — the latter covers a device-key
+        // (Format-A) decrypt that arms no v2 epoch but must NOT return or re-cache
+        // key material under a session that no longer exists.
+        const currentEpoch = SessionKeyVault.currentEpoch();
         if (
-          v2VaultEpoch !== -1 &&
-          SessionKeyVault.currentEpoch() !== v2VaultEpoch
+          (v2VaultEpoch !== -1 && currentEpoch !== v2VaultEpoch) ||
+          (gatedVaultEpoch !== -1 && currentEpoch !== gatedVaultEpoch)
         ) {
           privateKey.fill(0);
           throw new VaultLockedError();

--- a/src/services/secure/AccountSecureStorage.ts
+++ b/src/services/secure/AccountSecureStorage.ts
@@ -1210,19 +1210,23 @@ export class AccountSecureStorage {
           // the device key decrypts regardless of vault state, so this is
           // behavior-preserving.
           //
-          // §6.4 READER GATE (PR7): the pin=undefined read is allowed when EITHER
-          // biometrics is enabled OR the SessionKeyVault is unlocked. The vault is
-          // populated at unlock from the just-verified PIN/passphrase, so once the
-          // user has unlocked, the ~14 background callers (WC auto-approve,
-          // messaging poll, send/sign) can read without re-entering the secret —
-          // for PIN-only AND passphrase-only wallets, not just biometric ones.
-          // This is what makes v2 keys usable when locked-then-unlocked without
-          // biometrics. A LOCKED vault with a PIN and no biometrics still throws
-          // (require an explicit unlock) rather than reading ambiently.
-          const biometricEnabled = await this.isBiometricEnabled();
+          // §6.4 READER GATE (PR7, tightened per Codex): the pin=undefined read of
+          // a credentialed wallet requires an UNLOCKED SessionKeyVault — full stop.
+          // The vault is populated at unlock from the just-verified PIN/passphrase
+          // (manual OR biometric — unlockWithBiometrics populates it too, PR6), so
+          // once the user has unlocked, the ~14 background callers can read without
+          // re-entering the secret, for PIN-only, passphrase-only, AND biometric
+          // wallets alike. We deliberately do NOT let the persisted
+          // `biometricEnabled` flag bypass this: that flag alone (with the vault
+          // LOCKED) would let a background caller device-decrypt a still-legacy
+          // Format-A key with no auth prompt while the app is locked — the exact
+          // ambient-read hole DR-2 closes. Biometric unlock is a convenience that
+          // goes THROUGH the vault, never around it. A locked vault on a
+          // key-bearing wallet throws (require an explicit unlock); a wallet with
+          // no credential (hasPin false) still reads ambiently as before.
           const vaultUnlocked = SessionKeyVault.isUnlocked();
 
-          if (!biometricEnabled && !vaultUnlocked) {
+          if (!vaultUnlocked) {
             const hasPin = await this.hasPin();
             if (hasPin) {
               throw new AuthenticationRequiredError(

--- a/src/services/secure/AccountSecureStorage.ts
+++ b/src/services/secure/AccountSecureStorage.ts
@@ -275,8 +275,9 @@ export class AccountSecureStorage {
   // passphrase is ~60+ bits, the real at-rest entropy lever, and composition
   // rules reject strong passphrases. The 6-digit PIN stays the default; the
   // passphrase is the opt-in strength lever. A live strength meter guides the UI
-  // but the ONLY hard gate is this length floor.
-  private static readonly PASSPHRASE_MIN_LENGTH = 12;
+  // but the ONLY hard gate is this length floor. Public so the setup/change UI
+  // can render the same floor it enforces.
+  static readonly PASSPHRASE_MIN_LENGTH = 12;
 
   private static legacyCheckRequired: boolean | undefined;
 

--- a/src/services/secure/AccountSecureStorage.ts
+++ b/src/services/secure/AccountSecureStorage.ts
@@ -270,6 +270,14 @@ export class AccountSecureStorage {
   private static readonly LEGACY_PIN_ITERATIONS = 1000;
   private static readonly PREVIOUS_PIN_ITERATIONS: number[] = [];
 
+  // Minimum length for an alphanumeric passphrase credential (DOC-137 §7/§12 Q6,
+  // PR7). LENGTH-ONLY policy (Dave 2026-07-16): no composition rules — a ~12-char
+  // passphrase is ~60+ bits, the real at-rest entropy lever, and composition
+  // rules reject strong passphrases. The 6-digit PIN stays the default; the
+  // passphrase is the opt-in strength lever. A live strength meter guides the UI
+  // but the ONLY hard gate is this length floor.
+  private static readonly PASSPHRASE_MIN_LENGTH = 12;
+
   private static legacyCheckRequired: boolean | undefined;
 
   private static secretKey(accountId: string): string {
@@ -1199,15 +1207,25 @@ export class AccountSecureStorage {
           // AuthContext reads with getItemWithAuth at unlock to populate the
           // SessionKeyVault. getPrivateKey is a pure reader: for Format-A payloads
           // the device key decrypts regardless of vault state, so this is
-          // behavior-preserving. A no-biometric wallet that still has a PIN keeps
-          // requiring the PIN (the throw below) rather than reading ambiently.
+          // behavior-preserving.
+          //
+          // §6.4 READER GATE (PR7): the pin=undefined read is allowed when EITHER
+          // biometrics is enabled OR the SessionKeyVault is unlocked. The vault is
+          // populated at unlock from the just-verified PIN/passphrase, so once the
+          // user has unlocked, the ~14 background callers (WC auto-approve,
+          // messaging poll, send/sign) can read without re-entering the secret —
+          // for PIN-only AND passphrase-only wallets, not just biometric ones.
+          // This is what makes v2 keys usable when locked-then-unlocked without
+          // biometrics. A LOCKED vault with a PIN and no biometrics still throws
+          // (require an explicit unlock) rather than reading ambiently.
           const biometricEnabled = await this.isBiometricEnabled();
+          const vaultUnlocked = SessionKeyVault.isUnlocked();
 
-          if (!biometricEnabled) {
+          if (!biometricEnabled && !vaultUnlocked) {
             const hasPin = await this.hasPin();
             if (hasPin) {
               throw new AuthenticationRequiredError(
-                'PIN required to access private key'
+                'PIN or passphrase required to access private key'
               );
             }
           }
@@ -1909,23 +1927,57 @@ export class AccountSecureStorage {
   // PIN Management Methods
 
   /**
-   * Validate a user secret for its kind. PIN is the enforced 6-digit default;
-   * passphrase policy (min length / entropy meter) is finalized in PR7 — here we
-   * only reject an empty passphrase so a blank secret can never commit.
+   * True iff `secret` is well-formed for its kind (DOC-137 §7, PR7): a PIN is
+   * exactly 6 digits; a passphrase is at least PASSPHRASE_MIN_LENGTH chars
+   * (length-only — no composition rules). Pure predicate, no throw — used by the
+   * verifyPin fast-reject (so a malformed entry is never counted as a throttle
+   * attempt) and as the basis for validateSecret.
+   */
+  static isSecretFormatValid(
+    secret: string,
+    secretSource: SecretSource
+  ): boolean {
+    if (!secret) {
+      return false;
+    }
+    if (secretSource === 'passphrase') {
+      return secret.length >= this.PASSPHRASE_MIN_LENGTH;
+    }
+    return secret.length === 6 && /^\d{6}$/.test(secret);
+  }
+
+  /**
+   * Validate a user secret for its kind, THROWING a user-facing message on
+   * failure (used at setup/change where we want to explain why). PIN = 6 digits;
+   * passphrase = min PASSPHRASE_MIN_LENGTH chars, length-only (DOC-137 §12 Q6).
    */
   private static validateSecret(
     secret: string,
     secretSource: SecretSource
   ): void {
-    if (secretSource === 'passphrase') {
-      if (!secret || secret.length === 0) {
-        throw new Error('Passphrase must not be empty');
-      }
+    if (this.isSecretFormatValid(secret, secretSource)) {
       return;
     }
-    if (!secret || secret.length !== 6 || !/^\d{6}$/.test(secret)) {
-      throw new Error('PIN must be 6 digits');
+    if (secretSource === 'passphrase') {
+      throw new Error(
+        `Passphrase must be at least ${this.PASSPHRASE_MIN_LENGTH} characters`
+      );
     }
+    throw new Error('PIN must be 6 digits');
+  }
+
+  /**
+   * The kind of the currently-stored credential (PIN vs passphrase), or null if
+   * no credential is set. Public so the UI (LockScreen / auth modals / settings)
+   * can render the numeric keypad vs a masked passphrase field. Never returns the
+   * secret itself — only its kind.
+   */
+  static async getCredentialSource(): Promise<SecretSource | null> {
+    const stored = await this.getStoredPinData();
+    if (!stored) {
+      return null;
+    }
+    return stored.secretSource ?? 'pin';
   }
 
   /**
@@ -1950,22 +2002,16 @@ export class AccountSecureStorage {
    * device-key copies intact; crash after commit → v2 copies valid, cleanup
    * idempotent).
    *
-   * TODO(PR7): allow `secretSource: 'passphrase'` once verifyPin supports a
-   * non-6-digit secret. Until then a passphrase credential would be
-   * UNRECOVERABLE — verifyPin rejects any non-6-digit input BEFORE the hash
-   * check — so passphrase is REFUSED here (Codex P1-4).
+   * PR7: `secretSource: 'passphrase'` is now supported — verifyPin validates and
+   * unlocks a passphrase credential by reading the stored kind, so a passphrase
+   * is recoverable. validateSecret enforces the per-kind format (PIN 6 digits,
+   * passphrase ≥ PASSPHRASE_MIN_LENGTH) before the credential commits.
    */
   static async setupPin(
     newSecret: string,
     secretSource: SecretSource = 'pin'
   ): Promise<void> {
     try {
-      if (secretSource !== 'pin') {
-        // TODO(PR7): remove once verifyPin can unlock a passphrase credential.
-        throw new Error(
-          'Passphrase credentials are not supported yet (PR7); only a 6-digit PIN can be set'
-        );
-      }
       this.validateSecret(newSecret, secretSource);
       // Acquire the GLOBAL key-mutation mutex, then run the atomic rewrap+commit
       // under it (P1-3: no verify/commit races). setupPin has no current secret
@@ -2001,9 +2047,15 @@ export class AccountSecureStorage {
    */
   static async verifyPin(pin: string): Promise<boolean> {
     // Malformed input never reaches the throttle: it can't unlock the wallet and
-    // is not produced by the UI (which only submits 6 digits), so it is not
-    // counted as an attempt.
-    if (!pin || pin.length !== 6 || !/^\d{6}$/.test(pin)) {
+    // is not counted as an attempt. Validate against the STORED credential's kind
+    // (PR7) so a passphrase credential accepts a ≥12-char passphrase while a PIN
+    // credential still rejects anything but 6 digits. No credential → reject.
+    const stored = await this.getStoredPinData();
+    if (!stored) {
+      return false;
+    }
+    const source: SecretSource = stored.secretSource ?? 'pin';
+    if (!this.isSecretFormatValid(pin, source)) {
       return false;
     }
 
@@ -2334,21 +2386,20 @@ export class AccountSecureStorage {
     }
   }
 
-  static async changePin(currentPin: string, newPin: string): Promise<void> {
+  static async changePin(
+    currentPin: string,
+    newPin: string,
+    newSource: SecretSource = 'pin'
+  ): Promise<void> {
     try {
-      // Validate inputs
-      if (
-        !currentPin ||
-        currentPin.length !== 6 ||
-        !/^\d{6}$/.test(currentPin)
-      ) {
-        throw new Error('Current PIN must be 6 digits');
-      }
-      if (!newPin || newPin.length !== 6 || !/^\d{6}$/.test(newPin)) {
-        throw new Error('New PIN must be 6 digits');
-      }
+      // Validate the NEW secret against its chosen kind (PR7: PIN=6 digits,
+      // passphrase=min length). The CURRENT secret's format is validated by
+      // verifyPin below (which reads the stored credential's kind), so a
+      // PIN→passphrase or passphrase→PIN switch is supported: `currentPin` is
+      // whatever the existing credential is, `newPin`/`newSource` is the target.
+      this.validateSecret(newPin, newSource);
       if (currentPin === newPin) {
-        throw new Error('New PIN must be different from current PIN');
+        throw new Error('New secret must be different from the current one');
       }
 
       // Acquire the GLOBAL key-mutation mutex FIRST, THEN verify the current PIN
@@ -2367,12 +2418,12 @@ export class AccountSecureStorage {
       await this.runKeyMutationExclusive(async () => {
         const isCurrentValid = await this.verifyPin(currentPin);
         if (!isCurrentValid) {
-          throw new Error('Current PIN is incorrect');
+          throw new Error('Current secret is incorrect');
         }
         await this.rewrapAndCommitCredentialLocked({
           currentSecret: currentPin,
           newSecret: newPin,
-          newSource: 'pin',
+          newSource,
         });
       });
       this.legacyCheckRequired = false;
@@ -2434,16 +2485,10 @@ export class AccountSecureStorage {
   }): Promise<void> {
     const { currentSecret, newSecret, newSource } = opts;
 
-    // TODO(PR7): a passphrase credential is UNRECOVERABLE today (verifyPin rejects
-    // any non-6-digit input before the hash check), so refuse to CREATE one until
-    // PR7 wires the passphrase verify/unlock path (Codex P1-4). Defense-in-depth:
-    // setupPin also rejects passphrase up front; changePin only ever passes 'pin'.
-    if (newSource !== 'pin') {
-      throw new AccountStorageError(
-        'Passphrase credentials are not supported yet (PR7)'
-      );
-    }
-
+    // PR7: both 'pin' and 'passphrase' new-credential kinds are supported here —
+    // verifyPin reads the stored `secretSource` and validates/unlocks accordingly,
+    // so a passphrase credential is fully recoverable. The new kind is folded into
+    // the credential (persistPinCredential) and each v2 blob (secretSource).
     const deviceSecret = await this.getStableDeviceId();
     const ids = await this.getAllAccountIds();
 

--- a/src/services/secure/__tests__/keyWriterChangePin.test.ts
+++ b/src/services/secure/__tests__/keyWriterChangePin.test.ts
@@ -750,7 +750,7 @@ describe('global key-mutation mutex (P1-B / P1-1a) — writers serialize with re
     expect(fulfilled).toHaveLength(1);
     expect(rejected).toHaveLength(1);
     expect((rejected[0] as PromiseRejectedResult).reason).toMatchObject({
-      message: expect.stringMatching(/Current PIN is incorrect/),
+      message: expect.stringMatching(/Current secret is incorrect/),
     });
 
     // The first changePin (acquires the lock first) wins → 222222.
@@ -793,15 +793,10 @@ describe('global key-mutation mutex (P1-B / P1-1a) — writers serialize with re
   }, 20000);
 });
 
-describe('passphrase credential rejected until PR7 (Codex P1-4)', () => {
-  it('setupPin with secretSource=passphrase throws (verifyPin cannot unlock it yet)', async () => {
-    await expect(
-      AccountSecureStorage.setupPin('correct horse battery', 'passphrase')
-    ).rejects.toThrow(/not supported yet|PR7/i);
-    // No credential was created.
-    expect(await AccountSecureStorage.hasPin()).toBe(false);
-  });
-});
+// NOTE: PR4's "passphrase credential rejected until PR7" guard was REMOVED in
+// PR7 — passphrase credentials are now supported end-to-end. That behavior is
+// covered by src/services/secure/__tests__/passphrase.test.ts (setupPin +
+// verifyPin + changePin PIN↔passphrase + the length-only policy).
 
 // ─────────────────────────────────────────────────────────────────────────────
 describe('payload budget enforced on write (§2.4 / PR1 carry-forward)', () => {
@@ -863,7 +858,7 @@ describe('changePin verify gate is throttle-aware (§8)', () => {
     // aborts BEFORE any re-wrap.
     await expect(
       AccountSecureStorage.changePin('999999', '222222')
-    ).rejects.toThrow(/Current PIN is incorrect/);
+    ).rejects.toThrow(/Current secret is incorrect/);
 
     // The secret payload is byte-for-byte unchanged; account still readable OLD.
     expect(mockPlatform.__secure.get(secretKey('acct-a'))).toBe(before);

--- a/src/services/secure/__tests__/passphrase.test.ts
+++ b/src/services/secure/__tests__/passphrase.test.ts
@@ -1,0 +1,323 @@
+// PR7 (TASK-27, DOC-137 §7) — optional PASSPHRASE credential + §6.4 reader gate.
+//
+// Proves:
+//   * validateSecret enforces the length-only passphrase policy (min 12, no
+//     composition rules) and the 6-digit PIN policy;
+//   * setupPin can create a PASSPHRASE credential and verifyPin unlocks it (the
+//     old "passphrase not supported yet" guards are gone);
+//   * a wrong-length passphrase is fast-rejected by verifyPin (no throttle spend);
+//   * changePin switches PIN → passphrase, re-wrapping keys byte-identically so
+//     the account still signs the SAME Algorand address afterward (AC8);
+//   * the §6.4 reader gate: getPrivateKey(pin=undefined) succeeds under an
+//     unlocked vault for a PIN-only/passphrase-only wallet (no biometrics), and
+//     still throws when the vault is locked.
+//
+// SECURITY NOTE: throwaway Ed25519 keypair + throwaway secrets. Nothing logged.
+
+jest.mock('@/platform', () => {
+  const nodeCrypto = require('crypto');
+  const secure = new Map<string, string>();
+  const kv = new Map<string, string>();
+  return {
+    __secure: secure,
+    __kv: kv,
+    __reset: () => {
+      secure.clear();
+      kv.clear();
+    },
+    crypto: {
+      getRandomBytes: async (n: number): Promise<Uint8Array> =>
+        Uint8Array.from(nodeCrypto.randomBytes(n)),
+      sha256: async (input: string): Promise<string> =>
+        nodeCrypto.createHash('sha256').update(input).digest('hex'),
+      randomUUID: () => nodeCrypto.randomUUID(),
+    },
+    secureStorage: {
+      getItem: jest.fn(async (k: string) =>
+        secure.has(k) ? secure.get(k)! : null
+      ),
+      setItem: jest.fn(async (k: string, v: string) => {
+        secure.set(k, v);
+      }),
+      deleteItem: jest.fn(async (k: string) => {
+        secure.delete(k);
+      }),
+      getItemWithAuth: jest.fn(async (k: string) =>
+        secure.has(k) ? secure.get(k)! : null
+      ),
+      setItemWithAuth: jest.fn(async (k: string, v: string) => {
+        secure.set(k, v);
+      }),
+    },
+    storage: {
+      getItem: jest.fn(async (k: string) => (kv.has(k) ? kv.get(k)! : null)),
+      setItem: jest.fn(async (k: string, v: string) => {
+        kv.set(k, v);
+      }),
+      removeItem: jest.fn(async (k: string) => {
+        kv.delete(k);
+      }),
+      multiRemove: jest.fn(async (keys: string[]) => {
+        keys.forEach((k) => kv.delete(k));
+      }),
+    },
+    biometrics: {
+      isAvailable: async () => false,
+      isEnrolled: async () => false,
+    },
+    deviceId: {
+      getDeviceId: async () => 'pr7-test-device-idfv',
+    },
+  };
+});
+
+import 'crypto-js';
+import 'crypto-js/hmac-sha256';
+import 'crypto-js/sha256';
+import 'crypto-js/aes';
+import 'crypto-js/mode-ctr';
+import 'crypto-js/pad-nopadding';
+import 'crypto-js/enc-hex';
+import 'crypto-js/pbkdf2';
+import { randomBytes } from 'crypto';
+import nacl from 'tweetnacl';
+import algosdk from 'algosdk';
+import * as platform from '@/platform';
+import { AccountSecureStorage } from '../AccountSecureStorage';
+import { SessionKeyVault } from '../SessionKeyVault';
+import { encryptKeyEnvelopeV2, KeyEnvelopeV2 } from '../envelopeV2';
+import type { ScryptKdfParams } from '../../backup/types';
+
+const DEVICE_ID = 'pr7-test-device-idfv';
+const FAST_PARAMS: ScryptKdfParams = { N: 2 ** 12, r: 8, p: 1, dkLen: 32 };
+const PIN = '246802';
+const PASSPHRASE = 'correct horse battery staple'; // 28 chars, ≥ 12
+
+const mockPlatform = platform as unknown as {
+  __secure: Map<string, string>;
+  __kv: Map<string, string>;
+  __reset: () => void;
+  secureStorage: { getItem: jest.Mock; setItem: jest.Mock };
+};
+
+const asPriv = AccountSecureStorage as unknown as {
+  encryptPrivateKeyV2: (
+    keyBytes: Uint8Array,
+    secret: string,
+    secretSource: 'pin' | 'passphrase',
+    options: { deviceBound: boolean }
+  ) => Promise<KeyEnvelopeV2>;
+  validateSecret: (secret: string, source: 'pin' | 'passphrase') => void;
+  throttleMirror: unknown;
+  legacyCheckRequired: boolean | undefined;
+};
+
+function hex(b: Uint8Array): string {
+  return Buffer.from(b).toString('hex');
+}
+
+function makeAlgoKey(): {
+  sk: Uint8Array;
+  pubkey: Uint8Array;
+  address: string;
+} {
+  const kp = nacl.sign.keyPair();
+  return {
+    sk: kp.secretKey,
+    pubkey: kp.publicKey,
+    address: algosdk.encodeAddress(kp.publicKey),
+  };
+}
+
+function addToList(id: string): void {
+  const raw = mockPlatform.__kv.get('voi_account_list');
+  const list: string[] = raw ? JSON.parse(raw) : [];
+  if (!list.includes(id)) list.push(id);
+  mockPlatform.__kv.set('voi_account_list', JSON.stringify(list));
+}
+
+async function seedV2(
+  id: string,
+  sk: Uint8Array,
+  secret: string,
+  source: 'pin' | 'passphrase'
+): Promise<void> {
+  const blob = await encryptKeyEnvelopeV2({
+    plaintext: sk,
+    secret,
+    secretSource: source,
+    deviceSecret: DEVICE_ID,
+    kdfParams: FAST_PARAMS,
+  });
+  mockPlatform.__secure.set(
+    `voi_account_secret_${id}`,
+    JSON.stringify({
+      accountId: id,
+      encryptedPrivateKey: '',
+      authMethod: 'pin',
+      version: 2,
+      blobs: [blob],
+    })
+  );
+  addToList(id);
+}
+
+function useFastWriter(): void {
+  jest
+    .spyOn(asPriv, 'encryptPrivateKeyV2')
+    .mockImplementation(async (keyBytes, secret, secretSource, options) =>
+      encryptKeyEnvelopeV2({
+        plaintext: keyBytes,
+        secret,
+        secretSource,
+        deviceSecret: options.deviceBound ? DEVICE_ID : undefined,
+        kdfParams: FAST_PARAMS,
+      })
+    );
+}
+
+function enableBiometrics(): void {
+  mockPlatform.__kv.set('voi_biometric_enabled', 'true');
+}
+
+beforeEach(() => {
+  mockPlatform.__reset();
+  AccountSecureStorage.clearPrivateKeyCache();
+  SessionKeyVault.clear();
+  asPriv.throttleMirror = null;
+  asPriv.legacyCheckRequired = undefined;
+  mockPlatform.secureStorage.getItem.mockImplementation(async (k: string) =>
+    mockPlatform.__secure.has(k) ? mockPlatform.__secure.get(k)! : null
+  );
+});
+
+afterEach(() => {
+  SessionKeyVault.clear();
+  jest.restoreAllMocks();
+});
+
+describe('validateSecret / isSecretFormatValid — passphrase policy', () => {
+  it('accepts a ≥12-char passphrase and rejects a shorter one', () => {
+    expect(() => asPriv.validateSecret(PASSPHRASE, 'passphrase')).not.toThrow();
+    expect(() => asPriv.validateSecret('short', 'passphrase')).toThrow(
+      /at least 12/
+    );
+    expect(() =>
+      asPriv.validateSecret('exactly12chr', 'passphrase')
+    ).not.toThrow(); // 12
+    expect(() => asPriv.validateSecret('elevenchars', 'passphrase')).toThrow(); // 11
+  });
+
+  it('does NOT enforce composition rules (length only)', () => {
+    expect(() =>
+      asPriv.validateSecret('aaaaaaaaaaaa', 'passphrase')
+    ).not.toThrow();
+  });
+
+  it('still enforces exactly-6-digits for a PIN', () => {
+    expect(() => asPriv.validateSecret('123456', 'pin')).not.toThrow();
+    expect(() => asPriv.validateSecret('12345', 'pin')).toThrow(/6 digits/);
+    expect(() => asPriv.validateSecret('12345a', 'pin')).toThrow(/6 digits/);
+    expect(() =>
+      asPriv.validateSecret('correct horse battery staple', 'pin')
+    ).toThrow(/6 digits/);
+  });
+
+  it('isSecretFormatValid mirrors the policy without throwing', () => {
+    expect(
+      AccountSecureStorage.isSecretFormatValid(PASSPHRASE, 'passphrase')
+    ).toBe(true);
+    expect(
+      AccountSecureStorage.isSecretFormatValid('short', 'passphrase')
+    ).toBe(false);
+    expect(AccountSecureStorage.isSecretFormatValid('123456', 'pin')).toBe(
+      true
+    );
+    expect(AccountSecureStorage.isSecretFormatValid('123', 'pin')).toBe(false);
+  });
+});
+
+describe('setupPin + verifyPin — passphrase credential end-to-end', () => {
+  it('creates a passphrase credential and verifyPin unlocks it', async () => {
+    await AccountSecureStorage.setupPin(PASSPHRASE, 'passphrase');
+    expect(await AccountSecureStorage.getCredentialSource()).toBe('passphrase');
+    expect(await AccountSecureStorage.verifyPin(PASSPHRASE)).toBe(true);
+    // A 6-digit PIN is NOT the credential → rejected.
+    expect(await AccountSecureStorage.verifyPin('123456')).toBe(false);
+  });
+
+  it('rejects setting a too-short passphrase', async () => {
+    await expect(
+      AccountSecureStorage.setupPin('short', 'passphrase')
+    ).rejects.toThrow(/Failed to set up PIN/);
+    expect(await AccountSecureStorage.getCredentialSource()).toBeNull();
+  });
+
+  it('fast-rejects a wrong-length passphrase without spending a throttle attempt', async () => {
+    await AccountSecureStorage.setupPin(PASSPHRASE, 'passphrase');
+    const before = await AccountSecureStorage.getPinThrottleState();
+    expect(await AccountSecureStorage.verifyPin('tooshort')).toBe(false);
+    const after = await AccountSecureStorage.getPinThrottleState();
+    // Malformed input is not counted as a failed attempt.
+    expect(after.attemptsRemaining).toBe(before.attemptsRemaining);
+  });
+});
+
+describe('changePin — PIN → passphrase switch re-wraps keys byte-identically', () => {
+  it('switches to a passphrase and the account still signs the SAME address', async () => {
+    const k = makeAlgoKey();
+    // Start with a PIN credential + a v2 account under the PIN.
+    await AccountSecureStorage.setupPin(PIN, 'pin');
+    await seedV2('acct', k.sk, PIN, 'pin');
+    useFastWriter();
+
+    await AccountSecureStorage.changePin(PIN, PASSPHRASE, 'passphrase');
+
+    // Credential is now a passphrase; the old PIN no longer verifies.
+    expect(await AccountSecureStorage.getCredentialSource()).toBe('passphrase');
+    expect(await AccountSecureStorage.verifyPin(PASSPHRASE)).toBe(true);
+    expect(await AccountSecureStorage.verifyPin(PIN)).toBe(false);
+
+    // The key round-trips byte-identically → same Algorand address + valid sign.
+    const sk = await AccountSecureStorage.getPrivateKey('acct', PASSPHRASE);
+    expect(hex(sk)).toBe(hex(k.sk));
+    expect(algosdk.encodeAddress(sk.slice(32))).toBe(k.address);
+    const msg = Uint8Array.from(randomBytes(32));
+    expect(
+      nacl.sign.detached.verify(msg, nacl.sign.detached(msg, sk), k.pubkey)
+    ).toBe(true);
+  });
+});
+
+describe('§6.4 reader gate — pin=undefined works under an unlocked vault', () => {
+  it('reads a v2 account with pin=undefined when the vault is unlocked (no biometrics)', async () => {
+    const k = makeAlgoKey();
+    await AccountSecureStorage.setupPin(PASSPHRASE, 'passphrase');
+    await seedV2('acct', k.sk, PASSPHRASE, 'passphrase');
+    // No biometrics. Unlock the vault as AuthContext would.
+    SessionKeyVault.set(PASSPHRASE, 'passphrase');
+
+    const sk = await AccountSecureStorage.getPrivateKey('acct'); // pin=undefined
+    expect(hex(sk)).toBe(hex(k.sk));
+  });
+
+  it('throws with pin=undefined when the vault is LOCKED and no biometrics', async () => {
+    const k = makeAlgoKey();
+    await AccountSecureStorage.setupPin(PASSPHRASE, 'passphrase');
+    await seedV2('acct', k.sk, PASSPHRASE, 'passphrase');
+    SessionKeyVault.clear(); // locked
+
+    await expect(AccountSecureStorage.getPrivateKey('acct')).rejects.toThrow();
+  });
+
+  it('still allows pin=undefined when biometrics is enabled (unchanged path)', async () => {
+    const k = makeAlgoKey();
+    await AccountSecureStorage.setupPin(PIN, 'pin');
+    await seedV2('acct', k.sk, PIN, 'pin');
+    enableBiometrics();
+    SessionKeyVault.set(PIN, 'pin');
+
+    const sk = await AccountSecureStorage.getPrivateKey('acct');
+    expect(hex(sk)).toBe(hex(k.sk));
+  });
+});

--- a/src/services/secure/__tests__/passphrase.test.ts
+++ b/src/services/secure/__tests__/passphrase.test.ts
@@ -108,6 +108,7 @@ const asPriv = AccountSecureStorage as unknown as {
     options: { deviceBound: boolean }
   ) => Promise<KeyEnvelopeV2>;
   validateSecret: (secret: string, source: 'pin' | 'passphrase') => void;
+  updateLastAccessed: (accountId: string) => Promise<void>;
   throttleMirror: unknown;
   legacyCheckRequired: boolean | undefined;
 };
@@ -373,6 +374,32 @@ describe('§6.4 reader gate — pin=undefined works under an unlocked vault', ()
     enableBiometrics();
     SessionKeyVault.clear(); // LOCKED — the biometric flag alone must not bypass
 
+    await expect(AccountSecureStorage.getPrivateKey('acct')).rejects.toThrow(
+      /required to access private key/
+    );
+  });
+
+  // Codex PR7 P1 (lock-race) regression: a pin=undefined Format-A read authorized
+  // while UNLOCKED that straddles a lock must ABORT — not return the key post-lock
+  // and not re-populate the 60 s cache (which lock had just cleared). The Format-A
+  // path arms no v2 epoch, so the gated-vault epoch is what catches it.
+  it('aborts a pin=undefined Format-A read (and does not cache) if the vault locks mid-read', async () => {
+    const k = makeAlgoKey();
+    await AccountSecureStorage.setupPin(PIN, 'pin');
+    seedFormatA('acct', k.sk);
+    SessionKeyVault.set(PIN, 'pin'); // unlocked when the read STARTS
+
+    // Simulate a lock landing DURING the read: clear the vault (bumps the epoch)
+    // right after the device-key decrypt, at the updateLastAccessed await.
+    jest.spyOn(asPriv, 'updateLastAccessed').mockImplementation(async () => {
+      SessionKeyVault.clear();
+    });
+
+    await expect(AccountSecureStorage.getPrivateKey('acct')).rejects.toThrow();
+
+    // The read did NOT re-populate the cache: a subsequent read (vault still
+    // locked) throws the gate error rather than serving a cached key.
+    jest.restoreAllMocks();
     await expect(AccountSecureStorage.getPrivateKey('acct')).rejects.toThrow(
       /required to access private key/
     );

--- a/src/services/secure/__tests__/passphrase.test.ts
+++ b/src/services/secure/__tests__/passphrase.test.ts
@@ -136,6 +136,46 @@ function addToList(id: string): void {
   mockPlatform.__kv.set('voi_account_list', JSON.stringify(list));
 }
 
+/** Seed a legacy Format-A (device-key) account — a 4-colon blob wrapped by the
+ *  device key alone (no user secret needed to decrypt), as pre-Wave-2 wallets store. */
+function seedFormatA(id: string, sk: Uint8Array): void {
+  const CryptoJS = require('crypto-js');
+  const nodeCrypto = require('crypto');
+  const saltHex: string = nodeCrypto.randomBytes(32).toString('hex');
+  const ivHex: string = nodeCrypto.randomBytes(16).toString('hex');
+  const baseEntropy: string = nodeCrypto
+    .createHash('sha256')
+    .update(`voi_wallet_${DEVICE_ID}`)
+    .digest('hex');
+  const keyMaterial: string = CryptoJS.PBKDF2(
+    baseEntropy,
+    CryptoJS.enc.Hex.parse(saltHex),
+    { keySize: 8, iterations: 10000, hasher: CryptoJS.algo.SHA256 }
+  ).toString(CryptoJS.enc.Hex);
+  const ct: string = CryptoJS.AES.encrypt(
+    hex(sk),
+    CryptoJS.enc.Hex.parse(keyMaterial),
+    {
+      iv: CryptoJS.enc.Hex.parse(ivHex),
+      mode: CryptoJS.mode.CTR,
+      padding: CryptoJS.pad.NoPadding,
+    }
+  ).toString();
+  const hmac: string = CryptoJS.HmacSHA256(
+    ct,
+    CryptoJS.SHA256(keyMaterial + 'hmac_salt').toString()
+  ).toString();
+  mockPlatform.__secure.set(
+    `voi_account_secret_${id}`,
+    JSON.stringify({
+      accountId: id,
+      encryptedPrivateKey: `${saltHex}:${ivHex}:${ct}:${hmac}`,
+      authMethod: 'pin',
+    })
+  );
+  addToList(id);
+}
+
 async function seedV2(
   id: string,
   sk: Uint8Array,
@@ -310,14 +350,31 @@ describe('§6.4 reader gate — pin=undefined works under an unlocked vault', ()
     await expect(AccountSecureStorage.getPrivateKey('acct')).rejects.toThrow();
   });
 
-  it('still allows pin=undefined when biometrics is enabled (unchanged path)', async () => {
+  it('allows pin=undefined when biometrics is enabled AND the vault is unlocked', async () => {
     const k = makeAlgoKey();
     await AccountSecureStorage.setupPin(PIN, 'pin');
     await seedV2('acct', k.sk, PIN, 'pin');
     enableBiometrics();
-    SessionKeyVault.set(PIN, 'pin');
+    SessionKeyVault.set(PIN, 'pin'); // biometric unlock populates the vault
 
     const sk = await AccountSecureStorage.getPrivateKey('acct');
     expect(hex(sk)).toBe(hex(k.sk));
+  });
+
+  // Codex PR7 P1 regression: the persisted biometricEnabled flag ALONE must NOT
+  // open the gate while the vault is LOCKED — otherwise a background caller could
+  // device-decrypt a legacy Format-A key (which needs NO user secret) with no auth
+  // prompt on a locked wallet. Format A is used precisely because it WOULD decrypt
+  // absent the gate — so the throw proves the gate, not just a missing key.
+  it('THROWS with pin=undefined when biometrics is enabled but the vault is LOCKED (Format A)', async () => {
+    const k = makeAlgoKey();
+    await AccountSecureStorage.setupPin(PIN, 'pin');
+    seedFormatA('acct', k.sk); // device-key wrap — decryptable without a secret
+    enableBiometrics();
+    SessionKeyVault.clear(); // LOCKED — the biometric flag alone must not bypass
+
+    await expect(AccountSecureStorage.getPrivateKey('acct')).rejects.toThrow(
+      /required to access private key/
+    );
   });
 });

--- a/src/utils/__tests__/passphraseStrength.test.ts
+++ b/src/utils/__tests__/passphraseStrength.test.ts
@@ -1,0 +1,50 @@
+import { estimatePassphraseStrength } from '../passphraseStrength';
+
+const MIN = 12;
+
+describe('estimatePassphraseStrength', () => {
+  it('scores below the min length as "too short" (0)', () => {
+    const r = estimatePassphraseStrength('short', MIN);
+    expect(r.score).toBe(0);
+    expect(r.label).toBe('too short');
+    expect(r.meetsMinLength).toBe(false);
+    expect(r.bits).toBe(0);
+  });
+
+  it('treats the empty string as too short', () => {
+    expect(estimatePassphraseStrength('', MIN).score).toBe(0);
+  });
+
+  it('discounts a long but trivial (all-same-char) string', () => {
+    const r = estimatePassphraseStrength('aaaaaaaaaaaa', MIN); // 12 chars, 1 unique
+    expect(r.meetsMinLength).toBe(true);
+    expect(r.score).toBeLessThanOrEqual(2); // not "good"/"strong"
+  });
+
+  it('scores a 12-char mixed passphrase as good or strong', () => {
+    const r = estimatePassphraseStrength('Tr0ub4dour&3x', MIN);
+    expect(r.meetsMinLength).toBe(true);
+    expect(r.score).toBeGreaterThanOrEqual(3);
+  });
+
+  it('scores a long multi-word passphrase as strong', () => {
+    const r = estimatePassphraseStrength('correct horse battery staple', MIN);
+    expect(r.score).toBe(4);
+    expect(r.label).toBe('strong');
+  });
+
+  it('larger character pool + length ⇒ more bits', () => {
+    const lower = estimatePassphraseStrength('abcdefghijkl', MIN).bits;
+    const mixed = estimatePassphraseStrength('aB3$eFgH1jKl', MIN).bits;
+    expect(mixed).toBeGreaterThan(lower);
+  });
+
+  it('meetsMinLength flips exactly at the floor', () => {
+    expect(estimatePassphraseStrength('a'.repeat(11), MIN).meetsMinLength).toBe(
+      false
+    );
+    expect(estimatePassphraseStrength('a'.repeat(12), MIN).meetsMinLength).toBe(
+      true
+    );
+  });
+});

--- a/src/utils/passphraseStrength.ts
+++ b/src/utils/passphraseStrength.ts
@@ -1,0 +1,83 @@
+/**
+ * Lightweight, dependency-free passphrase strength estimate (TASK-27 PR7).
+ *
+ * This drives the passphrase entropy METER shown at setup — it is GUIDANCE ONLY.
+ * The single HARD gate on a passphrase is the min-length floor enforced by
+ * AccountSecureStorage.validateSecret (DOC-137 §7/§12 Q6: length-only, no
+ * composition rules). We deliberately avoid zxcvbn (~400 KB+) to keep the RN/Hermes
+ * bundle small; this is a rough character-pool × length entropy approximation with
+ * mild penalties so a long-but-trivial string ("aaaaaaaaaaaa") does not read as
+ * strong. It never rejects — it only scores.
+ *
+ * SECURITY NOTE: never log the secret. This module returns only an aggregate score.
+ */
+
+export type PassphraseStrengthScore = 0 | 1 | 2 | 3 | 4;
+
+export interface PassphraseStrength {
+  /** 0 = too short, 1 = weak … 4 = strong. */
+  score: PassphraseStrengthScore;
+  /** Short human label for the meter. */
+  label: 'too short' | 'weak' | 'fair' | 'good' | 'strong';
+  /** Rough estimated entropy in bits (for display/debug; not a gate). */
+  bits: number;
+  /** True once the length floor is met (mirrors the real hard gate). */
+  meetsMinLength: boolean;
+}
+
+const LABELS: Record<PassphraseStrengthScore, PassphraseStrength['label']> = {
+  0: 'too short',
+  1: 'weak',
+  2: 'fair',
+  3: 'good',
+  4: 'strong',
+};
+
+/** Size of the character pool the secret draws from (used ⇒ contributes). */
+function poolSize(secret: string): number {
+  let size = 0;
+  if (/[a-z]/.test(secret)) size += 26;
+  if (/[A-Z]/.test(secret)) size += 26;
+  if (/[0-9]/.test(secret)) size += 10;
+  // Everything else (symbols, punctuation, whitespace, unicode) — approximate.
+  if (/[^a-zA-Z0-9]/.test(secret)) size += 33;
+  return size || 1;
+}
+
+/**
+ * Estimate strength. `minLength` is the same floor validateSecret enforces — a
+ * secret shorter than it always scores 0 ('too short'), matching the hard gate.
+ */
+export function estimatePassphraseStrength(
+  secret: string,
+  minLength: number
+): PassphraseStrength {
+  const meetsMinLength = secret.length >= minLength;
+  if (!secret || !meetsMinLength) {
+    return { score: 0, label: LABELS[0], bits: 0, meetsMinLength };
+  }
+
+  const pool = poolSize(secret);
+  // Base entropy from an idealized draw: length × log2(pool).
+  let bits = secret.length * Math.log2(pool);
+
+  // Uniqueness penalty: repeated characters lower real entropy. Scale by the
+  // fraction of distinct characters (e.g. "aaaaaaaaaaaa" → heavy discount).
+  const uniqueRatio = new Set(secret).size / secret.length;
+  bits *= 0.35 + 0.65 * uniqueRatio;
+
+  // Map bits → a 0–4 score. Thresholds chosen so a ~12-char mixed passphrase
+  // (~60+ bits) reads 'good'/'strong' and a min-length all-same string reads 'weak'.
+  let score: PassphraseStrengthScore;
+  if (bits < 40) score = 1;
+  else if (bits < 60) score = 2;
+  else if (bits < 80) score = 3;
+  else score = 4;
+
+  return {
+    score,
+    label: LABELS[score],
+    bits: Math.round(bits),
+    meetsMinLength,
+  };
+}


### PR DESCRIPTION
## TASK-27 PR7 — optional passphrase + §6.4 reader-gate

The final unit of the Wave-2 key-at-rest hardening ([PLAN-10] / [DOC-137] §7). Adds an **optional alphanumeric passphrase** as an alternative to the 6-digit PIN — the real at-rest entropy lever — and makes the `SessionKeyVault` the load-bearing gate for background reads.

### Crypto / auth core

- **Passphrase policy** (Dave: min **12** chars, **length-only**, no composition rules — DOC-137 §12 Q6): `validateSecret` + a non-throwing `isSecretFormatValid` predicate; `PASSPHRASE_MIN_LENGTH = 12`.
- **`verifyPin`** fast-reject now dispatches on the **stored** credential kind (accepts a ≥12-char passphrase for a passphrase credential; still rejects non-6-digit for a PIN) — no throttle bypass; malformed input still isn't counted.
- **`setupPin` / `changePin` / `rewrapAndCommitCredentialLocked`**: removed the "passphrase not supported yet (PR7)" guards. `changePin` takes a target `newSource`, so a wallet can **switch PIN↔passphrase** — keys re-wrapped **byte-identically** via PR4's audited dual-blob transaction (same Algorand address, proven by an AC8 test + a real Ed25519/Pera-style sign).
- **`getCredentialSource()`**: public getter so the UI renders the numeric keypad vs a masked field.
- **§6.4 reader-gate**: `getPrivateKey`'s `pin=undefined` branch now requires **`SessionKeyVault.isUnlocked()`**. This both (a) makes v2 keys usable once unlocked for PIN-only *and* passphrase-only wallets (not just biometric ones), and (b) **closes a pre-existing locked-read hole** Codex flagged — the persisted `biometricEnabled` flag no longer bypasses the gate on its own, so a background caller can no longer device-decrypt a legacy Format-A key while the app is locked. Biometric unlock still works because it *populates* the vault (PR6) — convenience goes through the vault, never around it. A no-credential wallet still reads ambiently.
- **AuthContext**: `unlock(secret)` / `setupPin(secret, source)` generalized; the vault is tagged with the stored kind.

### UI

- **`PassphraseStrengthMeter`** + `passphraseStrength` util: dependency-free strength meter (guidance only; the hard gate is the length floor — no zxcvbn, keeps the Hermes bundle small).
- **`SecuritySetupScreen`**: PIN vs passphrase mode toggle; masked passphrase inputs + live meter; biometric-convenience captures the chosen kind.
- **`LockScreen`**: reads the stored kind and renders the numeric keypad (PIN) or a masked passphrase field + Unlock; kind-aware copy.
- **`UnifiedAuthModal` + `SignerAuthModal`** (step-up signing): same keypad-vs-masked switch; the full passphrase string flows through `verifyPin` → `onSuccess` (never truncated, never logged). PIN keypad path unchanged (6 digits, auto-submit).

### Review

Codex (multi-round) → final **CLEAN**: **recoverability SAFE · PIN↔passphrase switch SAFE · throttle SAFE · UI secret-handling SAFE** (masked, untrimmed, no logging, policy consistent). The reader-gate went through **two Codex fix rounds** (both Dave-approved, both with regression tests): (1) dropped the `biometricEnabled` bypass so a `pin=undefined` read requires an unlocked vault; (2) closed the follow-on **lock-race** — an in-flight Format-A read authorized while unlocked could resolve post-lock and re-cache the key, now aborted by a `gatedVaultEpoch` guard (zero + throw before the cache write). Independently verified: lock clears the 60s cache, no post-guard await, explicit-pin/no-credential reads unchanged.

### Gates

- `npm run typecheck` — **0** · `npm run lint` — **0** · `npm test` — **486 pass** (+35 PR7: passphrase policy, setup/verify, changePin PIN→passphrase byte-identity/Pera AC8, reader-gate on/off, **biometrics+locked-vault→throws** regression, strength meter).

### ⚠️ Merge gate — device verification (auth/signing surface)

Touches unlock + signing. Before merge, verify on a dev-client build: create a **passphrase** wallet (min-12, meter), lock + unlock with the passphrase, send / WC-sign / messaging; switch an existing PIN wallet to a passphrase (addresses unchanged, Pera cross-signs); confirm a biometric wallet still unlocks + signs, and that a **locked** biometric wallet no longer background-reads without unlock.

### Deferred fast-follow (noted for your call)

The "**switch an existing PIN wallet to a passphrase**" affordance in **ChangePinScreen / SecuritySettings** is not wired — but the change-kind **crypto is already implemented + tested** (`changePin` PIN↔passphrase byte-identity); only the settings UI remains. New wallets get the full passphrase feature today. Also: WC background auto-approve-while-locked (R-15) will now throw `AuthenticationRequiredError` instead of ambient-reading — messaging already defers on lock (PR3); WC's locked-state routing should be confirmed/wired as part of R-15.

https://claude.ai/code/session_01FfbFvUJtj9hVCaYZ4MS4y3
