### PR TITLE
test(fixtures): shared algosdk-v3 test fixtures (TASK-149)

### DIFF
--- a/node_modules
+++ b/node_modules
@@ -1,0 +1,1 @@
+/Users/dave/Dev/voi/voiapp/node_modules

--- a/src/__tests__/fixtures/algorand.test.ts
+++ b/src/__tests__/fixtures/algorand.test.ts
@@ -1,0 +1,168 @@
+/**
+ * Proves the shared fixtures (TASK-149) actually work with real algosdk v3 /
+ * tweetnacl, and that transactions decode into the same field shape production
+ * consumes. These assertions are the contract downstream P0 tests rely on.
+ */
+
+import algosdk from 'algosdk';
+import { Buffer } from 'buffer';
+
+import {
+  makeAccount,
+  makeAddress,
+  paymentTxn,
+  assetTransferTxn,
+  assetConfigTxn,
+  appCallTxn,
+  arc200TransferTxn,
+  roundTripTxn,
+  createStoreHarness,
+  harnessForStore,
+  FIXTURE_ASSET_ID,
+  FIXTURE_APP_ID,
+} from './algorand';
+
+describe('fixtures/algorand: deterministic account factory (real crypto)', () => {
+  it('produces a real, well-formed algosdk account (seed(32)||pubkey(32))', () => {
+    const a = makeAccount('alice');
+
+    // 64-byte sk, 32-byte pk, valid checksummed address.
+    expect(a.sk).toHaveLength(64);
+    expect(a.pk).toHaveLength(32);
+    expect(algosdk.isValidAddress(a.addr)).toBe(true);
+
+    // The address is the Algorand encoding of the appended public key, and the
+    // key really signs/verifies via algosdk — i.e. genuine Ed25519 crypto, not
+    // fabricated bytes.
+    expect(algosdk.encodeAddress(a.pk)).toBe(a.addr);
+    const message = new TextEncoder().encode('fixture-signing-check');
+    const sig = algosdk.signBytes(message, a.sk);
+    expect(algosdk.verifyBytes(message, sig, a.addr)).toBe(true);
+  });
+
+  it('is deterministic per label and distinct across labels', () => {
+    expect(makeAccount('alice').addr).toBe(makeAccount('alice').addr);
+    expect(makeAccount(1).addr).toBe(makeAddress(1));
+    expect(makeAccount('alice').addr).not.toBe(makeAccount('bob').addr);
+  });
+
+  it('round-trips through the algosdk mnemonic import path (Pera-compatible)', () => {
+    const a = makeAccount('carol');
+    const imported = algosdk.mnemonicToSecretKey(a.mnemonic);
+    expect(imported.addr.toString()).toBe(a.addr);
+    // Compare secret keys by equality result only — never serialize the key
+    // itself, so a failure can't leak the private key into test logs (DR-3).
+    expect(Buffer.from(imported.sk).equals(Buffer.from(a.sk))).toBe(true);
+  });
+});
+
+describe('fixtures/algorand: transaction factory (production decode path)', () => {
+  const sender = makeAddress('sender');
+  const attacker = makeAddress('attacker');
+
+  it('payment: exposes closeRemainderTo and rekeyTo where production reads them', () => {
+    const decoded = roundTripTxn(
+      paymentTxn(sender, {
+        receiver: attacker,
+        amount: 5,
+        closeRemainderTo: attacker,
+        rekeyTo: attacker,
+      })
+    );
+
+    expect(decoded.type).toBe(algosdk.TransactionType.pay);
+    expect(decoded.payment?.amount).toBe(5n);
+    expect(decoded.payment?.closeRemainderTo?.toString()).toBe(attacker);
+    expect(decoded.rekeyTo?.toString()).toBe(attacker);
+  });
+
+  it('asset-transfer close-out lands under assetTransfer.closeRemainderTo (S-01 shape)', () => {
+    const decoded = roundTripTxn(
+      assetTransferTxn(sender, {
+        receiver: attacker,
+        closeRemainderTo: attacker,
+      })
+    );
+
+    expect(decoded.type).toBe(algosdk.TransactionType.axfer);
+    expect(decoded.assetTransfer?.assetIndex).toBe(BigInt(FIXTURE_ASSET_ID));
+    expect(decoded.assetTransfer?.closeRemainderTo?.toString()).toBe(attacker);
+    // Production reads assetTransfer.closeRemainderTo — there is NO top-level field.
+    expect(
+      (decoded as unknown as { assetCloseTo?: unknown }).assetCloseTo
+    ).toBeUndefined();
+  });
+
+  it('asset-config: carries the manager/reserve/freeze/clawback reconfig', () => {
+    const decoded = roundTripTxn(assetConfigTxn(sender, { manager: attacker }));
+
+    expect(decoded.type).toBe(algosdk.TransactionType.acfg);
+    expect(decoded.assetConfig?.assetIndex).toBe(BigInt(FIXTURE_ASSET_ID));
+    expect(decoded.assetConfig?.manager?.toString()).toBe(attacker);
+  });
+
+  it('app-call: appId lands under applicationCall.appIndex', () => {
+    const decoded = roundTripTxn(appCallTxn(sender));
+
+    expect(decoded.type).toBe(algosdk.TransactionType.appl);
+    expect(decoded.applicationCall?.appIndex).toBe(BigInt(FIXTURE_APP_ID));
+    expect(decoded.applicationCall?.onComplete).toBe(
+      algosdk.OnApplicationComplete.NoOpOC
+    );
+  });
+
+  it('ARC-200 transfer: real ABI selector + encoded (address, uint256) args', () => {
+    const decoded = roundTripTxn(arc200TransferTxn(sender, attacker, 1000n));
+    const method = algosdk.ABIMethod.fromSignature(
+      'arc200_transfer(address,uint256)bool'
+    );
+
+    const args = decoded.applicationCall?.appArgs ?? [];
+    expect(args).toHaveLength(3);
+    // First arg is the real 4-byte method selector (not fabricated bytes).
+    expect(Buffer.from(args[0]).toString('hex')).toBe(
+      Buffer.from(method.getSelector()).toString('hex')
+    );
+    // Third arg decodes back to the amount via the real ABI type.
+    const amount = algosdk.ABIType.from('uint256').decode(
+      Uint8Array.from(args[2])
+    );
+    expect(amount).toBe(1000n);
+  });
+});
+
+describe('fixtures/algorand: zustand store harness', () => {
+  interface Counter {
+    n: number;
+    inc: () => void;
+  }
+
+  it('createStoreHarness drives a fresh store and resets to baseline', () => {
+    const h = createStoreHarness<Counter>((set) => ({
+      n: 0,
+      inc: () => set((s) => ({ n: s.n + 1 })),
+    }));
+
+    expect(h.getState().n).toBe(0);
+    h.getState().inc();
+    h.getState().inc();
+    expect(h.getState().n).toBe(2);
+
+    h.reset();
+    expect(h.getState().n).toBe(0);
+  });
+
+  it('harnessForStore snapshots an existing store and restores it', () => {
+    const h = createStoreHarness<Counter>((set) => ({
+      n: 5,
+      inc: () => set((s) => ({ n: s.n + 1 })),
+    }));
+    const wrapped = harnessForStore(h.store);
+
+    h.setState({ n: 99 });
+    expect(wrapped.getState().n).toBe(99);
+
+    wrapped.reset();
+    expect(wrapped.getState().n).toBe(5);
+  });
+});

