### PR TITLE
test(auth): P0 AuthContext unit tests (unlock/biometric, timeout/background lock, teardown)

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -85,6 +85,7 @@
       },
       "devDependencies": {
         "@eslint/js": "^9.35.0",
+        "@testing-library/react-native": "13.3.3",
         "@types/crypto-js": "^4.2.2",
         "@types/jest": "29.5.14",
         "@types/react": "~19.1.0",
@@ -101,6 +102,7 @@
         "jest": "~29.7.0",
         "jest-expo": "~54.0.17",
         "prettier": "^3.6.2",
+        "react-test-renderer": "19.1.0",
         "typescript": "~5.9.2"
       }
     },
@@ -3505,6 +3507,16 @@
         "node": "^14.15.0 || ^16.10.0 || >=18.0.0"
       }
     },
+    "node_modules/@jest/diff-sequences": {
+      "version": "30.4.0",
+      "resolved": "https://registry.npmjs.org/@jest/diff-sequences/-/diff-sequences-30.4.0.tgz",
+      "integrity": "sha512-zOpzlfUs45l6u7jm39qr87JCHUDsaeCtvL+kQe/Vn9jSnRB4/5IPXISm0h9I1vZW/o00Kn4UTJ2MOlhnUGwv3g==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": "^18.14.0 || ^20.0.0 || ^22.0.0 || >=24.0.0"
+      }
+    },
     "node_modules/@jest/environment": {
       "version": "29.7.0",
       "resolved": "https://registry.npmjs.org/@jest/environment/-/environment-29.7.0.tgz",
@@ -3562,6 +3574,16 @@
       },
       "engines": {
         "node": "^14.15.0 || ^16.10.0 || >=18.0.0"
+      }
+    },
+    "node_modules/@jest/get-type": {
+      "version": "30.1.0",
+      "resolved": "https://registry.npmjs.org/@jest/get-type/-/get-type-30.1.0.tgz",
+      "integrity": "sha512-eMbZE2hUnx1WV0pmURZY9XoXPkUYjpc55mb0CrhtdWLtzMQPFvu/rZkTLZFTsdaVQa+Tr4eWAteqcUzoawq/uA==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": "^18.14.0 || ^20.0.0 || ^22.0.0 || >=24.0.0"
       }
     },
     "node_modules/@jest/globals": {
@@ -4909,6 +4931,114 @@
       },
       "engines": {
         "node": ">=20.0.0"
+      }
+    },
+    "node_modules/@testing-library/react-native": {
+      "version": "13.3.3",
+      "resolved": "https://registry.npmjs.org/@testing-library/react-native/-/react-native-13.3.3.tgz",
+      "integrity": "sha512-k6Mjsd9dbZgvY4Bl7P1NIpePQNi+dfYtlJ5voi9KQlynxSyQkfOgJmYGCYmw/aSgH/rUcFvG8u5gd4npzgRDyg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "jest-matcher-utils": "^30.0.5",
+        "picocolors": "^1.1.1",
+        "pretty-format": "^30.0.5",
+        "redent": "^3.0.0"
+      },
+      "engines": {
+        "node": ">=18"
+      },
+      "peerDependencies": {
+        "jest": ">=29.0.0",
+        "react": ">=18.2.0",
+        "react-native": ">=0.71",
+        "react-test-renderer": ">=18.2.0"
+      },
+      "peerDependenciesMeta": {
+        "jest": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@testing-library/react-native/node_modules/@jest/schemas": {
+      "version": "30.4.1",
+      "resolved": "https://registry.npmjs.org/@jest/schemas/-/schemas-30.4.1.tgz",
+      "integrity": "sha512-i6b4qw5qnP8c5FEeBJg/uZQ4ddrkN6Ca8qISJh0pr7a5hfn3h3v5x60BEbOC7OYAGZNMs1LfFLwnW2CuK8F57Q==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@sinclair/typebox": "^0.34.0"
+      },
+      "engines": {
+        "node": "^18.14.0 || ^20.0.0 || ^22.0.0 || >=24.0.0"
+      }
+    },
+    "node_modules/@testing-library/react-native/node_modules/@sinclair/typebox": {
+      "version": "0.34.52",
+      "resolved": "https://registry.npmjs.org/@sinclair/typebox/-/typebox-0.34.52.tgz",
+      "integrity": "sha512-XiMQh7qqVlxZzcVD+kkGMNGMzcTrDMLWI7S4x7z1MkCkbDPrekpZXEUK0eZqZFMuHQg2a2DZOcDIh9o5v3Gonw==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/@testing-library/react-native/node_modules/ansi-styles": {
+      "version": "5.2.0",
+      "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-5.2.0.tgz",
+      "integrity": "sha512-Cxwpt2SfTzTtXcfOlzGEee8O+c+MmUgGrNiBcXnuWxuFJHe6a5Hz7qwhwe5OgaSYI0IJvkLqWX1ASG+cJOkEiA==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=10"
+      },
+      "funding": {
+        "url": "https://github.com/chalk/ansi-styles?sponsor=1"
+      }
+    },
+    "node_modules/@testing-library/react-native/node_modules/jest-diff": {
+      "version": "30.4.1",
+      "resolved": "https://registry.npmjs.org/jest-diff/-/jest-diff-30.4.1.tgz",
+      "integrity": "sha512-CRpFK0RtLriVDGcPPAnR6HMVI8bSR2jnUIgralhauzYQZIb4RH9AtEInTuQr65LmmGggGcRT6HIASxwqsVsmlA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@jest/diff-sequences": "30.4.0",
+        "@jest/get-type": "30.1.0",
+        "chalk": "^4.1.2",
+        "pretty-format": "30.4.1"
+      },
+      "engines": {
+        "node": "^18.14.0 || ^20.0.0 || ^22.0.0 || >=24.0.0"
+      }
+    },
+    "node_modules/@testing-library/react-native/node_modules/jest-matcher-utils": {
+      "version": "30.4.1",
+      "resolved": "https://registry.npmjs.org/jest-matcher-utils/-/jest-matcher-utils-30.4.1.tgz",
+      "integrity": "sha512-zvYfX5CaeEkFrrLS9suWe9rvJrm9J1Iv3ua8kIBv9GEPzcnsfBf0bob37la7s67fs0nlBC3EuvkOLnXQKxtx4A==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@jest/get-type": "30.1.0",
+        "chalk": "^4.1.2",
+        "jest-diff": "30.4.1",
+        "pretty-format": "30.4.1"
+      },
+      "engines": {
+        "node": "^18.14.0 || ^20.0.0 || ^22.0.0 || >=24.0.0"
+      }
+    },
+    "node_modules/@testing-library/react-native/node_modules/pretty-format": {
+      "version": "30.4.1",
+      "resolved": "https://registry.npmjs.org/pretty-format/-/pretty-format-30.4.1.tgz",
+      "integrity": "sha512-K6KiKMHTL4jjX4u3Kir2EW07nRfcqVTXIImx50wbjHQTcZPgg+gjVeNTIT3l3L1Rd4UefxfogquC9J37SoFyyw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@jest/schemas": "30.4.1",
+        "ansi-styles": "^5.2.0",
+        "react-is-18": "npm:react-is@^18.3.1",
+        "react-is-19": "npm:react-is@^19.2.5"
+      },
+      "engines": {
+        "node": "^18.14.0 || ^20.0.0 || ^22.0.0 || >=24.0.0"
       }
     },
     "node_modules/@tokenizer/token": {
@@ -11896,6 +12026,16 @@
         "node": ">=0.8.19"
       }
     },
