### PR TITLE
fix(secure): harden airgap key-transfer key-in-state hygiene + wallet-side confirmation checks (TASK-146)

### DIFF
--- a/src/components/remoteSigner/TransferToAirgapFlow.tsx
+++ b/src/components/remoteSigner/TransferToAirgapFlow.tsx
@@ -20,7 +20,6 @@ import {
   TouchableOpacity,
   ActivityIndicator,
   Modal,
-  Alert,
   ScrollView,
 } from 'react-native';
 import { SafeAreaView } from 'react-native-safe-area-context';
@@ -36,8 +35,9 @@ import { MultiAccountWalletService } from '@/services/wallet';
 import { AccountSecureStorage } from '@/services/secure/AccountSecureStorage';
 import { AnimatedQRCode } from '@/components/remoteSigner/AnimatedQRCode';
 import { AnimatedQRScanner } from '@/components/remoteSigner/AnimatedQRScanner';
-import { verifySignedTransaction } from '@/utils/signatureVerification';
+import { verifyAirgapTransferConfirmation } from '@/utils/signatureVerification';
 import { generateArc0300AccountExportUri } from '@/utils/arc0300';
+import { getNetworkConfig } from '@/services/network/config';
 import { useCurrentNetwork } from '@/store/networkStore';
 import { useSecureScreen } from '@/hooks/useSecureScreen';
 
