### PR TITLE
chore: untrack accidentally-committed node_modules symlink

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,6 +1,7 @@
 # Learn more https://docs.github.com/en/get-started/getting-started-with-git/ignoring-files
 
 # dependencies
+node_modules
 node_modules/
 
 # Expo

--- a/node_modules
+++ b/node_modules
@@ -1,1 +1,0 @@
-/Users/dave/Dev/voi/voiapp/node_modules


### PR DESCRIPTION
Fixes a repo landmine introduced in #115: a self-referential `node_modules -> node_modules` symlink was committed (tracked, mode 120000) because `.gitignore` used the directory-only `node_modules/` pattern, which does not match a symlink named `node_modules`. This broke dependency resolution in every fresh worktree/checkout; CI survived only because it runs `npm ci`.

**Fix:** `git rm --cached node_modules` + add a bare `node_modules` ignore line so a symlink can't be re-added. On-disk `node_modules` (real dir) is untouched. No runtime/source impact. Surfaced during the PLAN-102 ultra-codex run.