+    "node_modules/indent-string": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/indent-string/-/indent-string-4.0.0.tgz",
+      "integrity": "sha512-EdDDZu4A2OyIK7Lr/2zG+w5jmbuk1DVBnEwREQvBzspBJkCEbRa8GxU1lghYcaGJCnRWibjDXlq779X1/y5xwg==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=8"
+      }
+    },
     "node_modules/inflight": {
       "version": "1.0.6",
       "resolved": "https://registry.npmjs.org/inflight/-/inflight-1.0.6.tgz",
@@ -14747,6 +14887,16 @@
         "node": ">=4"
       }
     },
+    "node_modules/min-indent": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/min-indent/-/min-indent-1.0.1.tgz",
+      "integrity": "sha512-I9jwMn07Sy/IwOj3zVkVik2JTvgpaykDZEigL6Rx6N9LbMywwUSMtxET+7lVoDLLd3O3IXwJwvuuns8UB/HeAg==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=4"
+      }
+    },
     "node_modules/minimatch": {
       "version": "9.0.9",
       "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-9.0.9.tgz",
@@ -16476,6 +16626,22 @@
       "integrity": "sha512-x3Ax3kNSMIIkyVYhWPyO09bu0uttcAIoecO/um/rKGQ4EltYWVYtyiGkS/3xMynrbVQdS69Jhlv8FXUEZehlzA==",
       "license": "MIT"
     },
