### PR TITLE
fix(remoteSigner): durable, serialized replay-guard persistence + clear stale error (TASK-166)

### DIFF
--- a/src/store/__tests__/remoteSignerStore.test.ts
+++ b/src/store/__tests__/remoteSignerStore.test.ts
@@ -476,98 +476,112 @@ describe('remoteSignerStore (TASK-159)', () => {
       );
     });
 
-    // KNOWN GAP (reported, source intentionally NOT modified): markRequestProcessed
-    // persists fire-and-forget. If that durable write is rejected (disk full) or
-    // the app terminates before it lands, the id is only in the volatile Set —
-    // so after a restart the SAME request id is accepted again (replay). The
-    // in-session guard held (see test above), but cross-restart durability is
-    // best-effort. This it.failing asserts the DESIRED secure behaviour (replay
-    // still blocked) and currently fails, documenting the gap without a source fix.
-    it.failing(
-      'a processed id whose durable write failed is NOT replay-blocked after restart',
-      async () => {
-        setItemMock.mockImplementationOnce(async () => {
-          throw new Error('disk full');
-        });
+    // FIXED (TASK-166 BUG1): a TRANSIENT durable-write failure no longer drops
+    // the replay guard. The serialized persistence chain retries the write, so a
+    // first-attempt failure (disk full) is recovered, the id lands on disk, and
+    // a restart re-hydrates it — the replay stays blocked cross-restart.
+    // (A PERMANENT/retry-exhausted failure is the accepted residual of the
+    // sync/void contract; closing that fully would require awaiting the write
+    // before releasing the signature.)
+    it('re-blocks replay after restart when the first durable write attempt failed (retried)', async () => {
+      // Fail ONLY the first setItem for the processed-ids write; the retry wins.
+      setItemMock.mockImplementationOnce(async () => {
+        throw new Error('disk full');
+      });
 
-        const store = useRemoteSignerStore.getState();
-        store.markRequestProcessed('req-lost');
-        await flush();
+      const store = useRemoteSignerStore.getState();
+      store.markRequestProcessed('req-lost');
+      await flush();
 
-        // The durable write was rejected — nothing landed on disk.
-        expect(
-          mockAsyncStore.get(STORAGE_KEYS.PROCESSED_REQUESTS)
-        ).toBeUndefined();
+      // The retry persisted the id despite the first failure.
+      expect(mockAsyncStore.get(STORAGE_KEYS.PROCESSED_REQUESTS)).toBe(
+        JSON.stringify(['req-lost'])
+      );
 
-        // Restart: only AsyncStorage survives, the in-memory Set is gone.
-        useRemoteSignerStore.setState({
-          processedRequestIds: new Set(),
-          isInitialized: false,
-        });
-        await useRemoteSignerStore.getState().initialize();
+      // Restart: only AsyncStorage survives, the in-memory Set is gone.
+      useRemoteSignerStore.setState({
+        processedRequestIds: new Set(),
+        isInitialized: false,
+      });
+      await useRemoteSignerStore.getState().initialize();
 
-        // DESIRED: replay still rejected. ACTUAL: accepted → this fails, so
-        // it.failing turns the documented gap into a green (expected-fail) test.
-        expect(
-          useRemoteSignerStore
-            .getState()
-            .validateRequest(makeRequest({ id: 'req-lost' }))
-        ).toEqual({
-          valid: false,
-          error: 'Request has already been processed',
-        });
-      }
-    );
+      // Replay still rejected after restart.
+      expect(
+        useRemoteSignerStore
+          .getState()
+          .validateRequest(makeRequest({ id: 'req-lost' }))
+      ).toEqual({
+        valid: false,
+        error: 'Request has already been processed',
+      });
+    });
 