@@ -79,23 +79,29 @@ export function TransferToAirgapFlow({
   const [verifiedSignerDeviceId, setVerifiedSignerDeviceId] = useState<
     string | null
   >(null);
-  const [verifiedSignerDeviceName, setVerifiedSignerDeviceName] = useState<
-    string | undefined
-  >(undefined);
+  // The airgap confirmation carries no device name today; the setter is unused,
+  // so keep only the (undefined) value passed to convertStandardToRemoteSigner.
+  const [verifiedSignerDeviceName] = useState<string | undefined>(undefined);
 
   // Handle disclaimer acceptance
   const handleAcceptDisclaimer = useCallback(async () => {
     setState('generating');
 
+    // Hoisted so the finally block can zero the raw secret key on EVERY path
+    // (success, error, early throw), not just success.
+    let privateKey: Uint8Array | null = null;
+
     try {
       // Retrieve the private key (will prompt for biometric/PIN authentication internally)
-      const privateKey = await AccountSecureStorage.getPrivateKey(account.id);
+      privateKey = await AccountSecureStorage.getPrivateKey(account.id);
 
       if (!privateKey) {
         throw new Error('Could not retrieve private key for this account');
       }
 
-      // Generate ARC-300 URI
+      // Generate ARC-300 URI. The returned string embeds the key and is an
+      // immutable JS string (cannot be zeroed); its lifetime is minimized by
+      // clearing privateKeyQrData the moment the QR leaves screen (below).
       const arc300Uri = generateArc0300AccountExportUri({
         privateKeyBytes: privateKey,
         name: account.label,
@@ -104,9 +110,6 @@ export function TransferToAirgapFlow({
       // For now we'll just use the raw URI - if it needs animation, AnimatedQRCode handles it
       setPrivateKeyQrData(arc300Uri);
       setState('displaying_qr');
-
-      // Zero out the private key from memory
-      privateKey.fill(0);
     } catch (err) {
       const message =
         err instanceof Error ? err.message : 'Failed to prepare transfer';
@@ -123,6 +126,10 @@ export function TransferToAirgapFlow({
         setError(message);
       }
       setState('error');
+    } finally {
+      // Zero the raw secret key on EVERY path so the mutable Uint8Array never
+      // lingers in memory after this handler returns.
+      privateKey?.fill(0);
     }
   }, [account]);
 
@@ -168,11 +175,21 @@ export function TransferToAirgapFlow({
           );
         }
 
-        // Verify the signature locally
+        // Verify the confirmation locally before we ever delete the local key.
+        // verifyAirgapTransferConfirmation layers wallet-side checks (bounded
+        // blob, amount === 0, genesis === active network) on top of the
+        // sig/self-payment/no-rekey/no-msig core. NOTE: this proves the airgap
+        // can sign for this address on this chain — it is NOT a freshness/replay
+        // guard (see the helper's docblock; closing that needs a two-sided
+        // nonce, declined in TASK-146).
         const signedTxnBase64 = Buffer.from(signedTxns[0]).toString('base64');
-        const verificationResult = verifySignedTransaction(
+        const netConfig = getNetworkConfig(networkId);
+        const verificationResult = verifyAirgapTransferConfirmation(
           signedTxnBase64,
-          account.address
+          {
+            expectedSignerAddress: account.address,
+            expectedGenesisHashBase64: netConfig.genesisHash,
+          }
         );
 
         if (!verificationResult.valid) {
@@ -180,6 +197,11 @@ export function TransferToAirgapFlow({
             verificationResult.error || 'Signature verification failed'
           );
         }
+
+        // The private-key QR has served its purpose and the transfer is
+        // verified; drop the key-bearing URI from React state NOW rather than
+        // holding it through confirm_deletion → converting → success.
+        setPrivateKeyQrData(null);
 
         // Extract signer device info from the response metadata if available
         // For now, we'll use a generated device ID since the response might not have it
@@ -195,7 +217,7 @@ export function TransferToAirgapFlow({
         setState('error');
       }
     },
-    [account.address]
+    [account.address, networkId]
   );
 
   // Handle user confirming deletion
@@ -240,7 +262,19 @@ export function TransferToAirgapFlow({
   // Handle retry
   const handleRetry = useCallback(() => {
     setError(null);
+    // Drop any key-bearing URI before returning to the disclaimer; a fresh key
+    // is re-generated on re-acceptance.
+    setPrivateKeyQrData(null);
     setState('disclaimer');
+  }, []);
+
+  // Belt-and-suspenders: drop the key-bearing URI from state on unmount so it is
+  // never retained past the lifetime of this flow (e.g. if the modal is
+  // dismissed while the QR is on screen).
+  useEffect(() => {
+    return () => {
+      setPrivateKeyQrData(null);
+    };
   }, []);
 
   // Handle back to QR

--- a/src/utils/__tests__/arc0300.test.ts
+++ b/src/utils/__tests__/arc0300.test.ts
@@ -82,6 +82,20 @@ describe('arc0300', () => {
         generateArc0300AccountExportUri({ privateKeyBytes: new Uint8Array(0) })
       ).toThrow('Invalid private key length: expected 64 bytes, got 0');
     });
+
+    // TASK-146 secret-hygiene contract: the function zeroes only its OWN
+    // transient Buffer copy of the secret and must NOT mutate the caller's
+    // array (the caller owns zeroing its own key). A regression that zeroed the
+    // input in place would corrupt the caller's key before it can be used/zeroed.
+    it('does not mutate the caller-supplied privateKeyBytes', () => {
+      const sk = makeSecretKey(9);
+      const before = Array.from(sk);
+      const uri = generateArc0300AccountExportUri({ privateKeyBytes: sk });
+      // The input array is unchanged...
+      expect(Array.from(sk)).toEqual(before);
+      // ...and the URI encodes the original (unzeroed) key.
+      expect(uri).toBe(`avm://account/import?privatekey=${toB64Url(sk)}`);
+    });
   });
 
   describe('parseArc0300AccountImportUri', () => {

--- a/src/utils/__tests__/signatureVerification.test.ts
+++ b/src/utils/__tests__/signatureVerification.test.ts
@@ -21,6 +21,7 @@ import {
   verifyEd25519Signature,
   verifySignedTransactionBytes,
   verifyAirgapTransferConfirmation,
+  readPaymentAmount,
   MAX_AIRGAP_CONFIRMATION_BASE64_LEN,
 } from '../signatureVerification';
 
@@ -256,6 +257,36 @@ describe('verifySignedTransaction', () => {
       senderAddr
     );
     expect(result.valid).toBe(false);
+  });
+});
+
+describe('readPaymentAmount', () => {
+  it('reads the v3 shape (txn.payment.amount)', () => {
+    expect(readPaymentAmount({ payment: { amount: 1000n } })).toBe(1000n);
+  });
+
+  it('reads the v2 shape (txn.amount) — the field the raw v3 accessor missed', () => {
+    // A v2-decoded non-zero self-payment must NOT fall through to 0 and be
+    // accepted as "zero-amount" (Codex P2 regression).
+    expect(readPaymentAmount({ amount: 1000n })).toBe(1000n);
+    expect(readPaymentAmount({ amount: 12345 })).toBe(12345n);
+  });
+
+  it('reads the raw msgpack shape (amt)', () => {
+    expect(readPaymentAmount({ amt: 500 })).toBe(500n);
+  });
+
+  it('treats an omitted/zero amount as 0n across shapes', () => {
+    expect(readPaymentAmount({})).toBe(0n);
+    expect(readPaymentAmount({ payment: {} })).toBe(0n);
+    expect(readPaymentAmount({ payment: { amount: 0n } })).toBe(0n);
+    expect(readPaymentAmount({ amount: 0 })).toBe(0n);
+  });
+
+  it('prefers the v3 field when multiple shapes are present', () => {
+    expect(
+      readPaymentAmount({ payment: { amount: 7n }, amount: 99n, amt: 42 })
+    ).toBe(7n);
   });
 });
 

--- a/src/utils/__tests__/signatureVerification.test.ts
+++ b/src/utils/__tests__/signatureVerification.test.ts
@@ -20,6 +20,8 @@ import {
   extractTransactionComponents,
   verifyEd25519Signature,
   verifySignedTransactionBytes,
+  verifyAirgapTransferConfirmation,
+  MAX_AIRGAP_CONFIRMATION_BASE64_LEN,
 } from '../signatureVerification';
 
 // Deterministic-enough suggested params. genesisHash is 32 zero bytes; we never
@@ -254,6 +256,113 @@ describe('verifySignedTransaction', () => {
       senderAddr
     );
     expect(result.valid).toBe(false);
+  });
+});
+
+describe('verifyAirgapTransferConfirmation', () => {
+  // Use a REAL (non-zero) genesis hash: algosdk omits an all-zero genesisHash
+  // from the encoding, which never happens for a real network. The Voi mainnet
+  // genesis stands in for "the active network" here.
+  const ACTIVE_GENESIS_B64 = 'r20fSQI8gWe/kFZziNonSPCXLwcQmH/nxROvnnueWOk=';
+  const ACTIVE_GENESIS = new Uint8Array(
+    Buffer.from(ACTIVE_GENESIS_B64, 'base64')
+  );
+  const OTHER_GENESIS_B64 = 'wGHE2Pwdvd7S12BL5FaOP20EGYesN73ktiC1qzkkit8=';
+
+  /** Sign a self-payment on ACTIVE_GENESIS (overridable), mirroring the airgap. */
+  function signConfirmation(overrides: Record<string, unknown> = {}) {
+    const acct = algosdk.generateAccount();
+    const address = addrOf(acct);
+    const txn = algosdk.makePaymentTxnWithSuggestedParamsFromObject({
+      sender: address,
+      receiver: address,
+      amount: 0,
+      suggestedParams: {
+        ...SUGGESTED_PARAMS,
+        genesisHash: ACTIVE_GENESIS,
+      } as algosdk.SuggestedParams,
+      ...overrides,
+    } as Parameters<
+      typeof algosdk.makePaymentTxnWithSuggestedParamsFromObject
+    >[0]);
+    const signedBase64 = Buffer.from(txn.signTxn(acct.sk)).toString('base64');
+    return { acct, address, signedBase64 };
+  }
+
+  it('accepts a zero-amount self-payment on the matching network (happy path)', () => {
+    const { address, signedBase64 } = signConfirmation();
+    const result = verifyAirgapTransferConfirmation(signedBase64, {
+      expectedSignerAddress: address,
+      expectedGenesisHashBase64: ACTIVE_GENESIS_B64,
+    });
+    expect(result).toEqual({ valid: true });
+  });
+
+  it('rejects a confirmation for a DIFFERENT network (genesis mismatch)', () => {
+    const { address, signedBase64 } = signConfirmation();
+    const result = verifyAirgapTransferConfirmation(signedBase64, {
+      expectedSignerAddress: address,
+      expectedGenesisHashBase64: OTHER_GENESIS_B64,
+    });
+    expect(result.valid).toBe(false);
+    expect(result.error).toMatch(/different network/i);
+  });
+
+  it('rejects a non-zero-amount self-payment (shape bind)', () => {
+    // Still a self-payment (receiver === sender) so it clears the base checks,
+    // but the amount is non-zero → the confirmation-shape guard must reject it.
+    const { address, signedBase64 } = signConfirmation({ amount: 1000 });
+    const result = verifyAirgapTransferConfirmation(signedBase64, {
+      expectedSignerAddress: address,
+      expectedGenesisHashBase64: ACTIVE_GENESIS_B64,
+    });
+    expect(result.valid).toBe(false);
+    expect(result.error).toMatch(/zero-amount self-payment/i);
+  });
+
+  it('rejects an over-long payload before decoding (bounded input)', () => {
+    const address = addrOf(algosdk.generateAccount());
+    const tooLong = 'A'.repeat(MAX_AIRGAP_CONFIRMATION_BASE64_LEN + 1);
+    const result = verifyAirgapTransferConfirmation(tooLong, {
+      expectedSignerAddress: address,
+      expectedGenesisHashBase64: ACTIVE_GENESIS_B64,
+    });
+    expect(result.valid).toBe(false);
+    expect(result.error).toMatch(/missing or too large/i);
+  });
+
+  it('rejects an empty payload', () => {
+    const address = addrOf(algosdk.generateAccount());
+    const result = verifyAirgapTransferConfirmation('', {
+      expectedSignerAddress: address,
+      expectedGenesisHashBase64: ACTIVE_GENESIS_B64,
+    });
+    expect(result.valid).toBe(false);
+    expect(result.error).toMatch(/missing or too large/i);
+  });
+
+  it('delegates to the base verifier: rejects a rekeying confirmation', () => {
+    const rekeyTarget = addrOf(algosdk.generateAccount());
+    const { address, signedBase64 } = signConfirmation({
+      rekeyTo: rekeyTarget,
+    });
+    const result = verifyAirgapTransferConfirmation(signedBase64, {
+      expectedSignerAddress: address,
+      expectedGenesisHashBase64: ACTIVE_GENESIS_B64,
+    });
+    expect(result.valid).toBe(false);
+    expect(result.error).toMatch(/rekey/i);
+  });
+
+  it('delegates to the base verifier: rejects a wrong expected signer', () => {
+    const { signedBase64 } = signConfirmation();
+    const other = addrOf(algosdk.generateAccount());
+    const result = verifyAirgapTransferConfirmation(signedBase64, {
+      expectedSignerAddress: other,
+      expectedGenesisHashBase64: ACTIVE_GENESIS_B64,
+    });
+    expect(result.valid).toBe(false);
+    expect(result.error).toMatch(/does not match expected signer/i);
   });
 });
 

--- a/src/utils/arc0300.ts
+++ b/src/utils/arc0300.ts
@@ -164,6 +164,15 @@ export function isArc0300AccountImportUri(uri: string): boolean {
  * Generate an ARC-0300 account export URI containing a private key.
  * Used for transferring an account to an air-gapped device.
  *
+ * SECRET-HYGIENE CONTRACT (TASK-146): this function copies the secret bytes into
+ * a transient Buffer, zeroes THAT copy before returning, and does NOT mutate the
+ * caller's `privateKeyBytes` (the caller owns zeroing its own array). It CANNOT,
+ * however, make the returned value secret-free: the URI — and the intermediate
+ * base64 strings — are immutable JS strings that embed the raw private key and
+ * cannot be wiped; they persist in the heap until GC. This is irreducible for a
+ * "render the key as a QR" feature. Callers MUST minimize the returned string's
+ * lifetime (drop the reference the moment the QR is no longer displayed).
+ *
  * @param params.privateKeyBytes - The 64-byte Ed25519 secret key
  * @param params.name - Optional account name/label
  * @returns ARC-0300 URI string (e.g., avm://account/import?privatekey=<base64>&name=<name>)
@@ -181,13 +190,17 @@ export function generateArc0300AccountExportUri(params: {
     );
   }
 
-  // Convert to URL-safe base64 (RFC 4648 §5)
-  // Replace + with -, / with _, and remove padding =
-  const privateKeyBase64 = Buffer.from(privateKeyBytes)
+  // Convert to URL-safe base64 (RFC 4648 §5): replace + with -, / with _, and
+  // remove padding =. `Buffer.from(privateKeyBytes)` makes a fresh binary COPY
+  // of the secret; we zero that copy the instant base64 is derived so only the
+  // (unavoidable, immutable) base64 string form of the key survives this call.
+  const keyBuffer = Buffer.from(privateKeyBytes);
+  const privateKeyBase64 = keyBuffer
     .toString('base64')
     .replace(/\+/g, '-')
     .replace(/\//g, '_')
     .replace(/=+$/, '');
+  keyBuffer.fill(0);
 
   // Build the URI
   let uri = `avm://account/import?privatekey=${privateKeyBase64}`;

--- a/src/utils/signatureVerification.ts
+++ b/src/utils/signatureVerification.ts
@@ -217,6 +217,115 @@ export function verifySignedTransactionBytes(
   return verifySignedTransaction(base64, expectedSignerAddress);
 }
 
+/**
+ * Upper bound on the base64 length of an airgap-transfer confirmation blob.
+ *
+ * The confirmation is a single zero-amount self-payment with a short fixed note
+ * (~350 bytes raw → ~470 base64 chars). 2 KB leaves generous headroom while
+ * rejecting an implausibly large scanned payload BEFORE it reaches the msgpack
+ * decoder (untrusted QR input).
+ */
+export const MAX_AIRGAP_CONFIRMATION_BASE64_LEN = 2048;
+
+/** Expectations the wallet imposes on an airgap-transfer confirmation. */
+export interface AirgapConfirmationExpectations {
+  /** The STANDARD account being transferred; the confirmation must self-sign for it. */
+  expectedSignerAddress: string;
+  /** Active-network genesis hash (base64); the confirmation must be for this chain. */
+  expectedGenesisHashBase64: string;
+}
+
+/**
+ * Verify the airgap device's transfer confirmation before the online wallet
+ * deletes its local key copy (TASK-146). This is a PRE-DELETION SAFETY CHECK,
+ * not a confidentiality boundary — the airgap already received the full key via
+ * the export QR; this only proves the airgap can produce a valid signature for
+ * the address on the expected chain, so the user does not delete their only key
+ * copy after a failed/partial transfer.
+ *
+ * Layered on {@link verifySignedTransaction} (which already enforces a single
+ * Ed25519 `sig`, no rekey, no msig/lsig, sender === {@link
+ * AirgapConfirmationExpectations.expectedSignerAddress}, and the self-payment
+ * invariant), this ADDS wallet-side, protocol-neutral checks:
+ *   1. bound the untrusted base64 length before decode;
+ *   2. amount === 0 (binds the confirmation to the expected zero-value shape);
+ *   3. genesisHash === the active network (rejects a cross-chain confirmation).
+ *
+ * DELIBERATELY NOT CHECKED: freshness/replay. The confirmation carries no
+ * wallet-chosen nonce, so a confirmation captured from a prior transfer of the
+ * SAME account still verifies. Closing that needs a two-sided nonce protocol
+ * (declined in TASK-146 for cross-version-compat reasons). The exact validity
+ * window / note text are also intentionally NOT asserted — they would couple the
+ * wallet to the airgap's exact constants (a cross-version foot-gun) for ~zero
+ * added value on a zero-amount self-payment.
+ */
+export function verifyAirgapTransferConfirmation(
+  signedTxnBase64: string,
+  expected: AirgapConfirmationExpectations
+): VerificationResult {
+  // Bound the untrusted scanned payload before it reaches the decoder.
+  if (
+    typeof signedTxnBase64 !== 'string' ||
+    signedTxnBase64.length === 0 ||
+    signedTxnBase64.length > MAX_AIRGAP_CONFIRMATION_BASE64_LEN
+  ) {
+    return {
+      valid: false,
+      error: 'Confirmation payload is missing or too large',
+    };
+  }
+
+  // Crypto + self-payment + no-rekey + no-msig/lsig + signer-identity core.
+  const base = verifySignedTransaction(
+    signedTxnBase64,
+    expected.expectedSignerAddress
+  );
+  if (!base.valid) {
+    return base;
+  }
+
+  // Additional shape/chain binding (defense-in-depth; NOT a freshness guard).
+  try {
+    const signedTxn = algosdk.decodeSignedTransaction(
+      Buffer.from(signedTxnBase64, 'base64')
+    );
+    const txnAny = signedTxn.txn as any;
+
+    // The verification self-payment must move zero value. algosdk omits a zero
+    // amount from the encoding, so `undefined` is treated as 0.
+    const rawAmount = txnAny.payment?.amount ?? txnAny.amt ?? 0;
+    if (BigInt(rawAmount ?? 0) !== 0n) {
+      return {
+        valid: false,
+        error: 'Verification transaction must be a zero-amount self-payment',
+      };
+    }
+
+    // Genesis hash must match the active network (reject cross-chain proofs).
+    const genesisHash: Uint8Array | undefined = txnAny.genesisHash ?? txnAny.gh;
+    const expectedGenesisHash = new Uint8Array(
+      Buffer.from(expected.expectedGenesisHashBase64, 'base64')
+    );
+    if (
+      !genesisHash ||
+      !bytesEqual(new Uint8Array(genesisHash), expectedGenesisHash)
+    ) {
+      return {
+        valid: false,
+        error: 'Verification transaction is for a different network',
+      };
+    }
+  } catch (error) {
+    const message = error instanceof Error ? error.message : 'Unknown error';
+    return {
+      valid: false,
+      error: `Failed to verify confirmation: ${message}`,
+    };
+  }
+
+  return { valid: true };
+}
+
 // ============================================================================
 // Remote-signer signed-response verification (DR-6)
 // ============================================================================

--- a/src/utils/signatureVerification.ts
+++ b/src/utils/signatureVerification.ts
@@ -227,6 +227,19 @@ export function verifySignedTransactionBytes(
  */
 export const MAX_AIRGAP_CONFIRMATION_BASE64_LEN = 2048;
 
+/**
+ * Read a payment transaction's amount across algosdk field shapes — v3
+ * (`txn.payment.amount`), v2 (`txn.amount`), and raw msgpack (`amt`) — mirroring
+ * the v2/v3 receiver handling in {@link verifySignedTransaction}. A zero amount
+ * is frequently omitted from the encoding, so a missing value reads as `0n`.
+ * Exported so the multi-shape fallback (esp. the v2 path) is unit-testable
+ * directly, since algosdk 3.x's decoder only ever emits the v3 shape at runtime.
+ */
+export function readPaymentAmount(txnAny: any): bigint {
+  const raw = txnAny?.payment?.amount ?? txnAny?.amount ?? txnAny?.amt ?? 0;
+  return BigInt(raw ?? 0);
+}
+
 /** Expectations the wallet imposes on an airgap-transfer confirmation. */
 export interface AirgapConfirmationExpectations {
   /** The STANDARD account being transferred; the confirmation must self-sign for it. */
@@ -291,10 +304,10 @@ export function verifyAirgapTransferConfirmation(
     );
     const txnAny = signedTxn.txn as any;
 
-    // The verification self-payment must move zero value. algosdk omits a zero
-    // amount from the encoding, so `undefined` is treated as 0.
-    const rawAmount = txnAny.payment?.amount ?? txnAny.amt ?? 0;
-    if (BigInt(rawAmount ?? 0) !== 0n) {
+    // The verification self-payment must move zero value. Read the amount across
+    // v3/v2/msgpack field shapes (a zero amount is often omitted → treated as 0)
+    // so a v2-decoded non-zero self-payment cannot slip through as "zero".
+    if (readPaymentAmount(txnAny) !== 0n) {
       return {
         valid: false,
         error: 'Verification transaction must be a zero-amount self-payment',


### PR DESCRIPTION
## TASK-146 — ARC-0300 airgap key-transfer hygiene + verification hardening

Run via `/pad ultra-codex TASK-146`. Highest-risk crypto surface — all scope decisions taken with the human per `CLAUDE.md` (STOP-and-ask). Decision Record recorded on TASK-146.

### What & why
The airgap **key-transfer** flow exports a STANDARD account's private key as an ARC-0300 QR, then deletes the local copy after the airgap device returns a signed confirmation. Two hardening threads:

**DR-1 — Key-in-state hygiene.** JS strings are immutable and can't be zeroed, so a QR-*of-a-private-key* can't be fully ephemeral; realistic wins only:
- `arc0300.ts`: zero the transient `Buffer` copy after deriving base64; JSDoc the irreducible immutable-string residual; the caller's `Uint8Array` is **not** mutated (locked by a test).
- `TransferToAirgapFlow.tsx`: zero the raw `Uint8Array` on **every** path via `finally`; **clear the key-bearing `privateKeyQrData` from React state the moment the QR leaves screen** (verify-success → `confirm_deletion`, retry, unmount) instead of holding it through `confirm → convert → success`.

**DR-3 — Verification tightening, wallet-side only (no protocol change).** The airgap already holds the full key, so the confirmation is a *pre-deletion safety check*. New pure helper `verifyAirgapTransferConfirmation` layers, on top of the existing sig / self-payment / no-rekey / no-msig core:
- bounded blob length before decode (untrusted scanned QR);
- `amount === 0` read across v3/v2/msgpack shapes (`readPaymentAmount`);
- `genesisHash === active network` (rejects cross-chain confirmations).

**Intentionally out of scope:** freshness/replay. Closing it needs a two-sided nonce protocol (declined for cross-version-compat). Documented in code.

### Gates
- `npm run typecheck` — clean (0 errors)
- `npm run lint` — 0 errors (also drops 2 pre-existing unused-symbol warnings in the touched file)
- `npm test` — **582 passed** (extended `arc0300` + `signatureVerification`, incl. v2/v3/msgpack amount regression)
- **Codex** review — CLEAN after fixing one P2 (v2 `txn.amount` field-access gap)

### ⚠️ Remaining human gate (device testing, per `CLAUDE.md`)
The end-to-end airgap transfer requires **two devices** (online wallet + airgap) and could not be exercised in-session. Automated gates cover the pure-util logic + typecheck/lint + Codex. A manual two-device pass (export QR → import on airgap → scan confirmation → key deletion; plus the Back-to-QR path) is the remaining gate before this ships to users — filed as a Human Task.

Closes TASK-146.