+    "node_modules/react-is-18": {
+      "name": "react-is",
+      "version": "18.3.1",
+      "resolved": "https://registry.npmjs.org/react-is/-/react-is-18.3.1.tgz",
+      "integrity": "sha512-/LLMVyas0ljjAtoYiPqYiL8VWXzUUdThrmU5+n20DZv+a+ClRoevUzw5JxU+Ieh5/c87ytoTBV9G1FiKfNJdmg==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/react-is-19": {
+      "name": "react-is",
+      "version": "19.2.7",
+      "resolved": "https://registry.npmjs.org/react-is/-/react-is-19.2.7.tgz",
+      "integrity": "sha512-kZFnouyVv7eP/Phmrlo9FK+zcAdriZJvzxXHF1Sl1P377WSGe2G/JxVolhTrB/jeV47lKImhNUsijjHAAbcl/A==",
+      "dev": true,
+      "license": "MIT"
+    },
     "node_modules/react-native": {
       "version": "0.81.5",
       "resolved": "https://registry.npmjs.org/react-native/-/react-native-0.81.5.tgz",
@@ -17082,6 +17248,20 @@
       "license": "MIT",
       "engines": {
         "node": ">= 12.13.0"
+      }
+    },
+    "node_modules/redent": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/redent/-/redent-3.0.0.tgz",
+      "integrity": "sha512-6tDA8g98We0zd0GvVeMT9arEOnTw9qM03L9cJXaCjrip1OO764RDBLBfrB4cwzNGDj5OA5ioymC9GkizgWJDUg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "indent-string": "^4.0.0",
+        "strip-indent": "^3.0.0"
+      },
+      "engines": {
+        "node": ">=8"
       }
     },
     "node_modules/reflect.getprototypeof": {
@@ -18435,6 +18615,19 @@
       "license": "MIT",
       "engines": {
         "node": ">=6"
+      }
+    },
+    "node_modules/strip-indent": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/strip-indent/-/strip-indent-3.0.0.tgz",
+      "integrity": "sha512-laJTa3Jb+VQpaC6DseHhF7dXVqHTfJPCRDaEbid/drOhgitgYku/letMUqOXFoWV0zIIUbjpdH2t+tYj4bQMRQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "min-indent": "^1.0.0"
+      },
+      "engines": {
+        "node": ">=8"
       }
     },
     "node_modules/strip-json-comments": {

--- a/package.json
+++ b/package.json
@@ -96,6 +96,7 @@
   },
   "devDependencies": {
     "@eslint/js": "^9.35.0",
+    "@testing-library/react-native": "13.3.3",
     "@types/crypto-js": "^4.2.2",
     "@types/jest": "29.5.14",
     "@types/react": "~19.1.0",
@@ -112,6 +113,7 @@
     "jest": "~29.7.0",
     "jest-expo": "~54.0.17",
     "prettier": "^3.6.2",
+    "react-test-renderer": "19.1.0",
     "typescript": "~5.9.2"
   },
   "private": true

