### PR TITLE
fix(auth): close suspended-app lock bypass + AppState listener leak (TASK-165)

### DIFF
--- a/src/contexts/AuthContext.tsx
+++ b/src/contexts/AuthContext.tsx
@@ -205,8 +205,6 @@ export function AuthProvider({ children }: { children: React.ReactNode }) {
       return () => {};
     }
 
-    let previousAppState = AppState.currentState;
-
     const handleAppStateChange = (nextAppState: AppStateStatus) => {
       const now = Date.now();
 
@@ -232,12 +230,16 @@ export function AuthProvider({ children }: { children: React.ReactNode }) {
         }, BACKGROUND_GRACE_PERIOD);
       } else if (
         nextAppState === 'active' &&
-        previousAppState === 'background'
+        backgroundedAtRef.current !== null
       ) {
-        // App is returning from background. Read the synchronous ref (not the
-        // closed-over React state, which is stale for a listener created once
-        // at mount) so a return AFTER the grace window locks even when the
-        // 60s JS timer never fired because the OS suspended the runtime.
+        // Returning to foreground after a background. Gate on the ref being set
+        // (NOT previousAppState === 'background'): iOS returns via
+        // background -> inactive -> active, and an intervening 'inactive' would
+        // otherwise make the subsequent 'active' skip the expiry check entirely
+        // — re-opening the suspend bypass and leaving the ref/timer dangling.
+        // Read the synchronous ref (not the closed-over React state, stale for a
+        // listener created once at mount) so a return AFTER the grace window
+        // locks even when the 60s JS timer never fired because JS was suspended.
         const backgroundedAt = backgroundedAtRef.current;
 
         // Clear the background timer
@@ -247,7 +249,7 @@ export function AuthProvider({ children }: { children: React.ReactNode }) {
         }
 
         // Check if grace period has expired
-        if (backgroundedAt && now - backgroundedAt > BACKGROUND_GRACE_PERIOD) {
+        if (now - backgroundedAt > BACKGROUND_GRACE_PERIOD) {
           // Grace period expired - lock the app (lock() clears the ref)
           lock();
         } else {
@@ -260,8 +262,6 @@ export function AuthProvider({ children }: { children: React.ReactNode }) {
           }));
         }
       }