--- a/src/__tests__/fixtures/algorand.ts
+++ b/src/__tests__/fixtures/algorand.ts
@@ -1,0 +1,311 @@
+/**
+ * Shared Algorand / algosdk-v3 test fixtures (TASK-149).
+ *
+ * Purpose: give the P0 signing / transaction / state test tasks one place to get
+ * (a) real deterministic accounts, (b) real algosdk-v3 Transaction fixtures, and
+ * (c) a minimal zustand store harness — so parallel worktrees stop re-rolling
+ * their own inline copies (and stop conflicting on them).
+ *
+ * SECURITY / DR-3 (non-negotiable): every key here is REAL crypto. Accounts are
+ * derived entirely through algosdk itself — a deterministic 32-byte seed is turned
+ * into a 25-word mnemonic (`algosdk.mnemonicFromSeed`) and then into the real
+ * Ed25519 secret key / address (`algosdk.mnemonicToSecretKey`). There is NO
+ * hardcoded/mocked private key or fabricated signature anywhere, and no undeclared
+ * crypto dependency (only algosdk + Node's core `crypto` hash for the seed). The
+ * seeds come from harmless fixture labels ("voi-test-fixture:<label>"), so no real
+ * user key material exists to leak — but as a rule, callers must never log
+ * `sk`/`mnemonic` from these fixtures either.
+ *
+ * These are throwaway keys for offline tests. The transactions are never
+ * submitted, so the network identity (genesisHash) is intentionally a fixed,
+ * obviously-fake value.
+ */
+
+import { createHash } from 'crypto';
+
+import algosdk from 'algosdk';
+import { Buffer } from 'buffer';
+import { createStore } from 'zustand/vanilla';
+
+// ---------------------------------------------------------------------------
+// (a) Deterministic account factory
+// ---------------------------------------------------------------------------
+
+export interface TestAccount {
+  /** 25-word Algorand mnemonic (algosdk-derived, Pera/MyAlgo compatible). */
+  readonly mnemonic: string;
+  /** 64-byte Ed25519 secret key: seed(32) || publicKey(32) — algosdk `sk` layout. */
+  readonly sk: Uint8Array;
+  /** 32-byte Ed25519 public key. */
+  readonly pk: Uint8Array;
+  /** Base32 Algorand address (checksummed), as a string. */
+  readonly addr: string;
+  /** algosdk Account (has `.addr` as an Address object and `.sk`). */
+  readonly account: algosdk.Account;
+}
+
+/**
+ * Deterministically derive a 32-byte seed from a human-readable label using a
+ * real hash (SHA-512, truncated to 32 bytes). Same label -> same account, every
+ * run; different labels -> independent accounts. Node's core `crypto` is used so
+ * no extra crypto dependency is pulled in (this file only ever runs under jest).
+ */
+function seedFromLabel(label: string): Uint8Array {
+  const digest = createHash('sha512')
+    .update(`voi-test-fixture:${label}`)
+    .digest();
+  return new Uint8Array(digest.subarray(0, 32));
+}
+
+/**
+ * Build a real, deterministic Algorand account from a label (or number).
+ *
+ * The 32-byte seed is turned into a 25-word mnemonic and then into a real
+ * Ed25519 keypair entirely by algosdk (`mnemonicFromSeed` -> `mnemonicToSecretKey`),
+ * yielding the exact seed(32) || publicKey(32) secret-key layout and the matching
+ * address. This is byte-for-byte what importing the mnemonic in any Algorand
+ * wallet would produce.
+ */
+export function makeAccount(label: string | number): TestAccount {
+  const seed = seedFromLabel(String(label));
+  const mnemonic = algosdk.mnemonicFromSeed(seed);
+  const { addr, sk } = algosdk.mnemonicToSecretKey(mnemonic);
+  const pk = sk.slice(32); // 64-byte sk is seed(32) || publicKey(32)
+
+  return {
+    mnemonic,
+    sk,
+    pk,
+    addr: addr.toString(),
+    account: { addr, sk },
+  };
+}
+
+/** Convenience: just the address string for a labelled account. */
+export function makeAddress(label: string | number): string {
+  return makeAccount(label).addr;
+}
+
+// ---------------------------------------------------------------------------
+// (b) algosdk-v3 Transaction fixture factory
+// ---------------------------------------------------------------------------
+
+/**
+ * Deterministic suggested params. genesisHash is a fixed, obviously-fake 32-byte
+ * value; these transactions are never submitted so the network identity is
+ * irrelevant. flatFee keeps the fee stable across algosdk versions.
+ */
+export const SUGGESTED_PARAMS: algosdk.SuggestedParams = {
+  fee: 1000,
+  firstValid: 1,
+  lastValid: 1001,
+  genesisID: 'voi-test-v1',
+  genesisHash: new Uint8Array(32),
+  flatFee: true,
+  minFee: 1000,
+};
+
+/** A fixed asset id used by the asset fixtures (arbitrary; never hits a network). */
+export const FIXTURE_ASSET_ID = 12345;
+/** A fixed application id used by the app-call fixtures. */
+export const FIXTURE_APP_ID = 67890;
+
+/**
+ * Round-trip a built transaction through the EXACT production decode path:
+ * encode -> base64 -> `algosdk.decodeUnsignedTransaction`. This is what
+ * TransactionRequestScreen / UniversalTransactionSigningScreen feed to the
+ * danger detector and signer, so fixtures decoded this way expose fields in the
+ * same shape production sees (e.g. asset close-out lives under
+ * `assetTransfer.closeRemainderTo`, app id under `applicationCall.appIndex`).
+ */
+export function roundTripTxn(txn: algosdk.Transaction): algosdk.Transaction {
+  const bytes = algosdk.encodeUnsignedTransaction(txn);
+  const base64 = Buffer.from(bytes).toString('base64');
+  return algosdk.decodeUnsignedTransaction(Buffer.from(base64, 'base64'));
+}
+
+type PaymentParams = Parameters<
+  typeof algosdk.makePaymentTxnWithSuggestedParamsFromObject
+>[0];
+type AssetTransferParams = Parameters<
+  typeof algosdk.makeAssetTransferTxnWithSuggestedParamsFromObject
+>[0];
+type AssetConfigParams = Parameters<
+  typeof algosdk.makeAssetConfigTxnWithSuggestedParamsFromObject
+>[0];
+type AppNoOpParams = Parameters<
+  typeof algosdk.makeApplicationNoOpTxnFromObject
+>[0];
+
+/**
+ * Payment transaction. `overrides` can set `receiver`, `amount`,
+ * `closeRemainderTo` (account-close / native-balance sweep) and `rekeyTo`.
+ * Defaults to a harmless 0-amount self-payment.
+ */
+export function paymentTxn(
+  sender: string,
+  overrides: Partial<PaymentParams> = {}
+): algosdk.Transaction {
+  return algosdk.makePaymentTxnWithSuggestedParamsFromObject({
+    sender,
+    receiver: sender,
+    amount: 0,
+    suggestedParams: SUGGESTED_PARAMS,
+    ...overrides,
+  } as PaymentParams);
+}
+
+/**
+ * Asset-transfer (axfer) transaction. `overrides.closeRemainderTo` produces an
+ * asset close-out (the S-01 asset-drain vector) — algosdk v3 stores that under
+ * `assetTransfer.closeRemainderTo`, NOT a top-level `assetCloseTo`.
+ * Defaults to a harmless 0-amount self-transfer of FIXTURE_ASSET_ID.
+ */
+export function assetTransferTxn(
+  sender: string,
+  overrides: Partial<AssetTransferParams> = {}
+): algosdk.Transaction {
+  return algosdk.makeAssetTransferTxnWithSuggestedParamsFromObject({
+    sender,
+    receiver: sender,
+    amount: 0,
+    assetIndex: FIXTURE_ASSET_ID,
+    suggestedParams: SUGGESTED_PARAMS,
+    ...overrides,
+  } as AssetTransferParams);
+}
+
+/**
+ * Asset-config (acfg) transaction — asset reconfiguration by default (mutates
+ * manager/reserve/freeze/clawback of an existing asset). Pass `assetIndex: 0`
+ * plus `total`/`decimals` via overrides to model a creation instead.
+ */
+export function assetConfigTxn(
+  sender: string,
+  overrides: Partial<AssetConfigParams> = {}
+): algosdk.Transaction {
+  return algosdk.makeAssetConfigTxnWithSuggestedParamsFromObject({
+    sender,
+    assetIndex: FIXTURE_ASSET_ID,
+    manager: sender,
+    reserve: sender,
+    freeze: sender,
+    clawback: sender,
+    suggestedParams: SUGGESTED_PARAMS,
+    ...overrides,
+  } as AssetConfigParams);
+}
+
+/**
+ * Generic application NoOp call (appl). Mirrors how production builds app calls
+ * (`makeApplicationNoOpTxnFromObject`, e.g. unifiedSigner / arc72 / arc200).
+ * Defaults to a bare call against FIXTURE_APP_ID with no args.
+ */
+export function appCallTxn(
+  sender: string,
+  overrides: Partial<AppNoOpParams> = {}
+): algosdk.Transaction {
+  return algosdk.makeApplicationNoOpTxnFromObject({
+    sender,
+    appIndex: FIXTURE_APP_ID,
+    suggestedParams: SUGGESTED_PARAMS,
+    ...overrides,
+  } as AppNoOpParams);
+}
+
+/**
+ * ARC-200 `arc200_transfer(address,uint256)bool` app call, built the SAME way
+ * production does in services/transactions/arc200.ts: real ABI method selector
+ * followed by ABI-encoded (address, uint256) app args. No fabricated bytes.
+ */
+export function arc200TransferTxn(
+  sender: string,
+  to: string,
+  amount: bigint | number,
+  overrides: Partial<AppNoOpParams> = {}
+): algosdk.Transaction {
+  const method = algosdk.ABIMethod.fromSignature(
+    'arc200_transfer(address,uint256)bool'
+  );
+  const addressType = algosdk.ABIType.from('address');
+  const uint256Type = algosdk.ABIType.from('uint256');
+
+  const appArgs = [
+    method.getSelector(),
+    addressType.encode(to),
+    uint256Type.encode(typeof amount === 'bigint' ? amount : BigInt(amount)),
+  ];
+
+  return appCallTxn(sender, { appArgs, ...overrides });
+}
+
+// ---------------------------------------------------------------------------
+// (c) Minimal zustand store test harness
+// ---------------------------------------------------------------------------
+
+// Structural (non-React) view of a zustand store instance. Matches both a
+// vanilla `createStore` and the `.getState/.setState/.subscribe` surface a
+// React `create(...)` store exposes, without importing zustand's types (so the
+// harness stays usable from any test regardless of middleware).
+export interface MinimalStoreApi<T> {
+  getState: () => T;
+  setState: (
+    partial: Partial<T> | ((state: T) => Partial<T>),
+    replace?: boolean
+  ) => void;
+  subscribe: (listener: (state: T, prev: T) => void) => () => void;
+}
+
+export interface StoreHarness<T> {
+  /** The underlying zustand store api (getState / setState / subscribe). */
+  readonly store: MinimalStoreApi<T>;
+  /** Current state snapshot. */
+  getState: () => T;
+  /** Patch state (partial or updater), same semantics as zustand setState. */
+  setState: MinimalStoreApi<T>['setState'];
+  /**
+   * Reset the store back to the state captured when the harness was created.
+   * Call in `beforeEach`/`afterEach` to isolate tests. Uses replace semantics
+   * so keys added during a test are dropped.
+   */
+  reset: () => void;
+}
+
+/**
+ * Wrap an existing zustand store (vanilla or React) in a test harness that can
+ * snapshot-and-reset its state between tests. The snapshot is taken at wrap time.
+ *
+ *   import { walletStore } from '@/store/walletStore';
+ *   const harness = harnessForStore(walletStore);
+ *   beforeEach(() => harness.reset());
+ */
+export function harnessForStore<T>(store: MinimalStoreApi<T>): StoreHarness<T> {
+  // Shallow-clone the initial state so later mutations don't corrupt the baseline.
+  const initial = { ...(store.getState() as object) } as T;
+
+  return {
+    store,
+    getState: () => store.getState(),
+    setState: (partial, replace) => store.setState(partial, replace),
+    reset: () => store.setState({ ...(initial as object) } as T, true),
+  };
+}
+
+/**
+ * Create a fresh in-memory zustand store from an initializer for tests that want
+ * an isolated store rather than the app singleton. Returns a harness (see above).
+ * Uses zustand's vanilla `createStore` so no React runtime is required.
+ *
+ *   const { getState, setState, reset } = createStoreHarness<{ n: number }>(
+ *     (set) => ({ n: 0, inc: () => set((s) => ({ n: s.n + 1 })) })
+ *   );
+ */
+export function createStoreHarness<T>(
+  initializer: (set: MinimalStoreApi<T>['setState'], get: () => T) => T
+): StoreHarness<T> {
+  // Uses zustand's vanilla `createStore` (no React runtime required).
+  const store = createStore<T>(
+    initializer as never
+  ) as unknown as MinimalStoreApi<T>;
+  return harnessForStore(store);
+}