--- a/src/contexts/__tests__/AuthContext.test.tsx
+++ b/src/contexts/__tests__/AuthContext.test.tsx
@@ -1,0 +1,494 @@
+/**
+ * P0 unit tests for AuthContext (TASK-160).
+ *
+ * Covers the session-lock security surface:
+ *  - initial locked/unlocked state derivation
+ *  - PIN unlock and biometric unlock (success / failure / invalidation)
+ *  - inactivity-timeout lock
+ *  - background -> foreground app-state lock
+ *  - unmount teardown: NO leaked AppState subscription, NO leaked timers
+ *
+ * DR-3 / CLAUDE.md: expo-local-authentication, AppState, and every secure-store
+ * leaf are mocked. No real key/mnemonic material is ever fabricated or logged —
+ * the vault/teardown/lock-signal modules are mocked as opaque effect sinks and
+ * the tests only assert that the wiring calls them, never that they hold a key.
+ *
+ * TEST-ONLY: AuthContext and the crypto/secure source are never modified.
+ */
+import React from 'react';
+import { AppState, type AppStateStatus } from 'react-native';
+import { act, renderHook } from '@testing-library/react-native';
+
+import { AuthProvider, useAuth } from '../AuthContext';
+
+import { MultiAccountWalletService } from '@/services/wallet';
+import { AccountSecureStorage } from '@/services/secure';
+import { SessionKeyVault } from '@/services/secure/SessionKeyVault';
+import { unlockVaultWithBiometrics } from '@/services/secure/biometricUnlock';
+import { enterLockedState } from '@/services/secure/sessionTeardown';
+import { AppLockSignal } from '@/services/secure/appLockState';
+import * as LocalAuthentication from 'expo-local-authentication';
+
+// --- Mocks: wallet + every secure-store leaf, vault, teardown, lock signal. ---
+jest.mock('@/services/wallet', () => ({
+  MultiAccountWalletService: {
+    getCurrentWallet: jest.fn(),
+  },
+}));
+
+jest.mock('@/services/secure', () => ({
+  AccountSecureStorage: {
+    hasPin: jest.fn(),
+    isBiometricEnabled: jest.fn(),
+    getPinTimeout: jest.fn(),
+    verifyPin: jest.fn(),
+    getCredentialSource: jest.fn(),
+    migrateAllAccountsToV2: jest.fn(),
+    setupPin: jest.fn(),
+    setBiometricSecret: jest.fn(),
+    setBiometricEnabled: jest.fn(),
+    clearBiometricSecret: jest.fn(),
+  },
+}));
+
+jest.mock('@/services/secure/SessionKeyVault', () => ({
+  SessionKeyVault: {
+    set: jest.fn(),
+    getSecret: jest.fn(() => null),
+    getSecretSource: jest.fn(() => 'pin'),
+  },
+}));
+
+jest.mock('@/services/secure/biometricUnlock', () => ({
+  unlockVaultWithBiometrics: jest.fn(),
+}));
+
+jest.mock('@/services/secure/sessionTeardown', () => ({
+  enterLockedState: jest.fn(),
+}));
+
+jest.mock('@/services/secure/appLockState', () => ({
+  AppLockSignal: { setUnlocked: jest.fn() },
+}));
+
+jest.mock('@/utils/security', () => ({
+  SecurityUtils: { generateSessionId: jest.fn(() => 'test-session-id') },
+}));
+
+jest.mock('@/services/deeplink', () => ({
+  DeepLinkService: {
+    getInstance: jest.fn(() => ({ setUnlockState: jest.fn() })),
+  },
+}));
+
+jest.mock('expo-local-authentication', () => ({
+  hasHardwareAsync: jest.fn(async () => true),
+  isEnrolledAsync: jest.fn(async () => true),
+}));
+
+// Typed handles to the mocked members we drive per-test.
+const mockWallet = MultiAccountWalletService.getCurrentWallet as jest.Mock;
+const mockHasPin = AccountSecureStorage.hasPin as jest.Mock;
+const mockIsBiometricEnabled =
+  AccountSecureStorage.isBiometricEnabled as jest.Mock;
+const mockGetPinTimeout = AccountSecureStorage.getPinTimeout as jest.Mock;
+const mockVerifyPin = AccountSecureStorage.verifyPin as jest.Mock;
+const mockGetCredentialSource =
+  AccountSecureStorage.getCredentialSource as jest.Mock;
+const mockMigrate = AccountSecureStorage.migrateAllAccountsToV2 as jest.Mock;
+const mockVaultSet = SessionKeyVault.set as jest.Mock;
+const mockBiometricUnlock = unlockVaultWithBiometrics as jest.Mock;
+const mockEnterLocked = enterLockedState as jest.Mock;
+const mockSetUnlocked = AppLockSignal.setUnlocked as jest.Mock;
+
+// A non-empty account list so checkInitialAuthState treats the wallet as
+// "requires auth". Address is a throwaway label, never key material.
+const WALLET_WITH_ACCOUNTS = {
+  accounts: [{ address: 'ACCT-PLACEHOLDER' }],
+} as never;
+
+// Not a real secret — an arbitrary 6-char string only used to exercise the
+// verifyPin branch (verifyPin itself is fully mocked; nothing derives a key).
+const TEST_PIN = 'abc123';
+
+// AppState listener capture.
+let appStateHandler: ((s: AppStateStatus) => void) | undefined;
+let appStateRemove: jest.Mock;
+let addEventListenerSpy: jest.SpyInstance;
+
+const wrapper = ({ children }: { children: React.ReactNode }) => (
+  <AuthProvider>{children}</AuthProvider>
+);
+
+// Flush the sequential awaits inside checkInitialAuthState (and any queued
+// microtasks) under fake timers.
+const flush = async () => {
+  await act(async () => {
+    for (let i = 0; i < 10; i += 1) {
+      await Promise.resolve();
+    }
+  });
+};
+
+const mountAuth = async () => {
+  // renderHook manages its own act(); wrapping it in an outer act() leaves the
+  // renderer looking unmounted. Render directly, then flush the mount effects'
+  // async checkInitialAuthState chain.
+  const rendered = renderHook(() => useAuth(), { wrapper });
+  await flush();
+  return rendered;
+};
+
+beforeEach(() => {
+  jest.useFakeTimers();
+
+  appStateHandler = undefined;
+  appStateRemove = jest.fn();
+  addEventListenerSpy = jest
+    .spyOn(AppState, 'addEventListener')
+    .mockImplementation(
+      (_event: string, handler: (s: AppStateStatus) => void) => {
+        appStateHandler = handler;
+        return { remove: appStateRemove } as never;
+      }
+    );
+
+  // Default baseline: a wallet that exists, has a PIN, 5-min timeout, biometrics
+  // available + enabled. Individual tests override as needed.
+  mockWallet.mockResolvedValue(WALLET_WITH_ACCOUNTS);
+  mockHasPin.mockResolvedValue(true);
+  mockIsBiometricEnabled.mockResolvedValue(true);
+  mockGetPinTimeout.mockResolvedValue(5);
+  mockVerifyPin.mockResolvedValue(true);
+  mockGetCredentialSource.mockResolvedValue('pin');
+  mockMigrate.mockResolvedValue(undefined);
+  mockBiometricUnlock.mockResolvedValue({ status: 'unlocked' });
+});
+
+afterEach(() => {
+  addEventListenerSpy.mockRestore();
+  jest.clearAllTimers();
+  jest.useRealTimers();
+});
+
+describe('AuthContext — initial state', () => {
+  it('starts LOCKED when a wallet with a PIN exists', async () => {
+    const { result } = await mountAuth();
+
+    expect(result.current.authState.isLocked).toBe(true);
+    expect(result.current.authState.isAuthenticated).toBe(false);
+    expect(result.current.authState.hasPin).toBe(true);
+    expect(result.current.authState.biometricEnabled).toBe(true);
+    expect(result.current.authState.sessionId).toBeNull();
+  });
+
+  it('starts UNLOCKED (setup mode) when no wallet / no PIN exists', async () => {
+    mockWallet.mockResolvedValue(null);
+    mockHasPin.mockResolvedValue(false);
+
+    const { result } = await mountAuth();
+
+    expect(result.current.authState.isLocked).toBe(false);
+    expect(result.current.authState.isAuthenticated).toBe(true);
+    expect(result.current.authState.hasPin).toBe(false);
+  });
+
+  it('reports biometricEnabled=false when hardware is unavailable even if the flag is on', async () => {
+    (LocalAuthentication.hasHardwareAsync as jest.Mock).mockResolvedValueOnce(
+      false
+    );
+
+    const { result } = await mountAuth();
+
+    expect(result.current.authState.biometricEnabled).toBe(false);
+  });
+});
+
+describe('AuthContext — PIN unlock', () => {
+  it('unlocks with a valid PIN and populates the session vault + lock signal', async () => {
+    const { result } = await mountAuth();
+
+    let ok!: boolean;
+    await act(async () => {
+      ok = await result.current.unlock(TEST_PIN);
+    });
+
+    expect(ok).toBe(true);
+    expect(result.current.authState.isLocked).toBe(false);
+    expect(result.current.authState.isAuthenticated).toBe(true);
+    expect(result.current.authState.sessionId).toBe('test-session-id');
+    expect(mockVaultSet).toHaveBeenCalledWith(TEST_PIN, 'pin');
+    expect(mockSetUnlocked).toHaveBeenCalledWith(true);
+  });
+
+  it('rejects an invalid PIN and stays locked without touching the vault', async () => {
+    mockVerifyPin.mockResolvedValue(false);
+    const { result } = await mountAuth();
+
+    let ok!: boolean;
+    await act(async () => {
+      ok = await result.current.unlock(TEST_PIN);
+    });
+
+    expect(ok).toBe(false);
+    expect(result.current.authState.isLocked).toBe(true);
+    expect(result.current.authState.isAuthenticated).toBe(false);
+    expect(mockVaultSet).not.toHaveBeenCalled();
+  });
+
+  it('rejects an empty secret without calling verifyPin', async () => {
+    const { result } = await mountAuth();
+
+    let ok!: boolean;
+    await act(async () => {
+      ok = await result.current.unlock('');
+    });
+
+    expect(ok).toBe(false);
+    expect(result.current.authState.isLocked).toBe(true);
+    expect(mockVerifyPin).not.toHaveBeenCalled();
+  });
+});
+
+describe('AuthContext — biometric unlock', () => {
+  it('unlocks on biometric success', async () => {
+    const { result } = await mountAuth();
+
+    let ok!: boolean;
+    await act(async () => {
+      ok = await result.current.unlockWithBiometrics();
+    });
+
+    expect(ok).toBe(true);
+    expect(result.current.authState.isLocked).toBe(false);
+    expect(result.current.authState.isAuthenticated).toBe(true);
+    expect(mockSetUnlocked).toHaveBeenCalledWith(true);
+  });
+
+  it('stays locked when biometric auth is cancelled', async () => {
+    mockBiometricUnlock.mockResolvedValue({ status: 'cancelled' });
+    const { result } = await mountAuth();
+
+    let ok!: boolean;
+    await act(async () => {
+      ok = await result.current.unlockWithBiometrics();
+    });
+
+    expect(ok).toBe(false);
+    expect(result.current.authState.isLocked).toBe(true);
+    expect(result.current.authState.isAuthenticated).toBe(false);
+    // A cancel must NOT flip the lock signal to unlocked.
+    expect(mockSetUnlocked).not.toHaveBeenCalledWith(true);
+  });
+
+  it('disables biometrics on an invalidation and stays locked (never asks for the mnemonic)', async () => {
+    mockBiometricUnlock.mockResolvedValue({ status: 'invalidated' });
+    const { result } = await mountAuth();
+
+    let ok!: boolean;
+    await act(async () => {
+      ok = await result.current.unlockWithBiometrics();
+    });
+
+    expect(ok).toBe(false);
+    expect(result.current.authState.isLocked).toBe(true);
+    expect(result.current.authState.biometricEnabled).toBe(false);
+  });
+
+  it('refuses biometric unlock when biometrics are not enabled', async () => {
+    mockIsBiometricEnabled.mockResolvedValue(false);
+    const { result } = await mountAuth();
+
+    let ok!: boolean;
+    await act(async () => {
+      ok = await result.current.unlockWithBiometrics();
+    });
+
+    expect(ok).toBe(false);
+    expect(mockBiometricUnlock).not.toHaveBeenCalled();
+    expect(result.current.authState.isLocked).toBe(true);
+  });
+});
+
+describe('AuthContext — inactivity timeout lock', () => {
+  it('locks the session and runs teardown after the inactivity window elapses', async () => {
+    const { result } = await mountAuth();
+
+    await act(async () => {
+      await result.current.unlock(TEST_PIN);
+    });
+    expect(result.current.authState.isLocked).toBe(false);
+
+    mockEnterLocked.mockClear();
+
+    // Advance past the 5-minute timeout; the session timer + activity interval
+    // both route inactivity through lock().
+    await act(async () => {
+      jest.advanceTimersByTime(5 * 60 * 1000 + 1000);
+      await Promise.resolve();
+    });
+
+    expect(result.current.authState.isLocked).toBe(true);
+    expect(result.current.authState.isAuthenticated).toBe(false);
+    expect(result.current.authState.sessionId).toBeNull();
+    // Single teardown path must have fired (session vault / caches).
+    expect(mockEnterLocked).toHaveBeenCalled();
+  });
+
+  it('does NOT lock while activity keeps getting refreshed', async () => {
+    const { result } = await mountAuth();
+
+    await act(async () => {
+      await result.current.unlock(TEST_PIN);
+    });
+
+    // Repeatedly poke activity every 2 minutes across a 6-minute span.
+    for (let i = 0; i < 3; i += 1) {
+      await act(async () => {
+        jest.advanceTimersByTime(2 * 60 * 1000);
+        result.current.updateActivity();
+        await Promise.resolve();
+      });
+    }
+
+    expect(result.current.authState.isLocked).toBe(false);
+    expect(result.current.authState.isAuthenticated).toBe(true);
+  });
+});
+
+describe('AuthContext — background/foreground app-state lock', () => {
+  it('locks after the background grace period expires', async () => {
+    const { result } = await mountAuth();
+
+    await act(async () => {
+      await result.current.unlock(TEST_PIN);
+    });
+    expect(result.current.authState.isLocked).toBe(false);
+    expect(appStateHandler).toBeDefined();
+
+    // App backgrounds -> a 60s grace timer is armed.
+    await act(async () => {
+      appStateHandler!('background');
+      await Promise.resolve();
+    });
+
+    mockEnterLocked.mockClear();
+
+    // Grace period elapses without returning -> auto-lock.
+    await act(async () => {
+      jest.advanceTimersByTime(60 * 1000 + 1000);
+      await Promise.resolve();
+    });
+
+    expect(result.current.authState.isLocked).toBe(true);
+    expect(result.current.authState.isAuthenticated).toBe(false);
+    expect(mockEnterLocked).toHaveBeenCalled();
+  });
+
+  it('stays unlocked when returning to foreground within the grace period', async () => {
+    const { result } = await mountAuth();
+
+    await act(async () => {
+      await result.current.unlock(TEST_PIN);
+    });
+
+    await act(async () => {
+      appStateHandler!('background');
+      await Promise.resolve();
+    });
+
+    // Return well within the 60s grace window.
+    await act(async () => {
+      jest.advanceTimersByTime(10 * 1000);
+      appStateHandler!('active');
+      await Promise.resolve();
+    });
+
+    // And let more (formerly-grace) time pass to prove the timer was cancelled.
+    await act(async () => {
+      jest.advanceTimersByTime(60 * 1000);
+      await Promise.resolve();
+    });
+
+    expect(result.current.authState.isLocked).toBe(false);
+    expect(result.current.authState.isAuthenticated).toBe(true);
+  });
+});
+
+describe('AuthContext — unmount teardown (no leaks)', () => {
+  it('clears its activity interval and session timeout on unmount', async () => {
+    const rendered = await mountAuth();
+
+    await act(async () => {
+      await rendered.result.current.unlock(TEST_PIN);
+    });
+
+    // Sanity: an unlocked session has live timers (activity interval + session
+    // timeout) — otherwise the cleanup assertion below would be vacuous.
+    // (Absolute getTimerCount()===0 is NOT asserted: React's own scheduler
+    // leaves framework timers behind on unmount that AuthContext neither owns
+    // nor should clear.)
+    expect(jest.getTimerCount()).toBeGreaterThan(0);
+
+    const clearIntervalSpy = jest.spyOn(global, 'clearInterval');
+    const clearTimeoutSpy = jest.spyOn(global, 'clearTimeout');
+
+    await act(async () => {
+      rendered.unmount();
+    });
+
+    // The mount-effect cleanup clears the activity interval and the session
+    // timeout it owns — the concrete no-leak guarantee for its own handles.
+    expect(clearIntervalSpy).toHaveBeenCalled();
+    expect(clearTimeoutSpy).toHaveBeenCalled();
+
+    clearIntervalSpy.mockRestore();
+    clearTimeoutSpy.mockRestore();
+  });
+
+  // KNOWN BUG (reported, source intentionally NOT fixed — TASK-160 is test-only):
+  // the mount useEffect calls setupAppStateListener(), which RETURNS a
+  // `() => subscription.remove()` cleanup, but the effect discards that return
+  // value — its own cleanup only clears timers. So AppState.addEventListener's
+  // subscription is never removed on unmount and leaks. This test documents the
+  // leak via it.failing; flip to a plain `it` once AuthContext wires the
+  // subscription cleanup (e.g. store the remover in a ref and call it in the
+  // effect teardown).
+  it.failing(
+    'removes the AppState subscription on unmount (LEAK: remove() never called)',
+    async () => {
+      const rendered = await mountAuth();
+
+      expect(appStateRemove).not.toHaveBeenCalled();
+
+      await act(async () => {
+        rendered.unmount();
+      });
+
+      // Currently receives 0 calls — the subscription is leaked.
+      expect(appStateRemove).toHaveBeenCalledTimes(1);
+    }
+  );
+
+  it('does not fire a lock after unmount even once the timeout window passes', async () => {
+    const rendered = await mountAuth();
+
+    await act(async () => {
+      await rendered.result.current.unlock(TEST_PIN);
+    });
+
+    await act(async () => {
+      rendered.unmount();
+    });
+
+    mockEnterLocked.mockClear();
+
+    // Advancing past the timeout must NOT trigger teardown — the timers are gone.
+    await act(async () => {
+      jest.advanceTimersByTime(10 * 60 * 1000);
+      await Promise.resolve();
+    });
+
+    expect(mockEnterLocked).not.toHaveBeenCalled();
+  });
+});