-    // KNOWN GAP (reported, source NOT modified): markRequestProcessed persists
-    // the WHOLE set each call, fire-and-forget and un-serialized. If two writes
-    // land out of order, the older (smaller) set clobbers the newer one on disk,
-    // dropping the most recent id — a replay of that id is accepted after a
-    // restart. it.failing asserts the DESIRED behaviour (both ids stay blocked)
-    // and currently fails, documenting the last-write-wins race.
-    it.failing(
-      'out-of-order fire-and-forget writes can drop the newer id (replay after restart)',
-      async () => {
-        // Defer the two processed-id writes and release them in REVERSE order.
-        const commits: (() => void)[] = [];
-        const deferWrite = (key: string, value: string) =>
+    // FIXED (TASK-166 BUG2): processed-id writes are SERIALIZED through one
+    // module-level chain and each writes the LATEST full set read at execution
+    // time, so two rapid marks can no longer clobber each other — both ids are
+    // durably persisted and survive a restart. The old code wrote the whole set
+    // per call unserialized, so an out-of-order landing dropped the newer id.
+    it('serializes processed-id writes so rapid marks cannot clobber each other (both survive restart)', async () => {
+      const store = useRemoteSignerStore.getState();
+      store.markRequestProcessed('req-a');
+      store.markRequestProcessed('req-b');
+      await flush();
+
+      // Disk holds BOTH ids (serialized, latest-set-at-write-time writes).
+      const persisted = new Set<string>(
+        JSON.parse(mockAsyncStore.get(STORAGE_KEYS.PROCESSED_REQUESTS)!)
+      );
+      expect(persisted.has('req-a')).toBe(true);
+      expect(persisted.has('req-b')).toBe(true);
+
+      // Restart from disk only — both replays stay blocked.
+      useRemoteSignerStore.setState({
+        processedRequestIds: new Set(),
+        isInitialized: false,
+      });
+      await useRemoteSignerStore.getState().initialize();
+
+      const state = useRemoteSignerStore.getState();
+      expect(state.validateRequest(makeRequest({ id: 'req-a' }))).toEqual({
+        valid: false,
+        error: 'Request has already been processed',
+      });
+      expect(state.validateRequest(makeRequest({ id: 'req-b' }))).toEqual({
+        valid: false,
+        error: 'Request has already been processed',
+      });
+    });
+
+    // A delayed write still persists EVERY id, because each queued task reads
+    // the latest set at execution time (belt-and-suspenders on ordering): defer
+    // the first write, mark two ids, then release — the single write captures
+    // both. Proves the latest-set-at-write-time property directly.
+    it('a delayed processed-id write persists every id marked before it runs', async () => {
+      let releaseFirstWrite!: () => void;
+      setItemMock.mockImplementationOnce(
+        (key: string, value: string) =>
           new Promise<void>((resolve) => {
-            commits.push(() => {
+            releaseFirstWrite = () => {
               mockAsyncStore.set(key, value);
               resolve();
-            });
-          });
-        setItemMock.mockImplementationOnce(deferWrite);
-        setItemMock.mockImplementationOnce(deferWrite);
+            };
+          })
+      );
 
-        const store = useRemoteSignerStore.getState();
-        store.markRequestProcessed('req-a'); // write #1 persists ["req-a"]
-        store.markRequestProcessed('req-b'); // write #2 persists ["req-a","req-b"]
+      const store = useRemoteSignerStore.getState();
+      store.markRequestProcessed('req-a'); // enqueues the (deferred) first write
+      store.markRequestProcessed('req-b'); // marked before the write executes
+      await flush(); // let the first (deferred) write reach setItem and park
 
-        // Newer write lands first, then the older write overwrites it.
-        commits[1]();
-        commits[0]();
-        await flush();
+      releaseFirstWrite();
+      await flush();
 
-        // Restart from disk only.
-        useRemoteSignerStore.setState({
-          processedRequestIds: new Set(),
-          isInitialized: false,
-        });
-        await useRemoteSignerStore.getState().initialize();
-
-        const state = useRemoteSignerStore.getState();
-        // DESIRED: both durably blocked. ACTUAL: req-b was clobbered → accepted.
-        expect(state.validateRequest(makeRequest({ id: 'req-a' }))).toEqual({
-          valid: false,
-          error: 'Request has already been processed',
-        });
-        expect(state.validateRequest(makeRequest({ id: 'req-b' }))).toEqual({
-          valid: false,
-          error: 'Request has already been processed',
-        });
-      }
-    );
+      const persisted = new Set<string>(
+        JSON.parse(mockAsyncStore.get(STORAGE_KEYS.PROCESSED_REQUESTS)!)
+      );
+      expect(persisted.has('req-a')).toBe(true);
+      expect(persisted.has('req-b')).toBe(true);
+    });
 
     it('persists processed ids so replays are blocked after a restart', async () => {
       const store = useRemoteSignerStore.getState();
@@ -737,13 +751,11 @@ describe('remoteSignerStore (TASK-159)', () => {
       });
     });
 