### PR DESCRIPTION
## What

Adds `src/__tests__/fixtures/algorand.ts` — shared test fixtures so downstream P0 signing/tx/state test tasks stop re-rolling their own inline copies (avoids merge conflicts across parallel worktrees). TASK-149.

Provides:
- **Deterministic account factory** `makeAccount(label)` / `makeAddress(label)` → `{ mnemonic, sk, pk, addr, account }`. Real crypto only (DR-3): a SHA-512-derived 32-byte seed is turned into a real 25-word mnemonic and Ed25519 keypair entirely via `algosdk.mnemonicFromSeed` → `algosdk.mnemonicToSecretKey`. No mocked/hardcoded keys, no undeclared crypto dependency (algosdk + Node core `crypto` only).
- **algosdk-v3 Transaction factory**: `paymentTxn`, `assetTransferTxn` (incl. `closeRemainderTo` asset-drain), `assetConfigTxn`, `appCallTxn`, `arc200TransferTxn` (real ABI selector + encoded args, matching `services/transactions/arc200.ts`), plus `roundTripTxn` mirroring the production `encode → base64 → decodeUnsignedTransaction` path so fields decode into the exact shape production consumes (e.g. asset close-out under `assetTransfer.closeRemainderTo`, app id under `applicationCall.appIndex`).
- **Minimal zustand harness**: `createStoreHarness` (fresh vanilla store) and `harnessForStore` (snapshot/reset an existing store).

Plus `algorand.test.ts` — a 10-test suite proving the fixtures work and decode as production does. Secret keys are never serialized to logs (equality compared via boolean).

## Scope

Test-only. No source/runtime changes.

## Gates

- `npm run typecheck` — clean
- `npm run lint` — 0 errors (pre-existing warnings only)
- `npm test -- --ci` — 45 suites / 592 tests pass

Codex review: CLEAN.