### PR TITLE
test(store): P0 remoteSignerStore tests — persistence, replay, state machine (TASK-159)

### DIFF
--- a/src/store/__tests__/remoteSignerStore.test.ts
+++ b/src/store/__tests__/remoteSignerStore.test.ts
@@ -101,17 +101,27 @@ function persistedKeys(): string[] {
   return setItemMock.mock.calls.map((call) => String(call[0]));
 }
 
+/** Flatten an Error to a scannable string (JSON.stringify(Error) === "{}"). */
+function errorToString(err: Error): string {
+  return `${err.name}: ${err.message}\n${err.stack ?? ''}`;
+}
+
 /**
- * Serialize a console argument so an object/typed-array carrying a secret is
- * surfaced (a naive `String(obj)` would collapse to "[object Object]" and hide
- * a leak). Uint8Arrays become plain number arrays so byte-form leaks are seen.
+ * Serialize a console argument so an object/typed-array/Error carrying a secret
+ * is surfaced (a naive `String(obj)` collapses to "[object Object]" and
+ * `JSON.stringify(new Error(secret))` collapses to "{}", both hiding a leak).
+ * Uint8Arrays become plain number arrays so byte-form leaks are seen; Errors
+ * expose message + stack.
  */
 function serializeArg(arg: unknown): string {
   if (typeof arg === 'string') return arg;
+  if (arg instanceof Error) return errorToString(arg);
   try {
-    return JSON.stringify(arg, (_key, value) =>
-      value instanceof Uint8Array ? Array.from(value) : value
-    );
+    return JSON.stringify(arg, (_key, value) => {
+      if (value instanceof Uint8Array) return Array.from(value);
+      if (value instanceof Error) return errorToString(value);
+      return value;
+    });
   } catch {
     return String(arg);
   }
@@ -462,6 +472,56 @@ describe('remoteSignerStore (TASK-159)', () => {
             .getState()
             .validateRequest(makeRequest({ id: 'req-lost' }))
         ).toEqual({
+          valid: false,
+          error: 'Request has already been processed',
+        });
+      }
+    );
+
+    // KNOWN GAP (reported, source NOT modified): markRequestProcessed persists
+    // the WHOLE set each call, fire-and-forget and un-serialized. If two writes
+    // land out of order, the older (smaller) set clobbers the newer one on disk,
+    // dropping the most recent id — a replay of that id is accepted after a
+    // restart. it.failing asserts the DESIRED behaviour (both ids stay blocked)
+    // and currently fails, documenting the last-write-wins race.
+    it.failing(
+      'out-of-order fire-and-forget writes can drop the newer id (replay after restart)',
+      async () => {
+        // Defer the two processed-id writes and release them in REVERSE order.
+        const commits: (() => void)[] = [];
+        const deferWrite = (key: string, value: string) =>
+          new Promise<void>((resolve) => {
+            commits.push(() => {
+              mockAsyncStore.set(key, value);
+              resolve();
+            });
+          });
+        setItemMock.mockImplementationOnce(deferWrite);
+        setItemMock.mockImplementationOnce(deferWrite);
+
+        const store = useRemoteSignerStore.getState();
+        store.markRequestProcessed('req-a'); // write #1 persists ["req-a"]
+        store.markRequestProcessed('req-b'); // write #2 persists ["req-a","req-b"]
+
+        // Newer write lands first, then the older write overwrites it.
+        commits[1]();
+        commits[0]();
+        await flush();
+
+        // Restart from disk only.
+        useRemoteSignerStore.setState({
+          processedRequestIds: new Set(),
+          isInitialized: false,
+        });
+        await useRemoteSignerStore.getState().initialize();
+
+        const state = useRemoteSignerStore.getState();
+        // DESIRED: both durably blocked. ACTUAL: req-b was clobbered → accepted.
+        expect(state.validateRequest(makeRequest({ id: 'req-a' }))).toEqual({
+          valid: false,
+          error: 'Request has already been processed',
+        });
+        expect(state.validateRequest(makeRequest({ id: 'req-b' }))).toEqual({
           valid: false,
           error: 'Request has already been processed',
         });

--- a/src/store/__tests__/remoteSignerStore.test.ts
+++ b/src/store/__tests__/remoteSignerStore.test.ts
@@ -119,7 +119,7 @@ function serializeArg(arg: unknown): string {
 
 /** All console output captured this test, fully serialized. */
 function allConsoleOutput(): string {
-  return [logSpy, warnSpy, errorSpy]
+  return [logSpy, infoSpy, debugSpy, warnSpy, errorSpy]
     .flatMap((spy) => spy.mock.calls)
     .map((call) => call.map(serializeArg).join(' '))
     .join('\n');
@@ -176,6 +176,8 @@ const INITIAL_PROGRESS = {
 };
 
 let logSpy: jest.SpyInstance;
+let infoSpy: jest.SpyInstance;
+let debugSpy: jest.SpyInstance;
 let warnSpy: jest.SpyInstance;
 let errorSpy: jest.SpyInstance;
 
@@ -185,6 +187,8 @@ describe('remoteSignerStore (TASK-159)', () => {
     // Silence + capture the store's chatty logging (also lets us assert no
     // secret is ever logged).
     logSpy = jest.spyOn(console, 'log').mockImplementation(() => {});
+    infoSpy = jest.spyOn(console, 'info').mockImplementation(() => {});
+    debugSpy = jest.spyOn(console, 'debug').mockImplementation(() => {});
     warnSpy = jest.spyOn(console, 'warn').mockImplementation(() => {});
     errorSpy = jest.spyOn(console, 'error').mockImplementation(() => {});
     // Reset the singleton store to a pristine slate (fresh Set/Map instances).
@@ -233,11 +237,14 @@ describe('remoteSignerStore (TASK-159)', () => {
       // disk during any of these would be caught.
       await store.setAppMode('signer');
       await store.initializeSignerConfig('Air-gapped Pixel');
+      await store.updateSignerDeviceName('Renamed Signer');
       await store.addPairedSigner({
         deviceId: 'voi-signer-abc',
         pairedAt: Date.now(),
         addresses: [makeAccount('paired').addr],
       });
+      await store.updateSignerActivity('voi-signer-abc');
+      await store.removePairedSigner('voi-signer-abc');
       store.markRequestProcessed(request.id);
       await flush();
 
@@ -418,6 +425,49 @@ describe('remoteSignerStore (TASK-159)', () => {
       );
     });
 
+    // KNOWN GAP (reported, source intentionally NOT modified): markRequestProcessed
+    // persists fire-and-forget. If that durable write is rejected (disk full) or
+    // the app terminates before it lands, the id is only in the volatile Set —
+    // so after a restart the SAME request id is accepted again (replay). The
+    // in-session guard held (see test above), but cross-restart durability is
+    // best-effort. This it.failing asserts the DESIRED secure behaviour (replay
+    // still blocked) and currently fails, documenting the gap without a source fix.
+    it.failing(
+      'a processed id whose durable write failed is NOT replay-blocked after restart',
+      async () => {
+        setItemMock.mockImplementationOnce(async () => {
+          throw new Error('disk full');
+        });
+
+        const store = useRemoteSignerStore.getState();
+        store.markRequestProcessed('req-lost');
+        await flush();
+
+        // The durable write was rejected — nothing landed on disk.
+        expect(
+          mockAsyncStore.get(STORAGE_KEYS.PROCESSED_REQUESTS)
+        ).toBeUndefined();
+
+        // Restart: only AsyncStorage survives, the in-memory Set is gone.
+        useRemoteSignerStore.setState({
+          processedRequestIds: new Set(),
+          isInitialized: false,
+        });
+        await useRemoteSignerStore.getState().initialize();
+
+        // DESIRED: replay still rejected. ACTUAL: accepted → this fails, so
+        // it.failing turns the documented gap into a green (expected-fail) test.
+        expect(
+          useRemoteSignerStore
+            .getState()
+            .validateRequest(makeRequest({ id: 'req-lost' }))
+        ).toEqual({
+          valid: false,
+          error: 'Request has already been processed',
+        });
+      }
+    );
+
     it('persists processed ids so replays are blocked after a restart', async () => {
       const store = useRemoteSignerStore.getState();
       store.markRequestProcessed('req-replayable');
@@ -570,6 +620,30 @@ describe('remoteSignerStore (TASK-159)', () => {
         status: 'error',
         error: 'user rejected',
       });
+    });
+
+    it('merges partially: recovering from error requires clearing it explicitly', () => {
+      const store = useRemoteSignerStore.getState();
+      store.setPendingRequest(makeRequest({}, 1));
+      store.setSigningProgress({ status: 'error', error: 'boom' });
+
+      // setSigningProgress does a shallow merge, so flipping status back to
+      // 'signing' alone does NOT drop the prior `error` field. This documents
+      // the store's merge contract (the SigningProgress type intends `error`
+      // only when status === 'error', so a clean recovery must clear it).
+      store.setSigningProgress({ status: 'signing', currentIndex: 1 });
+      expect(useRemoteSignerStore.getState().signingProgress).toEqual({
+        currentIndex: 1,
+        totalTransactions: 1,
+        status: 'signing',
+        error: 'boom',
+      });
+
+      // A caller recovering cleanly clears it explicitly.
+      store.setSigningProgress({ error: undefined });
+      expect(
+        useRemoteSignerStore.getState().signingProgress.error
+      ).toBeUndefined();
     });
 
     it('resets to idle and clears the request when set to null', () => {

--- a/src/store/__tests__/remoteSignerStore.test.ts
+++ b/src/store/__tests__/remoteSignerStore.test.ts
@@ -127,9 +127,9 @@ function serializeArg(arg: unknown): string {
   }
 }
 
-/** All console output captured this test, fully serialized. */
+/** All console output captured this test, fully serialized across EVERY channel. */
 function allConsoleOutput(): string {
-  return [logSpy, infoSpy, debugSpy, warnSpy, errorSpy]
+  return consoleSpies
     .flatMap((spy) => spy.mock.calls)
     .map((call) => call.map(serializeArg).join(' '))
     .join('\n');
@@ -188,22 +188,38 @@ const INITIAL_PROGRESS = {
   status: 'idle' as const,
 };
 
-let logSpy: jest.SpyInstance;
-let infoSpy: jest.SpyInstance;
-let debugSpy: jest.SpyInstance;
-let warnSpy: jest.SpyInstance;
-let errorSpy: jest.SpyInstance;
+// Every console logging channel a leak could plausibly use. Spying on ALL of
+// them (not a hand-picked subset) keeps allConsoleOutput()'s "capture EVERY
+// channel" claim honest — a regression logging a secret via console.trace /
+// dir / table / group / assert cannot slip past the no-leak assertion.
+const CONSOLE_METHODS = [
+  'log',
+  'info',
+  'debug',
+  'warn',
+  'error',
+  'trace',
+  'dir',
+  'dirxml',
+  'table',
+  'group',
+  'groupCollapsed',
+  'groupEnd',
+  'assert',
+] as const;
+
+let consoleSpies: jest.SpyInstance[];
 
 describe('remoteSignerStore (TASK-159)', () => {
   beforeEach(() => {
     mockAsyncStore.clear();
-    // Silence + capture the store's chatty logging (also lets us assert no
-    // secret is ever logged).
-    logSpy = jest.spyOn(console, 'log').mockImplementation(() => {});
-    infoSpy = jest.spyOn(console, 'info').mockImplementation(() => {});
-    debugSpy = jest.spyOn(console, 'debug').mockImplementation(() => {});
-    warnSpy = jest.spyOn(console, 'warn').mockImplementation(() => {});
-    errorSpy = jest.spyOn(console, 'error').mockImplementation(() => {});
+    // Silence + capture the store's chatty logging across every channel (also
+    // lets us assert no secret is ever logged, on any method).
+    consoleSpies = CONSOLE_METHODS.filter(
+      (name) =>
+        typeof (console as unknown as Record<string, unknown>)[name] ===
+        'function'
+    ).map((name) => jest.spyOn(console, name).mockImplementation(() => {}));
     // Reset the singleton store to a pristine slate (fresh Set/Map instances).
     useRemoteSignerStore.setState({
       appMode: 'wallet',

--- a/src/store/__tests__/remoteSignerStore.test.ts
+++ b/src/store/__tests__/remoteSignerStore.test.ts
@@ -136,16 +136,19 @@ function allConsoleOutput(): string {
 }
 
 /**
- * Every plausible serialized encoding of a real secret key. If any of these
- * substrings appears in persisted state or logs, the key leaked.
+ * Every plausible serialized encoding of a byte array. If any of these
+ * substrings appears in persisted state or logs, those bytes leaked. Covers
+ * the four ways a byte buffer typically ends up in a string: hex, base64,
+ * `JSON.stringify(Array.from(bytes))` ("[..]") and `JSON.stringify(bytes)`
+ * ("{\"0\":..}", how a raw Uint8Array serializes).
  */
-function secretKeyEncodings(sk: Uint8Array): string[] {
-  const buf = Buffer.from(sk);
+function byteEncodings(bytes: Uint8Array): string[] {
+  const buf = Buffer.from(bytes);
   return [
     buf.toString('hex'),
     buf.toString('base64'),
-    JSON.stringify(Array.from(sk)), // e.g. JSON.stringify(state.txns bytes)
-    JSON.stringify(sk), // e.g. {"0":..} if a Uint8Array were stringified
+    JSON.stringify(Array.from(bytes)),
+    JSON.stringify(bytes),
   ];
 }
 
@@ -224,7 +227,11 @@ describe('remoteSignerStore (TASK-159)', () => {
     it('never persists or logs the pending request, its txn bytes, or key material', async () => {
       const canary = makeAccount('leak-canary');
       const acct = makeAccount('signer-primary');
-      const blob = txnBlob(acct.addr);
+      const rawTxn = algosdk.encodeUnsignedTransaction(paymentTxn(acct.addr));
+      const blob = Buffer.from(rawTxn).toString('base64');
+      // The private half of the 64-byte sk is its first 32 bytes (seed); a
+      // regression could leak just that.
+      const seed = canary.sk.slice(0, 32);
 
       // Route REAL secrets through in-memory state in three forms: a 25-word
       // mnemonic (meta.desc), the raw 64-byte secret key (attached to the
@@ -258,10 +265,16 @@ describe('remoteSignerStore (TASK-159)', () => {
       store.markRequestProcessed(request.id);
       await flush();
 
+      // Check the mnemonic plus every byte encoding of the full secret key, the
+      // 32-byte seed, and the decoded transaction bytes — so a leak of any of
+      // them (hex/base64/JSON array/JSON object, or a decode-then-persist of the
+      // blob) is caught, not just the original base64 blob string.
       const canaries = [
         canary.mnemonic,
         blob,
-        ...secretKeyEncodings(canary.sk),
+        ...byteEncodings(canary.sk),
+        ...byteEncodings(seed),
+        ...byteEncodings(rawTxn),
       ];
 
       const persisted = allPersistedValues();
@@ -682,25 +695,35 @@ describe('remoteSignerStore (TASK-159)', () => {
       });
     });
 
-    it('merges partially: recovering from error requires clearing it explicitly', () => {
+    it('merges partial updates for non-error fields (advancing the index)', () => {
+      const store = useRemoteSignerStore.getState();
+      store.setPendingRequest(makeRequest({}, 2));
+
+      // A bare index bump merges over the existing progress without disturbing
+      // the (error-free) status/total.
+      store.setSigningProgress({ currentIndex: 1 });
+      expect(useRemoteSignerStore.getState().signingProgress).toEqual({
+        currentIndex: 1,
+        totalTransactions: 2,
+        status: 'reviewing',
+      });
+    });
+
+    // KNOWN GAP (reported, source NOT modified): setSigningProgress is a shallow
+    // partial-merge setter, so transitioning error -> signing/complete does NOT
+    // drop the stale `error` message. That contradicts SigningProgress' contract
+    // (`error` is the "error message if status is 'error'"). it.failing asserts
+    // the DESIRED behaviour (error cleared once the status leaves 'error') and
+    // currently fails, rather than pinning the buggy retention as correct.
+    it.failing('leaving the error state drops the stale error message', () => {
       const store = useRemoteSignerStore.getState();
       store.setPendingRequest(makeRequest({}, 1));
       store.setSigningProgress({ status: 'error', error: 'boom' });
 
-      // setSigningProgress does a shallow merge, so flipping status back to
-      // 'signing' alone does NOT drop the prior `error` field. This documents
-      // the store's merge contract (the SigningProgress type intends `error`
-      // only when status === 'error', so a clean recovery must clear it).
+      // Recover: flip back to signing.
       store.setSigningProgress({ status: 'signing', currentIndex: 1 });
-      expect(useRemoteSignerStore.getState().signingProgress).toEqual({
-        currentIndex: 1,
-        totalTransactions: 1,
-        status: 'signing',
-        error: 'boom',
-      });
 
-      // A caller recovering cleanly clears it explicitly.
-      store.setSigningProgress({ error: undefined });
+      // DESIRED: no stale error once we're no longer in the error state.
       expect(
         useRemoteSignerStore.getState().signingProgress.error
       ).toBeUndefined();

--- a/src/store/__tests__/remoteSignerStore.test.ts
+++ b/src/store/__tests__/remoteSignerStore.test.ts
@@ -10,14 +10,21 @@
  *      (persisted `processedRequestIds` are re-hydrated by `initialize`).
  *   3. Request state-machine transitions — the `SigningProgress` progression
  *      idle → reviewing → signing → complete (and the error branch), plus the
- *      reset back to idle when the pending request is cleared.
+ *      reset back to idle / request replacement.
  *
  * DR-3 / CLAUDE.md: this is TEST-ONLY — the store/crypto source is never
  * modified. All key material used as leak canaries is REAL algosdk-derived
- * crypto from the shared fixtures (no fabricated bytes). A real secret is
- * deliberately routed THROUGH the store's in-memory state so the "not
- * persisted / not logged" assertions would genuinely FAIL if the store ever
- * leaked it — they are not vacuous.
+ * crypto from the shared fixtures (no fabricated bytes). Real secrets are
+ * deliberately routed THROUGH the store's in-memory state — as a mnemonic
+ * string, as the raw 64-byte secret key, and as a base64 transaction blob — so
+ * the "not persisted / not logged" assertions check EVERY serialized encoding
+ * (hex, base64, JSON array, JSON object) and would genuinely FAIL if the store
+ * ever wrote or logged that state. They are not vacuous.
+ *
+ * The AsyncStorage mock commits writes only after a microtask (mirroring the
+ * real async native module), so every assertion that depends on a durable value
+ * must await a flush — that makes the store's fire-and-forget persistence of
+ * processed-request ids explicit rather than hidden behind a synchronous mock.
  */
 
 import algosdk from 'algosdk';
@@ -44,8 +51,9 @@ jest.mock('@/platform', () => {
 
 // In-memory AsyncStorage. The backing map (mock-prefixed so the jest.mock
 // factory may close over it) persists across the module's own reads/writes so
-// initialize() can re-hydrate what the actions wrote; tests clear it via the
-// exposed `__store` handle in beforeEach.
+// initialize() can re-hydrate what the actions wrote; tests clear it via
+// mockAsyncStore in beforeEach. setItem commits only after a microtask so the
+// store's non-awaited (fire-and-forget) persistence surfaces in tests.
 const mockAsyncStore = new Map<string, string>();
 jest.mock('@react-native-async-storage/async-storage', () => ({
   __esModule: true,
@@ -54,12 +62,13 @@ jest.mock('@react-native-async-storage/async-storage', () => ({
       mockAsyncStore.has(key) ? mockAsyncStore.get(key)! : null
     ),
     setItem: jest.fn(async (key: string, value: string) => {
+      await Promise.resolve();
       mockAsyncStore.set(key, value);
     }),
     removeItem: jest.fn(async (key: string) => {
+      await Promise.resolve();
       mockAsyncStore.delete(key);
     }),
-    __store: mockAsyncStore,
   },
 }));
 
@@ -79,6 +88,9 @@ const ALLOWED_KEYS = new Set<string>(Object.values(STORAGE_KEYS));
 
 const setItemMock = AsyncStorage.setItem as jest.Mock;
 
+/** Drain microtasks + the 0ms macrotask queue so deferred writes commit. */
+const flush = () => new Promise((resolve) => setTimeout(resolve, 0));
+
 /** Every value written to AsyncStorage this test, concatenated. */
 function allPersistedValues(): string {
   return setItemMock.mock.calls.map((call) => String(call[1])).join('\n');
@@ -87,6 +99,44 @@ function allPersistedValues(): string {
 /** Distinct keys written to AsyncStorage this test. */
 function persistedKeys(): string[] {
   return setItemMock.mock.calls.map((call) => String(call[0]));
+}
+
+/**
+ * Serialize a console argument so an object/typed-array carrying a secret is
+ * surfaced (a naive `String(obj)` would collapse to "[object Object]" and hide
+ * a leak). Uint8Arrays become plain number arrays so byte-form leaks are seen.
+ */
+function serializeArg(arg: unknown): string {
+  if (typeof arg === 'string') return arg;
+  try {
+    return JSON.stringify(arg, (_key, value) =>
+      value instanceof Uint8Array ? Array.from(value) : value
+    );
+  } catch {
+    return String(arg);
+  }
+}
+
+/** All console output captured this test, fully serialized. */
+function allConsoleOutput(): string {
+  return [logSpy, warnSpy, errorSpy]
+    .flatMap((spy) => spy.mock.calls)
+    .map((call) => call.map(serializeArg).join(' '))
+    .join('\n');
+}
+
+/**
+ * Every plausible serialized encoding of a real secret key. If any of these
+ * substrings appears in persisted state or logs, the key leaked.
+ */
+function secretKeyEncodings(sk: Uint8Array): string[] {
+  const buf = Buffer.from(sk);
+  return [
+    buf.toString('hex'),
+    buf.toString('base64'),
+    JSON.stringify(Array.from(sk)), // e.g. JSON.stringify(state.txns bytes)
+    JSON.stringify(sk), // e.g. {"0":..} if a Uint8Array were stringified
+  ];
 }
 
 /** Base64 msgpack of a real (harmless self-payment) unsigned transaction. */
@@ -129,14 +179,6 @@ let logSpy: jest.SpyInstance;
 let warnSpy: jest.SpyInstance;
 let errorSpy: jest.SpyInstance;
 
-/** All console output captured this test, concatenated. */
-function allConsoleOutput(): string {
-  return [logSpy, warnSpy, errorSpy]
-    .flatMap((spy) => spy.mock.calls)
-    .map((call) => call.map((a: unknown) => String(a)).join(' '))
-    .join('\n');
-}
-
 describe('remoteSignerStore (TASK-159)', () => {
   beforeEach(() => {
     mockAsyncStore.clear();
@@ -165,53 +207,56 @@ describe('remoteSignerStore (TASK-159)', () => {
   // 1. Persistence — no sensitive material at rest
   // -------------------------------------------------------------------------
   describe('persistence', () => {
-    it('never persists the pending request or its transaction bytes', () => {
-      const secretMnemonic = makeAccount('leak-canary').mnemonic;
+    it('never persists or logs the pending request, its txn bytes, or key material', async () => {
+      const canary = makeAccount('leak-canary');
       const acct = makeAccount('signer-primary');
       const blob = txnBlob(acct.addr);
 
-      // Route a REAL secret (25-word mnemonic) and the real txn blob through
-      // in-memory state. If the store persisted the pending request, these
-      // assertions would fail — so they are not vacuous.
+      // Route REAL secrets through in-memory state in three forms: a 25-word
+      // mnemonic (meta.desc), the raw 64-byte secret key (attached to the
+      // request object), and a base64 transaction blob (txns[].b).
       const request = makeRequest({
         txns: [{ i: 0, b: blob, s: acct.addr }],
-        meta: { desc: secretMnemonic },
-      });
-
-      useRemoteSignerStore.getState().setPendingRequest(request);
-
-      // The request lives in memory…
-      expect(useRemoteSignerStore.getState().pendingRequest).toBe(request);
-      // …but setPendingRequest touched AsyncStorage not at all.
-      expect(setItemMock).not.toHaveBeenCalled();
-
-      // And even after exercising every persisting action, none of the
-      // sensitive material reaches disk.
-      const persisted = allPersistedValues();
-      expect(persisted).not.toContain(secretMnemonic);
-      expect(persisted).not.toContain(blob);
-    });
-
-    it('does not leak a routed secret into persisted state or logs', async () => {
-      const canary = makeAccount('leak-canary');
-      const request = makeRequest({ meta: { desc: canary.mnemonic } });
+        meta: { desc: canary.mnemonic },
+      }) as RemoteSignerRequest & { skCanary?: Uint8Array };
+      request.skCanary = canary.sk;
 
       const store = useRemoteSignerStore.getState();
       store.setPendingRequest(request);
-      store.setSigningProgress({ status: 'signing', currentIndex: 1 });
+
+      // setPendingRequest is in-memory only — it writes nothing at all.
+      expect(setItemMock).not.toHaveBeenCalled();
+      expect(useRemoteSignerStore.getState().pendingRequest).toBe(request);
+
+      // Drive EVERY persisting action while the secret-bearing request is set,
+      // so a regression that serialized store state (incl. pendingRequest) to
+      // disk during any of these would be caught.
       await store.setAppMode('signer');
       await store.initializeSignerConfig('Air-gapped Pixel');
+      await store.addPairedSigner({
+        deviceId: 'voi-signer-abc',
+        pairedAt: Date.now(),
+        addresses: [makeAccount('paired').addr],
+      });
       store.markRequestProcessed(request.id);
+      await flush();
 
-      // Real secret key bytes (hex) and mnemonic never touch storage or logs.
-      const secretHex = Buffer.from(canary.sk).toString('hex');
+      const canaries = [
+        canary.mnemonic,
+        blob,
+        ...secretKeyEncodings(canary.sk),
+      ];
+
       const persisted = allPersistedValues();
-      expect(persisted).not.toContain(canary.mnemonic);
-      expect(persisted).not.toContain(secretHex);
+      expect(setItemMock).toHaveBeenCalled(); // guard: writes DID happen…
+      for (const secret of canaries) {
+        expect(persisted).not.toContain(secret); // …none carried a secret.
+      }
 
       const logs = allConsoleOutput();
-      expect(logs).not.toContain(canary.mnemonic);
-      expect(logs).not.toContain(secretHex);
+      for (const secret of canaries) {
+        expect(logs).not.toContain(secret);
+      }
     });
 
     it('only ever writes the four whitelisted storage keys', async () => {
@@ -228,6 +273,7 @@ describe('remoteSignerStore (TASK-159)', () => {
         addresses: [makeAccount('paired').addr],
       });
       store.markRequestProcessed('req-x');
+      await flush();
 
       const keys = persistedKeys();
       expect(keys.length).toBeGreaterThan(0);
@@ -271,6 +317,7 @@ describe('remoteSignerStore (TASK-159)', () => {
         addresses: [pairedAddr],
       });
       store.markRequestProcessed('req-persisted-1');
+      await flush(); // let the fire-and-forget processed-ids write land
 
       // Simulate a fresh app launch: wipe in-memory state, keep AsyncStorage.
       useRemoteSignerStore.setState({
@@ -330,9 +377,51 @@ describe('remoteSignerStore (TASK-159)', () => {
       });
     });
 
+    it('updates the in-memory replay guard synchronously; persistence is fire-and-forget', async () => {
+      const store = useRemoteSignerStore.getState();
+      store.markRequestProcessed('req-fire');
+
+      // In-session replay protection is effective immediately…
+      expect(
+        useRemoteSignerStore.getState().processedRequestIds.has('req-fire')
+      ).toBe(true);
+      // …while the durable write is fire-and-forget: nothing on disk yet.
+      expect(
+        mockAsyncStore.get(STORAGE_KEYS.PROCESSED_REQUESTS)
+      ).toBeUndefined();
+
+      await flush();
+      expect(mockAsyncStore.get(STORAGE_KEYS.PROCESSED_REQUESTS)).toBe(
+        JSON.stringify(['req-fire'])
+      );
+    });
+
+    it('keeps the in-memory replay guard even when the durable write fails', async () => {
+      // Model a rejected native write (e.g. disk full) for the processed-ids
+      // persistence. markRequestProcessed must not throw and must still block
+      // replays within the session.
+      setItemMock.mockImplementationOnce(async () => {
+        throw new Error('disk full');
+      });
+
+      const store = useRemoteSignerStore.getState();
+      expect(() => store.markRequestProcessed('req-nowrite')).not.toThrow();
+      await flush();
+
+      const state = useRemoteSignerStore.getState();
+      expect(state.processedRequestIds.has('req-nowrite')).toBe(true);
+      expect(state.validateRequest(makeRequest({ id: 'req-nowrite' }))).toEqual(
+        {
+          valid: false,
+          error: 'Request has already been processed',
+        }
+      );
+    });
+
     it('persists processed ids so replays are blocked after a restart', async () => {
       const store = useRemoteSignerStore.getState();
       store.markRequestProcessed('req-replayable');
+      await flush();
 
       expect(mockAsyncStore.get(STORAGE_KEYS.PROCESSED_REQUESTS)).toBe(
         JSON.stringify(['req-replayable'])
@@ -359,10 +448,12 @@ describe('remoteSignerStore (TASK-159)', () => {
       expect(useRemoteSignerStore.getState().processedRequestIds.size).toBe(1);
     });
 
-    it('markRequestProcessed accumulates ids without dropping earlier ones', () => {
+    it('markRequestProcessed accumulates ids without dropping earlier ones', async () => {
       const store = useRemoteSignerStore.getState();
       store.markRequestProcessed('req-a');
       store.markRequestProcessed('req-b');
+      await flush();
+
       const ids = useRemoteSignerStore.getState().processedRequestIds;
       expect(ids.has('req-a')).toBe(true);
       expect(ids.has('req-b')).toBe(true);
@@ -491,6 +582,32 @@ describe('remoteSignerStore (TASK-159)', () => {
       const state = useRemoteSignerStore.getState();
       expect(state.pendingRequest).toBeNull();
       expect(state.signingProgress).toEqual(INITIAL_PROGRESS);
+    });
+
+    it('replacing an in-flight request resets progress and drops any stale error', () => {
+      const store = useRemoteSignerStore.getState();
+      // First request advances into an error state.
+      store.setPendingRequest(makeRequest({ id: 'req-first' }, 3));
+      store.setSigningProgress({
+        status: 'error',
+        currentIndex: 2,
+        error: 'boom',
+      });
+
+      // A brand-new request arrives while the previous one is errored.
+      const next = makeRequest({ id: 'req-next' }, 1);
+      store.setPendingRequest(next);
+
+      const state = useRemoteSignerStore.getState();
+      expect(state.pendingRequest).toBe(next);
+      // Progress is fully reset for the new request — index/total/status…
+      expect(state.signingProgress).toEqual({
+        currentIndex: 0,
+        totalTransactions: 1,
+        status: 'reviewing',
+      });
+      // …and crucially no stale error carried over.
+      expect(state.signingProgress.error).toBeUndefined();
     });
 
     it('setPendingRequest does not mark the request processed', () => {

--- a/src/store/__tests__/remoteSignerStore.test.ts
+++ b/src/store/__tests__/remoteSignerStore.test.ts
@@ -1,0 +1,509 @@
+/**
+ * TASK-159 — P0 tests for remoteSignerStore (zustand).
+ *
+ * Three concerns, per acceptance criteria:
+ *   1. Persistence — assert NO sensitive material is written to AsyncStorage
+ *      (the air-gapped signer's pending request / transaction bytes stay in
+ *      memory only), and that only the four whitelisted keys are ever persisted.
+ *   2. Replay / duplicate-request prevention — a processed request id is
+ *      rejected by `validateRequest`, and that rejection survives a restart
+ *      (persisted `processedRequestIds` are re-hydrated by `initialize`).
+ *   3. Request state-machine transitions — the `SigningProgress` progression
+ *      idle → reviewing → signing → complete (and the error branch), plus the
+ *      reset back to idle when the pending request is cleared.
+ *
+ * DR-3 / CLAUDE.md: this is TEST-ONLY — the store/crypto source is never
+ * modified. All key material used as leak canaries is REAL algosdk-derived
+ * crypto from the shared fixtures (no fabricated bytes). A real secret is
+ * deliberately routed THROUGH the store's in-memory state so the "not
+ * persisted / not logged" assertions would genuinely FAIL if the store ever
+ * leaked it — they are not vacuous.
+ */
+
+import algosdk from 'algosdk';
+import { Buffer } from 'buffer';
+
+import { makeAccount, paymentTxn } from '@/__tests__/fixtures/algorand';
+import {
+  REMOTE_SIGNER_CONSTANTS,
+  RemoteSignerRequest,
+  SignerDeviceInfo,
+} from '@/types/remoteSigner';
+
+// getCrypto().randomUUID() backs generateDeviceId (initializeSignerConfig).
+// Route it through Node's CSPRNG so the store runs under jest without the
+// native/expo platform adapter — real random ids, no fabricated bytes.
+jest.mock('@/platform', () => {
+  const nodeCrypto = require('crypto');
+  return {
+    getCrypto: () => ({
+      randomUUID: (): string => nodeCrypto.randomUUID(),
+    }),
+  };
+});
+
+// In-memory AsyncStorage. The backing map (mock-prefixed so the jest.mock
+// factory may close over it) persists across the module's own reads/writes so
+// initialize() can re-hydrate what the actions wrote; tests clear it via the
+// exposed `__store` handle in beforeEach.
+const mockAsyncStore = new Map<string, string>();
+jest.mock('@react-native-async-storage/async-storage', () => ({
+  __esModule: true,
+  default: {
+    getItem: jest.fn(async (key: string) =>
+      mockAsyncStore.has(key) ? mockAsyncStore.get(key)! : null
+    ),
+    setItem: jest.fn(async (key: string, value: string) => {
+      mockAsyncStore.set(key, value);
+    }),
+    removeItem: jest.fn(async (key: string) => {
+      mockAsyncStore.delete(key);
+    }),
+    __store: mockAsyncStore,
+  },
+}));
+
+import AsyncStorage from '@react-native-async-storage/async-storage';
+
+import { useRemoteSignerStore } from '../remoteSignerStore';
+
+// Storage keys — mirror the (unexported) STORAGE_KEYS in the source. If the
+// source keys ever drift, the persisted-keys whitelist test below catches it.
+const STORAGE_KEYS = {
+  APP_MODE: '@voi_remote_signer_mode',
+  SIGNER_CONFIG: '@voi_signer_config',
+  PAIRED_SIGNERS: '@voi_paired_signers',
+  PROCESSED_REQUESTS: '@voi_processed_requests',
+} as const;
+const ALLOWED_KEYS = new Set<string>(Object.values(STORAGE_KEYS));
+
+const setItemMock = AsyncStorage.setItem as jest.Mock;
+
+/** Every value written to AsyncStorage this test, concatenated. */
+function allPersistedValues(): string {
+  return setItemMock.mock.calls.map((call) => String(call[1])).join('\n');
+}
+
+/** Distinct keys written to AsyncStorage this test. */
+function persistedKeys(): string[] {
+  return setItemMock.mock.calls.map((call) => String(call[0]));
+}
+
+/** Base64 msgpack of a real (harmless self-payment) unsigned transaction. */
+function txnBlob(sender: string): string {
+  return Buffer.from(
+    algosdk.encodeUnsignedTransaction(paymentTxn(sender))
+  ).toString('base64');
+}
+
+/** A well-formed, currently-valid signing request with `count` real txns. */
+function makeRequest(
+  overrides: Partial<RemoteSignerRequest> = {},
+  count = 1
+): RemoteSignerRequest {
+  const acct = makeAccount('signer-primary');
+  const txns = Array.from({ length: count }, (_, i) => ({
+    i,
+    b: txnBlob(acct.addr),
+    s: acct.addr,
+  }));
+  return {
+    v: REMOTE_SIGNER_CONSTANTS.PROTOCOL_VERSION,
+    t: 'req',
+    id: 'req-00000000-0000-4000-8000-000000000001',
+    ts: Date.now(),
+    net: 'voi',
+    gh: 'AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA=',
+    txns,
+    ...overrides,
+  };
+}
+
+const INITIAL_PROGRESS = {
+  currentIndex: 0,
+  totalTransactions: 0,
+  status: 'idle' as const,
+};
+
+let logSpy: jest.SpyInstance;
+let warnSpy: jest.SpyInstance;
+let errorSpy: jest.SpyInstance;
+
+/** All console output captured this test, concatenated. */
+function allConsoleOutput(): string {
+  return [logSpy, warnSpy, errorSpy]
+    .flatMap((spy) => spy.mock.calls)
+    .map((call) => call.map((a: unknown) => String(a)).join(' '))
+    .join('\n');
+}
+
+describe('remoteSignerStore (TASK-159)', () => {
+  beforeEach(() => {
+    mockAsyncStore.clear();
+    // Silence + capture the store's chatty logging (also lets us assert no
+    // secret is ever logged).
+    logSpy = jest.spyOn(console, 'log').mockImplementation(() => {});
+    warnSpy = jest.spyOn(console, 'warn').mockImplementation(() => {});
+    errorSpy = jest.spyOn(console, 'error').mockImplementation(() => {});
+    // Reset the singleton store to a pristine slate (fresh Set/Map instances).
+    useRemoteSignerStore.setState({
+      appMode: 'wallet',
+      isInitialized: false,
+      signerConfig: null,
+      pendingRequest: null,
+      signingProgress: { ...INITIAL_PROGRESS },
+      processedRequestIds: new Set<string>(),
+      pairedSigners: new Map<string, SignerDeviceInfo>(),
+    });
+  });
+
+  afterEach(() => {
+    jest.restoreAllMocks();
+  });
+
+  // -------------------------------------------------------------------------
+  // 1. Persistence — no sensitive material at rest
+  // -------------------------------------------------------------------------
+  describe('persistence', () => {
+    it('never persists the pending request or its transaction bytes', () => {
+      const secretMnemonic = makeAccount('leak-canary').mnemonic;
+      const acct = makeAccount('signer-primary');
+      const blob = txnBlob(acct.addr);
+
+      // Route a REAL secret (25-word mnemonic) and the real txn blob through
+      // in-memory state. If the store persisted the pending request, these
+      // assertions would fail — so they are not vacuous.
+      const request = makeRequest({
+        txns: [{ i: 0, b: blob, s: acct.addr }],
+        meta: { desc: secretMnemonic },
+      });
+
+      useRemoteSignerStore.getState().setPendingRequest(request);
+
+      // The request lives in memory…
+      expect(useRemoteSignerStore.getState().pendingRequest).toBe(request);
+      // …but setPendingRequest touched AsyncStorage not at all.
+      expect(setItemMock).not.toHaveBeenCalled();
+
+      // And even after exercising every persisting action, none of the
+      // sensitive material reaches disk.
+      const persisted = allPersistedValues();
+      expect(persisted).not.toContain(secretMnemonic);
+      expect(persisted).not.toContain(blob);
+    });
+
+    it('does not leak a routed secret into persisted state or logs', async () => {
+      const canary = makeAccount('leak-canary');
+      const request = makeRequest({ meta: { desc: canary.mnemonic } });
+
+      const store = useRemoteSignerStore.getState();
+      store.setPendingRequest(request);
+      store.setSigningProgress({ status: 'signing', currentIndex: 1 });
+      await store.setAppMode('signer');
+      await store.initializeSignerConfig('Air-gapped Pixel');
+      store.markRequestProcessed(request.id);
+
+      // Real secret key bytes (hex) and mnemonic never touch storage or logs.
+      const secretHex = Buffer.from(canary.sk).toString('hex');
+      const persisted = allPersistedValues();
+      expect(persisted).not.toContain(canary.mnemonic);
+      expect(persisted).not.toContain(secretHex);
+
+      const logs = allConsoleOutput();
+      expect(logs).not.toContain(canary.mnemonic);
+      expect(logs).not.toContain(secretHex);
+    });
+
+    it('only ever writes the four whitelisted storage keys', async () => {
+      const store = useRemoteSignerStore.getState();
+
+      await store.setAppMode('signer');
+      await store.initializeSignerConfig('Air-gapped Pixel');
+      // In-memory-only actions must not add any storage writes.
+      store.setPendingRequest(makeRequest());
+      store.setSigningProgress({ status: 'signing' });
+      await store.addPairedSigner({
+        deviceId: 'voi-signer-abc',
+        pairedAt: Date.now(),
+        addresses: [makeAccount('paired').addr],
+      });
+      store.markRequestProcessed('req-x');
+
+      const keys = persistedKeys();
+      expect(keys.length).toBeGreaterThan(0);
+      for (const key of keys) {
+        expect(ALLOWED_KEYS.has(key)).toBe(true);
+      }
+      // The four persisting actions each wrote their own key.
+      expect(new Set(keys)).toEqual(
+        new Set([
+          STORAGE_KEYS.APP_MODE,
+          STORAGE_KEYS.SIGNER_CONFIG,
+          STORAGE_KEYS.PAIRED_SIGNERS,
+          STORAGE_KEYS.PROCESSED_REQUESTS,
+        ])
+      );
+    });
+
+    it('persisted signer config contains only public device metadata', async () => {
+      await useRemoteSignerStore
+        .getState()
+        .initializeSignerConfig('Air-gapped Pixel');
+
+      const raw = mockAsyncStore.get(STORAGE_KEYS.SIGNER_CONFIG);
+      expect(raw).toBeTruthy();
+      const config = JSON.parse(raw!);
+      // Exactly the public config shape — no key/seed/mnemonic fields.
+      expect(new Set(Object.keys(config))).toEqual(
+        new Set(['deviceId', 'deviceName', 'requirePinPerTxn'])
+      );
+      expect(config.deviceId).toMatch(/^voi-signer-/);
+      expect(config.deviceName).toBe('Air-gapped Pixel');
+    });
+
+    it('re-hydrates paired signers and processed ids across a restart', async () => {
+      const store = useRemoteSignerStore.getState();
+      const pairedAddr = makeAccount('paired').addr;
+      await store.addPairedSigner({
+        deviceId: 'voi-signer-xyz',
+        deviceName: 'Old Phone',
+        pairedAt: 1000,
+        addresses: [pairedAddr],
+      });
+      store.markRequestProcessed('req-persisted-1');
+
+      // Simulate a fresh app launch: wipe in-memory state, keep AsyncStorage.
+      useRemoteSignerStore.setState({
+        pairedSigners: new Map(),
+        processedRequestIds: new Set(),
+        isInitialized: false,
+      });
+
+      await useRemoteSignerStore.getState().initialize();
+
+      const rehydrated = useRemoteSignerStore.getState();
+      expect(rehydrated.isInitialized).toBe(true);
+      expect(rehydrated.pairedSigners.get('voi-signer-xyz')).toEqual({
+        deviceId: 'voi-signer-xyz',
+        deviceName: 'Old Phone',
+        pairedAt: 1000,
+        addresses: [pairedAddr],
+      });
+      expect(rehydrated.processedRequestIds.has('req-persisted-1')).toBe(true);
+    });
+
+    it('initialize() on empty storage yields safe wallet-mode defaults', async () => {
+      await useRemoteSignerStore.getState().initialize();
+      const state = useRemoteSignerStore.getState();
+      expect(state.appMode).toBe('wallet');
+      expect(state.signerConfig).toBeNull();
+      expect(state.pairedSigners.size).toBe(0);
+      expect(state.processedRequestIds.size).toBe(0);
+      expect(state.isInitialized).toBe(true);
+    });
+  });
+
+  // -------------------------------------------------------------------------
+  // 2. Replay / duplicate-request prevention
+  // -------------------------------------------------------------------------
+  describe('replay prevention', () => {
+    it('accepts a fresh request but rejects the same id on replay', () => {
+      const store = useRemoteSignerStore.getState();
+      const request = makeRequest();
+
+      // First presentation: valid.
+      expect(store.validateRequest(request)).toEqual({ valid: true });
+      expect(store.isRequestProcessed(request.id)).toBe(false);
+
+      // Signer processes it.
+      store.markRequestProcessed(request.id);
+      expect(
+        useRemoteSignerStore.getState().isRequestProcessed(request.id)
+      ).toBe(true);
+
+      // Replay of the identical request id is now rejected as a duplicate,
+      // even though every other field is still valid (fresh timestamp etc.).
+      const replay = makeRequest({ ts: Date.now() });
+      expect(useRemoteSignerStore.getState().validateRequest(replay)).toEqual({
+        valid: false,
+        error: 'Request has already been processed',
+      });
+    });
+
+    it('persists processed ids so replays are blocked after a restart', async () => {
+      const store = useRemoteSignerStore.getState();
+      store.markRequestProcessed('req-replayable');
+
+      expect(mockAsyncStore.get(STORAGE_KEYS.PROCESSED_REQUESTS)).toBe(
+        JSON.stringify(['req-replayable'])
+      );
+
+      // Fresh launch: only AsyncStorage survives.
+      useRemoteSignerStore.setState({
+        processedRequestIds: new Set(),
+        isInitialized: false,
+      });
+      await useRemoteSignerStore.getState().initialize();
+
+      const replay = makeRequest({ id: 'req-replayable' });
+      expect(useRemoteSignerStore.getState().validateRequest(replay)).toEqual({
+        valid: false,
+        error: 'Request has already been processed',
+      });
+    });
+
+    it('marking the same id twice is idempotent (no duplicate set entries)', () => {
+      const store = useRemoteSignerStore.getState();
+      store.markRequestProcessed('req-dup');
+      store.markRequestProcessed('req-dup');
+      expect(useRemoteSignerStore.getState().processedRequestIds.size).toBe(1);
+    });
+
+    it('markRequestProcessed accumulates ids without dropping earlier ones', () => {
+      const store = useRemoteSignerStore.getState();
+      store.markRequestProcessed('req-a');
+      store.markRequestProcessed('req-b');
+      const ids = useRemoteSignerStore.getState().processedRequestIds;
+      expect(ids.has('req-a')).toBe(true);
+      expect(ids.has('req-b')).toBe(true);
+      expect(mockAsyncStore.get(STORAGE_KEYS.PROCESSED_REQUESTS)).toBe(
+        JSON.stringify(['req-a', 'req-b'])
+      );
+    });
+
+    it('rejects expired, future, wrong-version, wrong-type, and empty requests', () => {
+      const store = useRemoteSignerStore.getState();
+
+      // Expired (older than the 5-minute window).
+      expect(
+        store.validateRequest(
+          makeRequest({
+            ts: Date.now() - REMOTE_SIGNER_CONSTANTS.MAX_REQUEST_AGE_MS - 1000,
+          })
+        )
+      ).toEqual({
+        valid: false,
+        error: 'Request has expired (older than 5 minutes)',
+      });
+
+      // Future timestamp beyond the 30s clock-skew allowance.
+      expect(
+        store.validateRequest(makeRequest({ ts: Date.now() + 60_000 }))
+      ).toEqual({
+        valid: false,
+        error: 'Request timestamp is in the future',
+      });
+
+      // Unsupported protocol version.
+      expect(
+        store.validateRequest(
+          makeRequest({ v: 2 as unknown as RemoteSignerRequest['v'] })
+        )
+      ).toEqual({ valid: false, error: 'Unsupported protocol version: 2' });
+
+      // Wrong payload type.
+      expect(
+        store.validateRequest(
+          makeRequest({ t: 'res' as unknown as RemoteSignerRequest['t'] })
+        )
+      ).toEqual({
+        valid: false,
+        error: 'Invalid payload type - expected signing request',
+      });
+
+      // No transactions.
+      expect(store.validateRequest(makeRequest({ txns: [] }))).toEqual({
+        valid: false,
+        error: 'No transactions in request',
+      });
+    });
+
+    it('allows a request timestamp within the 30s future clock-skew window', () => {
+      const store = useRemoteSignerStore.getState();
+      expect(
+        store.validateRequest(makeRequest({ ts: Date.now() + 10_000 }))
+      ).toEqual({ valid: true });
+    });
+  });
+
+  // -------------------------------------------------------------------------
+  // 3. Request state-machine transitions (SigningProgress)
+  // -------------------------------------------------------------------------
+  describe('request state transitions', () => {
+    it('starts idle with no pending request', () => {
+      const state = useRemoteSignerStore.getState();
+      expect(state.pendingRequest).toBeNull();
+      expect(state.signingProgress).toEqual(INITIAL_PROGRESS);
+    });
+
+    it('enters reviewing with the correct txn count on setPendingRequest', () => {
+      const request = makeRequest({}, 3);
+      useRemoteSignerStore.getState().setPendingRequest(request);
+
+      const state = useRemoteSignerStore.getState();
+      expect(state.pendingRequest).toBe(request);
+      expect(state.signingProgress).toEqual({
+        currentIndex: 0,
+        totalTransactions: 3,
+        status: 'reviewing',
+      });
+    });
+
+    it('progresses reviewing → signing → complete, preserving the txn total', () => {
+      const store = useRemoteSignerStore.getState();
+      store.setPendingRequest(makeRequest({}, 2));
+
+      store.setSigningProgress({ status: 'signing', currentIndex: 1 });
+      expect(useRemoteSignerStore.getState().signingProgress).toEqual({
+        currentIndex: 1,
+        totalTransactions: 2,
+        status: 'signing',
+      });
+
+      store.setSigningProgress({ status: 'complete', currentIndex: 2 });
+      expect(useRemoteSignerStore.getState().signingProgress).toEqual({
+        currentIndex: 2,
+        totalTransactions: 2,
+        status: 'complete',
+      });
+    });
+
+    it('supports the error branch with a message', () => {
+      const store = useRemoteSignerStore.getState();
+      store.setPendingRequest(makeRequest({}, 1));
+      store.setSigningProgress({ status: 'error', error: 'user rejected' });
+
+      expect(useRemoteSignerStore.getState().signingProgress).toEqual({
+        currentIndex: 0,
+        totalTransactions: 1,
+        status: 'error',
+        error: 'user rejected',
+      });
+    });
+
+    it('resets to idle and clears the request when set to null', () => {
+      const store = useRemoteSignerStore.getState();
+      store.setPendingRequest(makeRequest({}, 2));
+      store.setSigningProgress({ status: 'signing', currentIndex: 1 });
+
+      store.setPendingRequest(null);
+
+      const state = useRemoteSignerStore.getState();
+      expect(state.pendingRequest).toBeNull();
+      expect(state.signingProgress).toEqual(INITIAL_PROGRESS);
+    });
+
+    it('setPendingRequest does not mark the request processed', () => {
+      const request = makeRequest();
+      useRemoteSignerStore.getState().setPendingRequest(request);
+      // Presenting a request for review must not consume its replay-nonce;
+      // only explicit markRequestProcessed does.
+      expect(
+        useRemoteSignerStore.getState().isRequestProcessed(request.id)
+      ).toBe(false);
+      expect(useRemoteSignerStore.getState().validateRequest(request)).toEqual({
+        valid: true,
+      });
+    });
+  });
+});

--- a/src/store/__tests__/remoteSignerStore.test.ts
+++ b/src/store/__tests__/remoteSignerStore.test.ts
@@ -188,25 +188,30 @@ const INITIAL_PROGRESS = {
   status: 'idle' as const,
 };
 
-// Every console logging channel a leak could plausibly use. Spying on ALL of
-// them (not a hand-picked subset) keeps allConsoleOutput()'s "capture EVERY
-// channel" claim honest — a regression logging a secret via console.trace /
-// dir / table / group / assert cannot slip past the no-leak assertion.
-const CONSOLE_METHODS = [
-  'log',
-  'info',
-  'debug',
-  'warn',
-  'error',
-  'trace',
-  'dir',
-  'dirxml',
-  'table',
-  'group',
-  'groupCollapsed',
-  'groupEnd',
-  'assert',
-] as const;
+/**
+ * Every function-valued property of `console` (own + inherited), so the no-leak
+ * assertion captures EVERY output channel — log/info/warn/error, but also
+ * trace/dir/table/group*, and the argument-taking utilities count/assert/
+ * timeLog/timeEnd/timeStamp. Enumerating dynamically (rather than a hand-picked
+ * list) means a regression can't leak a secret via some rarely-used method the
+ * harness forgot to spy.
+ */
+function allConsoleMethodNames(): string[] {
+  const names = new Set<string>();
+  let obj: object | null = console;
+  while (obj && obj !== Object.prototype) {
+    for (const name of Object.getOwnPropertyNames(obj)) {
+      if (
+        typeof (console as unknown as Record<string, unknown>)[name] ===
+        'function'
+      ) {
+        names.add(name);
+      }
+    }
+    obj = Object.getPrototypeOf(obj);
+  }
+  return [...names];
+}
 
 let consoleSpies: jest.SpyInstance[];
 
@@ -215,11 +220,18 @@ describe('remoteSignerStore (TASK-159)', () => {
     mockAsyncStore.clear();
     // Silence + capture the store's chatty logging across every channel (also
     // lets us assert no secret is ever logged, on any method).
-    consoleSpies = CONSOLE_METHODS.filter(
-      (name) =>
-        typeof (console as unknown as Record<string, unknown>)[name] ===
-        'function'
-    ).map((name) => jest.spyOn(console, name).mockImplementation(() => {}));
+    consoleSpies = [];
+    for (const name of allConsoleMethodNames()) {
+      try {
+        consoleSpies.push(
+          jest
+            .spyOn(console, name as jest.FunctionPropertyNames<Console>)
+            .mockImplementation(() => {})
+        );
+      } catch {
+        // Non-configurable property — cannot spy; skip it.
+      }
+    }
     // Reset the singleton store to a pristine slate (fresh Set/Map instances).
     useRemoteSignerStore.setState({
       appMode: 'wallet',


### PR DESCRIPTION
## TASK-159 — P0 tests: remoteSignerStore

Adds `src/store/__tests__/remoteSignerStore.test.ts` covering the three P0 concerns for the remote-signer zustand store. **Test-only — no store/crypto source modified.** Real algosdk-derived crypto throughout (no fabricated keys/signatures); shared fixtures reused (`makeAccount`, `paymentTxn`).

### Coverage (24 tests, 21 passing + 3 `it.failing` documenting real source gaps)

**Persistence / secret-at-rest**
- No sensitive material reaches AsyncStorage or logs: real mnemonic, the 64-byte secret key, its private 32-byte seed, and decoded txn bytes are routed *through* in-memory state, then asserted absent from every persisted write and every console channel — in hex, base64, JSON-array and JSON-object encodings (so the assertions genuinely fail if a secret *were* persisted/logged).
- Only the four whitelisted keys are ever written; signer config persists only public device metadata; re-hydration round-trips paired signers + processed ids across a simulated restart; empty-storage defaults are safe wallet-mode.

**Replay / duplicate prevention**
- Fresh request accepted, identical id rejected on replay; duplicate survives a restart via persisted `processedRequestIds`; idempotent marking; expiry / future-timestamp / version / type / empty-txn validation branches; 30s clock-skew window.

**Request state machine (`SigningProgress`)**
- idle → reviewing → signing → complete, error branch, reset-to-idle on clear, request replacement resets progress and drops stale error, partial-merge semantics, and setPendingRequest not consuming the replay nonce.

### Documented source gaps (`it.failing`, source intentionally NOT fixed here)
All three are best-effort/hygiene limitations of `markRequestProcessed` / `setSigningProgress`, not regressions in this PR:
1. **Fire-and-forget durability** — a rejected processed-id write leaves the id non-durable, so a replay is accepted after restart.
2. **Out-of-order write clobber** — unserialized full-set writes can let an older write overwrite a newer one, dropping the latest id (replay after restart).
3. **Stale error on recovery** — `setSigningProgress` shallow-merges, so `error → signing` retains the stale `error` message, contradicting the `SigningProgress` contract.

### Gates
- `npm run typecheck` ✅  `npm run lint` ✅ (only a pre-existing-style `require()` warning inside a `jest.mock` factory)  `npm test -- --ci` ✅ (854 tests, 52 suites)
- Codex-reviewed to convergence (assertions hardened against vacuous secret checks, missed leak channels, and weak replay coverage).

https://claude.ai/code/session_01TGQqENc5aZyAqHos1P31Jn