--- a/src/contexts/__tests__/AuthContext.test.tsx
+++ b/src/contexts/__tests__/AuthContext.test.tsx
@@ -533,4 +533,34 @@ describe('AuthContext — unmount teardown (no leaks)', () => {
 
     expect(mockEnterLocked).not.toHaveBeenCalled();
   });
+
+  it('does not fire the armed background-grace lock after unmount', async () => {
+    const rendered = await mountAuth();
+
+    await act(async () => {
+      await rendered.result.current.unlock(TEST_PIN);
+    });
+
+    // Background the app so the 60s grace timer is ARMED before we unmount —
+    // this is the timer the mount-effect cleanup must clear (regression guard:
+    // dropping the backgroundTimer cleanup would let it fire post-unmount).
+    await act(async () => {
+      appStateHandler!('background');
+      await Promise.resolve();
+    });
+
+    await act(async () => {
+      rendered.unmount();
+    });
+
+    mockEnterLocked.mockClear();
+
+    // Grace window elapses after unmount — the cleared timer must never fire.
+    await act(async () => {
+      jest.advanceTimersByTime(60 * 1000 + 5000);
+      await Promise.resolve();
+    });
+
+    expect(mockEnterLocked).not.toHaveBeenCalled();
+  });
 });

--- a/src/contexts/__tests__/AuthContext.test.tsx
+++ b/src/contexts/__tests__/AuthContext.test.tsx
@@ -262,6 +262,10 @@ describe('AuthContext — biometric unlock', () => {
     expect(ok).toBe(true);
     expect(result.current.authState.isLocked).toBe(false);
     expect(result.current.authState.isAuthenticated).toBe(true);
+    // The unlock MUST route through the biometric gate + vault-population path,
+    // not just flip flags — otherwise a regression could "unlock" without ever
+    // authenticating or loading the session vault.
+    expect(mockBiometricUnlock).toHaveBeenCalledWith('Unlock your wallet');
     expect(mockSetUnlocked).toHaveBeenCalledWith(true);
   });
 
