### PR TITLE
fix(signing): sign rekeyed WalletConnect txns via on-chain authority (TASK-163)

### DIFF
--- a/src/services/transactions/__tests__/unifiedSigner.test.ts
+++ b/src/services/transactions/__tests__/unifiedSigner.test.ts
@@ -93,6 +93,13 @@ const mockGetInstance = NetworkService.getInstance as unknown as jest.Mock;
 
 const keyRegistry = new Map<string, Uint8Array>();
 
+// Models the on-chain rekey resolution that the REAL SecureKeyManager performs:
+// maps a rekeyed account's address -> the authority address whose key actually
+// signs. The signTransaction mock consults this so a test can prove the source
+// passes the SENDER (and the authority key resolves internally), exactly as the
+// production keyManager does via getAccountRekeyInfo.
+const rekeyRegistry = new Map<string, string>();
+
 /** Real single-sig signature over `txn` using the fixture key for `address`. */
 function realSign(txn: algosdk.Transaction, address: string): Uint8Array {
   const sk = keyRegistry.get(address);
@@ -202,6 +209,7 @@ let signer: UnifiedTransactionSigner;
 
 beforeEach(() => {
   keyRegistry.clear();
+  rekeyRegistry.clear();
   signer = new UnifiedTransactionSigner();
 
   // Default happy-path leaf behaviour (clearMocks resets call data each test).
@@ -218,9 +226,12 @@ beforeEach(() => {
     confirmed: false,
   });
 
-  // Real signing at the secure-storage boundary.
+  // Real signing at the secure-storage boundary. Resolves rekey authority the
+  // way the production SecureKeyManager does: if `address` is a rekeyed account,
+  // sign with the mapped authority's key; otherwise sign with `address` itself.
   mockSignTransaction.mockImplementation(
-    async (txn: algosdk.Transaction, address: string) => realSign(txn, address)
+    async (txn: algosdk.Transaction, address: string) =>
+      realSign(txn, rekeyRegistry.get(address) ?? address)
   );
 
   // Default algod stub for keyreg / appl paths.
@@ -646,46 +657,44 @@ describe('signTransaction — batch routing (local vs ledger)', () => {
     );
   });
 
-  // KNOWN SOURCE BUG (reported, NOT fixed here — DR-3 forbids touching source).
-  // When a dApp marks a rekeyed account's WalletConnect txn with `authAddr`
-  // (the WC convention for "sign with this authority"), the handler sets
-  // `signerAddress = authAddr` and then applies the guard
-  // `if (txnSender !== signerAddress) pass-through-unsigned`
-  // (unifiedSigner.ts ~L421-435). For a rekeyed account the sender (A) and the
-  // authority (B) are necessarily different, so the txn is returned UNSIGNED yet
-  // reported as a success — it is never handed to SecureKeyManager. The
-  // non-authAddr path is unaffected (there SecureKeyManager resolves the rekey
-  // internally). `it.failing` pins the CORRECT expectation (the txn is signed by
-  // the authority key) so this suite goes green today and flips red the moment
-  // the source is fixed.
-  it.failing(
-    'BUG: a rekeyed WalletConnect txn (authAddr set) is signed by the authority',
-    async () => {
-      const authority = accountOf('wc-authority', AccountType.STANDARD); // B
-      const account = accountOf('wc-rekeyed', AccountType.STANDARD); // A (sender)
-      const rekeyed = account.address;
-      const txn = paymentTxn(rekeyed, { amount: 1 });
+  // FIXED (TASK-163): a rekeyed account's WalletConnect txn carrying `authAddr`
+  // used to be returned UNSIGNED yet reported success. The handler overrode
+  // `signerAddress = authAddr` and then the guard `txnSender !== signerAddress`
+  // tripped (a rekeyed account's sender A and authority B differ by design), so
+  // it was never handed to SecureKeyManager. The fix removes that override:
+  // on-chain rekey state is the source of truth, so the SENDER is passed to
+  // SecureKeyManager, which resolves the authority (B) internally and signs with
+  // it — identical to the already-working non-authAddr rekey path. The
+  // dApp-supplied authAddr is advisory and no longer selects the signing key.
+  it('signs a rekeyed WalletConnect txn (authAddr set) with the on-chain authority key', async () => {
+    const authority = accountOf('wc-authority', AccountType.STANDARD); // B
+    const account = accountOf('wc-rekeyed', AccountType.STANDARD); // A (sender)
+    const rekeyed = account.address;
+    // A is rekeyed to B on-chain (what SecureKeyManager would resolve).
+    rekeyRegistry.set(rekeyed, authority.address);
+    const txn = paymentTxn(rekeyed, { amount: 1 });
 
-      const result = await signer.signTransaction({
-        type: 'batch_transaction',
-        account,
-        pin: '1234',
-        walletConnectParams: {
-          transactions: [
-            { txn: unsignedB64(txn), authAddr: authority.address },
-          ],
-          accountAddress: rekeyed,
-        },
-      });
+    const result = await signer.signTransaction({
+      type: 'batch_transaction',
+      account,
+      pin: '1234',
+      walletConnectParams: {
+        transactions: [{ txn: unsignedB64(txn), authAddr: authority.address }],
+        accountAddress: rekeyed,
+      },
+    });
 
-      // CORRECT behavior: the authority key signs the rekeyed account's txn.
-      expect(mockSignTransaction).toHaveBeenCalled();
-      const blob = new Uint8Array(
-        Buffer.from((result.signedTransactions as string[])[0], 'base64')
-      );
-      expect(blobIsSignedBy(blob, authority.address)).toBe(true);
-    }
-  );
+    expect(result.success).toBe(true);
+    // The SENDER (A) is routed through SecureKeyManager — NOT the dApp authAddr
+    // (B). SecureKeyManager resolves A -> B from on-chain state and signs with B.
+    expect(mockSignTransaction).toHaveBeenCalledTimes(1);
+    expect(mockSignTransaction.mock.calls[0][1]).toBe(rekeyed);
+    // The produced blob is a real signature by the authority B.
+    const blob = new Uint8Array(
+      Buffer.from((result.signedTransactions as string[])[0], 'base64')
+    );
+    expect(blobIsSignedBy(blob, authority.address)).toBe(true);
+  });
 
   it('passes through an already-signed / undecodable entry unchanged', async () => {
     const account = accountOf('batch-logicsig', AccountType.STANDARD);

--- a/src/services/transactions/__tests__/unifiedSigner.test.ts
+++ b/src/services/transactions/__tests__/unifiedSigner.test.ts
@@ -658,14 +658,14 @@ describe('signTransaction — batch routing (local vs ledger)', () => {
   });
 
   // FIXED (TASK-163): a rekeyed account's WalletConnect txn carrying `authAddr`
-  // used to be returned UNSIGNED yet reported success. The handler overrode
-  // `signerAddress = authAddr` and then the guard `txnSender !== signerAddress`
-  // tripped (a rekeyed account's sender A and authority B differ by design), so
-  // it was never handed to SecureKeyManager. The fix removes that override:
-  // on-chain rekey state is the source of truth, so the SENDER is passed to
-  // SecureKeyManager, which resolves the authority (B) internally and signs with
-  // it — identical to the already-working non-authAddr rekey path. The
-  // dApp-supplied authAddr is advisory and no longer selects the signing key.
+  // used to be returned UNSIGNED yet reported success. The handler used the
+  // dApp-supplied `authAddr`/`signers` to select the signing key, then the guard
+  // `txnSender !== signerAddress` tripped (a rekeyed account's sender A and
+  // authority B differ by design), so it was never handed to SecureKeyManager.
+  // The fix decides eligibility from the sender and always passes the SENDER to
+  // SecureKeyManager, which resolves the authority (B) from on-chain state and
+  // signs with it — identical to the already-working non-authAddr rekey path.
+  // The dApp-supplied authAddr/signers are advisory and never select the key.
   it('signs a rekeyed WalletConnect txn (authAddr set) with the on-chain authority key', async () => {
     const authority = accountOf('wc-authority', AccountType.STANDARD); // B
     const account = accountOf('wc-rekeyed', AccountType.STANDARD); // A (sender)
@@ -690,6 +690,75 @@ describe('signTransaction — batch routing (local vs ledger)', () => {
     expect(mockSignTransaction).toHaveBeenCalledTimes(1);
     expect(mockSignTransaction.mock.calls[0][1]).toBe(rekeyed);
     // The produced blob is a real signature by the authority B.
+    const blob = new Uint8Array(
+      Buffer.from((result.signedTransactions as string[])[0], 'base64')
+    );
+    expect(blobIsSignedBy(blob, authority.address)).toBe(true);
+  });
+
+  // Codex diff-review P1: the same bug reachable via `signers: [authority]`.
+  // Some dApps mark a rekeyed account's WC txn with signers = [authAddr] (the
+  // ARC-0001 "these addresses must sign" hint = the authority). The old code
+  // used signers[0] as the KEY, so the guard txnSender(A) !== signers[0](B)
+  // skipped it unsigned. Eligibility now comes from the sender, and the key is
+  // always the sender (authority resolved on-chain) — so this signs correctly.
+  it('signs a rekeyed WalletConnect txn when signers lists the authority (standard path)', async () => {
+    const authority = accountOf('wc-auth-signers', AccountType.STANDARD); // B
+    const account = accountOf('wc-rekeyed-signers', AccountType.STANDARD); // A
+    const rekeyed = account.address;
+    rekeyRegistry.set(rekeyed, authority.address); // A -> B on-chain
+    const txn = paymentTxn(rekeyed, { amount: 1 });
+
+    const result = await signer.signTransaction({
+      type: 'batch_transaction',
+      account,
+      pin: '1234',
+      walletConnectParams: {
+        transactions: [
+          {
+            txn: unsignedB64(txn),
+            authAddr: authority.address,
+            signers: [authority.address],
+          },
+        ],
+        accountAddress: rekeyed,
+      },
+    });
+
+    expect(result.success).toBe(true);
+    expect(mockSignTransaction).toHaveBeenCalledTimes(1);
+    expect(mockSignTransaction.mock.calls[0][1]).toBe(rekeyed); // sender, not B
+    const blob = new Uint8Array(
+      Buffer.from((result.signedTransactions as string[])[0], 'base64')
+    );
+    expect(blobIsSignedBy(blob, authority.address)).toBe(true);
+  });
+
+  it('signs a rekeyed WalletConnect txn when signers lists the authority (Ledger path)', async () => {
+    const authority = accountOf('wc-auth-signers-l', AccountType.STANDARD); // B
+    const account = accountOf('wc-rekeyed-signers-l', AccountType.LEDGER); // A
+    const rekeyed = account.address;
+    rekeyRegistry.set(rekeyed, authority.address); // A -> B on-chain
+    const txn = paymentTxn(rekeyed, { amount: 1 });
+
+    const result = await signer.signTransaction({
+      type: 'batch_transaction',
+      account,
+      walletConnectParams: {
+        transactions: [
+          {
+            txn: unsignedB64(txn),
+            authAddr: authority.address,
+            signers: [authority.address],
+          },
+        ],
+        accountAddress: rekeyed,
+      },
+    });
+
+    expect(result.success).toBe(true);
+    expect(mockSignTransaction).toHaveBeenCalledTimes(1);
+    expect(mockSignTransaction.mock.calls[0][1]).toBe(rekeyed); // sender, not B
     const blob = new Uint8Array(
       Buffer.from((result.signedTransactions as string[])[0], 'base64')
     );

--- a/src/services/transactions/unifiedSigner.ts
+++ b/src/services/transactions/unifiedSigner.ts
@@ -418,23 +418,21 @@ export class UnifiedTransactionSigner {
             // Get the transaction sender address
             const txnSender = algosdk.encodeAddress(txn.sender.publicKey);
 
-            // Determine signer address
-            let signerAddress = request.walletConnectParams!.accountAddress;
-            if (wtxn.signers && wtxn.signers.length > 0 && wtxn.signers[0]) {
-              signerAddress = wtxn.signers[0];
-            }
-            // NOTE (TASK-163): wtxn.authAddr (the dApp-supplied rekey
-            // authority) is intentionally NOT used to select the signing key.
-            // On-chain rekey state is the source of truth — we pass the SENDER
-            // to SecureKeyManager.signTransaction below, which resolves the
-            // current authority itself and signs with it (emitting the correct
-            // sgnr). Overriding signerAddress with authAddr both broke the
-            // ownership guard for rekeyed accounts (sender ≠ authority → the txn
-            // was passed through UNSIGNED yet reported success) and would let a
-            // dApp choose which of our keys signs.
-
-            // Skip signing if the transaction sender doesn't match our account
-            if (txnSender !== signerAddress) {
+            // Decide whether this batch entry is one we should sign, then sign
+            // it with the SENDER's key. The dApp-supplied `authAddr`/`signers`
+            // are advisory hints for ELIGIBILITY only — never key selection: a
+            // dApp must not be able to direct which of our keys signs, and rekey
+            // authority is resolved from on-chain state, not from the request
+            // (TASK-163). SecureKeyManager.signTransaction(txn, txnSender)
+            // resolves any current rekey authority itself and signs with it
+            // (emitting the correct sgnr) — identical to the non-rekeyed path.
+            if (
+              !this.shouldSignBatchEntry(
+                txnSender,
+                request.walletConnectParams!.accountAddress,
+                wtxn
+              )
+            ) {
               signedTxns.push(wtxn.txn);
               callbacks?.onLedgerSigned?.({ index: i + 1, total });
               continue;
@@ -442,7 +440,7 @@ export class UnifiedTransactionSigner {
 
             const signedTxnBlob = await SecureKeyManager.signTransaction(
               txn,
-              signerAddress,
+              txnSender,
               request.pin // optional; controller supplies for software keys, undefined for Ledger
             );
 
@@ -495,30 +493,28 @@ export class UnifiedTransactionSigner {
               // Get the transaction sender address
               const txnSender = algosdk.encodeAddress(txn.sender.publicKey);
 
-              // Determine signer address
-              let signerAddress = request.walletConnectParams!.accountAddress;
-              if (wtxn.signers && wtxn.signers.length > 0 && wtxn.signers[0]) {
-                signerAddress = wtxn.signers[0];
-              }
-              // NOTE (TASK-163): wtxn.authAddr (the dApp-supplied rekey
-              // authority) is intentionally NOT used to select the signing key.
-              // On-chain rekey state is the source of truth — we pass the SENDER
-              // to SecureKeyManager.signTransaction below, which resolves the
-              // current authority itself and signs with it (emitting the correct
-              // sgnr). Overriding signerAddress with authAddr both broke the
-              // ownership guard for rekeyed accounts (sender ≠ authority → the
-              // txn was passed through UNSIGNED yet reported success) and would
-              // let a dApp choose which of our keys signs.
-
-              // Skip signing if the transaction sender doesn't match our account
-              // This handles cases where the transaction is for a different signer
-              if (txnSender !== signerAddress) {
+              // Decide whether this batch entry is one we should sign, then sign
+              // it with the SENDER's key. The dApp-supplied `authAddr`/`signers`
+              // are advisory hints for ELIGIBILITY only — never key selection: a
+              // dApp must not be able to direct which of our keys signs, and
+              // rekey authority is resolved from on-chain state, not from the
+              // request (TASK-163). SecureKeyManager.signTransaction(txn,
+              // txnSender) resolves any current rekey authority itself and signs
+              // with it (emitting the correct sgnr) — same as the non-rekeyed
+              // path.
+              if (
+                !this.shouldSignBatchEntry(
+                  txnSender,
+                  request.walletConnectParams!.accountAddress,
+                  wtxn
+                )
+              ) {
                 return wtxn.txn;
               }
 
               const signedTxnBlob = await SecureKeyManager.signTransaction(
                 txn,
-                signerAddress,
+                txnSender,
                 request.pin
               );
 
@@ -568,6 +564,31 @@ export class UnifiedTransactionSigner {
       AccountSecureStorage.clearPrivateKeyCache();
       throw error;
     }
+  }
+
+  /**
+   * Decide whether a WalletConnect batch entry should be signed by this wallet.
+   *
+   * The signing KEY is always the transaction sender's — SecureKeyManager
+   * resolves any on-chain rekey authority itself. This gates ELIGIBILITY only,
+   * from the DECODED sender and the dApp's advisory `signers` hint; it never
+   * lets request metadata (`authAddr`/`signers`) select which key signs
+   * (TASK-163). We sign when:
+   *  - the sender is our WC session account (covers normal AND rekeyed senders —
+   *    a rekey does not change the transaction sender), or
+   *  - the dApp's `signers` hint designates the sender and we control it
+   *    (multi-account atomic groups; preserves the pre-existing `signers`
+   *    behavior, minus the ability to point at a different key than the sender).
+   */
+  private shouldSignBatchEntry(
+    txnSender: string,
+    sessionAccount: string,
+    wtxn: WalletTransaction
+  ): boolean {
+    if (txnSender === sessionAccount) {
+      return true;
+    }
+    return wtxn.signers?.includes(txnSender) ?? false;
   }
 
   /**

--- a/src/services/transactions/unifiedSigner.ts
+++ b/src/services/transactions/unifiedSigner.ts
@@ -423,9 +423,15 @@ export class UnifiedTransactionSigner {
             if (wtxn.signers && wtxn.signers.length > 0 && wtxn.signers[0]) {
               signerAddress = wtxn.signers[0];
             }
-            if (wtxn.authAddr) {
-              signerAddress = wtxn.authAddr;
-            }
+            // NOTE (TASK-163): wtxn.authAddr (the dApp-supplied rekey
+            // authority) is intentionally NOT used to select the signing key.
+            // On-chain rekey state is the source of truth — we pass the SENDER
+            // to SecureKeyManager.signTransaction below, which resolves the
+            // current authority itself and signs with it (emitting the correct
+            // sgnr). Overriding signerAddress with authAddr both broke the
+            // ownership guard for rekeyed accounts (sender ≠ authority → the txn
+            // was passed through UNSIGNED yet reported success) and would let a
+            // dApp choose which of our keys signs.
 
             // Skip signing if the transaction sender doesn't match our account
             if (txnSender !== signerAddress) {
@@ -494,9 +500,15 @@ export class UnifiedTransactionSigner {
               if (wtxn.signers && wtxn.signers.length > 0 && wtxn.signers[0]) {
                 signerAddress = wtxn.signers[0];
               }
-              if (wtxn.authAddr) {
-                signerAddress = wtxn.authAddr;
-              }
+              // NOTE (TASK-163): wtxn.authAddr (the dApp-supplied rekey
+              // authority) is intentionally NOT used to select the signing key.
+              // On-chain rekey state is the source of truth — we pass the SENDER
+              // to SecureKeyManager.signTransaction below, which resolves the
+              // current authority itself and signs with it (emitting the correct
+              // sgnr). Overriding signerAddress with authAddr both broke the
+              // ownership guard for rekeyed accounts (sender ≠ authority → the
+              // txn was passed through UNSIGNED yet reported success) and would
+              // let a dApp choose which of our keys signs.
 
               // Skip signing if the transaction sender doesn't match our account
               // This handles cases where the transaction is for a different signer


### PR DESCRIPTION
## Summary

Fixes a **real signing defect** (TASK-163, under PLAN-167): a rekeyed account's WalletConnect transaction was returned **UNSIGNED yet reported as success** — a silent no-op the caller believed was signed. Driven through **ultra-codex**: pre-implementation Codex consensus + a Codex diff-review loop to CLEAN (the loop caught a P1 completeness gap that widened the fix to be fully correct).

## Bug

In `signWalletConnectBatch` (both the Ledger sequential and standard parallel loops), the handler used the dApp-supplied `authAddr`/`signers[0]` to pick the signing key, then applied `if (txnSender !== signerAddress) pass-through-unsigned`. For a rekeyed account the sender (A) and authority (B) differ by design, so the txn was pushed back unsigned and never handed to `SecureKeyManager`. A user with a rekeyed account signing a dApp transaction got a silent failure reported as success.

## Fix (on-chain resolution — signed off)

- **Eligibility from the decoded sender, not request metadata.** New `shouldSignBatchEntry(txnSender, sessionAccount, wtxn)`: sign when the sender is our WC session account (covers normal *and* rekeyed senders — a rekey doesn't change the sender) or when the dApp's advisory `signers` hint designates the sender and we control it (multi-account atomic groups).
- **The signing key is always the transaction sender's.** `SecureKeyManager.signTransaction(txn, txnSender)` resolves any on-chain rekey authority itself and signs with it (emitting the correct `sgnr`) — identical to the already-working non-`authAddr` rekey path.
- **`authAddr`/`signers` are advisory only** and can no longer direct which of our keys signs (a dApp trust-boundary tightening). On-chain rekey state is the source of truth.

Applied to both the Ledger sequential and standard parallel loops.

## Tests

The pinned `it.failing` flips to `it` and now models on-chain rekey resolution (a `rekeyRegistry` the signing mock consults, mirroring the production keyManager). Adds regression tests for the `signers: [authority]` rekey variant in **both** paths, asserting the **sender** is routed to `SecureKeyManager` and the blob is a real authority signature. Existing `signers[0]` and passthrough behavior preserved. **Full suite: 1004/1004 · typecheck clean · lint 0 errors.**

## Review
Codex CLI review of `main..HEAD`: **CLEAN** — eligibility correct across normal/rekeyed/multi-account/foreign/empty-signers/mixed batches; `authAddr`/`signers` cannot select the key; correct `sgnr`; no key/mnemonic leak; no Algorand-compat regression.

## Follow-ups (filed, need own sign-off — pre-existing, surfaced by Codex consensus)
- **TASK-169** — `networkId` not passed to the batch sign calls (rekey authority resolves on the active network, not the txn's).
- **TASK-170** — batch not serialized when a rekeyed account's on-chain authority is a Ledger.

## Verification note
JS-only change (OTA-eligible). Signing logic is exercised end-to-end in the unit suite with real algosdk signatures. A device spot-check of a rekeyed-account WalletConnect signing flow is recommended before release.

https://claude.ai/code/session_01TGQqENc5aZyAqHos1P31Jn