-    // KNOWN GAP (reported, source NOT modified): setSigningProgress is a shallow
-    // partial-merge setter, so transitioning error -> signing/complete does NOT
-    // drop the stale `error` message. That contradicts SigningProgress' contract
-    // (`error` is the "error message if status is 'error'"). it.failing asserts
-    // the DESIRED behaviour (error cleared once the status leaves 'error') and
-    // currently fails, rather than pinning the buggy retention as correct.
-    it.failing('leaving the error state drops the stale error message', () => {
+    // FIXED (TASK-166 BUG3): setSigningProgress now drops a stale `error` message
+    // whenever the merged status leaves 'error' (e.g. error -> signing on
+    // recovery), honoring the SigningProgress contract (`error` is only
+    // meaningful while status is 'error').
+    it('leaving the error state drops the stale error message', () => {
       const store = useRemoteSignerStore.getState();
       store.setPendingRequest(makeRequest({}, 1));
       store.setSigningProgress({ status: 'error', error: 'boom' });

--- a/src/store/__tests__/remoteSignerStore.test.ts
+++ b/src/store/__tests__/remoteSignerStore.test.ts
@@ -74,7 +74,10 @@ jest.mock('@react-native-async-storage/async-storage', () => ({
 
 import AsyncStorage from '@react-native-async-storage/async-storage';
 
-import { useRemoteSignerStore } from '../remoteSignerStore';
+import {
+  useRemoteSignerStore,
+  __resetProcessedPersistChainForTests,
+} from '../remoteSignerStore';
 
 // Storage keys — mirror the (unexported) STORAGE_KEYS in the source. If the
 // source keys ever drift, the persisted-keys whitelist test below catches it.
@@ -218,6 +221,9 @@ let consoleSpies: jest.SpyInstance[];
 describe('remoteSignerStore (TASK-159)', () => {
   beforeEach(() => {
     mockAsyncStore.clear();
+    // Settle the module-level persistence chain so a deferred/pending write from
+    // a prior test can't bleed into this one.
+    __resetProcessedPersistChainForTests();
     // Silence + capture the store's chatty logging across every channel (also
     // lets us assert no secret is ever logged, on any method).
     consoleSpies = [];
@@ -516,12 +522,11 @@ describe('remoteSignerStore (TASK-159)', () => {
       });
     });
 
-    // FIXED (TASK-166 BUG2): processed-id writes are SERIALIZED through one
-    // module-level chain and each writes the LATEST full set read at execution
-    // time, so two rapid marks can no longer clobber each other — both ids are
-    // durably persisted and survive a restart. The old code wrote the whole set
-    // per call unserialized, so an out-of-order landing dropped the newer id.
-    it('serializes processed-id writes so rapid marks cannot clobber each other (both survive restart)', async () => {
+    // Durability integration check: two rapid marks both persist and survive a
+    // restart. (This passes on the old code too under a FIFO write mock — the
+    // out-of-order race is guarded non-vacuously by the delayed-write test
+    // below, which fails against the pre-fix source.)
+    it('persists both ids from rapid marks and blocks each replay after restart', async () => {
       const store = useRemoteSignerStore.getState();
       store.markRequestProcessed('req-a');
       store.markRequestProcessed('req-b');
@@ -581,6 +586,69 @@ describe('remoteSignerStore (TASK-159)', () => {
       );
       expect(persisted.has('req-a')).toBe(true);
       expect(persisted.has('req-b')).toBe(true);
+    });
+
+    // FIXED (TASK-166, Codex diff-review P1): a markRequestProcessed that lands
+    // WHILE initialize() is hydrating from disk must not lose durability. Its
+    // queued write can persist a partial set and clobber the loaded ids on disk;
+    // initialize() re-persists the merged union so the durable copy matches
+    // memory and a later restart still blocks both.
+    it('re-persists the merged union so a mark during hydration survives restart', async () => {
+      // Disk already holds an old processed id from a prior session.
+      mockAsyncStore.set(
+        STORAGE_KEYS.PROCESSED_REQUESTS,
+        JSON.stringify(['old-id'])
+      );
+      // Fresh process: in-memory guard empty, not yet initialized.
+      useRemoteSignerStore.setState({
+        processedRequestIds: new Set(),
+        isInitialized: false,
+      });
+
+      // Defer the mark's persist write so it lands AFTER initialize() has read
+      // the old id — modelling the clobber: the mark's partial write (['new-id'])
+      // would otherwise overwrite ['old-id'] on disk.
+      let releaseMarkWrite!: () => void;
+      setItemMock.mockImplementationOnce(
+        (key: string, value: string) =>
+          new Promise<void>((resolve) => {
+            releaseMarkWrite = () => {
+              mockAsyncStore.set(key, value);
+              resolve();
+            };
+          })
+      );
+
+      // Start hydration and, while it is in flight, mark a new id.
+      const initP = useRemoteSignerStore.getState().initialize();
+      useRemoteSignerStore.getState().markRequestProcessed('new-id');
+
+      await initP; // union merges {new-id} with loaded {old-id}; re-persist queued
+      releaseMarkWrite(); // the mark's clobber write lands (['new-id'])
+      await flush(); // then the re-persist writes the full union
+
+      // Durable copy has BOTH ids despite the clobber.
+      const persisted = new Set<string>(
+        JSON.parse(mockAsyncStore.get(STORAGE_KEYS.PROCESSED_REQUESTS)!)
+      );
+      expect(persisted.has('old-id')).toBe(true);
+      expect(persisted.has('new-id')).toBe(true);
+
+      // Restart from disk only — both replays stay blocked.
+      useRemoteSignerStore.setState({
+        processedRequestIds: new Set(),
+        isInitialized: false,
+      });
+      await useRemoteSignerStore.getState().initialize();
+      const state = useRemoteSignerStore.getState();
+      expect(state.validateRequest(makeRequest({ id: 'old-id' }))).toEqual({
+        valid: false,
+        error: 'Request has already been processed',
+      });
+      expect(state.validateRequest(makeRequest({ id: 'new-id' }))).toEqual({
+        valid: false,
+        error: 'Request has already been processed',
+      });
     });
 
     it('persists processed ids so replays are blocked after a restart', async () => {

--- a/src/store/__tests__/remoteSignerStore.test.ts
+++ b/src/store/__tests__/remoteSignerStore.test.ts
@@ -76,7 +76,7 @@ import AsyncStorage from '@react-native-async-storage/async-storage';
 
 import {
   useRemoteSignerStore,
-  __resetProcessedPersistChainForTests,
+  __drainProcessedPersistChainForTests,
 } from '../remoteSignerStore';
 
 // Storage keys — mirror the (unexported) STORAGE_KEYS in the source. If the
@@ -219,11 +219,12 @@ function allConsoleMethodNames(): string[] {
 let consoleSpies: jest.SpyInstance[];
 
 describe('remoteSignerStore (TASK-159)', () => {
-  beforeEach(() => {
+  beforeEach(async () => {
+    // Drain + reset the module-level persistence chain FIRST so any queued write
+    // from a prior test runs to completion (against the about-to-be-cleared
+    // store), then wipe storage — this guarantees no cross-test write bleed.
+    await __drainProcessedPersistChainForTests();
     mockAsyncStore.clear();
-    // Settle the module-level persistence chain so a deferred/pending write from
-    // a prior test can't bleed into this one.
-    __resetProcessedPersistChainForTests();
     // Silence + capture the store's chatty logging across every channel (also
     // lets us assert no secret is ever logged, on any method).
     consoleSpies = [];

--- a/src/store/remoteSignerStore.ts
+++ b/src/store/remoteSignerStore.ts
@@ -70,6 +70,15 @@ function enqueueProcessedPersist(getIds: () => Set<string>): void {
 }
 
 /**
+ * TEST-ONLY: reset the module-level persistence chain to a settled promise so a
+ * pending/deferred write from a previous test cannot bleed into the next one.
+ * Not part of the runtime API.
+ */
+export function __resetProcessedPersistChainForTests(): void {
+  processedPersistChain = Promise.resolve();
+}
+
+/**
  * Get app mode early, before store hydration completes.
  * Used by AppNavigator to determine which services to initialize.
  * This avoids a race condition where services start before the store is ready.
@@ -217,8 +226,9 @@ export const useRemoteSignerStore = create<RemoteSignerState>()(
         const storedProcessed = await AsyncStorage.getItem(
           STORAGE_KEYS.PROCESSED_REQUESTS
         );
+        const inMemoryIds = get().processedRequestIds;
         const processedRequestIds = new Set<string>([
-          ...get().processedRequestIds,
+          ...inMemoryIds,
           ...(storedProcessed ? (JSON.parse(storedProcessed) as string[]) : []),
         ]);
 
@@ -229,6 +239,17 @@ export const useRemoteSignerStore = create<RemoteSignerState>()(
           processedRequestIds,
           isInitialized: true,
         });
+
+        // If any id was already in memory during this async hydration (a
+        // markRequestProcessed that landed mid-load), its queued write may have
+        // persisted only a partial set and clobbered the loaded ids on disk.
+        // Re-persist the merged union so the DURABLE copy matches memory —
+        // otherwise the union heals memory but a later restart could still
+        // accept a replay of a clobbered id. Serialized after that write, and a
+        // no-op in the common fresh-start case (nothing in memory yet).
+        if (inMemoryIds.size > 0) {
+          enqueueProcessedPersist(() => get().processedRequestIds);
+        }
 
         // Clean up old processed requests
         get().cleanupProcessedRequests();

--- a/src/store/remoteSignerStore.ts
+++ b/src/store/remoteSignerStore.ts
@@ -23,6 +23,52 @@ const STORAGE_KEYS = {
 // Module-level promise for early mode detection (before store hydration)
 let appModePromise: Promise<AppMode> | null = null;
 
+// Bounded retry for the replay-guard persistence so a transient native write
+// failure (e.g. momentary disk pressure) does not silently drop a processed id.
+const PROCESSED_PERSIST_MAX_ATTEMPTS = 3;
+
+// Serialized persistence chain for the processed-request-id set. ALL durable
+// writes of PROCESSED_REQUESTS go through this single chain so they can never
+// interleave — an out-of-order landing can no longer let an older/smaller set
+// clobber a newer one (replay after restart). Each queued task writes the
+// LATEST full set (read at execution time, so a delayed write still persists
+// every id) and NEVER rejects the chain: it swallows a final, retry-exhausted
+// failure so a single bad write cannot stall every later persist.
+let processedPersistChain: Promise<void> = Promise.resolve();
+
+async function writeProcessedIds(ids: string[]): Promise<void> {
+  let lastError: unknown;
+  for (
+    let attempt = 1;
+    attempt <= PROCESSED_PERSIST_MAX_ATTEMPTS;
+    attempt += 1
+  ) {
+    try {
+      await AsyncStorage.setItem(
+        STORAGE_KEYS.PROCESSED_REQUESTS,
+        JSON.stringify(ids)
+      );
+      return;
+    } catch (error) {
+      lastError = error;
+    }
+  }
+  // Retry-exhausted: the in-memory guard still blocks in-session replays, but
+  // cross-restart durability is lost for this id (accepted residual — a full
+  // guarantee would require awaiting the write before releasing the signature).
+  console.warn(
+    '[RemoteSignerStore] Failed to persist processed requests after retries:',
+    lastError
+  );
+}
+
+function enqueueProcessedPersist(getIds: () => Set<string>): void {
+  processedPersistChain = processedPersistChain
+    // Recover before chaining so a prior failure can never block later writes.
+    .catch(() => {})
+    .then(() => writeProcessedIds(Array.from(getIds())));
+}
+
 /**
  * Get app mode early, before store hydration completes.
  * Used by AppNavigator to determine which services to initialize.
@@ -163,13 +209,18 @@ export const useRemoteSignerStore = create<RemoteSignerState>()(
           storedSigners ? JSON.parse(storedSigners) : []
         );
 
-        // Load processed requests (for replay prevention in signer mode)
+        // Load processed requests (for replay prevention in signer mode). UNION
+        // with any ids already in memory rather than replacing: a
+        // markRequestProcessed that lands during this async hydration must not
+        // be dropped (which would let that id replay). Union keeps both the
+        // persisted history and any just-marked id.
         const storedProcessed = await AsyncStorage.getItem(
           STORAGE_KEYS.PROCESSED_REQUESTS
         );
-        const processedRequestIds = new Set<string>(
-          storedProcessed ? JSON.parse(storedProcessed) : []
-        );
+        const processedRequestIds = new Set<string>([
+          ...get().processedRequestIds,
+          ...(storedProcessed ? (JSON.parse(storedProcessed) as string[]) : []),
+        ]);
 
         set({
           appMode,
@@ -255,9 +306,15 @@ export const useRemoteSignerStore = create<RemoteSignerState>()(
 
     setSigningProgress: (progress: Partial<SigningProgress>) => {
       const { signingProgress } = get();
-      set({
-        signingProgress: { ...signingProgress, ...progress },
-      });
+      const merged: SigningProgress = { ...signingProgress, ...progress };
+      // Per the SigningProgress contract, `error` is only meaningful while
+      // status is 'error'. Drop any stale message once the state leaves 'error'
+      // (e.g. error -> signing on recovery), unless this same update set a new
+      // error explicitly.
+      if (merged.status !== 'error') {
+        delete merged.error;
+      }
+      set({ signingProgress: merged });
     },
 
     markRequestProcessed: (requestId: string) => {
@@ -266,16 +323,12 @@ export const useRemoteSignerStore = create<RemoteSignerState>()(
       updated.add(requestId);
       set({ processedRequestIds: updated });
 
-      // Persist asynchronously
-      AsyncStorage.setItem(
-        STORAGE_KEYS.PROCESSED_REQUESTS,
-        JSON.stringify(Array.from(updated))
-      ).catch((err) =>
-        console.warn(
-          '[RemoteSignerStore] Failed to persist processed requests:',
-          err
-        )
-      );
+      // Durability goes through the serialized, retrying persistence chain. The
+      // in-memory guard above is already effective for in-session replays; this
+      // makes the cross-restart guard robust against out-of-order writes and
+      // transient failures. The task reads the LATEST set at write time (not the
+      // `updated` snapshot) so a delayed write still persists every id.
+      enqueueProcessedPersist(() => get().processedRequestIds);
     },
 
     isRequestProcessed: (requestId: string) => {

--- a/src/store/remoteSignerStore.ts
+++ b/src/store/remoteSignerStore.ts
@@ -70,12 +70,18 @@ function enqueueProcessedPersist(getIds: () => Set<string>): void {
 }
 
 /**
- * TEST-ONLY: reset the module-level persistence chain to a settled promise so a
- * pending/deferred write from a previous test cannot bleed into the next one.
- * Not part of the runtime API.
+ * TEST-ONLY: DRAIN the module-level persistence chain (await any queued/in-flight
+ * write to completion) and reset it to a settled promise, so a pending write from
+ * a previous test cannot still run — and mutate storage — during the next one.
+ * Awaiting is required: merely reassigning the module variable would leave an
+ * already-queued task running against its live getIds() callback. Not part of the
+ * runtime API. (All tests release any deferred write before ending, so this never
+ * hangs.)
  */
-export function __resetProcessedPersistChainForTests(): void {
+export async function __drainProcessedPersistChainForTests(): Promise<void> {
+  const pending = processedPersistChain;
   processedPersistChain = Promise.resolve();
+  await pending.catch(() => {});
 }
 
 /**


### PR DESCRIPTION
## Summary

Hardens the **air-gapped remote-signer** replay protection and fixes a progress-state contract bug (TASK-166, under PLAN-167). Three issues, all pinned by `it.failing` tests. Driven through **ultra-codex**: pre-implementation Codex consensus + a Codex diff-review loop to CLEAN (the loop caught a real durability P1 and a test-isolation P2).

## Bugs

- **BUG1 (durability):** `markRequestProcessed` persisted fire-and-forget with no retry — a transient write rejection + restart accepted a replay.
- **BUG2 (out-of-order clobber):** it wrote the whole set per call, unserialized — an out-of-order landing let an older/smaller set overwrite a newer one, dropping the latest id → replay after restart.
- **BUG3 (stale error):** `setSigningProgress` shallow-merged, retaining a stale `error` after an `error → signing` recovery, contradicting the `SigningProgress` contract.

## Fix (on-chain… er, signed off: serialized retry queue)

- All `PROCESSED_REQUESTS` writes go through **one module-level serialized promise chain** — they can never interleave (fixes BUG2). Each queued task writes the **latest full set** read at execution time (a delayed write still persists every id) with **bounded retry** on transient failure (fixes BUG1). The chain is **self-healing** — a task swallows a final failure and recovers before the next write.
- `initialize()` **union-merges** loaded ids with any already in memory, and **re-persists the union** when ids were in memory during hydration — so a `markRequestProcessed` that lands mid-load can't be durably clobbered (Codex-consensus + diff-review findings).
- `setSigningProgress` drops `error` whenever the merged status leaves `'error'`, while still allowing an update that sets a new error (fixes BUG3).

`markRequestProcessed` stays sync/void; the in-memory guard updates synchronously as before.

**Accepted residual (the chosen Option A):** a *permanent*, retry-exhausted durable-write failure still can't block a post-restart replay — fully closing that needs an awaited acknowledgement before releasing the signature.

## Tests

Rewrites the 2 replay `it.failing` tests into non-vacuous guards (retry durability; serialized no-clobber via a delayed-write/latest-set test that **fails on main**; a deterministic hydration-clobber regression test), flips the BUG3 test, and adds real cross-test isolation (`__drainProcessedPersistChainForTests` drained in an async `beforeEach`). **Full suite: 1006/1006 · typecheck 0 · lint 0.**

## Review
Codex CLI `main..HEAD`: **CLEAN** — self-healing chain, latest-set writes close the clobber, hydration re-persist sound, error-clear correct, no key/mnemonic leak, no Algorand-compat concern.

## Follow-ups filed (independent, need own sign-off)
- **TASK-172** — backup restore clears processed-ids → ~5min replay window.
- **TASK-173** — `cleanupProcessedRequests` is a no-op; tracker grows unbounded.

## Verification note
JS/state-only change (OTA-eligible). Replay durability is exercised in the unit suite (retry, serialization, hydration race). A device spot-check of the signer's process-request → restart → replay-rejected flow is recommended before release.

https://claude.ai/code/session_01TGQqENc5aZyAqHos1P31Jn