-
-      previousAppState = nextAppState;
     };
 
     const subscription = AppState.addEventListener(

--- a/src/contexts/AuthContext.tsx
+++ b/src/contexts/AuthContext.tsx
@@ -80,6 +80,15 @@ export function AuthProvider({ children }: { children: React.ReactNode }) {
   const sessionTimer = useRef<NodeJS.Timeout | undefined>(undefined);
   const backgroundTimer = useRef<NodeJS.Timeout | undefined>(undefined);
 
+  // Synchronous, render-independent record of WHEN the app was backgrounded.
+  // The AppState handler must decide lock-vs-unlock on foreground from a value
+  // written the instant we background — NOT from React state, whose commit can
+  // be skipped entirely if the OS suspends the JS runtime before the render
+  // lands (that stale-null read was the lock-BYPASS this ref closes). authState
+  // .backgroundedAt is kept in sync for any external observer, but THIS ref is
+  // the source of truth for the grace-window decision.
+  const backgroundedAtRef = useRef<number | null>(null);
+
   // Always-fresh mirror of authState so the inactivity interval can read the
   // latest activity/auth flags and route through the single lock() (below)
   // rather than mutating state inline (needed so lock's session teardown runs).
@@ -88,12 +97,17 @@ export function AuthProvider({ children }: { children: React.ReactNode }) {
 
   useEffect(() => {
     checkInitialAuthState();
-    setupAppStateListener();
+    // Capture the subscription remover so the effect cleanup can tear the
+    // AppState listener down — otherwise it leaks across every mount. The
+    // remover is callable on both native (subscription.remove()) and web
+    // (no-op) paths.
+    const removeAppStateListener = setupAppStateListener();
 
     return () => {
       if (activityTimer.current) clearInterval(activityTimer.current);
       if (sessionTimer.current) clearTimeout(sessionTimer.current);
       if (backgroundTimer.current) clearTimeout(backgroundTimer.current);
+      removeAppStateListener();
     };
   }, []);
 
@@ -197,7 +211,11 @@ export function AuthProvider({ children }: { children: React.ReactNode }) {
       const now = Date.now();
 
       if (nextAppState === 'background') {
-        // App is going to background - start grace period timer
+        // App is going to background - start grace period timer.
+        // Record the background timestamp SYNCHRONOUSLY in the ref (before the
+        // async setAuthState) so a foreground return can compute the true
+        // elapsed time even if the OS suspends JS before React commits.
+        backgroundedAtRef.current = now;
         setAuthState((prev) => ({
           ...prev,
           backgroundedAt: now,
@@ -216,8 +234,11 @@ export function AuthProvider({ children }: { children: React.ReactNode }) {
         nextAppState === 'active' &&
         previousAppState === 'background'
       ) {
-        // App is returning from background
-        const backgroundedAt = authState.backgroundedAt;
+        // App is returning from background. Read the synchronous ref (not the
+        // closed-over React state, which is stale for a listener created once
+        // at mount) so a return AFTER the grace window locks even when the
+        // 60s JS timer never fired because the OS suspended the runtime.
+        const backgroundedAt = backgroundedAtRef.current;
 
         // Clear the background timer
         if (backgroundTimer.current) {
@@ -227,10 +248,11 @@ export function AuthProvider({ children }: { children: React.ReactNode }) {
 
         // Check if grace period has expired
         if (backgroundedAt && now - backgroundedAt > BACKGROUND_GRACE_PERIOD) {
-          // Grace period expired - lock the app
+          // Grace period expired - lock the app (lock() clears the ref)
           lock();
         } else {
           // Within grace period - update activity and keep unlocked
+          backgroundedAtRef.current = null;
           setAuthState((prev) => ({
             ...prev,
             backgroundedAt: null,
@@ -413,6 +435,10 @@ export function AuthProvider({ children }: { children: React.ReactNode }) {
       clearTimeout(backgroundTimer.current);
       backgroundTimer.current = undefined;
     }
+
+    // Keep the synchronous background marker in lockstep with the state reset
+    // above so a subsequent foreground return can't re-read a stale timestamp.
+    backgroundedAtRef.current = null;
   };
 
   const setupPin = async (

--- a/src/contexts/AuthContext.tsx
+++ b/src/contexts/AuthContext.tsx
@@ -209,6 +209,15 @@ export function AuthProvider({ children }: { children: React.ReactNode }) {
       const now = Date.now();
 
       if (nextAppState === 'background') {
+        // Ignore duplicate background events while a background is already
+        // pending: iOS can emit several, and resetting the timestamp/timer on a
+        // later one would extend an already-backgrounded session past the grace
+        // window (e.g. a second 'background' at 59s → ~119s of unlocked grace).
+        // The FIRST background starts the window; subsequent ones are no-ops.
+        if (backgroundedAtRef.current !== null) {
+          return;
+        }
+
         // App is going to background - start grace period timer.
         // Record the background timestamp SYNCHRONOUSLY in the ref (before the
         // async setAuthState) so a foreground return can compute the true

--- a/src/contexts/__tests__/AuthContext.test.tsx
+++ b/src/contexts/__tests__/AuthContext.test.tsx
@@ -423,47 +423,43 @@ describe('AuthContext — background/foreground app-state lock', () => {
     expect(result.current.authState.isAuthenticated).toBe(true);
   });
 
-  // KNOWN BUG (reported, source intentionally NOT fixed — TASK-160 is test-only).
-  // Lock-BYPASS on a suspended app: the AppState 'change' handler is created once
-  // in the mount effect and closes over a STALE `authState.backgroundedAt` (the
-  // value at first render — null). The only thing that actually locks after
-  // backgrounding is the 60s JS setTimeout. If the OS suspends the JS runtime
-  // (common on real devices) that timer never fires; when the user returns after
-  // the grace window the handler reads the stale null backgroundedAt, so the
-  // `now - backgroundedAt > grace` branch is skipped and the wallet stays
-  // UNLOCKED. Documented via it.failing; flip to a plain `it` once the handler
-  // reads live state (e.g. via a ref) so a post-grace foreground return locks.
-  it.failing(
-    'locks on foreground return after the grace window when the background timer never fired (suspended app)',
-    async () => {
-      const { result } = await mountAuth();
+  // FIXED (TASK-165): Lock-BYPASS on a suspended app. The AppState 'change'
+  // handler used to close over a STALE `authState.backgroundedAt` (null from the
+  // first render); the only thing that locked after backgrounding was the 60s JS
+  // setTimeout. If the OS suspended the JS runtime (common on real devices) that
+  // timer never fired, and on a post-grace foreground return the handler read the
+  // stale null so the `now - backgroundedAt > grace` branch was skipped and the
+  // wallet stayed UNLOCKED. The handler now reads a synchronous `backgroundedAtRef`
+  // written the instant we background (render-independent), so a post-grace
+  // foreground return locks even when the timer never fired.
+  it('locks on foreground return after the grace window when the background timer never fired (suspended app)', async () => {
+    const { result } = await mountAuth();
 
-      await act(async () => {
-        await result.current.unlock(TEST_PIN);
-      });
-      expect(result.current.authState.isLocked).toBe(false);
+    await act(async () => {
+      await result.current.unlock(TEST_PIN);
+    });
+    expect(result.current.authState.isLocked).toBe(false);
 
-      const t0 = Date.now();
+    const t0 = Date.now();
 
-      // App backgrounds; a 60s JS lock timer is armed.
-      await act(async () => {
-        appStateHandler!('background');
-        await Promise.resolve();
-      });
+    // App backgrounds; a 60s JS lock timer is armed.
+    await act(async () => {
+      appStateHandler!('background');
+      await Promise.resolve();
+    });
 
-      // Model a SUSPENDED app: the JS runtime was frozen so the armed background
-      // timer never ran, yet real wall-clock time advanced well past the grace
-      // window. setSystemTime moves Date.now WITHOUT firing any pending timer.
-      await act(async () => {
-        jest.setSystemTime(t0 + 60 * 1000 + 5000);
-        appStateHandler!('active');
-        await Promise.resolve();
-      });
+    // Model a SUSPENDED app: the JS runtime was frozen so the armed background
+    // timer never ran, yet real wall-clock time advanced well past the grace
+    // window. setSystemTime moves Date.now WITHOUT firing any pending timer.
+    await act(async () => {
+      jest.setSystemTime(t0 + 60 * 1000 + 5000);
+      appStateHandler!('active');
+      await Promise.resolve();
+    });
 
-      // SECURITY EXPECTATION: must be locked. Currently stays unlocked (bug).
-      expect(result.current.authState.isLocked).toBe(true);
-    }
-  );
+    // SECURITY EXPECTATION: must be locked. Currently stays unlocked (bug).
+    expect(result.current.authState.isLocked).toBe(true);
+  });
 });
 
 describe('AuthContext — unmount teardown (no leaks)', () => {
@@ -497,29 +493,22 @@ describe('AuthContext — unmount teardown (no leaks)', () => {
     clearTimeoutSpy.mockRestore();
   });
 
-  // KNOWN BUG (reported, source intentionally NOT fixed — TASK-160 is test-only):
-  // the mount useEffect calls setupAppStateListener(), which RETURNS a
-  // `() => subscription.remove()` cleanup, but the effect discards that return
-  // value — its own cleanup only clears timers. So AppState.addEventListener's
-  // subscription is never removed on unmount and leaks. This test documents the
-  // leak via it.failing; flip to a plain `it` once AuthContext wires the
-  // subscription cleanup (e.g. store the remover in a ref and call it in the
-  // effect teardown).
-  it.failing(
-    'removes the AppState subscription on unmount (LEAK: remove() never called)',
-    async () => {
-      const rendered = await mountAuth();
+  // FIXED (TASK-165): the mount useEffect used to call setupAppStateListener()
+  // and discard its returned `() => subscription.remove()` cleanup — its own
+  // cleanup only cleared timers, so the AppState subscription leaked on every
+  // unmount. The effect now captures the remover and invokes it in its teardown.
+  it('removes the AppState subscription on unmount (LEAK: remove() never called)', async () => {
+    const rendered = await mountAuth();
 
-      expect(appStateRemove).not.toHaveBeenCalled();
+    expect(appStateRemove).not.toHaveBeenCalled();
 
-      await act(async () => {
-        rendered.unmount();
-      });
+    await act(async () => {
+      rendered.unmount();
+    });
 
-      // Currently receives 0 calls — the subscription is leaked.
-      expect(appStateRemove).toHaveBeenCalledTimes(1);
-    }
-  );
+    // Currently receives 0 calls — the subscription is leaked.
+    expect(appStateRemove).toHaveBeenCalledTimes(1);
+  });
 
   it('does not fire a lock after unmount even once the timeout window passes', async () => {
     const rendered = await mountAuth();

--- a/src/contexts/__tests__/AuthContext.test.tsx
+++ b/src/contexts/__tests__/AuthContext.test.tsx
@@ -493,6 +493,44 @@ describe('AuthContext — background/foreground app-state lock', () => {
 
     expect(result.current.authState.isLocked).toBe(true);
   });
+
+  // FIXED (TASK-165, Codex diff-review P2): the grace window is measured from
+  // the FIRST background event. A duplicate 'background' (iOS emits several)
+  // must NOT reset the timestamp/timer, or an attacker/flaky OS could extend an
+  // already-backgrounded unlocked session indefinitely.
+  it('does not extend the grace window when a duplicate background event fires', async () => {
+    const { result } = await mountAuth();
+
+    await act(async () => {
+      await result.current.unlock(TEST_PIN);
+    });
+    expect(result.current.authState.isLocked).toBe(false);
+
+    const t0 = Date.now();
+
+    // First background starts the 60s window.
+    await act(async () => {
+      appStateHandler!('background');
+      await Promise.resolve();
+    });
+
+    // A second background at 59s must be ignored (no timestamp/timer reset).
+    await act(async () => {
+      jest.setSystemTime(t0 + 59 * 1000);
+      appStateHandler!('background');
+      await Promise.resolve();
+    });
+
+    // Foreground at 61s — past grace measured from the FIRST background. If the
+    // duplicate had reset the marker, elapsed would read 2s and stay unlocked.
+    await act(async () => {
+      jest.setSystemTime(t0 + 61 * 1000);
+      appStateHandler!('active');
+      await Promise.resolve();
+    });
+
+    expect(result.current.authState.isLocked).toBe(true);
+  });
 });
 
 describe('AuthContext — unmount teardown (no leaks)', () => {

--- a/src/contexts/__tests__/AuthContext.test.tsx
+++ b/src/contexts/__tests__/AuthContext.test.tsx
@@ -460,6 +460,39 @@ describe('AuthContext — background/foreground app-state lock', () => {
     // SECURITY EXPECTATION: must be locked. Currently stays unlocked (bug).
     expect(result.current.authState.isLocked).toBe(true);
   });
+
+  // FIXED (TASK-165, Codex diff-review P1): iOS returns to the foreground via
+  // background -> inactive -> active. The foreground decision must NOT gate on
+  // `previousAppState === 'background'` — an intervening 'inactive' would make
+  // the 'active' event skip the expiry check, re-opening the suspend bypass on
+  // iOS. Gating on the synchronous `backgroundedAtRef` instead means any
+  // 'active' with a pending background marker is evaluated.
+  it('locks on an iOS background -> inactive -> active return after the grace window', async () => {
+    const { result } = await mountAuth();
+
+    await act(async () => {
+      await result.current.unlock(TEST_PIN);
+    });
+    expect(result.current.authState.isLocked).toBe(false);
+
+    const t0 = Date.now();
+
+    await act(async () => {
+      appStateHandler!('background');
+      await Promise.resolve();
+    });
+
+    // Suspended past the grace window, then the iOS wake sequence: an 'inactive'
+    // event precedes 'active'. The armed 60s timer never fired (JS was frozen).
+    await act(async () => {
+      jest.setSystemTime(t0 + 60 * 1000 + 5000);
+      appStateHandler!('inactive');
+      appStateHandler!('active');
+      await Promise.resolve();
+    });
+
+    expect(result.current.authState.isLocked).toBe(true);
+  });
 });
 
 describe('AuthContext — unmount teardown (no leaks)', () => {


### PR DESCRIPTION
## Summary

Fixes the **P1 security lock-bypass** and the leaked AppState subscription in `src/contexts/AuthContext.tsx` (TASK-165, under PLAN-167). Driven through the **ultra-codex** playbook: pre-implementation Codex consensus on the fix design, then a Codex diff-review loop to CLEAN (three rounds; two additional real findings caught and fixed along the way).

## Bugs fixed

1. **Suspended-app lock BYPASS (security, high).** The AppState `change` handler was created once at mount and closed over a stale `authState.backgroundedAt` (null from first render). The only thing that locked after backgrounding was the 60s JS `setTimeout`; if the OS suspended the JS runtime that timer never fired, and a post-grace foreground return read the stale null so the expiry branch was skipped — the wallet reopened **UNLOCKED** past the grace window.
2. **Leaked AppState subscription.** The mount `useEffect` discarded the `() => subscription.remove()` cleanup returned by `setupAppStateListener()`, leaking the listener across every mount.

## Fix

- Record the background timestamp **synchronously** in a dedicated `backgroundedAtRef` (render-independent), so a foreground return computes true elapsed time even when JS was suspended before React committed. (Codex consensus: a mirror of React state is insufficient — `authStateRef` only updates on render commit, which suspension can skip.)
- Gate the foreground expiry check on `backgroundedAtRef.current !== null` instead of `previousAppState === 'background'`, so the iOS `background → inactive → active` sequence can't skip the check. *(Codex diff-review P1.)*
- Ignore duplicate `background` events while a background is already pending, so repeated iOS background events can't extend the grace window. *(Codex diff-review P2.)*
- Capture and invoke the AppState remover in the mount-effect cleanup (native `remove()` / web no-op).

## Tests

Flips the two documenting `it.failing` tests → `it` and adds two regression tests (iOS `background → inactive → active`; duplicate-background grace non-extension). **Full suite: 1002/1002 green · typecheck clean · lint 0 errors.**

## Verification note

JS-only change (OTA-eligible; no native module / config-plugin). The exact failure mode (OS-level JS suspension) is not deterministically reproducible in a simulator; it's modelled faithfully in the unit tests via `jest.setSystemTime`. A physical-device background/suspend spot-check is recommended before release.

## Review
Codex CLI review of `main..HEAD`: **CLEAN** (crypto/auth-focused — no key/mnemonic leakage, no missing validation, no Algorand-compat regression).

https://claude.ai/code/session_01TGQqENc5aZyAqHos1P31Jn