### PR TITLE
feat(secure): authenticated v2 pairing export/import UX (TASK-144)

### DIFF
--- a/src/components/remoteSigner/SignerAuthModal.tsx
+++ b/src/components/remoteSigner/SignerAuthModal.tsx
@@ -34,6 +34,17 @@ interface SignerAuthModalProps {
   onCancel: () => void;
   /** Number of transactions being signed */
   transactionCount?: number;
+  /**
+   * Optional override for the main prompt text. Defaults to the transaction
+   * signing wording ("Sign N transaction(s)"). Callers that unlock for a
+   * non-signing purpose (e.g. authorizing a pairing export) pass their own.
+   */
+  message?: string;
+  /**
+   * Optional override for the biometric system prompt. Defaults to
+   * "Authenticate to sign transactions".
+   */
+  biometricPromptMessage?: string;
 }
 
 export default function SignerAuthModal({
@@ -41,6 +52,8 @@ export default function SignerAuthModal({
   onSuccess,
   onCancel,
   transactionCount = 1,
+  message,
+  biometricPromptMessage,
 }: SignerAuthModalProps) {
   const { theme } = useTheme();
   const styles = useThemedStyles(createStyles);
@@ -196,7 +209,8 @@ export default function SignerAuthModal({
 
     try {
       const result = await LocalAuthentication.authenticateAsync({
-        promptMessage: 'Authenticate to sign transactions',
+        promptMessage:
+          biometricPromptMessage ?? 'Authenticate to sign transactions',
         fallbackLabel: 'Use PIN',
         cancelLabel: 'Cancel',
         requireConfirmation: false,
@@ -220,6 +234,9 @@ export default function SignerAuthModal({
   };
 
   const getMessage = () => {
+    if (message) {
+      return message;
+    }
     if (transactionCount === 1) {
       return 'Sign 1 transaction';
     }

--- a/src/screens/remoteSigner/ExportAccountsScreen.tsx
+++ b/src/screens/remoteSigner/ExportAccountsScreen.tsx
@@ -14,6 +14,7 @@ import {
   TouchableOpacity,
   ScrollView,
   Platform,
+  ActivityIndicator,
 } from 'react-native';
 import { SafeAreaView } from 'react-native-safe-area-context';
 import { useNavigation } from '@react-navigation/native';
@@ -24,13 +25,38 @@ import { useSecureScreen } from '@/hooks/useSecureScreen';
 import { useTheme } from '@/contexts/ThemeContext';
 import { Theme } from '@/constants/themes';
 import { useWalletStore } from '@/store/walletStore';
+import { useSignerConfig } from '@/store/remoteSignerStore';
 import {
-  useRemoteSignerStore,
-  useSignerConfig,
-} from '@/store/remoteSignerStore';
-import { RemoteSignerService } from '@/services/remoteSigner';
-import { AccountType, AccountMetadata } from '@/types/wallet';
+  RemoteSignerService,
+  shouldUseAnimatedQR,
+} from '@/services/remoteSigner';
+import { AnimatedQRCode } from '@/components/remoteSigner';
+import SignerAuthModal from '@/components/remoteSigner/SignerAuthModal';
+import {
+  AccountType,
+  AccountMetadata,
+  AuthenticationRequiredError,
+} from '@/types/wallet';
 import { formatAddress } from '@/utils/address';
+
+/**
+ * A frozen, signed pairing session ready to render as a QR.
+ *
+ * `key` binds the exact (device, selected address SET) the payload was signed
+ * for. Any change to the account selection produces a different `key`, which
+ * invalidates this session: each per-account signature binds the whole set + the
+ * single frozen `ts`, so a changed selection can NEVER reuse these signatures —
+ * the session must be regenerated and re-signed as a whole (DR-9, whole-session
+ * cache — NOT per-address).
+ */
+interface PairingSession {
+  /** `${deviceId}::${sortedSelectedAddrs.join(',')}` — the cache/invalidation key. */
+  key: string;
+  /** Encoded (raw-JSON) pairing payload for the QR. */
+  encoded: string;
+  /** Whether the payload exceeds one static frame and needs BC-UR animation. */
+  useAnimated: boolean;
+}
 
 export default function ExportAccountsScreen() {
   const { theme } = useTheme();
@@ -56,28 +82,34 @@ export default function ExportAccountsScreen() {
     () => new Set(signableAccounts.map((a: AccountMetadata) => a.id))
   );
 
-  // Generate QR code data
-  const qrData = useMemo(() => {
-    if (!signerConfig || selectedAccountIds.size === 0) return null;
+  // The frozen, signed pairing session (whole-session cache — see PairingSession).
+  const [session, setSession] = useState<PairingSession | null>(null);
+  const [isGenerating, setIsGenerating] = useState(false);
+  const [showAuthModal, setShowAuthModal] = useState(false);
 
-    const selectedAccounts = signableAccounts.filter((acc: AccountMetadata) =>
-      selectedAccountIds.has(acc.id)
-    );
+  const selectedAccounts = useMemo(
+    () =>
+      signableAccounts.filter((acc: AccountMetadata) =>
+        selectedAccountIds.has(acc.id)
+      ),
+    [signableAccounts, selectedAccountIds]
+  );
 
-    const accountsForPairing = selectedAccounts.map((acc: AccountMetadata) => ({
-      address: acc.address,
-      publicKey: acc.publicKey,
-      label: acc.label,
-    }));
+  // Canonical cache key for the current selection: device id + the sorted
+  // address SET. Recomputes on any selection change; when it diverges from the
+  // frozen session's key the displayed QR is stale and must be regenerated
+  // (re-signed as a whole — each signature binds the full set + ts).
+  const selectedKey = useMemo(() => {
+    if (!signerConfig || selectedAccounts.length === 0) return null;
+    const sortedAddrs = selectedAccounts
+      .map((acc: AccountMetadata) => acc.address)
+      .sort();
+    return `${signerConfig.deviceId}::${sortedAddrs.join(',')}`;
+  }, [signerConfig, selectedAccounts]);
 
-    const pairing = RemoteSignerService.createPairingPayload(
-      signerConfig.deviceId,
-      signerConfig.deviceName,
-      accountsForPairing
-    );
-
-    return RemoteSignerService.encodePayload(pairing);
-  }, [signerConfig, selectedAccountIds, signableAccounts]);
+  // The displayed QR is only valid while the frozen session matches the current
+  // selection. A selection change invalidates it (cache miss) → user regenerates.
+  const isSessionValid = session !== null && session.key === selectedKey;
 
   const toggleAccount = (accountId: string) => {
     setSelectedAccountIds((prev) => {
@@ -99,6 +131,68 @@ export default function ExportAccountsScreen() {
 
   const selectNone = () => {
     setSelectedAccountIds(new Set());
+  };
+
+  // Freeze + sign the current selection into a session (all accounts signed
+  // after a SINGLE unlock; the 60s key cache means one PIN entry covers them).
+  const generateSession = async (pin?: string) => {
+    if (
+      !signerConfig ||
+      selectedAccounts.length === 0 ||
+      selectedKey === null
+    ) {
+      return;
+    }
+
+    setIsGenerating(true);
+    try {
+      const accountsForPairing = selectedAccounts.map(
+        (acc: AccountMetadata) => ({
+          address: acc.address,
+          publicKey: acc.publicKey,
+          label: acc.label,
+        })
+      );
+
+      const pairing = await RemoteSignerService.createSignedPairingPayload(
+        signerConfig.deviceId,
+        signerConfig.deviceName,
+        accountsForPairing,
+        pin
+      );
+      const encoded = RemoteSignerService.encodePayload(pairing);
+
+      setSession({
+        key: selectedKey,
+        encoded,
+        useAnimated: shouldUseAnimatedQR(encoded),
+      });
+    } catch (error) {
+      const messageText =
+        error instanceof AuthenticationRequiredError
+          ? 'Authentication failed. Please try again.'
+          : error instanceof Error
+            ? error.message
+            : 'Failed to generate the pairing QR code.';
+      showAlert('Could Not Generate QR', messageText);
+    } finally {
+      setIsGenerating(false);
+    }
+  };
+
+  // Explicit "Generate pairing QR" action — gate behind unlock/PIN.
+  const handleGeneratePress = () => {
+    if (selectedAccounts.length === 0 || isGenerating) return;
+    setShowAuthModal(true);
+  };
+
+  const handleAuthSuccess = (pin?: string) => {
+    setShowAuthModal(false);
+    void generateSession(pin);
+  };
+
+  const handleAuthCancel = () => {
+    setShowAuthModal(false);
   };
 
   // Cross-platform alert helper
@@ -265,17 +359,62 @@ export default function ExportAccountsScreen() {
           ))}
         </View>
 
-        {/* QR Code Display */}
-        {qrData && selectedAccountIds.size > 0 && (
+        {/* Generate action — explicit, PIN-gated, async. Shown until a valid
+            (matching-selection) signed session exists. */}
+        {selectedAccountIds.size > 0 && !isSessionValid && (
+          <TouchableOpacity
+            style={[
+              styles.generateButton,
+              isGenerating && styles.generateButtonDisabled,
+            ]}
+            onPress={handleGeneratePress}
+            disabled={isGenerating}
+          >
+            {isGenerating ? (
+              <ActivityIndicator size="small" color={theme.colors.buttonText} />
+            ) : (
+              <Ionicons
+                name="qr-code-outline"
+                size={20}
+                color={theme.colors.buttonText}
+              />
+            )}
+            <Text style={styles.generateButtonText}>
+              {isGenerating ? 'Generating…' : 'Generate Pairing QR'}
+            </Text>
+          </TouchableOpacity>
+        )}
+
+        {selectedAccountIds.size > 0 && !isSessionValid && !isGenerating && (
+          <Text style={styles.generateHint}>
+            You&apos;ll be asked to authenticate. Each account is
+            cryptographically signed so the wallet can verify this device
+            controls it.
+          </Text>
+        )}
+
+        {/* QR Code Display — only while the frozen session matches the current
+            selection. Static payloads render RAW JSON via the plain QRCode; only
+            multi-frame payloads use the BC-UR animated transport. */}
+        {isSessionValid && session && (
           <View style={styles.qrSection}>
             <Text style={styles.sectionTitle}>Scan with Wallet Device</Text>
             <View style={styles.qrContainer}>
-              <QRCode
-                value={qrData}
-                size={220}
-                backgroundColor="white"
-                color="#000000"
-              />
+              {session.useAnimated ? (
+                <AnimatedQRCode
+                  data={session.encoded}
+                  size={220}
+                  showControls
+                  showFrameCounter
+                />
+              ) : (
+                <QRCode
+                  value={session.encoded}
+                  size={220}
+                  backgroundColor="white"
+                  color="#000000"
+                />
+              )}
             </View>
             <Text style={styles.qrHint}>
               Open the Voi Wallet app on your online device and scan this QR
@@ -297,6 +436,19 @@ export default function ExportAccountsScreen() {
           </View>
         )}
       </ScrollView>
+
+      <SignerAuthModal
+        visible={showAuthModal}
+        onSuccess={handleAuthSuccess}
+        onCancel={handleAuthCancel}
+        transactionCount={selectedAccounts.length}
+        message={
+          selectedAccounts.length === 1
+            ? 'Sign pairing for 1 account'
+            : `Sign pairing for ${selectedAccounts.length} accounts`
+        }
+        biometricPromptMessage="Authenticate to sign this pairing"
+      />
     </SafeAreaView>
   );
 }
@@ -457,6 +609,32 @@ const createStyles = (theme: Theme) =>
       color: theme.colors.textSecondary,
       fontFamily: Platform.OS === 'ios' ? 'Menlo' : 'monospace',
       marginTop: 2,
+    },
+    generateButton: {
+      flexDirection: 'row',
+      alignItems: 'center',
+      justifyContent: 'center',
+      gap: theme.spacing.sm,
+      backgroundColor: theme.colors.primary,
+      paddingVertical: theme.spacing.md,
+      borderRadius: theme.borderRadius.lg,
+      marginTop: theme.spacing.sm,
+    },
+    generateButtonDisabled: {
+      opacity: 0.6,
+    },
+    generateButtonText: {
+      fontSize: 16,
+      fontWeight: '600',
+      color: theme.colors.buttonText,
+    },
+    generateHint: {
+      fontSize: 13,
+      color: theme.colors.textSecondary,
+      textAlign: 'center',
+      marginTop: theme.spacing.sm,
+      paddingHorizontal: theme.spacing.md,
+      lineHeight: 18,
     },
     qrSection: {
       alignItems: 'center',

--- a/src/screens/remoteSigner/ImportRemoteSignerScreen.tsx
+++ b/src/screens/remoteSigner/ImportRemoteSignerScreen.tsx
@@ -5,7 +5,7 @@
  * device to import accounts as REMOTE_SIGNER accounts.
  */
 
-import React, { useState, useEffect, useRef, useCallback } from 'react';
+import React, { useState, useRef } from 'react';
 import {
   View,
   Text,
@@ -13,30 +13,31 @@ import {
   TouchableOpacity,
   ScrollView,
   Platform,
-  Dimensions,
   ActivityIndicator,
 } from 'react-native';
 import { SafeAreaView } from 'react-native-safe-area-context';
 import { useNavigation } from '@react-navigation/native';
 import { Ionicons } from '@expo/vector-icons';
-import { CameraView, Camera } from 'expo-camera';
 import jsQR from 'jsqr';
 import { useThemedStyles } from '@/hooks/useThemedStyles';
 import { useTheme } from '@/contexts/ThemeContext';
 import { Theme } from '@/constants/themes';
 import { useWalletStore } from '@/store/walletStore';
 import { useRemoteSignerStore } from '@/store/remoteSignerStore';
-import { RemoteSignerService } from '@/services/remoteSigner';
-import { AccountType, ImportRemoteSignerAccountRequest } from '@/types/wallet';
 import {
-  RemoteSignerPairing,
-  isRemoteSignerPairing,
-  SignerDeviceInfo,
-} from '@/types/remoteSigner';
+  RemoteSignerService,
+  AnimatedQRService,
+  isUrEncodedFrame,
+  mapVerifiedPairingToImportRequests,
+} from '@/services/remoteSigner';
+import type { VerifiedPairing } from '@/services/remoteSigner';
+import { AnimatedQRScanner } from '@/components/remoteSigner';
+import { SignerDeviceInfo } from '@/types/remoteSigner';
 import { formatAddress } from '@/utils/address';
 import { getFromClipboard } from '@/utils/clipboard';
 
-const { width } = Dimensions.get('window');
+/** Verification outcome that gates the preview UI. */
+type VerifiedStatus = 'v2-verified' | 'v1-unsigned';
 
 // Cross-platform alert helper
 const showAlert = (
@@ -80,81 +81,109 @@ export default function ImportRemoteSignerScreen() {
   );
 
   const [screenState, setScreenState] = useState<ScreenState>('scanning');
-  const [hasPermission, setHasPermission] = useState<boolean | null>(null);
-  const [scanned, setScanned] = useState(false);
-  const [pairing, setPairing] = useState<RemoteSignerPairing | null>(null);
+  // The TRUSTED, sanitized pairing from verifyPairing (pubkeys DERIVED from
+  // addr; never the wire `pk`). `null` until a scan verifies.
+  const [verified, setVerified] = useState<VerifiedPairing | null>(null);
+  const [authStatus, setAuthStatus] = useState<VerifiedStatus | null>(null);
+  // ACTIVE confirmation gate for an unauthenticated (v1) pairing (DR-7). Must be
+  // explicitly toggled on before a v1 import is allowed; reset on every rescan.
+  const [confirmedUnverified, setConfirmedUnverified] = useState(false);
   const [selectedAccountAddresses, setSelectedAccountAddresses] = useState<
     Set<string>
   >(new Set());
   const [isImporting, setIsImporting] = useState(false);
+  // Bumped to force-remount the native scanner after a failed scan. A rejected
+  // or malformed QR leaves AnimatedQRScanner in a 'completed' state that ignores
+  // subsequent frames; remounting lets the user retry without leaving the screen.
+  const [scannerKey, setScannerKey] = useState(0);
+  const resetScanner = () => setScannerKey((k) => k + 1);
   const fileInputRef = useRef<HTMLInputElement>(null);
   const canvasRef = useRef<HTMLCanvasElement>(null);
 
-  useEffect(() => {
-    if (Platform.OS !== 'web') {
-      requestCameraPermission();
-    } else {
-      setHasPermission(true);
-    }
-  }, []);
-
-  const requestCameraPermission = async () => {
+  /**
+   * Verify a fully-decoded pairing JSON string (raw JSON from a static frame, or
+   * the reassembled payload from a BC-UR multipart scan) and route on the result.
+   */
+  const verifyAndPreview = (json: string) => {
+    let parsed: unknown;
     try {
-      const { status } = await Camera.requestCameraPermissionsAsync();
-      setHasPermission(status === 'granted');
-    } catch (error) {
-      console.error('Camera permission error:', error);
-      setHasPermission(false);
-    }
-  };
-
-  const handleBarCodeScanned = useCallback(
-    ({ data }: { data: string }) => {
-      if (scanned) return;
-      setScanned(true);
-      processQRData(data);
-    },
-    [scanned]
-  );
-
-  const processQRData = (data: string) => {
-    try {
-      const payload = RemoteSignerService.decodePayload(data);
-
-      if (!isRemoteSignerPairing(payload)) {
-        showAlert(
-          'Invalid QR Code',
-          'This QR code is not an air-gapped signer pairing code.'
-        );
-        setScanned(false);
-        return;
-      }
-
-      // Validate pairing data
-      if (!payload.accts || payload.accts.length === 0) {
-        showAlert('Invalid Pairing', 'No accounts found in the pairing data.');
-        setScanned(false);
-        return;
-      }
-
-      setPairing(payload);
-      setSelectedAccountAddresses(new Set(payload.accts.map((a) => a.addr)));
-      setScreenState('preview');
-    } catch (error) {
-      console.error('Failed to parse QR data:', error);
+      parsed = JSON.parse(json);
+    } catch {
       showAlert(
         'Invalid QR Code',
         'Could not read the QR code. Make sure you are scanning an air-gapped signer pairing QR code.'
       );
-      setScanned(false);
+      resetScanner();
+      return;
     }
+
+    const result = RemoteSignerService.verifyPairing(parsed);
+
+    if (result.status === 'rejected') {
+      showAlert(
+        'Pairing Rejected',
+        `This pairing could not be verified and was blocked.\n\nReason: ${result.reason}`
+      );
+      resetScanner();
+      return;
+    }
+
+    setVerified(result.pairing);
+    setAuthStatus(result.status);
+    setConfirmedUnverified(false);
+    setSelectedAccountAddresses(
+      new Set(result.pairing.accounts.map((a) => a.addr))
+    );
+    setScreenState('preview');
+  };
+
+  /**
+   * Handle a scanned frame from the native BC-UR-aware scanner. The scanner has
+   * already reassembled multipart UR and passes the final decoded string here
+   * (or a raw non-UR QR verbatim), so this only needs to verify.
+   */
+  const handleScannerResult = (data: string) => {
+    verifyAndPreview(data);
+  };
+
+  const handleScannerError = (error: string) => {
+    showAlert('Scan Error', error || 'Failed to read the QR code.');
+    resetScanner();
+  };
+
+  /**
+   * Route a single scanned string that has NOT been through the reassembly path
+   * (web file/clipboard). A single static image can only carry a raw-JSON frame
+   * or a single-part UR; a MULTIPART (animated) pairing needs a camera.
+   */
+  const handleSingleFrame = (data: string) => {
+    if (isUrEncodedFrame(data)) {
+      if (AnimatedQRService.isMultipartURFrame(data)) {
+        showAlert(
+          'Animated QR Not Supported Here',
+          'This is a multi-frame (animated) pairing code. Import it using the camera scanner on a mobile device.'
+        );
+        return;
+      }
+      try {
+        verifyAndPreview(AnimatedQRService.decodeSinglePartUR(data));
+      } catch {
+        showAlert(
+          'Invalid QR Code',
+          'Could not decode the pairing QR code from this image.'
+        );
+      }
+      return;
+    }
+    // Raw-JSON static fast-path.
+    verifyAndPreview(data);
   };
 
   const handlePasteFromClipboard = async () => {
     try {
       const text = await getFromClipboard();
       if (text) {
-        processQRData(text.trim());
+        handleSingleFrame(text.trim());
       }
     } catch (error) {
       showAlert('Error', 'Failed to read from clipboard');
@@ -187,7 +216,7 @@ export default function ImportRemoteSignerScreen() {
 
           const code = jsQR(imageData.data, imageData.width, imageData.height);
           if (code?.data) {
-            processQRData(code.data);
+            handleSingleFrame(code.data);
           } else {
             showAlert(
               'No QR Code Found',
@@ -215,43 +244,43 @@ export default function ImportRemoteSignerScreen() {
     });
   };
 
+  // A v1 (unauthenticated) pairing must be actively confirmed before import.
+  const importBlockedForV1 =
+    authStatus === 'v1-unsigned' && !confirmedUnverified;
+  const canImport =
+    selectedAccountAddresses.size > 0 && !importBlockedForV1 && !isImporting;
+
   const handleImport = async () => {
-    if (!pairing || selectedAccountAddresses.size === 0) return;
+    if (!verified || !authStatus || !canImport) return;
 
     setIsImporting(true);
     setScreenState('importing');
 
     try {
-      // Import selected accounts
-      const selectedAccounts = pairing.accts.filter((a) =>
-        selectedAccountAddresses.has(a.addr)
+      // Map the VERIFIED pairing → import requests: each request carries the
+      // pubkey DERIVED from addr (never the wire `pk`) and the verified
+      // authLevel ('v2-signed' | 'v1-unsigned').
+      const requests = mapVerifiedPairingToImportRequests(
+        verified,
+        selectedAccountAddresses
       );
 
-      for (const account of selectedAccounts) {
-        const request: ImportRemoteSignerAccountRequest = {
-          type: AccountType.REMOTE_SIGNER,
-          address: account.addr,
-          publicKey: account.pk,
-          signerDeviceId: pairing.dev,
-          signerDeviceName: pairing.name,
-          label: account.label,
-        };
-
+      for (const request of requests) {
         await addRemoteSignerAccount(request);
       }
 
-      // Add/update paired signer info
+      // Add/update paired signer info.
       const signerInfo: SignerDeviceInfo = {
-        deviceId: pairing.dev,
-        deviceName: pairing.name,
+        deviceId: verified.dev,
+        deviceName: verified.name,
         pairedAt: Date.now(),
-        addresses: selectedAccounts.map((a) => a.addr),
+        addresses: requests.map((r) => r.address),
       };
       await addPairedSigner(signerInfo);
 
       showAlert(
         'Success',
-        `Successfully imported ${selectedAccounts.length} account${selectedAccounts.length > 1 ? 's' : ''} from the air-gapped signer.`,
+        `Successfully imported ${requests.length} account${requests.length > 1 ? 's' : ''} from the air-gapped signer.`,
         [{ text: 'OK', onPress: () => navigation.goBack() }]
       );
     } catch (error) {
@@ -266,8 +295,9 @@ export default function ImportRemoteSignerScreen() {
   };
 
   const handleRescan = () => {
-    setScanned(false);
-    setPairing(null);
+    setVerified(null);
+    setAuthStatus(null);
+    setConfirmedUnverified(false);
     setSelectedAccountAddresses(new Set());
     setScreenState('scanning');
   };
@@ -330,72 +360,63 @@ export default function ImportRemoteSignerScreen() {
       );
     }
 
-    if (hasPermission === null) {
-      return (
-        <View style={styles.centerContainer}>
-          <ActivityIndicator size="large" color={theme.colors.primary} />
-          <Text style={styles.statusText}>Requesting camera permission...</Text>
-        </View>
-      );
-    }
-
-    if (hasPermission === false) {
-      return (
-        <View style={styles.centerContainer}>
-          <Ionicons
-            name="camera-off-outline"
-            size={48}
-            color={theme.colors.error}
-          />
-          <Text style={styles.statusText}>Camera permission denied</Text>
-          <Text style={styles.statusSubtext}>
-            Please enable camera access in your device settings to scan QR
-            codes.
-          </Text>
-          <TouchableOpacity
-            style={styles.retryButton}
-            onPress={requestCameraPermission}
-          >
-            <Text style={styles.retryButtonText}>Request Permission</Text>
-          </TouchableOpacity>
-        </View>
-      );
-    }
-
+    // Native: the BC-UR-aware scanner handles camera permission, raw-QR
+    // pass-through, AND multi-frame (animated) UR reassembly. It calls onScan
+    // with the final decoded payload string in every case.
     return (
       <View style={styles.cameraContainer}>
-        <CameraView
-          style={StyleSheet.absoluteFillObject}
-          onBarcodeScanned={scanned ? undefined : handleBarCodeScanned}
-          barcodeScannerSettings={{ barcodeTypes: ['qr'] }}
+        <AnimatedQRScanner
+          key={scannerKey}
+          onScan={handleScannerResult}
+          onError={handleScannerError}
+          instructionsText="Scan the pairing QR code displayed on your signer device"
         />
-        <View style={styles.overlay}>
-          <View style={styles.scanArea}>
-            <View style={[styles.corner, styles.topLeft]} />
-            <View style={[styles.corner, styles.topRight]} />
-            <View style={[styles.corner, styles.bottomLeft]} />
-            <View style={[styles.corner, styles.bottomRight]} />
-          </View>
-        </View>
-        <View style={styles.scanInstructions}>
-          <Text style={styles.scanText}>
-            Scan the QR code displayed on your signer device
-          </Text>
-        </View>
       </View>
     );
   };
 
   // Render preview state
   const renderPreview = () => {
-    if (!pairing) return null;
+    if (!verified || !authStatus) return null;
+
+    const isVerified = authStatus === 'v2-verified';
 
     return (
       <ScrollView
         style={styles.previewContainer}
         contentContainerStyle={styles.previewContent}
       >
-        {/* Signer Device Info */}
+        {/* Trust status banner — the cryptographic verdict of verifyPairing. */}
+        {isVerified ? (
+          <View style={styles.verifiedBanner}>
+            <Ionicons
+              name="shield-checkmark"
+              size={24}
+              color={theme.colors.success}
+            />
+            <View style={styles.bannerText}>
+              <Text style={styles.verifiedTitle}>Verified pairing</Text>
+              <Text style={styles.verifiedSubtitle}>
+                The signer cryptographically proved it controls every account
+                below.
+              </Text>
+            </View>
+          </View>
+        ) : (
+          <View style={styles.warningBanner}>
+            <Ionicons name="warning" size={24} color={theme.colors.warning} />
+            <View style={styles.bannerText}>
+              <Text style={styles.warningTitle}>Unauthenticated pairing</Text>
+              <Text style={styles.warningSubtitle}>
+                This pairing is NOT cryptographically signed. The signer did not
+                prove it controls these accounts — only import it if you trust
+                the source.
+              </Text>
+            </View>
+          </View>
+        )}
+
+        {/* Signer Device Info — Device ID is the trust-bearing identity. */}
         <View style={styles.deviceCard}>
           <View style={styles.deviceIconContainer}>
             <Ionicons
@@ -405,10 +426,16 @@ export default function ImportRemoteSignerScreen() {
             />
           </View>
           <View style={styles.deviceInfo}>
-            <Text style={styles.deviceName}>
-              {pairing.name || 'Unknown Signer'}
-            </Text>
-            <Text style={styles.deviceId}>Device ID: {pairing.dev}</Text>
+            <Text style={styles.deviceIdLabel}>Signer Device ID</Text>
+            <Text style={styles.deviceId}>{verified.dev}</Text>
+            <View style={styles.unverifiedRow}>
+              <Text style={styles.deviceNameUnverified} numberOfLines={1}>
+                {verified.name || 'Unnamed device'}
+              </Text>
+              <View style={styles.unverifiedTag}>
+                <Text style={styles.unverifiedTagText}>user-supplied</Text>
+              </View>
+            </View>
           </View>
         </View>
 
@@ -417,11 +444,11 @@ export default function ImportRemoteSignerScreen() {
           <View style={styles.accountsHeader}>
             <Text style={styles.sectionTitle}>
               Select Accounts to Import ({selectedAccountAddresses.size}/
-              {pairing.accts.length})
+              {verified.accounts.length})
             </Text>
           </View>
 
-          {pairing.accts.map((account) => (
+          {verified.accounts.map((account) => (
             <TouchableOpacity
               key={account.addr}
               style={[
@@ -447,26 +474,60 @@ export default function ImportRemoteSignerScreen() {
                 )}
               </View>
               <View style={styles.accountDetails}>
-                {account.label && (
-                  <Text style={styles.accountLabel}>{account.label}</Text>
-                )}
+                {/* Address is cryptographically bound (pubkey derived from it). */}
                 <Text style={styles.accountAddress}>
                   {formatAddress(account.addr)}
                 </Text>
+                {account.label ? (
+                  <View style={styles.unverifiedRow}>
+                    <Text
+                      style={styles.accountLabelUnverified}
+                      numberOfLines={1}
+                    >
+                      {account.label}
+                    </Text>
+                    <View style={styles.unverifiedTag}>
+                      <Text style={styles.unverifiedTagText}>unverified</Text>
+                    </View>
+                  </View>
+                ) : null}
               </View>
             </TouchableOpacity>
           ))}
         </View>
 
+        {/* Active confirmation gate for an unauthenticated (v1) pairing. */}
+        {authStatus === 'v1-unsigned' && (
+          <TouchableOpacity
+            style={[
+              styles.confirmCard,
+              confirmedUnverified && styles.confirmCardChecked,
+            ]}
+            onPress={() => setConfirmedUnverified((prev) => !prev)}
+            activeOpacity={0.8}
+          >
+            <Ionicons
+              name={confirmedUnverified ? 'checkbox' : 'square-outline'}
+              size={24}
+              color={
+                confirmedUnverified
+                  ? theme.colors.warning
+                  : theme.colors.textSecondary
+              }
+            />
+            <Text style={styles.confirmText}>
+              This pairing is unauthenticated — the signer did not
+              cryptographically prove control of these accounts. I understand.
+            </Text>
+          </TouchableOpacity>
+        )}
+
         {/* Actions */}
         <View style={styles.previewActions}>
           <TouchableOpacity
-            style={[
-              styles.importButton,
-              selectedAccountAddresses.size === 0 && styles.buttonDisabled,
-            ]}
+            style={[styles.importButton, !canImport && styles.buttonDisabled]}
             onPress={handleImport}
-            disabled={selectedAccountAddresses.size === 0}
+            disabled={!canImport}
           >
             <Ionicons
               name="download-outline"
@@ -556,84 +617,114 @@ const createStyles = (theme: Theme) =>
       marginTop: theme.spacing.md,
       textAlign: 'center',
     },
-    statusSubtext: {
-      fontSize: 14,
-      color: theme.colors.textSecondary,
-      marginTop: theme.spacing.sm,
-      textAlign: 'center',
-    },
-    retryButton: {
-      marginTop: theme.spacing.lg,
-      paddingHorizontal: theme.spacing.lg,
-      paddingVertical: theme.spacing.md,
-      backgroundColor: theme.colors.primary,
-      borderRadius: theme.borderRadius.lg,
-    },
-    retryButtonText: {
-      fontSize: 16,
-      fontWeight: '600',
-      color: theme.colors.buttonText,
-    },
-    // Camera styles
+    // Camera styles — the BC-UR scanner fills this and renders its own overlay.
     cameraContainer: {
       flex: 1,
     },
-    overlay: {
-      ...StyleSheet.absoluteFillObject,
-      justifyContent: 'center',
+    // Trust status banners
+    verifiedBanner: {
+      flexDirection: 'row',
       alignItems: 'center',
-      backgroundColor: 'rgba(0,0,0,0.5)',
-    },
-    scanArea: {
-      width: width * 0.7,
-      height: width * 0.7,
-      position: 'relative',
-    },
-    corner: {
-      position: 'absolute',
-      width: 30,
-      height: 30,
-      borderColor: theme.colors.primary,
-    },
-    topLeft: {
-      top: 0,
-      left: 0,
-      borderTopWidth: 3,
-      borderLeftWidth: 3,
-    },
-    topRight: {
-      top: 0,
-      right: 0,
-      borderTopWidth: 3,
-      borderRightWidth: 3,
-    },
-    bottomLeft: {
-      bottom: 0,
-      left: 0,
-      borderBottomWidth: 3,
-      borderLeftWidth: 3,
-    },
-    bottomRight: {
-      bottom: 0,
-      right: 0,
-      borderBottomWidth: 3,
-      borderRightWidth: 3,
-    },
-    scanInstructions: {
-      position: 'absolute',
-      bottom: 100,
-      left: 0,
-      right: 0,
-      alignItems: 'center',
-    },
-    scanText: {
-      fontSize: 16,
-      color: 'white',
-      textAlign: 'center',
-      backgroundColor: 'rgba(0,0,0,0.6)',
-      paddingHorizontal: theme.spacing.lg,
-      paddingVertical: theme.spacing.sm,
+      gap: theme.spacing.md,
+      backgroundColor: `${theme.colors.success}15`,
       borderRadius: theme.borderRadius.lg,
+      padding: theme.spacing.md,
+      marginBottom: theme.spacing.lg,
+      borderWidth: 1,
+      borderColor: `${theme.colors.success}40`,
+    },
+    warningBanner: {
+      flexDirection: 'row',
+      alignItems: 'center',
+      gap: theme.spacing.md,
+      backgroundColor: `${theme.colors.warning}15`,
+      borderRadius: theme.borderRadius.lg,
+      padding: theme.spacing.md,
+      marginBottom: theme.spacing.lg,
+      borderWidth: 1,
+      borderColor: `${theme.colors.warning}40`,
+    },
+    bannerText: {
+      flex: 1,
+    },
+    verifiedTitle: {
+      fontSize: 15,
+      fontWeight: '700',
+      color: theme.colors.success,
+    },
+    verifiedSubtitle: {
+      fontSize: 13,
+      color: theme.colors.textSecondary,
+      marginTop: 2,
+      lineHeight: 18,
+    },
+    warningTitle: {
+      fontSize: 15,
+      fontWeight: '700',
+      color: theme.colors.warning,
+    },
+    warningSubtitle: {
+      fontSize: 13,
+      color: theme.colors.textSecondary,
+      marginTop: 2,
+      lineHeight: 18,
+    },
+    // Unverified (user-supplied) markers
+    unverifiedRow: {
+      flexDirection: 'row',
+      alignItems: 'center',
+      gap: theme.spacing.xs,
+      marginTop: 4,
+    },
+    unverifiedTag: {
+      paddingHorizontal: 6,
+      paddingVertical: 1,
+      borderRadius: theme.borderRadius.sm,
+      backgroundColor: `${theme.colors.warning}20`,
+    },
+    unverifiedTagText: {
+      fontSize: 10,
+      fontWeight: '600',
+      color: theme.colors.warning,
+      textTransform: 'uppercase',
+      letterSpacing: 0.3,
+    },
+    deviceIdLabel: {
+      fontSize: 12,
+      color: theme.colors.textSecondary,
+      marginBottom: 2,
+    },
+    deviceNameUnverified: {
+      flexShrink: 1,
+      fontSize: 13,
+      color: theme.colors.textSecondary,
+    },
+    accountLabelUnverified: {
+      flexShrink: 1,
+      fontSize: 13,
+      color: theme.colors.textSecondary,
+    },
+    // v1 active-confirmation gate
+    confirmCard: {
+      flexDirection: 'row',
+      alignItems: 'flex-start',
+      gap: theme.spacing.sm,
+      backgroundColor: theme.colors.card,
+      borderRadius: theme.borderRadius.lg,
+      padding: theme.spacing.md,
+      marginBottom: theme.spacing.lg,
+      borderWidth: 1,
+      borderColor: `${theme.colors.warning}40`,
+    },
+    confirmCardChecked: {
+      borderColor: theme.colors.warning,
+      backgroundColor: `${theme.colors.warning}12`,
+    },
+    confirmText: {
+      flex: 1,
+      fontSize: 13,
+      color: theme.colors.text,
+      lineHeight: 19,
     },
     // Web styles
     webContainer: {
@@ -714,15 +805,10 @@ const createStyles = (theme: Theme) =>
     deviceInfo: {
       flex: 1,
     },
-    deviceName: {
-      fontSize: 18,
+    deviceId: {
+      fontSize: 13,
       fontWeight: '600',
       color: theme.colors.text,
-    },
-    deviceId: {
-      fontSize: 12,
-      color: theme.colors.textSecondary,
-      marginTop: 4,
       fontFamily: Platform.OS === 'ios' ? 'Menlo' : 'monospace',
     },
     accountsSection: {
@@ -756,15 +842,10 @@ const createStyles = (theme: Theme) =>
     accountDetails: {
       flex: 1,
     },
-    accountLabel: {
-      fontSize: 16,
-      fontWeight: '500',
-      color: theme.colors.text,
-      marginBottom: 2,
-    },
     accountAddress: {
       fontSize: 14,
-      color: theme.colors.textSecondary,
+      fontWeight: '500',
+      color: theme.colors.text,
       fontFamily: Platform.OS === 'ios' ? 'Menlo' : 'monospace',
     },
     previewActions: {

--- a/src/services/remoteSigner/__tests__/pairingImport.test.ts
+++ b/src/services/remoteSigner/__tests__/pairingImport.test.ts
@@ -1,0 +1,107 @@
+/**
+ * Unit tests for the verify-result → wallet-import mapping.
+ *
+ * The security-critical invariants exercised here:
+ *   - the import request's `publicKey` is the DERIVED pubkey from the verified
+ *     pairing (never a wire `pk`), and
+ *   - the request's `authLevel` faithfully carries the verified level so a v1
+ *     (unauthenticated) pairing is persisted as such and a v2 (verified) pairing
+ *     records that it proved control.
+ */
+
+import algosdk from 'algosdk';
+import nacl from 'tweetnacl';
+
+import { mapVerifiedPairingToImportRequests } from '../pairingImport';
+import type { VerifiedPairing } from '../pairing';
+import { AccountType } from '@/types/wallet';
+
+/** Deterministic canonical address + derived hex pubkey from a fixed seed. */
+function seeded(seedByte: number): { addr: string; pkHex: string } {
+  const seed = new Uint8Array(32).fill(seedByte);
+  const kp = nacl.sign.keyPair.fromSeed(seed);
+  const addr = algosdk.encodeAddress(kp.publicKey);
+  const pkHex = Buffer.from(algosdk.decodeAddress(addr).publicKey).toString(
+    'hex'
+  );
+  return { addr, pkHex };
+}
+
+const A = seeded(1);
+const B = seeded(2);
+const C = seeded(3);
+
+const verifiedV2: VerifiedPairing = {
+  dev: 'voi-signer-11111111-2222-3333-4444-555555555555',
+  name: 'My Cold Phone',
+  ts: 1700000000000,
+  authLevel: 'v2-signed',
+  accounts: [
+    { addr: A.addr, publicKey: A.pkHex, label: 'Savings' },
+    { addr: B.addr, publicKey: B.pkHex },
+    { addr: C.addr, publicKey: C.pkHex, label: 'Ops' },
+  ],
+};
+
+describe('mapVerifiedPairingToImportRequests', () => {
+  it('maps a selected subset, preserving verified (canonical) order', () => {
+    const reqs = mapVerifiedPairingToImportRequests(
+      verifiedV2,
+      new Set([C.addr, A.addr])
+    );
+    expect(reqs.map((r) => r.address)).toEqual([A.addr, C.addr]);
+  });
+
+  it('feeds the DERIVED pubkey (never a wire pk) and the verified authLevel', () => {
+    const reqs = mapVerifiedPairingToImportRequests(
+      verifiedV2,
+      new Set([A.addr])
+    );
+    expect(reqs).toHaveLength(1);
+    expect(reqs[0]).toEqual({
+      type: AccountType.REMOTE_SIGNER,
+      address: A.addr,
+      publicKey: A.pkHex, // derived from addr by verifyPairing
+      signerDeviceId: verifiedV2.dev,
+      signerDeviceName: verifiedV2.name,
+      label: 'Savings',
+      authLevel: 'v2-signed',
+    });
+    // The derived pubkey must actually correspond to the address.
+    expect(
+      Buffer.from(algosdk.decodeAddress(A.addr).publicKey).toString('hex')
+    ).toBe(reqs[0].publicKey);
+  });
+
+  it('carries authLevel "v1-unsigned" for an unauthenticated pairing', () => {
+    const verifiedV1: VerifiedPairing = {
+      ...verifiedV2,
+      authLevel: 'v1-unsigned',
+    };
+    const reqs = mapVerifiedPairingToImportRequests(
+      verifiedV1,
+      new Set([A.addr, B.addr])
+    );
+    expect(reqs.every((r) => r.authLevel === 'v1-unsigned')).toBe(true);
+  });
+
+  it('omits addresses not present in the verified pairing', () => {
+    const reqs = mapVerifiedPairingToImportRequests(
+      verifiedV2,
+      new Set([A.addr, 'NOT-A-PAIRED-ADDRESS'])
+    );
+    expect(reqs.map((r) => r.address)).toEqual([A.addr]);
+  });
+
+  it('returns an empty list when nothing is selected', () => {
+    expect(mapVerifiedPairingToImportRequests(verifiedV2, new Set())).toEqual(
+      []
+    );
+  });
+
+  it('accepts an array of addresses as well as a Set', () => {
+    const reqs = mapVerifiedPairingToImportRequests(verifiedV2, [B.addr]);
+    expect(reqs.map((r) => r.address)).toEqual([B.addr]);
+    expect(reqs[0].label).toBeUndefined();
+  });
+});

--- a/src/services/remoteSigner/__tests__/qrTransport.test.ts
+++ b/src/services/remoteSigner/__tests__/qrTransport.test.ts
@@ -1,0 +1,80 @@
+/**
+ * Unit tests for the pairing QR transport helpers.
+ *
+ * These pin down the two routing decisions that keep the static raw-JSON
+ * fast-path compatible with older importers while still supporting BC-UR
+ * multipart for large payloads:
+ *   - the static-vs-animated size threshold (export side), and
+ *   - the UR-vs-raw-JSON frame detection (import side).
+ */
+
+import {
+  encodedByteLength,
+  shouldUseAnimatedQR,
+  isUrEncodedFrame,
+} from '../qrTransport';
+import { REMOTE_SIGNER_CONSTANTS } from '@/types/remoteSigner';
+
+const MAX = REMOTE_SIGNER_CONSTANTS.SINGLE_QR_MAX_BYTES;
+
+describe('encodedByteLength', () => {
+  it('counts ASCII as one byte each', () => {
+    expect(encodedByteLength('abc')).toBe(3);
+    expect(encodedByteLength('')).toBe(0);
+  });
+
+  it('counts multibyte UTF-8 by BYTES, not string length', () => {
+    // 'é' is 2 UTF-8 bytes; '😀' is 4.
+    expect(encodedByteLength('é')).toBe(2);
+    expect(encodedByteLength('😀')).toBe(4);
+    expect('😀'.length).toBe(2); // string length disagrees with byte length
+  });
+});
+
+describe('shouldUseAnimatedQR', () => {
+  it('uses the static fast-path for a small payload', () => {
+    expect(shouldUseAnimatedQR('{"v":2,"t":"pair"}')).toBe(false);
+  });
+
+  it('treats exactly SINGLE_QR_MAX_BYTES as static (boundary is inclusive)', () => {
+    const atLimit = 'a'.repeat(MAX);
+    expect(encodedByteLength(atLimit)).toBe(MAX);
+    expect(shouldUseAnimatedQR(atLimit)).toBe(false);
+  });
+
+  it('switches to animated one byte over the limit', () => {
+    const overLimit = 'a'.repeat(MAX + 1);
+    expect(shouldUseAnimatedQR(overLimit)).toBe(true);
+  });
+
+  it('measures the threshold in UTF-8 bytes (multibyte pushes over)', () => {
+    // (MAX - 1) ASCII + one 2-byte char = MAX + 1 bytes → animated.
+    const payload = 'a'.repeat(MAX - 1) + 'é';
+    expect(encodedByteLength(payload)).toBe(MAX + 1);
+    expect(shouldUseAnimatedQR(payload)).toBe(true);
+  });
+});
+
+describe('isUrEncodedFrame', () => {
+  it('detects a lower-case ur: prefix', () => {
+    expect(isUrEncodedFrame('ur:bytes/1-3/lpadaxcstring')).toBe(true);
+  });
+
+  it('detects an upper-case UR: prefix (QR text is often upper-cased)', () => {
+    expect(isUrEncodedFrame('UR:BYTES/1-3/LPADAXCSTRING')).toBe(true);
+  });
+
+  it('detects a single-part UR frame', () => {
+    expect(isUrEncodedFrame('ur:bytes/lpadaxcstring')).toBe(true);
+  });
+
+  it('treats raw JSON as NOT a UR frame (routes to JSON.parse)', () => {
+    expect(isUrEncodedFrame('{"v":2,"t":"pair","dev":"x"}')).toBe(false);
+  });
+
+  it('does not match an address or arbitrary text', () => {
+    expect(isUrEncodedFrame('')).toBe(false);
+    expect(isUrEncodedFrame('OURADDRESS...')).toBe(false);
+    expect(isUrEncodedFrame('nurse')).toBe(false);
+  });
+});

--- a/src/services/remoteSigner/index.ts
+++ b/src/services/remoteSigner/index.ts
@@ -563,3 +563,13 @@ export type {
   VerifiedPairingAccount,
   PairingVerificationResult,
 } from './pairing';
+
+// Pairing QR transport helpers (static-vs-animated threshold + UR detection).
+export {
+  encodedByteLength,
+  shouldUseAnimatedQR,
+  isUrEncodedFrame,
+} from './qrTransport';
+
+// Verify-result → wallet-import mapping (derived pubkey + authLevel wiring).
+export { mapVerifiedPairingToImportRequests } from './pairingImport';

--- a/src/services/remoteSigner/pairingImport.ts
+++ b/src/services/remoteSigner/pairingImport.ts
@@ -1,0 +1,46 @@
+/**
+ * Verify-result → wallet-import mapping (pure, no key/storage access).
+ *
+ * Bridges the trusted output of {@link verifyPairing} (a {@link VerifiedPairing})
+ * to the wallet's {@link ImportRemoteSignerAccountRequest}s. It exists as a
+ * separate pure function so the security-critical field wiring is unit-testable
+ * in isolation from the import screen:
+ *
+ *   - `publicKey` is the pubkey DERIVED FROM THE ADDRESS by `verifyPairing`
+ *     (hex), NEVER the transmitted `pk` — the wire `pk` is never carried into a
+ *     wallet record (DR-2/DR-3).
+ *   - `authLevel` is the verified pairing level ('v2-signed' | 'v1-unsigned'),
+ *     so an unauthenticated (v1) pairing is persisted as such and a verified
+ *     (v2) pairing records that it proved control.
+ *   - `label`/`name` are copied through verbatim but are cosmetic and UNVERIFIED
+ *     (they live outside the signed message); the UI marks them as such.
+ */
+
+import { AccountType, ImportRemoteSignerAccountRequest } from '@/types/wallet';
+import type { VerifiedPairing } from './pairing';
+
+/**
+ * Map a verified pairing plus a chosen subset of addresses to import requests.
+ *
+ * Only accounts whose `addr` is in `selectedAddresses` are included, preserving
+ * the canonical order of `verified.accounts`. Addresses not present in the
+ * verified pairing are ignored (they can never be imported).
+ */
+export function mapVerifiedPairingToImportRequests(
+  verified: VerifiedPairing,
+  selectedAddresses: Iterable<string>
+): ImportRemoteSignerAccountRequest[] {
+  const selected = new Set(selectedAddresses);
+  return verified.accounts
+    .filter((account) => selected.has(account.addr))
+    .map((account) => ({
+      type: AccountType.REMOTE_SIGNER,
+      address: account.addr,
+      // DERIVED from `addr` by verifyPairing — never the wire `pk`.
+      publicKey: account.publicKey,
+      signerDeviceId: verified.dev,
+      signerDeviceName: verified.name,
+      label: account.label,
+      authLevel: verified.authLevel,
+    }));
+}

--- a/src/services/remoteSigner/qrTransport.ts
+++ b/src/services/remoteSigner/qrTransport.ts
@@ -1,0 +1,58 @@
+/**
+ * Pairing QR transport helpers (pure, dependency-light).
+ *
+ * The pairing flow has two transport shapes on the wire:
+ *
+ *   - RAW JSON in a single STATIC frame — the legacy fast-path. Emitted by the
+ *     signer via the plain `react-native-qrcode-svg` `QRCode` and read by the
+ *     importer with a direct `JSON.parse`. Used whenever the encoded payload
+ *     fits one static frame. This preserves compatibility with older importers
+ *     that cannot decode BC-UR.
+ *
+ *   - BC-UR MULTIPART (animated) — used ONLY when the payload is too large for a
+ *     single static frame (multi-account pairings). Wrapping a single frame in
+ *     BC-UR would produce a `UR:BYTES` envelope that an older importer's raw
+ *     `JSON.parse` cannot read, so we deliberately do NOT UR-wrap small payloads.
+ *
+ * These helpers isolate the two decisions that drive that routing so they can be
+ * unit-tested without a camera / React surface:
+ *   1. {@link shouldUseAnimatedQR} — the payload-size / static-vs-animated
+ *      threshold on the EXPORT side.
+ *   2. {@link isUrEncodedFrame} — the UR-vs-raw-JSON detection on the IMPORT
+ *      side (a scanned frame beginning `ur:`/`UR:` must be routed to UR
+ *      reassembly; anything else is treated as raw JSON).
+ */
+
+import { REMOTE_SIGNER_CONSTANTS } from '@/types/remoteSigner';
+
+/** UTF-8 byte length of an encoded payload string (matches QR capacity units). */
+export function encodedByteLength(encoded: string): number {
+  return new TextEncoder().encode(encoded).length;
+}
+
+/**
+ * Decide whether an encoded pairing payload must be transmitted as an animated
+ * (BC-UR multipart) QR instead of a single static raw-JSON frame.
+ *
+ * Returns `false` (static fast-path) when the payload fits one static frame
+ * (`≤ SINGLE_QR_MAX_BYTES`) and `true` (animated BC-UR) when it is larger. The
+ * comparison is on UTF-8 BYTES, not string length, so multibyte device
+ * names/labels are measured correctly.
+ */
+export function shouldUseAnimatedQR(encoded: string): boolean {
+  return (
+    encodedByteLength(encoded) > REMOTE_SIGNER_CONSTANTS.SINGLE_QR_MAX_BYTES
+  );
+}
+
+/**
+ * Detect a BC-UR-encoded scanned frame (a `ur:`/`UR:` prefix, case-insensitive).
+ *
+ * When `true`, the importer must hand the frame to the BC-UR reassembly path
+ * (single- or multi-part). When `false`, the frame is raw JSON and goes to the
+ * legacy `JSON.parse` fast-path. Mirrors `AnimatedQRService.isURFrame` so the
+ * two agree on what counts as a UR frame.
+ */
+export function isUrEncodedFrame(data: string): boolean {
+  return typeof data === 'string' && data.toLowerCase().startsWith('ur:');
+}


### PR DESCRIPTION
## What
Wires the user-facing **authenticated (v2) remote-signer pairing** UX on top of the merged crypto core (TASK-142) and response verification (TASK-143). Completes TASK-135 / DOC-141. **Additive** — no TASK-142/143 logic changed; the legacy unsigned `createPairingPayload` remains but is no longer used by the UI.

## Export (signer)
- Sync unsigned `useMemo` QR → explicit async **"Generate pairing QR"**, gated behind the existing `SignerAuthModal` (PIN **or** biometric); calls `createSignedPairingPayload` to produce the **v2 signed** payload.
- **Whole-session cache** keyed by `(deviceId, sorted selected-address set)` — one unlock signs all selected accounts (60s key cache); changing the selection invalidates + regenerates.

## Transport (old-importer compatible)
- **Static fast-path = RAW JSON** (plain `QRCode`) when the payload fits one frame (`≤ SINGLE_QR_MAX_BYTES`, UTF-8 bytes) — a single frame is **never** UR-wrapped, so older importers' `JSON.parse` still works.
- **BC-UR animated** only for multi-frame (multi-account). Import detects a `ur:` prefix → UR reassembly (`AnimatedQRScanner`), else raw JSON. Web single-image import stays capped to small static payloads.

## Import (wallet)
- `verifyPairing(payload)` → route: **`rejected`** blocks with the reason; **`v1-unsigned`** requires an **active explicit confirmation** ("unauthenticated — I understand", reset on every scan) before import; **`v2-verified`** imports directly.
- Import maps through `mapVerifiedPairingToImportRequests` → each record carries the pubkey **derived from the address** (never the wire `pk`) + the verified `authLevel`.
- Device `name`/account `label` shown marked **"user-supplied (unverified)"**; address/device-id are the trust-bearing fields.
- Scanner **remounts after a failed scan** (Codex P2) so a rejected/malformed QR doesn't wedge the camera.

## Security review
- Codex review → **CLEAN** on all crypto/transport checks (derived-pubkey persisted, v1 gated, rejected/mixed blocked, static=raw-JSON, animated-only-above-threshold, name/label unverified, no key exposure, `getPrivateKey` path unchanged). The one P2 (scanner retry) is fixed.

## Tests / gates
- `npm run typecheck` ✅ · `npm run lint` (0 errors) ✅ · `npm test` → **44 suites / 569 tests** (17 new: transport threshold, UR-vs-JSON detection, verify→import mapping).

## ⚠️ On-device verification required before merge — HT-147
The full flow needs a **physical signer + wallet** (camera + two-device airgap) which can't be driven in a simulator. Please verify per **HT-147** (v2 pair+import, static vs animated QR, v1 active confirmation, tamper rejection, PIN/biometric, and an end-to-end signed send that also exercises TASK-143). I did **not** auto-merge this PR for that reason.

https://claude.ai/code/session_01FfbFvUJtj9hVCaYZ4MS4y3