### PR TITLE
chore(deps): declare tweetnacl as a direct dependency (TASK-161)

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -80,6 +80,7 @@
         "readable-stream": "^4.7.0",
         "text-encoding": "^0.7.0",
         "text-encoding-polyfill": "^0.6.7",
+        "tweetnacl": "^1.0.3",
         "tweetnacl-util": "^0.15.1",
         "zustand": "^5.0.8"
       },

--- a/package.json
+++ b/package.json
@@ -91,6 +91,7 @@
     "readable-stream": "^4.7.0",
     "text-encoding": "^0.7.0",
     "text-encoding-polyfill": "^0.6.7",
+    "tweetnacl": "^1.0.3",
     "tweetnacl-util": "^0.15.1",
     "zustand": "^5.0.8"
   },


### PR DESCRIPTION
## Summary

Makes an existing **implicit** dependency explicit (TASK-161, under PLAN-167). Production crypto source imports `tweetnacl` directly but `package.json` declared only `tweetnacl-util`; the app worked solely because `tweetnacl` was present transitively (via `algosdk` / `@ledgerhq/hw-app-algorand` / `ed2curve`). If a transitive provider dropped or bumped it, signing/verification could silently break.

## Change

- Add `"tweetnacl": "^1.0.3"` to `dependencies` — the version already resolved in the lockfile and `tweetnacl`'s latest stable.
- `package-lock.json`: **+1 line** (the `node_modules/tweetnacl` entry already existed transitively; it's now referenced from root and deduped with all transitive users).
- **Zero source/logic changes.** Resolved version is byte-identical before/after (1.0.3 → 1.0.3), so signing behavior is unchanged.

Direct importers made safe: `src/utils/signatureVerification.ts`, `src/utils/arc0300.ts`, `src/services/remoteSigner/index.ts`, `src/services/messaging/crypto.ts`, `src/services/messaging/keyDerivation.ts` (+ tests).

## Gates
`npm ci` ✅ · `npm run typecheck` ✅ (0 errors) · `npm test -- --ci` ✅ **1004/1004**. No Codex review — no runtime code changed (dependency declaration only; resolved graph unchanged).

https://claude.ai/code/session_01TGQqENc5aZyAqHos1P31Jn