### PR TITLE
chore(explorer): drop unused NetworkConfiguration import

### DIFF
--- a/src/utils/blockExplorer.ts
+++ b/src/utils/blockExplorer.ts
@@ -2,7 +2,7 @@
  * Utility functions for blockchain network block explorer integration
  */
 
-import { NetworkId, NetworkConfiguration } from '@/types/network';
+import { NetworkId } from '@/types/network';
 import { getNetworkConfig } from '@/services/network/config';
 
 // Legacy constant for backwards compatibility


### PR DESCRIPTION
Removes a dead import left after TASK-152 (#113) deleted the allo.info dead branches. `NetworkConfiguration` is no longer referenced. tsc (`noUnusedLocals` off) and eslint both pass; no runtime effect. Ties off PLAN-102 Wave-1 hygiene.