### PR TITLE
perf(startup): gate throwaway crypto self-test behind __DEV__ + jest coverage (F-35, TASK-181)

### DIFF
--- a/App.tsx
+++ b/App.tsx
@@ -19,7 +19,9 @@ function AppContent() {
     // Initialize debug logger first
     debugLogger.addDebugEntry('App startup initiated');
 
-    // Test crypto polyfills on app startup
+    // Verify crypto polyfills on startup. Cheap typeof checks run in every
+    // build; the heavier algosdk keygen probe is gated to __DEV__ inside
+    // testCryptoPolyfills() so it never runs on the release cold-boot path.
     const isWorking = testCryptoPolyfills();
     if (!isWorking) {
       console.warn('Crypto polyfills are not working correctly. Wallet functionality may be impaired.');

--- a/src/utils/__tests__/cryptoTest.test.ts
+++ b/src/utils/__tests__/cryptoTest.test.ts
@@ -1,0 +1,50 @@
+import algosdk from 'algosdk';
+import { testCryptoPolyfills } from '../cryptoTest';
+
+// These assertions preserve the coverage that used to run on every app launch
+// via testCryptoPolyfills(): the crypto/Buffer polyfills are present and
+// algosdk's ed25519 keygen + mnemonic round-trip work end-to-end. Keeping this
+// in jest lets us gate the runtime probe behind __DEV__ without losing the
+// guarantee that release builds ship a working crypto stack.
+describe('crypto polyfills', () => {
+  it('exposes crypto.getRandomValues', () => {
+    expect(typeof crypto).not.toBe('undefined');
+    expect(typeof crypto.getRandomValues).toBe('function');
+  });
+
+  it('exposes a global Buffer', () => {
+    expect(typeof global.Buffer).not.toBe('undefined');
+  });
+
+  it('crypto.getRandomValues fills a byte array with entropy', () => {
+    const bytes = new Uint8Array(32);
+    crypto.getRandomValues(bytes);
+    // A working RNG will not leave all 32 bytes zero.
+    expect(bytes.some((b) => b !== 0)).toBe(true);
+  });
+
+  it('algosdk.generateAccount + secretKeyToMnemonic round-trips', () => {
+    const account = algosdk.generateAccount();
+    let recovered: { sk: Uint8Array } | undefined;
+    try {
+      expect(account.addr).toBeTruthy();
+      expect(account.sk).toBeInstanceOf(Uint8Array);
+
+      const mnemonic = algosdk.secretKeyToMnemonic(account.sk);
+      expect(typeof mnemonic).toBe('string');
+      expect(mnemonic.split(' ')).toHaveLength(25);
+
+      // The mnemonic must recover the exact same secret key.
+      recovered = algosdk.mnemonicToSecretKey(mnemonic);
+      expect(recovered.sk).toEqual(account.sk);
+    } finally {
+      // Zero the throwaway secret keys so no key material lingers.
+      account.sk.fill(0);
+      recovered?.sk.fill(0);
+    }
+  });
+
+  it('testCryptoPolyfills() reports the polyfills are working', () => {
+    expect(testCryptoPolyfills()).toBe(true);
+  });
+});

--- a/src/utils/cryptoTest.ts
+++ b/src/utils/cryptoTest.ts
@@ -1,4 +1,9 @@
-// Test file to verify crypto polyfills are working
+// Verifies the crypto polyfills required by algosdk are present.
+//
+// The polyfills themselves are installed by the entry module (index.ts:1-13):
+// react-native-get-random-values, the global Buffer, and ./src/utils/polyfills.
+// This function only *checks* that they took effect — it does not initialize
+// anything, so it is safe to trim from the production cold-boot path.
 import algosdk from 'algosdk';
 
 export const testCryptoPolyfills = (): boolean => {
@@ -18,22 +23,34 @@ export const testCryptoPolyfills = (): boolean => {
       return false;
     }
 
-    // Test basic algosdk functionality
-    const account = algosdk.generateAccount();
-    if (!account || !account.addr || !account.sk) {
-      console.error('algosdk.generateAccount failed');
-      return false;
-    }
+    // The algosdk round-trip is a dev-only sanity probe. It is pure-JS ed25519
+    // keygen plus a SHA-512 mnemonic checksum and allocates a throwaway secret
+    // key, so it stays off the release cold-boot path; equivalent coverage lives
+    // in src/utils/__tests__/cryptoTest.test.ts. The cheap typeof checks above
+    // still run in production.
+    if (__DEV__) {
+      // Test basic algosdk functionality
+      const account = algosdk.generateAccount();
+      if (!account || !account.addr || !account.sk) {
+        console.error('algosdk.generateAccount failed');
+        return false;
+      }
 
-    // Test mnemonic generation
-    const mnemonic = algosdk.secretKeyToMnemonic(account.sk);
-    if (
-      !mnemonic ||
-      typeof mnemonic !== 'string' ||
-      mnemonic.split(' ').length !== 25
-    ) {
-      console.error('algosdk.secretKeyToMnemonic failed');
-      return false;
+      try {
+        // Test mnemonic generation
+        const mnemonic = algosdk.secretKeyToMnemonic(account.sk);
+        if (
+          !mnemonic ||
+          typeof mnemonic !== 'string' ||
+          mnemonic.split(' ').length !== 25
+        ) {
+          console.error('algosdk.secretKeyToMnemonic failed');
+          return false;
+        }
+      } finally {
+        // Overwrite the throwaway secret key so it does not linger in memory.
+        account.sk.fill(0);
+      }
     }
 
     console.log('✅ All crypto polyfills are working correctly');


### PR DESCRIPTION
## What / Why

`testCryptoPolyfills()` ran on **every** cold boot from `AppContent`'s first post-mount effect (`App.tsx:18-29`), calling `algosdk.generateAccount()` + `algosdk.secretKeyToMnemonic()` purely to self-verify the polyfills, then discarding both. That is pure-JS ed25519 keygen + a SHA-512 mnemonic checksum plus a throwaway secret-key allocation on the release cold-boot critical path, delivering **no user value** in production (`babel.config.js` even strips the success `console.log`).

The polyfills are actually initialized by the entry module (`index.ts:1-13` — `react-native-get-random-values`, global `Buffer`, `./src/utils/polyfills`), **not** by this probe, so gating it is safe.

## Changes

- **`src/utils/cryptoTest.ts`** — gate the algosdk keygen/mnemonic round-trip behind `__DEV__`; keep the cheap `typeof crypto` / `global.Buffer` checks in production. Zero (memzero) the throwaway secret key via `account.sk.fill(0)` in a `finally` block.
- **`App.tsx`** — clarifying comment only; the call site behaviour is unchanged (now cheap in prod).
- **`src/utils/__tests__/cryptoTest.test.ts`** (new) — preserves the coverage without the per-launch cost: asserts `crypto.getRandomValues` + `Buffer` are present, `getRandomValues` produces entropy, and `algosdk.generateAccount()` + `secretKeyToMnemonic()` round-trip back to the same secret key. The test also zeroes its throwaway keys in a `finally`.

Ref: **TASK-181** (F-35, P3/xs, startup).

## Gate results

- `npm run typecheck` — **0 errors**
- `npm run lint` (`eslint src/`) — **0 errors** (675 pre-existing warnings, none in touched files)
- `npm test -- --ci` — **57 suites / 1011 tests passed**, including the 5 new polyfill tests

## Codex self-review (CONVE-4)

**Verdict: CLEAN** (round 2). Confirmed: (1) `index.ts` polyfill initialization is unaffected; (2) no generated secret key lingers unzeroed in the retained dev probe or the jest test; (3) nothing else depended on `testCryptoPolyfills()` as a side effect. Round 1 flagged unzeroed keys in the new jest test (P2) — fixed by adding a `finally` that zeroes `account.sk` and `recovered.sk`.

## Manual verification needed

- App still boots normally (release + dev).
- Dev builds still log `✅ All crypto polyfills are working correctly` on startup.