@@ -277,7 +281,9 @@ describe('AuthContext — biometric unlock', () => {
     expect(ok).toBe(false);
     expect(result.current.authState.isLocked).toBe(true);
     expect(result.current.authState.isAuthenticated).toBe(false);
-    // A cancel must NOT flip the lock signal to unlocked.
+    // Went through the biometric gate, and a cancel must NOT flip the lock
+    // signal to unlocked.
+    expect(mockBiometricUnlock).toHaveBeenCalledWith('Unlock your wallet');
     expect(mockSetUnlocked).not.toHaveBeenCalledWith(true);
   });
 
@@ -293,6 +299,9 @@ describe('AuthContext — biometric unlock', () => {
     expect(ok).toBe(false);
     expect(result.current.authState.isLocked).toBe(true);
     expect(result.current.authState.biometricEnabled).toBe(false);
+    // The gate ran and the lock signal was never flipped to unlocked.
+    expect(mockBiometricUnlock).toHaveBeenCalledWith('Unlock your wallet');
+    expect(mockSetUnlocked).not.toHaveBeenCalledWith(true);
   });
 
   it('refuses biometric unlock when biometrics are not enabled', async () => {

--- a/src/contexts/__tests__/AuthContext.test.tsx
+++ b/src/contexts/__tests__/AuthContext.test.tsx
@@ -413,6 +413,48 @@ describe('AuthContext — background/foreground app-state lock', () => {
     expect(result.current.authState.isLocked).toBe(false);
     expect(result.current.authState.isAuthenticated).toBe(true);
   });
+
+  // KNOWN BUG (reported, source intentionally NOT fixed — TASK-160 is test-only).
+  // Lock-BYPASS on a suspended app: the AppState 'change' handler is created once
+  // in the mount effect and closes over a STALE `authState.backgroundedAt` (the
+  // value at first render — null). The only thing that actually locks after
+  // backgrounding is the 60s JS setTimeout. If the OS suspends the JS runtime
+  // (common on real devices) that timer never fires; when the user returns after
+  // the grace window the handler reads the stale null backgroundedAt, so the
+  // `now - backgroundedAt > grace` branch is skipped and the wallet stays
+  // UNLOCKED. Documented via it.failing; flip to a plain `it` once the handler
+  // reads live state (e.g. via a ref) so a post-grace foreground return locks.
+  it.failing(
+    'locks on foreground return after the grace window when the background timer never fired (suspended app)',
+    async () => {
+      const { result } = await mountAuth();
+
+      await act(async () => {
+        await result.current.unlock(TEST_PIN);
+      });
+      expect(result.current.authState.isLocked).toBe(false);
+
+      const t0 = Date.now();
+
+      // App backgrounds; a 60s JS lock timer is armed.
+      await act(async () => {
+        appStateHandler!('background');
+        await Promise.resolve();
+      });
+
+      // Model a SUSPENDED app: the JS runtime was frozen so the armed background
+      // timer never ran, yet real wall-clock time advanced well past the grace
+      // window. setSystemTime moves Date.now WITHOUT firing any pending timer.
+      await act(async () => {
+        jest.setSystemTime(t0 + 60 * 1000 + 5000);
+        appStateHandler!('active');
+        await Promise.resolve();
+      });
+
+      // SECURITY EXPECTATION: must be locked. Currently stays unlocked (bug).
+      expect(result.current.authState.isLocked).toBe(true);
+    }
+  );
 });
 
 describe('AuthContext — unmount teardown (no leaks)', () => {


### PR DESCRIPTION
## TASK-160 — P0 tests: AuthContext

Adds RN-Testing-Library (`@testing-library/react-native` + `react-test-renderer`, first component/context test harness in the repo) coverage for the `AuthContext` session-lock surface.

### Coverage (19 tests)
- **Initial state**: locked when a wallet+PIN exists; unlocked (setup mode) with no wallet/PIN; biometricEnabled=false when hardware unavailable.
- **PIN unlock**: valid PIN unlocks + populates session vault + flips lock signal; invalid PIN stays locked (vault untouched); empty secret rejected without calling verifyPin.
- **Biometric unlock**: success; cancelled stays locked; enrollment invalidation disables biometrics and never asks for the mnemonic; refused when biometrics not enabled. Each enabled-outcome asserts the biometric gate (`unlockVaultWithBiometrics`) actually ran.
- **Inactivity timeout**: locks + runs single teardown after the window; stays unlocked while activity is refreshed.
- **Background/foreground**: locks after the 60s grace timer; stays unlocked when returning within grace.
- **Unmount teardown**: clears its activity interval + session timeout; armed background-grace timer never fires post-unmount.

### DR-3 / CLAUDE.md
All secure-store leaves, session vault, teardown, lock signal, `expo-local-authentication`, and `AppState` are mocked. No real key/mnemonic material is fabricated or logged; `abc123` is a mocked test credential only. **Test-only — AuthContext/crypto source is not modified.**

### Real bugs found (documented via `it.failing`, source intentionally NOT fixed)
1. **Leaked AppState subscription on unmount** — the mount `useEffect` discards `setupAppStateListener()`'s returned `() => subscription.remove()` cleanup, so `remove()` is never called on unmount.
2. **Suspended-app lock bypass** — the AppState handler closes over a stale `authState.backgroundedAt` (null from the mount render). If the OS suspends the JS runtime so the 60s background timer never fires, returning to foreground after the grace window leaves the wallet **unlocked**.

Both are flagged for follow-up (out of scope for this test-only task).

Gates: `npm run typecheck`, `npm run lint`, `npm test -- --ci` all green (892 tests). Codex review: CLEAN.

https://claude.ai/code/session_01TGQqENc5aZyAqHos1P31Jn