### PR TITLE
feat(secure): v2 signed remote-signer pairing crypto core (TASK-142)

### DIFF
--- a/src/services/backup/collectors.ts
+++ b/src/services/backup/collectors.ts
@@ -15,6 +15,7 @@ import {
   RekeyedAccountMetadata,
   LedgerAccountMetadata,
   RemoteSignerAccountMetadata,
+  withDefaultAuthLevel,
 } from '@/types/wallet';
 import { Friend } from '@/types/social';
 import { NetworkId } from '@/types/network';
@@ -164,6 +165,8 @@ export async function collectAccounts(
             signerDeviceName: remoteSignerAccount.signerDeviceName,
             pairedAt: remoteSignerAccount.pairedAt,
             lastSigningActivity: remoteSignerAccount.lastSigningActivity,
+            // Conservative default for legacy records with no persisted level.
+            authLevel: withDefaultAuthLevel(remoteSignerAccount.authLevel),
           });
           break;
         }

--- a/src/services/backup/restorers.ts
+++ b/src/services/backup/restorers.ts
@@ -19,6 +19,7 @@ import {
   LedgerAccountMetadata,
   RemoteSignerAccountMetadata,
   Wallet,
+  withDefaultAuthLevel,
 } from '@/types/wallet';
 import { Friend } from '@/types/social';
 import {
@@ -334,6 +335,8 @@ export async function restoreAccounts(accounts: BackupAccountData[]): Promise<{
             signerDeviceName: backupAccount.signerDeviceName,
             pairedAt: backupAccount.pairedAt,
             lastSigningActivity: backupAccount.lastSigningActivity,
+            // Conservative default for backups written before this field existed.
+            authLevel: withDefaultAuthLevel(backupAccount.authLevel),
           };
 
           await AccountSecureStorage.storeAccount(remoteSignerAccount);

--- a/src/services/backup/types.ts
+++ b/src/services/backup/types.ts
@@ -4,7 +4,7 @@
  * Type definitions for the wallet backup and restore functionality.
  */
 
-import { AccountType } from '@/types/wallet';
+import { AccountType, RemoteSignerAuthLevel } from '@/types/wallet';
 import { Friend } from '@/types/social';
 import { NetworkId } from '@/types/network';
 
@@ -98,6 +98,8 @@ export interface BackupAccountData {
   pairedAt?: string;
   /** ISO timestamp of last signing activity */
   lastSigningActivity?: string;
+  /** Pairing authentication level (defaults to 'v1-unsigned' when absent) */
+  authLevel?: RemoteSignerAuthLevel;
 }
 
 /**

--- a/src/services/remoteSigner/__tests__/pairing.test.ts
+++ b/src/services/remoteSigner/__tests__/pairing.test.ts
@@ -1,0 +1,608 @@
+/**
+ * Unit tests for the authenticated remote-signer pairing crypto core.
+ *
+ * These are Layer-1 pure tests: they build REAL Ed25519 material in-process
+ * (algosdk accounts + tweetnacl) and assert the SPECIFICATION-correct behaviour
+ * of `buildPairingMessage` / `verifyPairing`, then tamper each field and assert
+ * fail-closed rejection.
+ *
+ * Signing here mirrors exactly what `signPairingMessage` does
+ * (`nacl.sign.detached` over `buildPairingMessage` bytes) WITHOUT the
+ * secure-storage graph, so the suite stays pure while covering the same bytes
+ * the signer produces.
+ */
+
+import algosdk from 'algosdk';
+import nacl from 'tweetnacl';
+
+import {
+  buildPairingMessage,
+  verifyPairing,
+  assertCanonicalAddressSet,
+  PAIRING_MESSAGE_DOMAIN,
+} from '../pairing';
+import { PAIRING_VERSION } from '@/types/remoteSigner';
+import { withDefaultAuthLevel } from '@/types/wallet';
+
+// ---------------------------------------------------------------------------
+// Fixtures / helpers
+// ---------------------------------------------------------------------------
+
+interface TestAccount {
+  addr: string;
+  sk: Uint8Array; // 64-byte ed25519 secret key (nacl-compatible)
+  pk: Uint8Array; // 32-byte public key
+}
+
+/** Deterministic account from a fixed 32-byte seed (reproducible addresses). */
+function seededAccount(seedByte: number): TestAccount {
+  const seed = new Uint8Array(32).fill(seedByte);
+  const kp = nacl.sign.keyPair.fromSeed(seed);
+  return {
+    addr: algosdk.encodeAddress(kp.publicKey),
+    sk: kp.secretKey,
+    pk: kp.publicKey,
+  };
+}
+
+const DEFAULT_DEV = 'voi-signer-11111111-2222-3333-4444-555555555555';
+const DEFAULT_TS = 1700000000000;
+
+const pkHex = (addr: string): string =>
+  Buffer.from(algosdk.decodeAddress(addr).publicKey).toString('hex');
+
+/** Sign a pairing message the same way `signPairingMessage` would. */
+function signPairing(
+  dev: string,
+  ts: number,
+  setAddrs: string[],
+  addr: string,
+  sk: Uint8Array
+): string {
+  const message = buildPairingMessage({
+    dev,
+    ts,
+    accts: setAddrs.map((a) => ({ addr: a })),
+    addr,
+  });
+  return Buffer.from(nacl.sign.detached(message, sk)).toString('base64');
+}
+
+interface PayloadAcct {
+  addr: string;
+  sk: Uint8Array;
+  pk?: string;
+  label?: string;
+}
+
+/** Assemble a valid v2 (signed) pairing payload from the given accounts. */
+function makeV2Payload(
+  accts: PayloadAcct[],
+  opts?: { dev?: string; ts?: number; name?: string }
+): Record<string, unknown> {
+  const dev = opts?.dev ?? DEFAULT_DEV;
+  const ts = opts?.ts ?? DEFAULT_TS;
+  const setAddrs = accts.map((a) => a.addr);
+  return {
+    v: PAIRING_VERSION,
+    t: 'pair',
+    dev,
+    ts,
+    ...(opts?.name !== undefined ? { name: opts.name } : {}),
+    accts: accts.map((a) => ({
+      addr: a.addr,
+      pk: a.pk ?? pkHex(a.addr),
+      sig: signPairing(dev, ts, setAddrs, a.addr, a.sk),
+      ...(a.label !== undefined ? { label: a.label } : {}),
+    })),
+  };
+}
+
+// ---------------------------------------------------------------------------
+// 1. Frozen test vector — the on-wire encoding must never silently drift.
+// ---------------------------------------------------------------------------
+
+describe('buildPairingMessage — frozen vector', () => {
+  // Computed once, out-of-band, from the intended layout:
+  //   "voi-remote-signer-pair/v2\n" + dev + "\n" + String(ts) + "\n" + setStr + "\n" + addr
+  const FROZEN_HEX =
+    '766f692d72656d6f74652d7369676e65722d706169722f76320a766f692d7369676e65722d66697865642d6465760a313730303030303030303030300a414444525f4f4e452c414444525f54574f0a414444525f4f4e45';
+
+  it('encodes the exact frozen bytes (unsorted input is canonically sorted)', () => {
+    const bytes = buildPairingMessage({
+      dev: 'voi-signer-fixed-dev',
+      ts: 1700000000000,
+      // Deliberately UNSORTED — the serializer must sort the set.
+      accts: [{ addr: 'ADDR_TWO' }, { addr: 'ADDR_ONE' }],
+      addr: 'ADDR_ONE',
+    });
+    expect(Buffer.from(bytes).toString('hex')).toBe(FROZEN_HEX);
+    expect(bytes.length).toBe(87);
+  });
+
+  it('starts with the domain-separation prefix beginning with 0x76 ("v")', () => {
+    expect(PAIRING_MESSAGE_DOMAIN).toBe('voi-remote-signer-pair/v2\n');
+    const bytes = buildPairingMessage({
+      dev: 'd',
+      ts: 1,
+      accts: [{ addr: 'A' }],
+      addr: 'A',
+    });
+    expect(bytes[0]).toBe(0x76); // 'v'
+    // Disjoint from Algorand tx domain: must NOT begin with "TX".
+    expect(bytes[0]).not.toBe(0x54); // 'T'
+  });
+
+  it('rejects a non-integer timestamp', () => {
+    expect(() =>
+      buildPairingMessage({
+        dev: 'd',
+        ts: 1.5,
+        accts: [{ addr: 'A' }],
+        addr: 'A',
+      })
+    ).toThrow(/integer/);
+    expect(() =>
+      buildPairingMessage({
+        dev: 'd',
+        ts: NaN,
+        accts: [{ addr: 'A' }],
+        addr: 'A',
+      })
+    ).toThrow(/integer/);
+  });
+
+  it('rejects non-ASCII dev or addr', () => {
+    expect(() =>
+      buildPairingMessage({
+        dev: 'dëv',
+        ts: 1,
+        accts: [{ addr: 'A' }],
+        addr: 'A',
+      })
+    ).toThrow(/ASCII/);
+    expect(() =>
+      buildPairingMessage({
+        dev: 'd',
+        ts: 1,
+        accts: [{ addr: 'A' }],
+        addr: 'Å',
+      })
+    ).toThrow(/ASCII/);
+  });
+
+  it('does not mutate the caller-supplied accts array', () => {
+    const accts = [{ addr: 'ZZZ' }, { addr: 'AAA' }];
+    buildPairingMessage({ dev: 'd', ts: 1, accts, addr: 'AAA' });
+    expect(accts.map((a) => a.addr)).toEqual(['ZZZ', 'AAA']);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// 2. Domain separation — a pairing sig and a txn sig are mutually non-verifying.
+// ---------------------------------------------------------------------------
+
+describe('domain separation: pairing sig <-> algorand txn sig', () => {
+  const acct = seededAccount(1);
+  const setAddrs = [acct.addr];
+
+  const pairingMessage = buildPairingMessage({
+    dev: DEFAULT_DEV,
+    ts: DEFAULT_TS,
+    accts: setAddrs.map((a) => ({ addr: a })),
+    addr: acct.addr,
+  });
+
+  // A real algosdk transaction's bytesToSign (prefixed with "TX").
+  const txn = algosdk.makePaymentTxnWithSuggestedParamsFromObject({
+    sender: acct.addr,
+    receiver: acct.addr,
+    amount: 0,
+    suggestedParams: {
+      fee: 1000,
+      firstValid: 1,
+      lastValid: 1001,
+      genesisID: 'voi-test-v1',
+      genesisHash: new Uint8Array(32),
+      flatFee: true,
+      minFee: 1000,
+    } as algosdk.SuggestedParams,
+  });
+  const txnBytesToSign = txn.bytesToSign();
+
+  const pairingSig = nacl.sign.detached(pairingMessage, acct.sk);
+  const txnSig = nacl.sign.detached(txnBytesToSign, acct.sk);
+
+  it('the two signed byte-strings are disjoint at the domain prefix', () => {
+    // Algorand tx bytes start with "TX"; pairing bytes start with "v".
+    expect(txnBytesToSign[0]).toBe(0x54); // 'T'
+    expect(pairingMessage[0]).toBe(0x76); // 'v'
+  });
+
+  it('a pairing signature does NOT verify as a transaction signature', () => {
+    expect(nacl.sign.detached.verify(txnBytesToSign, pairingSig, acct.pk)).toBe(
+      false
+    );
+  });
+
+  it('a transaction signature does NOT verify as a pairing signature', () => {
+    expect(nacl.sign.detached.verify(pairingMessage, txnSig, acct.pk)).toBe(
+      false
+    );
+  });
+
+  it('verifyPairing REJECTS a payload whose sig is actually a txn signature', () => {
+    const payload = {
+      v: PAIRING_VERSION,
+      t: 'pair',
+      dev: DEFAULT_DEV,
+      ts: DEFAULT_TS,
+      accts: [
+        {
+          addr: acct.addr,
+          pk: pkHex(acct.addr),
+          sig: Buffer.from(txnSig).toString('base64'),
+        },
+      ],
+    };
+    const result = verifyPairing(payload);
+    expect(result.status).toBe('rejected');
+  });
+});
+
+// ---------------------------------------------------------------------------
+// 3. Round-trip — a correctly-signed payload verifies.
+// ---------------------------------------------------------------------------
+
+describe('verifyPairing — round-trip accept', () => {
+  it('accepts a single-account v2 payload and derives the pubkey from addr', () => {
+    const a = seededAccount(1);
+    const payload = makeV2Payload([{ addr: a.addr, sk: a.sk, label: 'Cold' }]);
+
+    const result = verifyPairing(payload);
+    expect(result.status).toBe('v2-verified');
+    if (result.status !== 'v2-verified') return;
+
+    expect(result.pairing.authLevel).toBe('v2-signed');
+    expect(result.pairing.dev).toBe(DEFAULT_DEV);
+    expect(result.pairing.ts).toBe(DEFAULT_TS);
+    expect(result.pairing.accounts).toHaveLength(1);
+    expect(result.pairing.accounts[0].addr).toBe(a.addr);
+    expect(result.pairing.accounts[0].publicKey).toBe(pkHex(a.addr));
+    expect(result.pairing.accounts[0].label).toBe('Cold');
+  });
+
+  it('accepts a multi-account v2 payload (all set-bound sigs valid)', () => {
+    const accts = [seededAccount(1), seededAccount(2), seededAccount(3)];
+    const payload = makeV2Payload(
+      accts.map((a) => ({ addr: a.addr, sk: a.sk }))
+    );
+
+    const result = verifyPairing(payload);
+    expect(result.status).toBe('v2-verified');
+    if (result.status !== 'v2-verified') return;
+    expect(result.pairing.accounts.map((x) => x.addr).sort()).toEqual(
+      accts.map((a) => a.addr).sort()
+    );
+  });
+
+  it('IGNORES the transmitted pk and always derives from addr (T3)', () => {
+    const a = seededAccount(1);
+    const wrong = seededAccount(9);
+    // Attacker desyncs pk from addr; sig is still a valid self-sig for addr.
+    const payload = makeV2Payload([
+      { addr: a.addr, sk: a.sk, pk: pkHex(wrong.addr) },
+    ]);
+
+    const result = verifyPairing(payload);
+    expect(result.status).toBe('v2-verified');
+    if (result.status !== 'v2-verified') return;
+    // Verified pubkey is DERIVED from addr, not the transmitted (wrong) pk.
+    expect(result.pairing.accounts[0].publicKey).toBe(pkHex(a.addr));
+    expect(result.pairing.accounts[0].publicKey).not.toBe(pkHex(wrong.addr));
+  });
+
+  it('classifies a legacy v1 (unsigned) payload as v1-unsigned', () => {
+    const a = seededAccount(1);
+    const payload = {
+      v: 1,
+      t: 'pair',
+      dev: DEFAULT_DEV,
+      ts: DEFAULT_TS,
+      accts: [{ addr: a.addr, pk: pkHex(a.addr), label: 'Legacy' }],
+    };
+    const result = verifyPairing(payload);
+    expect(result.status).toBe('v1-unsigned');
+    if (result.status !== 'v1-unsigned') return;
+    expect(result.pairing.authLevel).toBe('v1-unsigned');
+    expect(result.pairing.accounts[0].publicKey).toBe(pkHex(a.addr));
+  });
+});
+
+// ---------------------------------------------------------------------------
+// 4. Splice — a captured single-account sig cannot be reused in a larger set.
+// ---------------------------------------------------------------------------
+
+describe('verifyPairing — splice resistance (set-binding, T4)', () => {
+  it('REJECTS an attacker account spliced under a victim single-account sig', () => {
+    const victim = seededAccount(1);
+    const attacker = seededAccount(2);
+
+    // 1) Victim's genuine single-account pairing (set = {victim}).
+    const victimOnly = makeV2Payload([{ addr: victim.addr, sk: victim.sk }]);
+    expect(verifyPairing(victimOnly).status).toBe('v2-verified');
+
+    const victimSig = (victimOnly.accts as Record<string, unknown>[])[0]
+      .sig as string;
+
+    // 2) Attacker splices in their own account under the SAME dev/ts, keeping
+    //    the captured victim sig (which was over the set {victim}), and signs
+    //    their own account over the NEW set {attacker,victim}.
+    const setAddrs = [victim.addr, attacker.addr];
+    const spliced = {
+      v: PAIRING_VERSION,
+      t: 'pair',
+      dev: DEFAULT_DEV,
+      ts: DEFAULT_TS,
+      accts: [
+        { addr: victim.addr, pk: pkHex(victim.addr), sig: victimSig },
+        {
+          addr: attacker.addr,
+          pk: pkHex(attacker.addr),
+          sig: signPairing(
+            DEFAULT_DEV,
+            DEFAULT_TS,
+            setAddrs,
+            attacker.addr,
+            attacker.sk
+          ),
+        },
+      ],
+    };
+
+    // The victim sig was bound to {victim}; recomputed setStr is {attacker,victim}
+    // → victim sig no longer verifies → whole pairing rejected.
+    const result = verifyPairing(spliced);
+    expect(result.status).toBe('rejected');
+  });
+});
+
+// ---------------------------------------------------------------------------
+// 5. All-or-nothing & mixed v1/v2.
+// ---------------------------------------------------------------------------
+
+describe('verifyPairing — all-or-nothing & mixed-version', () => {
+  it('REJECTS if any single account signature is invalid', () => {
+    const a = seededAccount(1);
+    const b = seededAccount(2);
+    const payload = makeV2Payload([
+      { addr: a.addr, sk: a.sk },
+      { addr: b.addr, sk: b.sk },
+    ]);
+    // Corrupt b's signature (still 64 bytes, but wrong).
+    (payload.accts as Record<string, unknown>[])[1].sig = Buffer.from(
+      new Uint8Array(64).fill(7)
+    ).toString('base64');
+
+    expect(verifyPairing(payload).status).toBe('rejected');
+  });
+
+  it('REJECTS a mixed payload: v2 with one account missing a sig', () => {
+    const a = seededAccount(1);
+    const b = seededAccount(2);
+    const payload = makeV2Payload([
+      { addr: a.addr, sk: a.sk },
+      { addr: b.addr, sk: b.sk },
+    ]);
+    delete (payload.accts as Record<string, unknown>[])[1].sig;
+
+    expect(verifyPairing(payload).status).toBe('rejected');
+  });
+
+  it('REJECTS a v1 payload that smuggles a signature', () => {
+    const a = seededAccount(1);
+    const payload = {
+      v: 1,
+      t: 'pair',
+      dev: DEFAULT_DEV,
+      ts: DEFAULT_TS,
+      accts: [
+        {
+          addr: a.addr,
+          pk: pkHex(a.addr),
+          sig: signPairing(DEFAULT_DEV, DEFAULT_TS, [a.addr], a.addr, a.sk),
+        },
+      ],
+    };
+    expect(verifyPairing(payload).status).toBe('rejected');
+  });
+});
+
+// ---------------------------------------------------------------------------
+// 6. Hard input validation.
+// ---------------------------------------------------------------------------
+
+describe('verifyPairing — hard input validation', () => {
+  const a = seededAccount(1);
+
+  it('REJECTS non-plain-object payloads', () => {
+    expect(verifyPairing(null).status).toBe('rejected');
+    expect(verifyPairing(undefined).status).toBe('rejected');
+    expect(verifyPairing('str').status).toBe('rejected');
+    expect(verifyPairing(42).status).toBe('rejected');
+    expect(verifyPairing([]).status).toBe('rejected');
+    expect(verifyPairing([{ t: 'pair' }]).status).toBe('rejected');
+  });
+
+  it('REJECTS the wrong type discriminator', () => {
+    const payload = makeV2Payload([{ addr: a.addr, sk: a.sk }]);
+    payload.t = 'req';
+    expect(verifyPairing(payload).status).toBe('rejected');
+  });
+
+  it('REJECTS an unsupported pairing version', () => {
+    const payload = makeV2Payload([{ addr: a.addr, sk: a.sk }]);
+    payload.v = 3;
+    expect(verifyPairing(payload).status).toBe('rejected');
+  });
+
+  it('REJECTS empty / oversized account arrays', () => {
+    const empty = makeV2Payload([{ addr: a.addr, sk: a.sk }]);
+    empty.accts = [];
+    expect(verifyPairing(empty).status).toBe('rejected');
+
+    const huge = makeV2Payload([{ addr: a.addr, sk: a.sk }]);
+    huge.accts = new Array(101).fill((huge.accts as unknown[])[0]);
+    expect(verifyPairing(huge).status).toBe('rejected');
+  });
+
+  it('REJECTS a duplicate address', () => {
+    const dup = seededAccount(5);
+    // Two entries for the same address (both correctly signed over the set).
+    const setAddrs = [dup.addr, dup.addr];
+    const payload = {
+      v: PAIRING_VERSION,
+      t: 'pair',
+      dev: DEFAULT_DEV,
+      ts: DEFAULT_TS,
+      accts: [
+        {
+          addr: dup.addr,
+          pk: pkHex(dup.addr),
+          sig: signPairing(DEFAULT_DEV, DEFAULT_TS, setAddrs, dup.addr, dup.sk),
+        },
+        {
+          addr: dup.addr,
+          pk: pkHex(dup.addr),
+          sig: signPairing(DEFAULT_DEV, DEFAULT_TS, setAddrs, dup.addr, dup.sk),
+        },
+      ],
+    };
+    expect(verifyPairing(payload).status).toBe('rejected');
+  });
+
+  it('REJECTS a non-canonical / checksum-invalid address', () => {
+    const payload = makeV2Payload([{ addr: a.addr, sk: a.sk }]);
+    // Lowercased address is non-canonical.
+    (payload.accts as Record<string, unknown>[])[0].addr = a.addr.toLowerCase();
+    expect(verifyPairing(payload).status).toBe('rejected');
+
+    const bad = makeV2Payload([{ addr: a.addr, sk: a.sk }]);
+    (bad.accts as Record<string, unknown>[])[0].addr = 'NOT_AN_ADDRESS';
+    expect(verifyPairing(bad).status).toBe('rejected');
+  });
+
+  it('REJECTS a signature that does not decode to exactly 64 bytes', () => {
+    const short = makeV2Payload([{ addr: a.addr, sk: a.sk }]);
+    (short.accts as Record<string, unknown>[])[0].sig = Buffer.from(
+      new Uint8Array(63).fill(1)
+    ).toString('base64');
+    expect(verifyPairing(short).status).toBe('rejected');
+
+    const long = makeV2Payload([{ addr: a.addr, sk: a.sk }]);
+    (long.accts as Record<string, unknown>[])[0].sig = Buffer.from(
+      new Uint8Array(65).fill(1)
+    ).toString('base64');
+    expect(verifyPairing(long).status).toBe('rejected');
+
+    const notB64 = makeV2Payload([{ addr: a.addr, sk: a.sk }]);
+    (notB64.accts as Record<string, unknown>[])[0].sig = 'not*valid*base64';
+    expect(verifyPairing(notB64).status).toBe('rejected');
+  });
+
+  it('REJECTS an oversized sig string BEFORE base64-decoding (allocation bound)', () => {
+    // The per-account sig length is bounded to the canonical 88 chars before
+    // any Buffer.from(...,'base64'), so a hostile QR cannot force a large alloc.
+    const huge = makeV2Payload([{ addr: a.addr, sk: a.sk }]);
+    (huge.accts as Record<string, unknown>[])[0].sig = 'A'.repeat(100000);
+    expect(verifyPairing(huge).status).toBe('rejected');
+  });
+
+  it('REJECTS a tampered signed field (ts changed after signing)', () => {
+    const payload = makeV2Payload([{ addr: a.addr, sk: a.sk }]);
+    // ts is inside the signed message → changing it invalidates every sig.
+    payload.ts = DEFAULT_TS + 1;
+    expect(verifyPairing(payload).status).toBe('rejected');
+  });
+
+  it('REJECTS a tampered signed field (dev changed after signing)', () => {
+    const payload = makeV2Payload([{ addr: a.addr, sk: a.sk }]);
+    payload.dev = 'voi-signer-other';
+    expect(verifyPairing(payload).status).toBe('rejected');
+  });
+
+  it('ACCEPTS when only the cosmetic label (outside the message) changes', () => {
+    const payload = makeV2Payload([
+      { addr: a.addr, sk: a.sk, label: 'Original' },
+    ]);
+    // Label is NOT part of the signed message, so editing it must not break.
+    (payload.accts as Record<string, unknown>[])[0].label = 'Renamed';
+    const result = verifyPairing(payload);
+    expect(result.status).toBe('v2-verified');
+    if (result.status !== 'v2-verified') return;
+    expect(result.pairing.accounts[0].label).toBe('Renamed');
+  });
+
+  it('REJECTS an over-long device name / label', () => {
+    const longName = makeV2Payload([{ addr: a.addr, sk: a.sk }], {
+      name: 'x'.repeat(200),
+    });
+    expect(verifyPairing(longName).status).toBe('rejected');
+
+    const longLabel = makeV2Payload([
+      { addr: a.addr, sk: a.sk, label: 'y'.repeat(200) },
+    ]);
+    expect(verifyPairing(longLabel).status).toBe('rejected');
+  });
+
+  it('does NOT hard-reject on a stale (old) timestamp', () => {
+    // Freshness is advisory (DR-5): an old ts must still verify if signed.
+    const a2 = seededAccount(1);
+    const payload = makeV2Payload([{ addr: a2.addr, sk: a2.sk }], {
+      ts: 1000000000000, // ~2001, very old
+    });
+    expect(verifyPairing(payload).status).toBe('v2-verified');
+  });
+});
+
+// ---------------------------------------------------------------------------
+// 7. authLevel legacy default.
+// ---------------------------------------------------------------------------
+
+describe('withDefaultAuthLevel — conservative legacy default', () => {
+  it('defaults a missing level to v1-unsigned', () => {
+    expect(withDefaultAuthLevel(undefined)).toBe('v1-unsigned');
+  });
+
+  it('preserves an explicit level', () => {
+    expect(withDefaultAuthLevel('v1-unsigned')).toBe('v1-unsigned');
+    expect(withDefaultAuthLevel('v2-signed')).toBe('v2-signed');
+  });
+});
+
+// ---------------------------------------------------------------------------
+// 8. assertCanonicalAddressSet — the signer must only sign a canonical set.
+// ---------------------------------------------------------------------------
+
+describe('assertCanonicalAddressSet — signer-side set guard', () => {
+  it('accepts a canonical, de-duplicated set', () => {
+    const a0 = seededAccount(7);
+    const a1 = seededAccount(8);
+    expect(() => assertCanonicalAddressSet([a0.addr, a1.addr])).not.toThrow();
+  });
+
+  it('throws on a non-canonical / checksum-invalid address', () => {
+    expect(() => assertCanonicalAddressSet(['NOT-AN-ADDRESS'])).toThrow();
+  });
+
+  it('throws on a duplicate address', () => {
+    const a0 = seededAccount(7);
+    expect(() => assertCanonicalAddressSet([a0.addr, a0.addr])).toThrow(
+      /duplicate/i
+    );
+  });
+
+  it('throws on a non-ASCII address', () => {
+    expect(() => assertCanonicalAddressSet(['évil'])).toThrow();
+  });
+});

--- a/src/services/remoteSigner/index.ts
+++ b/src/services/remoteSigner/index.ts
@@ -6,6 +6,7 @@
  */
 
 import algosdk from 'algosdk';
+import nacl from 'tweetnacl';
 import { getCrypto } from '@/platform';
 import { NetworkService } from '../network';
 import { SecureKeyManager } from '../secure/keyManager';
@@ -14,6 +15,7 @@ import {
   RemoteSignerResponse,
   RemoteSignerPairing,
   RemoteSignerPayload,
+  PairedAccount,
   SignableTransaction,
   SignedTransaction,
   DecodedTransactionInfo,
@@ -23,7 +25,115 @@ import {
   isRemoteSignerResponse,
   isRemoteSignerPairing,
   REMOTE_SIGNER_CONSTANTS,
+  PAIRING_VERSION,
 } from '../../types/remoteSigner';
+import {
+  buildPairingMessage,
+  verifyPairing,
+  assertCanonicalAddressSet,
+} from './pairing';
+
+// ============================================================================
+// Authenticated pairing crypto core (v2) — signer-side (key-touching)
+// ============================================================================
+//
+// The pure serializer/verifier (`buildPairingMessage`, `verifyPairing`) live in
+// `./pairing` (dependency-light, unit-tested in isolation). The two functions
+// below load the private key and therefore stay here alongside the rest of the
+// secure-storage-dependent service surface.
+//
+// A v2 pairing proves the signer device controls each exported account by
+// attaching a per-account Ed25519 self-signature over a DOMAIN-SEPARATED,
+// SET-BINDING message. The wallet re-derives every verification key from the
+// address (never from the transmitted `pk`) and requires ALL accounts to
+// verify, or the whole pairing is rejected (all-or-nothing). See DR-1..DR-8.
+
+/**
+ * Sign a pairing message with the account's Ed25519 secret key.
+ *
+ * Loads the key the SAME way transaction signing does
+ * (`SecureKeyManager.getPrivateKey`) and produces a RAW `nacl.sign.detached`
+ * signature over `messageBytes`. It deliberately does NOT route through
+ * `signTransaction`/`algosdk.signTransaction` (those prepend "TX" + msgpack),
+ * which would break domain separation.
+ *
+ * The secret key is zero-filled in a `finally` (mirrors keyManager.ts). The
+ * returned 64-byte signature is an independent buffer allocated by tweetnacl.
+ *
+ * @returns the 64-byte detached signature
+ */
+export async function signPairingMessage(
+  address: string,
+  messageBytes: Uint8Array,
+  pin?: string
+): Promise<Uint8Array> {
+  let sk: Uint8Array | null = null;
+  try {
+    sk = await SecureKeyManager.getPrivateKey(
+      { address, purpose: 'verification' },
+      pin
+    );
+    return nacl.sign.detached(messageBytes, sk);
+  } finally {
+    if (sk) {
+      sk.fill(0);
+      sk = null;
+    }
+  }
+}
+
+/**
+ * Assemble an authenticated (v2) pairing payload.
+ *
+ * Stamps ONE `ts`, computes the canonical set once, then signs EACH selected
+ * account over the shared set-binding message. Keeps `pk` on the wire
+ * (additive; never trusted on verify).
+ *
+ * This is a NEW function — the legacy sync {@link RemoteSignerServiceClass.createPairingPayload}
+ * (v1, unsigned) is intentionally left unchanged so the current export screen
+ * keeps compiling until it is migrated (later task).
+ */
+export async function createSignedPairingPayload(
+  deviceId: string,
+  deviceName: string | undefined,
+  accounts: { address: string; publicKey: string; label?: string }[],
+  pin?: string
+): Promise<RemoteSignerPairing> {
+  // The signer must only sign a canonical, de-duplicated set — otherwise the
+  // ","-joined set-binding in buildPairingMessage would be ambiguous. Throws
+  // before any key access on a malformed set.
+  assertCanonicalAddressSet(accounts.map((a) => a.address));
+
+  const ts = Date.now();
+  // The full set every per-account signature binds to.
+  const setAccts = accounts.map((a) => ({ addr: a.address }));
+
+  const signedAccts: PairedAccount[] = [];
+  for (const acc of accounts) {
+    const messageBytes = buildPairingMessage({
+      dev: deviceId,
+      ts,
+      accts: setAccts,
+      addr: acc.address,
+    });
+    const sig = await signPairingMessage(acc.address, messageBytes, pin);
+    signedAccts.push({
+      addr: acc.address,
+      pk: acc.publicKey, // additive; ignored by the verifier
+      sig: Buffer.from(sig).toString('base64'),
+      label: acc.label,
+    });
+  }
+
+  return {
+    v: PAIRING_VERSION,
+    t: 'pair',
+    dev: deviceId,
+    name: deviceName,
+    accts: signedAccts,
+    ts,
+  };
+}
 
 /**
  * Remote Signer Service - singleton instance
@@ -221,6 +331,18 @@ class RemoteSignerServiceClass {
       ts: Date.now(),
     };
   }
+
+  /**
+   * Create an authenticated (v2) pairing payload. Delegates to the shared
+   * module-level {@link createSignedPairingPayload}.
+   */
+  createSignedPairingPayload = createSignedPairingPayload;
+
+  /**
+   * Verify a scanned pairing payload (all-or-nothing, set-bound). Delegates to
+   * the shared module-level {@link verifyPairing}.
+   */
+  verifyPairing = verifyPairing;
 
   // ============ Transaction Decoding ============
 
@@ -432,3 +554,17 @@ export type {
   AnimatedQREncodeResult,
   AnimatedQRDecodeState,
 } from './animatedQR';
+
+// Re-export the pure pairing crypto surface so consumers (and tests) can import
+// it from the service entry point as well as from './pairing'.
+export {
+  buildPairingMessage,
+  verifyPairing,
+  PAIRING_MESSAGE_DOMAIN,
+} from './pairing';
+export type {
+  BuildPairingMessageParams,
+  VerifiedPairing,
+  VerifiedPairingAccount,
+  PairingVerificationResult,
+} from './pairing';

--- a/src/services/remoteSigner/pairing.ts
+++ b/src/services/remoteSigner/pairing.ts
@@ -1,0 +1,375 @@
+/**
+ * Authenticated remote-signer pairing — pure crypto core (v2).
+ *
+ * This module is intentionally dependency-light (algosdk + the pure Ed25519
+ * verifier only) so it can be unit-tested as a Layer-1 utility without pulling
+ * in the secure-storage / wallet service graph. The key-touching helpers
+ * (`signPairingMessage`, `createSignedPairingPayload`) live in `./index` and
+ * import `buildPairingMessage` from here.
+ *
+ * A v2 pairing proves the signer device controls each exported account by
+ * attaching a per-account Ed25519 self-signature over a DOMAIN-SEPARATED,
+ * SET-BINDING message. The wallet re-derives every verification key from the
+ * address (never from the transmitted `pk`) and requires ALL accounts to
+ * verify, or the whole pairing is rejected (all-or-nothing). See DR-1..DR-8.
+ */
+
+import algosdk from 'algosdk';
+import { verifyEd25519Signature } from '@/utils/signatureVerification';
+import { PAIRING_VERSION, PAIRING_LIMITS } from '@/types/remoteSigner';
+import type { RemoteSignerAuthLevel } from '@/types/wallet';
+
+/**
+ * Domain-separation prefix for the pairing message.
+ *
+ * Begins with 0x76 ('v') and is disjoint from every Algorand signing domain
+ * ("TX"/"MX"/"Program"/"ProgData") and from the messaging challenge
+ * ("voi-wallet-messaging-v1:", which diverges by byte 4). A pairing signature
+ * therefore can NEVER be replayed as a transaction/logicsig/auth signature and
+ * vice-versa. The trailing "\n" is part of the domain — do NOT change these
+ * bytes (a frozen test vector guards them).
+ */
+export const PAIRING_MESSAGE_DOMAIN = 'voi-remote-signer-pair/v2\n';
+
+/** Parameters for {@link buildPairingMessage}. */
+export interface BuildPairingMessageParams {
+  /** Signer device id (authenticated inside the message). */
+  dev: string;
+  /** Unix timestamp in ms (must be an integer). */
+  ts: number;
+  /**
+   * The FULL set of accounts in the pairing. Only `.addr` is consumed; the
+   * canonical sorted address set binds every signature to the whole pairing
+   * (defeats splice attacks — T4).
+   */
+  accts: { addr: string }[];
+  /** The specific account address this message is signed by. */
+  addr: string;
+}
+
+/** True iff every code unit of `s` is a 7-bit ASCII character. */
+function isAscii(s: string): boolean {
+  for (let i = 0; i < s.length; i++) {
+    if (s.charCodeAt(i) > 0x7f) return false;
+  }
+  return true;
+}
+
+/**
+ * Build the exact bytes signed/verified for a pairing account.
+ *
+ * SINGLE shared serializer used by BOTH the signer (sign) and the wallet
+ * (verify) — there is intentionally only one place these bytes are produced.
+ *
+ * Layout (utf-8):
+ *   "voi-remote-signer-pair/v2\n" + dev + "\n" + String(ts) + "\n" + setStr + "\n" + addr
+ * where setStr = accts.map(a => a.addr).sort().join(",") (canonical sorted SET).
+ *
+ * @throws if `ts` is not an integer, or `dev`/`addr` contain non-ASCII.
+ */
+export function buildPairingMessage(
+  params: BuildPairingMessageParams
+): Uint8Array {
+  const { dev, ts, accts, addr } = params;
+
+  if (!Number.isInteger(ts)) {
+    throw new Error('buildPairingMessage: ts must be an integer');
+  }
+  if (!isAscii(dev)) {
+    throw new Error('buildPairingMessage: dev must be ASCII');
+  }
+  if (!isAscii(addr)) {
+    throw new Error('buildPairingMessage: addr must be ASCII');
+  }
+
+  // `map` yields a fresh array, so sorting it does not mutate the caller's accts.
+  const setStr = accts
+    .map((a) => a.addr)
+    .sort()
+    .join(',');
+
+  const message =
+    PAIRING_MESSAGE_DOMAIN +
+    dev +
+    '\n' +
+    String(ts) +
+    '\n' +
+    setStr +
+    '\n' +
+    addr;
+
+  return new TextEncoder().encode(message);
+}
+
+/** A pairing account after verification — pubkey DERIVED from addr, never trusted from the wire. */
+export interface VerifiedPairingAccount {
+  /** Canonical Algorand address. */
+  addr: string;
+  /** Hex-encoded public key DERIVED from `addr` (never the transmitted `pk`). */
+  publicKey: string;
+  /** Cosmetic, UNVERIFIED label (outside the signed message). */
+  label?: string;
+}
+
+/** The trusted, sanitized result of a successful {@link verifyPairing}. */
+export interface VerifiedPairing {
+  /** Signer device id (authenticated in v2). */
+  dev: string;
+  /** Cosmetic, UNVERIFIED device name. */
+  name?: string;
+  /** Unix timestamp in ms (advisory freshness — NOT hard-rejected on staleness). */
+  ts: number;
+  /** Authentication level of the whole pairing. */
+  authLevel: RemoteSignerAuthLevel;
+  /** Accounts with pubkeys derived from their addresses. */
+  accounts: VerifiedPairingAccount[];
+}
+
+/** Discriminated result of {@link verifyPairing}. */
+export type PairingVerificationResult =
+  | { status: 'v2-verified'; pairing: VerifiedPairing }
+  | { status: 'v1-unsigned'; pairing: VerifiedPairing }
+  | { status: 'rejected'; reason: string };
+
+/** True for a plain (Object.prototype / null-proto) object — rejects arrays & class instances. */
+function isPlainObject(x: unknown): x is Record<string, unknown> {
+  if (typeof x !== 'object' || x === null) return false;
+  if (Array.isArray(x)) return false;
+  const proto = Object.getPrototypeOf(x);
+  return proto === Object.prototype || proto === null;
+}
+
+/**
+ * Strictly decode a base64 string, rejecting non-canonical encodings.
+ * Returns null if the input is not canonical base64 (round-trip re-encode must match).
+ */
+function decodeStrictBase64(s: string): Uint8Array | null {
+  if (typeof s !== 'string' || !/^[A-Za-z0-9+/]+={0,2}$/.test(s)) return null;
+  try {
+    const buf = Buffer.from(s, 'base64');
+    // Re-encode and compare to reject sloppy/non-canonical base64 (extra bits,
+    // wrong padding, embedded whitespace, etc.).
+    if (Buffer.from(buf).toString('base64') !== s) return null;
+    return new Uint8Array(buf);
+  } catch {
+    return null;
+  }
+}
+
+/** The canonical form of an address, or null if it is not a valid Algorand address. */
+function canonicalAddress(addr: string): string | null {
+  try {
+    return algosdk.encodeAddress(algosdk.decodeAddress(addr).publicKey);
+  } catch {
+    return null;
+  }
+}
+
+/**
+ * Assert that a set of addresses is canonical and de-duplicated BEFORE it is
+ * signed. `buildPairingMessage` binds the set by joining addresses with ",",
+ * which is only collision-free when every address is a canonical Algorand
+ * address (base32, never contains ",") and there are no duplicates. Algorand
+ * addresses always satisfy this, but the signer validates defensively so the
+ * set-binding guarantee holds for every producer of a pairing signature — it
+ * mirrors the checks {@link verifyPairing} runs on the wire.
+ *
+ * @throws if any address is non-canonical / checksum-invalid, or duplicated.
+ */
+export function assertCanonicalAddressSet(addresses: string[]): void {
+  const seen = new Set<string>();
+  for (const addr of addresses) {
+    if (typeof addr !== 'string' || !isAscii(addr)) {
+      throw new Error('assertCanonicalAddressSet: address is not ASCII');
+    }
+    const canonical = canonicalAddress(addr);
+    if (canonical === null || canonical !== addr) {
+      throw new Error(
+        'assertCanonicalAddressSet: address is not canonical / checksum-invalid'
+      );
+    }
+    if (seen.has(addr)) {
+      throw new Error('assertCanonicalAddressSet: duplicate address');
+    }
+    seen.add(addr);
+  }
+}
+
+/**
+ * Verify a scanned pairing payload — ALL-OR-NOTHING, set-bound, fail-closed.
+ *
+ * Hard input validation runs FIRST (never trust the wire). Then, for a v2
+ * (signed) payload, EVERY account's set-binding self-signature must verify
+ * against the pubkey DERIVED FROM ITS ADDRESS (the transmitted `pk` is ignored),
+ * or the whole pairing is rejected. Legacy v1 (no signatures) is returned as
+ * `v1-unsigned` for the caller to gate behind an explicit confirmation.
+ *
+ * Version/signature consistency:
+ *   - v === PAIRING_VERSION (2): every account MUST carry a valid 64-byte sig.
+ *   - v === 1: NO account may carry a sig (a v1 payload with any sig is rejected).
+ *   - a mixed payload (some signed, some not) is rejected under either version.
+ *
+ * `ts` staleness is NOT a hard reject (freshness is advisory — a later screen
+ * may warn).
+ *
+ * @param payload untrusted, freshly-parsed QR data
+ */
+export function verifyPairing(payload: unknown): PairingVerificationResult {
+  const reject = (reason: string): PairingVerificationResult => ({
+    status: 'rejected',
+    reason,
+  });
+
+  try {
+    // --- 1. Envelope shape -------------------------------------------------
+    if (!isPlainObject(payload)) return reject('Payload is not a plain object');
+    const p = payload;
+
+    if (p.t !== 'pair') return reject('Payload type is not "pair"');
+
+    const v = p.v;
+    if (v !== 1 && v !== PAIRING_VERSION) {
+      return reject(`Unsupported pairing version: ${String(v)}`);
+    }
+
+    if (
+      typeof p.dev !== 'string' ||
+      p.dev.length === 0 ||
+      p.dev.length > PAIRING_LIMITS.MAX_DEVICE_ID_LENGTH
+    ) {
+      return reject('Invalid device id');
+    }
+    if (!isAscii(p.dev)) return reject('Device id contains non-ASCII');
+
+    if (
+      p.name !== undefined &&
+      (typeof p.name !== 'string' ||
+        p.name.length > PAIRING_LIMITS.MAX_NAME_LENGTH)
+    ) {
+      return reject('Invalid device name');
+    }
+
+    if (typeof p.ts !== 'number' || !Number.isInteger(p.ts)) {
+      return reject('Invalid timestamp');
+    }
+
+    if (!Array.isArray(p.accts) || p.accts.length === 0) {
+      return reject('No accounts in pairing');
+    }
+    if (p.accts.length > PAIRING_LIMITS.MAX_ACCOUNTS) {
+      return reject('Too many accounts in pairing');
+    }
+
+    // --- 2. Per-account shape, canonical addr, dedupe, sig-presence --------
+    const addrs: string[] = [];
+    const seen = new Set<string>();
+    let sigCount = 0;
+
+    for (const raw of p.accts) {
+      if (!isPlainObject(raw)) return reject('Account is not a plain object');
+
+      if (typeof raw.addr !== 'string')
+        return reject('Account addr is not a string');
+      if (!isAscii(raw.addr)) return reject('Account addr contains non-ASCII');
+
+      const canonical = canonicalAddress(raw.addr);
+      if (canonical === null || canonical !== raw.addr) {
+        return reject('Account addr is not canonical / checksum-invalid');
+      }
+      if (seen.has(raw.addr)) return reject('Duplicate account addr');
+      seen.add(raw.addr);
+      addrs.push(raw.addr);
+
+      if (
+        raw.label !== undefined &&
+        (typeof raw.label !== 'string' ||
+          raw.label.length > PAIRING_LIMITS.MAX_LABEL_LENGTH)
+      ) {
+        return reject('Invalid account label');
+      }
+
+      if (raw.sig !== undefined) {
+        if (typeof raw.sig !== 'string')
+          return reject('Account sig is not a string');
+        // Bound the string length BEFORE base64-decoding (step 4) so a hostile
+        // payload cannot force an unbounded allocation ahead of the 64-byte check.
+        if (raw.sig.length !== PAIRING_LIMITS.SIGNATURE_B64_LENGTH)
+          return reject('Account sig has invalid length');
+        sigCount++;
+      }
+    }
+
+    // --- 3. Version / signature consistency (reject mixed v1/v2) -----------
+    if (v === PAIRING_VERSION) {
+      if (sigCount !== p.accts.length) {
+        return reject('v2 pairing has account(s) missing a signature');
+      }
+    } else {
+      // v === 1 (legacy, unsigned)
+      if (sigCount !== 0) {
+        return reject('v1 pairing must not carry signatures');
+      }
+      return {
+        status: 'v1-unsigned',
+        pairing: buildVerifiedPairing(p, addrs, 'v1-unsigned'),
+      };
+    }
+
+    // --- 4. Verify every set-bound signature (all-or-nothing) -------------
+    const setAccts = addrs.map((addr) => ({ addr }));
+    for (const raw of p.accts as Record<string, unknown>[]) {
+      const addr = raw.addr as string;
+      const sigBytes = decodeStrictBase64(raw.sig as string);
+      if (!sigBytes || sigBytes.length !== PAIRING_LIMITS.SIGNATURE_BYTES) {
+        return reject('Account signature is not exactly 64 bytes');
+      }
+      const message = buildPairingMessage({
+        dev: p.dev,
+        ts: p.ts,
+        accts: setAccts,
+        addr,
+      });
+      // Derive the verification key from the ADDRESS — never trust `pk`.
+      const pub = algosdk.decodeAddress(addr).publicKey;
+      if (!verifyEd25519Signature(message, sigBytes, pub)) {
+        return reject('Account signature failed verification');
+      }
+    }
+
+    return {
+      status: 'v2-verified',
+      pairing: buildVerifiedPairing(p, addrs, 'v2-signed'),
+    };
+  } catch (error) {
+    // Fail closed on any unexpected error.
+    const message = error instanceof Error ? error.message : 'unknown error';
+    return reject(`Pairing verification error: ${message}`);
+  }
+}
+
+/** Build the sanitized VerifiedPairing (pubkeys DERIVED from addresses). */
+function buildVerifiedPairing(
+  p: Record<string, unknown>,
+  addrs: string[],
+  authLevel: RemoteSignerAuthLevel
+): VerifiedPairing {
+  const rawAccts = p.accts as Record<string, unknown>[];
+  const accounts: VerifiedPairingAccount[] = addrs.map((addr, i) => {
+    const label = rawAccts[i].label;
+    return {
+      addr,
+      publicKey: Buffer.from(algosdk.decodeAddress(addr).publicKey).toString(
+        'hex'
+      ),
+      label: typeof label === 'string' ? label : undefined,
+    };
+  });
+
+  return {
+    dev: p.dev as string,
+    name: typeof p.name === 'string' ? p.name : undefined,
+    ts: p.ts as number,
+    authLevel,
+    accounts,
+  };
+}

--- a/src/services/wallet/index.ts
+++ b/src/services/wallet/index.ts
@@ -29,6 +29,7 @@ import {
   RekeyVerificationError,
   Wallet,
   WalletSettings,
+  withDefaultAuthLevel,
 } from '@/types/wallet';
 import { AccountSecureStorage } from '../secure/AccountSecureStorage';
 import { ledgerTransportService } from '@/services/ledger/transport';
@@ -586,6 +587,10 @@ export class MultiAccountWalletService {
         signerDeviceId: request.signerDeviceId,
         signerDeviceName: request.signerDeviceName,
         pairedAt: new Date().toISOString(),
+        // Persist the pairing authentication level. Defaults conservatively to
+        // 'v1-unsigned' until the import screen supplies a verified level
+        // (TASK-144).
+        authLevel: withDefaultAuthLevel(request.authLevel),
       };
 
       await this.addAccountToWallet(accountMetadata);
@@ -664,6 +669,9 @@ export class MultiAccountWalletService {
       signerDeviceId,
       signerDeviceName,
       pairedAt: new Date().toISOString(),
+      // Local conversion is not an authenticated (v2) pairing, so record the
+      // conservative default. Keeps the field present on all new records.
+      authLevel: 'v1-unsigned',
     };
 
     // Replace the account in the wallet

--- a/src/store/remoteSignerStore.ts
+++ b/src/store/remoteSignerStore.ts
@@ -2,6 +2,7 @@ import { create } from 'zustand';
 import { subscribeWithSelector } from 'zustand/middleware';
 import { useShallow } from 'zustand/react/shallow';
 import AsyncStorage from '@react-native-async-storage/async-storage';
+import { getCrypto } from '@/platform';
 import {
   AppMode,
   SignerDeviceConfig,
@@ -40,12 +41,17 @@ export async function getAppModeEarly(): Promise<AppMode> {
 }
 
 /**
- * Generate a unique device ID for this signer device
+ * Generate a unique device ID for this signer device.
+ *
+ * Uses a CSPRNG (`getCrypto().randomUUID()`) rather than `Math.random`, which
+ * is not cryptographically secure and could produce predictable/colliding ids
+ * (threat T2). The `dev` id is additionally authenticated inside each v2
+ * pairing signature. Existing persisted ids are NOT regenerated (that would
+ * break existing pairings) — this only runs when a fresh signer config is
+ * created (`initializeSignerConfig`).
  */
 function generateDeviceId(): string {
-  const timestamp = Date.now().toString(36);
-  const randomPart = Math.random().toString(36).substring(2, 10);
-  return `voi-signer-${timestamp}-${randomPart}`;
+  return `voi-signer-${getCrypto().randomUUID()}`;
 }
 
 /**

--- a/src/types/remoteSigner.ts
+++ b/src/types/remoteSigner.ts
@@ -98,13 +98,69 @@ export interface RemoteSignerResponse {
 }
 
 /**
+ * Pairing protocol version.
+ *
+ * This is a SEPARATE axis from {@link REMOTE_SIGNER_CONSTANTS.PROTOCOL_VERSION}
+ * (which gates request/response signing and MUST stay at 1). Pairing payloads
+ * are versioned independently:
+ *   - `1` — legacy, UNSIGNED pairing (no per-account signatures).
+ *   - `2` — authenticated pairing: every account carries a set-bound
+ *     Ed25519 self-signature (proof-of-possession). See {@link PAIRING_VERSION}.
+ */
+export type PairingVersion = 1 | 2;
+
+/**
+ * Current authenticated pairing version (signed, set-bound).
+ *
+ * Kept deliberately separate from `REMOTE_SIGNER_CONSTANTS.PROTOCOL_VERSION`:
+ * bumping the shared protocol version would break cross-version request/response
+ * signing. Pairing versioning is an independent axis.
+ */
+export const PAIRING_VERSION = 2 as const;
+
+/**
+ * Hard input bounds for pairing validation (defence-in-depth against a hostile
+ * QR payload — see verifyPairing). Generous but finite.
+ */
+export const PAIRING_LIMITS = {
+  /** Maximum number of accounts in a single pairing payload */
+  MAX_ACCOUNTS: 100,
+  /** Maximum length of the device id string */
+  MAX_DEVICE_ID_LENGTH: 128,
+  /** Maximum length of the (cosmetic, unverified) device name */
+  MAX_NAME_LENGTH: 128,
+  /** Maximum length of a per-account (cosmetic, unverified) label */
+  MAX_LABEL_LENGTH: 128,
+  /** Exact byte length of an Ed25519 detached signature */
+  SIGNATURE_BYTES: 64,
+  /**
+   * Exact base64 length of a 64-byte signature (canonical, `==`-padded).
+   * Enforced BEFORE base64-decoding so a hostile QR cannot force an unbounded
+   * allocation ahead of the byte-length check.
+   */
+  SIGNATURE_B64_LENGTH: 88,
+} as const;
+
+/**
  * Account information in pairing data
  */
 export interface PairedAccount {
   /** Algorand address */
   addr: string;
-  /** Hex-encoded public key */
+  /**
+   * Hex-encoded public key.
+   *
+   * SECURITY: kept on the wire for backward compatibility only. It is NEVER
+   * trusted by the verifier — the verification public key is ALWAYS derived
+   * from `addr` (checksum-validated). See DR-2/DR-3 in the design.
+   */
   pk: string;
+  /**
+   * Base64-encoded 64-byte Ed25519 detached self-signature over the
+   * domain-separated, set-binding pairing message (v2 pairings only).
+   * Absent on legacy v1 (unsigned) pairings.
+   */
+  sig?: string;
   /** Optional label set by user on signer device */
   label?: string;
 }
@@ -115,8 +171,8 @@ export interface PairedAccount {
  * This is displayed by the signer to export accounts to the wallet.
  */
 export interface RemoteSignerPairing {
-  /** Version number for protocol compatibility */
-  v: 1;
+  /** Pairing protocol version (1 = legacy unsigned, 2 = authenticated/signed) */
+  v: PairingVersion;
   /** Type discriminator: 'pair' for pairing */
   t: 'pair';
   /** Unique identifier of the signer device */

--- a/src/types/wallet.ts
+++ b/src/types/wallet.ts
@@ -61,6 +61,29 @@ export interface LedgerAccountMetadata extends BaseAccountMetadata {
   lastDeviceConnection?: string; // Last successful device connection timestamp
 }
 
+/**
+ * Pairing authentication level for a remote signer account.
+ *
+ * - `'v2-signed'`   — the account was imported from an authenticated (v2)
+ *   pairing whose set-bound Ed25519 self-signature verified.
+ * - `'v1-unsigned'` — legacy / unauthenticated pairing (no verified signature).
+ *   This is ALSO the conservative default for any record where the field is
+ *   missing (legacy metadata) — always read it as `authLevel ?? 'v1-unsigned'`.
+ */
+export type RemoteSignerAuthLevel = 'v1-unsigned' | 'v2-signed';
+
+/**
+ * Resolve a possibly-missing pairing auth level to a concrete value, defaulting
+ * conservatively to 'v1-unsigned'. Use this at EVERY read of a persisted
+ * `authLevel` (legacy records predate the field). Centralised so the default is
+ * single-sourced and unit-testable.
+ */
+export function withDefaultAuthLevel(
+  level?: RemoteSignerAuthLevel
+): RemoteSignerAuthLevel {
+  return level ?? 'v1-unsigned';
+}
+
 // Remote Signer Account (air-gapped QR-based signing)
 export interface RemoteSignerAccountMetadata extends BaseAccountMetadata {
   type: AccountType.REMOTE_SIGNER;
@@ -68,6 +91,12 @@ export interface RemoteSignerAccountMetadata extends BaseAccountMetadata {
   signerDeviceName?: string; // User-friendly device name (e.g., "My Cold Storage Phone")
   pairedAt: string; // ISO timestamp when account was paired
   lastSigningActivity?: string; // Last time a transaction was signed
+  /**
+   * Pairing authentication level. Optional for backward compatibility with
+   * records written before this field existed; treat a missing value as
+   * 'v1-unsigned' at EVERY read site (`authLevel ?? 'v1-unsigned'`).
+   */
+  authLevel?: RemoteSignerAuthLevel;
 }
 
 // Union type for all account metadata types
@@ -275,6 +304,12 @@ export interface ImportRemoteSignerAccountRequest {
   signerDeviceName?: string; // User-friendly device name
   label?: string; // User-defined label for the account
   color?: string; // UI color identifier
+  /**
+   * Pairing authentication level (from verifyPairing). Optional: when omitted
+   * the account is persisted as the conservative 'v1-unsigned'. The import
+   * screen wires this in a later task (TASK-144).
+   */
+  authLevel?: RemoteSignerAuthLevel;
 }
 
 // Account Error Types


### PR DESCRIPTION
## What
Additive, non-breaking crypto core for **authenticated (v2) remote-signer pairing** (part of TASK-135 / DOC-141; PLAN-10 security hardening). Proof-of-possession: each exported account self-signs a domain-separated, set-binding message; the wallet verifies against the pubkey **derived from the address** (never the transmitted `pk`).

Nothing existing changes behaviour — the legacy unsigned pairing flow keeps working. Production import/export **screen wiring** (calling `verifyPairing` / `createSignedPairingPayload`, animated-QR transport, PIN-gated export) intentionally lands in **TASK-144**; general signed-response verification in **TASK-143**.

## Highlights
- `buildPairingMessage` — single shared, domain-separated (`voi-remote-signer-pair/v2\n`), set-binding serializer (frozen test vector).
- `signPairingMessage` — reuses `getPrivateKey` → `nacl.sign.detached` over the raw message (NOT the txn signer, so pairing sigs can't cross-replay as tx sigs); zero-fills the key in `finally`.
- `verifyPairing` — all-or-nothing, fail-closed; hard hostile-input bounds; canonical checksum-valid addresses; exactly-64-byte sigs; rejects mixed v1/v2; derives pubkey from addr.
- `assertCanonicalAddressSet` — signer validates canonical/deduped set before signing.
- CSPRNG device id (was `Math.random`); `PAIRING_VERSION=2` separate from `PROTOCOL_VERSION` (unchanged = 1).
- Per-account `authLevel`, persisted through wallet + backup with a conservative `?? 'v1-unsigned'` default.

## Security review
- 2× Codex review of the diff → **CLEAN** (key zero-fill, no key/mnemonic leak, domain separation, hostile-input completeness, PROTOCOL_VERSION unchanged).
- Threat model + Decision Record: DOC-141.

## Tests / gates
- `npm run typecheck` ✅ · `npm run lint` (0 errors) ✅ · `npm test` → **40 suites / 522 tests** (36 new pairing tests: frozen vector, domain separation both directions, splice rejection, all-or-nothing, hostile-input battery).
- End-to-end in-app verification lands with TASK-144 (the flow isn't user-drivable until the screens are wired).

https://claude.ai/code/session_01FfbFvUJtj9hVCaYZ4MS4y3