### PR TITLE
perf(wallet): memoize getCurrentWallet() parse/validation (F-22, TASK-179)

### DIFF
--- a/src/services/wallet/__tests__/getCurrentWallet.memo.test.ts
+++ b/src/services/wallet/__tests__/getCurrentWallet.memo.test.ts
@@ -1,0 +1,320 @@
+// Unit tests for F-22 (TASK-179): MultiAccountWalletService.getCurrentWallet()
+// memoization. This is HIGH-RISK crypto code — getCurrentWallet() feeds signing
+// and key retrieval (keyManager/simplifiedKeyManager) and WalletConnect account
+// enumeration, so the memo must never (a) hand out a shared reference that a
+// caller can mutate into the cache, (b) serve a stale wallet after the stored
+// blob changes or is wiped out-of-band (restore clearAllData removes the key
+// directly), or (c) retain mnemonic material read from a legacy/unsanitized blob.
+//
+// SECURITY NOTE: no static/committed secret material is used. Every key/mnemonic
+// here is generated fresh in-process by algosdk (ephemeral, throwaway).
+
+// In-memory storage backing the platform mock. Prefixed `mock*` so jest's module
+// factory hoist allows referencing it (babel-plugin-jest-hoist rule).
+let mockStore: Record<string, string> = {};
+
+jest.mock('@/platform', () => ({
+  storage: {
+    getItem: jest.fn(async (k: string) =>
+      Object.prototype.hasOwnProperty.call(mockStore, k) ? mockStore[k] : null
+    ),
+    setItem: jest.fn(async (k: string, v: string) => {
+      mockStore[k] = v;
+    }),
+    removeItem: jest.fn(async (k: string) => {
+      delete mockStore[k];
+    }),
+  },
+  secureStorage: {
+    // Legacy secure-store location is empty in these tests, so migrateLegacyValue
+    // is a no-op and getStoredValue reflects mockStore exactly.
+    getItem: jest.fn(async () => null),
+    setItem: jest.fn(async () => {}),
+    deleteItem: jest.fn(async () => {}),
+  },
+}));
+
+// Mock the heavy/native side of the wallet dependency graph (untranspilable
+// native ESM); getCurrentWallet() itself only touches storage + algosdk.
+jest.mock('@/services/ledger/transport', () => ({
+  ledgerTransportService: {},
+}));
+jest.mock('@/services/ledger/algorand', () => ({ ledgerAlgorandService: {} }));
+jest.mock('@/services/network', () => ({ NetworkService: {} }));
+jest.mock('../../secure/AccountSecureStorage', () => ({
+  AccountSecureStorage: {},
+}));
+
+import algosdk from 'algosdk';
+import { Buffer } from 'buffer';
+import { storage } from '@/platform';
+import { AccountType, StandardAccountMetadata } from '@/types/wallet';
+import { MultiAccountWalletService } from '../index';
+
+const WALLET_KEY = 'voi_wallet_metadata';
+
+/**
+ * Build a valid persisted-wallet JSON blob backed by a freshly generated
+ * Algorand account (so its address passes algosdk.isValidAddress and the
+ * heal-on-read path never rewrites storage — keeping the raw string stable).
+ */
+function makeWalletBlob(opts?: { label?: string; mnemonic?: string }): {
+  blob: string;
+  address: string;
+  mnemonic: string;
+} {
+  const account = algosdk.generateAccount();
+  const address = account.addr.toString();
+  const mnemonic =
+    opts?.mnemonic !== undefined
+      ? opts.mnemonic
+      : /* sanitized blobs carry an empty mnemonic */ '';
+  const wallet = {
+    id: 'wallet-1',
+    version: '1.0',
+    createdAt: '2026-01-01T00:00:00.000Z',
+    accounts: [
+      {
+        id: 'acc-1',
+        address,
+        publicKey: Buffer.from(account.sk.slice(32)).toString('hex'),
+        type: AccountType.STANDARD,
+        label: opts?.label ?? 'Account 1',
+        mnemonic,
+        createdAt: '2026-01-01T00:00:00.000Z',
+      },
+    ],
+    activeAccountId: 'acc-1',
+  };
+  return { blob: JSON.stringify(wallet), address, mnemonic };
+}
+
+function firstStandard(wallet: {
+  accounts: unknown[];
+}): StandardAccountMetadata {
+  return wallet.accounts[0] as StandardAccountMetadata;
+}
+
+beforeEach(() => {
+  mockStore = {};
+});
+
+describe('getCurrentWallet() memoization (F-22, TASK-179)', () => {
+  it('(a) two reads of an unchanged wallet return deep-EQUAL but NOT same-reference objects', async () => {
+    mockStore[WALLET_KEY] = makeWalletBlob().blob;
+
+    const w1 = await MultiAccountWalletService.getCurrentWallet();
+    const w2 = await MultiAccountWalletService.getCurrentWallet();
+
+    if (!w1 || !w2) throw new Error('expected a wallet on both reads');
+    // Structurally identical...
+    expect(w1).toEqual(w2);
+    // ...but every level is an independent clone (no shared reference anywhere a
+    // caller could mutate into the cache).
+    expect(w1).not.toBe(w2);
+    expect(w1.accounts).not.toBe(w2.accounts);
+    expect(w1.accounts[0]).not.toBe(w2.accounts[0]);
+    expect(w1.settings).not.toBe(w2.settings);
+  });
+
+  it('(a2) always re-reads the current stored string (never caches the read itself)', async () => {
+    mockStore[WALLET_KEY] = makeWalletBlob().blob;
+
+    await MultiAccountWalletService.getCurrentWallet();
+    await MultiAccountWalletService.getCurrentWallet();
+
+    // getStoredValue -> storage.getItem runs on EVERY call (cache hit still reads
+    // storage) so an out-of-band wipe is always observed.
+    expect((storage.getItem as jest.Mock).mock.calls.length).toBe(2);
+  });
+
+  it('(b) mutating a returned wallet does not affect the next read', async () => {
+    mockStore[WALLET_KEY] = makeWalletBlob({ label: 'Original' }).blob;
+
+    const w1 = await MultiAccountWalletService.getCurrentWallet();
+    if (!w1) throw new Error('expected a wallet');
+
+    // Callers mutate the returned object in place before persisting.
+    firstStandard(w1).label = 'MUTATED';
+    w1.accounts.push({ id: 'ghost' } as never);
+    w1.activeAccountId = 'ghost';
+
+    const w2 = await MultiAccountWalletService.getCurrentWallet();
+    if (!w2) throw new Error('expected a wallet');
+
+    expect(w2.accounts).toHaveLength(1);
+    expect(firstStandard(w2).label).toBe('Original');
+    expect(w2.activeAccountId).toBe('acc-1');
+  });
+
+  it('(c) a change to the stored string busts the cache', async () => {
+    mockStore[WALLET_KEY] = makeWalletBlob({ label: 'First' }).blob;
+    const w1 = await MultiAccountWalletService.getCurrentWallet();
+    if (!w1) throw new Error('expected a wallet');
+    expect(firstStandard(w1).label).toBe('First');
+
+    // A different account/label => byte-different raw string.
+    mockStore[WALLET_KEY] = makeWalletBlob({ label: 'Second' }).blob;
+    const w2 = await MultiAccountWalletService.getCurrentWallet();
+    if (!w2) throw new Error('expected a wallet');
+    expect(firstStandard(w2).label).toBe('Second');
+  });
+
+  it('(d) removal of the stored key (clearAllWallets / restore clearAllData) makes the next read return null — no stale wallet', async () => {
+    mockStore[WALLET_KEY] = makeWalletBlob().blob;
+    const w1 = await MultiAccountWalletService.getCurrentWallet();
+    expect(w1).not.toBeNull();
+
+    // Simulate the out-of-band wipe: backup/restorers.ts clearAllData() and
+    // clearAllWallets() both remove the key directly, bypassing this service.
+    delete mockStore[WALLET_KEY];
+
+    const w2 = await MultiAccountWalletService.getCurrentWallet();
+    expect(w2).toBeNull();
+  });
+
+  it('(e) a legacy blob carrying a mnemonic is stripped, re-stored sanitized, and never memoized (no secret retained)', async () => {
+    const account = algosdk.generateAccount();
+    const realMnemonic = algosdk.secretKeyToMnemonic(account.sk);
+    const sensitive = {
+      id: 'wallet-1',
+      version: '1.0',
+      createdAt: '2026-01-01T00:00:00.000Z',
+      accounts: [
+        {
+          id: 'acc-1',
+          address: account.addr.toString(),
+          publicKey: Buffer.from(account.sk.slice(32)).toString('hex'),
+          type: AccountType.STANDARD,
+          label: 'Account 1',
+          mnemonic: realMnemonic,
+          createdAt: '2026-01-01T00:00:00.000Z',
+        },
+      ],
+      activeAccountId: 'acc-1',
+    };
+    const sensitiveBlob = JSON.stringify(sensitive);
+    mockStore[WALLET_KEY] = sensitiveBlob;
+
+    const w1 = await MultiAccountWalletService.getCurrentWallet();
+    if (!w1) throw new Error('expected a wallet');
+
+    // Returned wallet is mnemonic-stripped...
+    expect(firstStandard(w1).mnemonic).toBe('');
+    // ...and storage was rewritten to a sanitized blob (mnemonic gone).
+    expect(mockStore[WALLET_KEY]).not.toContain(realMnemonic);
+
+    // Prove the mnemonic-bearing raw string was NOT memoized: put it back and
+    // read again. If it had been cached, the second read would fast-path hit and
+    // skip the strip+re-store (storage.setItem). It must re-strip instead.
+    mockStore[WALLET_KEY] = sensitiveBlob;
+    (storage.setItem as jest.Mock).mockClear();
+    const w2 = await MultiAccountWalletService.getCurrentWallet();
+    if (!w2) throw new Error('expected a wallet');
+    expect(firstStandard(w2).mnemonic).toBe('');
+    expect((storage.setItem as jest.Mock).mock.calls.length).toBeGreaterThan(0);
+  });
+
+  it('(f) concurrent cold-boot reads collapse into a single parse and return independent clones', async () => {
+    mockStore[WALLET_KEY] = makeWalletBlob().blob;
+
+    // Fire concurrently against a cold cache: in-flight dedup should collapse the
+    // parse, and each caller must still get its own deep clone.
+    const [a, b, c] = await Promise.all([
+      MultiAccountWalletService.getCurrentWallet(),
+      MultiAccountWalletService.getCurrentWallet(),
+      MultiAccountWalletService.getCurrentWallet(),
+    ]);
+    if (!a || !b || !c) throw new Error('expected wallets');
+
+    expect(a).toEqual(b);
+    expect(a).toEqual(c);
+    expect(a).not.toBe(b);
+    expect(a.accounts[0]).not.toBe(b.accounts[0]);
+    expect(b.accounts[0]).not.toBe(c.accounts[0]);
+  });
+
+  it('(g) concurrent reads of a legacy mnemonic blob are handled inline (no dedup) and never leak the secret', async () => {
+    const account = algosdk.generateAccount();
+    const realMnemonic = algosdk.secretKeyToMnemonic(account.sk);
+    const sensitiveBlob = JSON.stringify({
+      id: 'wallet-1',
+      version: '1.0',
+      createdAt: '2026-01-01T00:00:00.000Z',
+      accounts: [
+        {
+          id: 'acc-1',
+          address: account.addr.toString(),
+          publicKey: Buffer.from(account.sk.slice(32)).toString('hex'),
+          type: AccountType.STANDARD,
+          label: 'Account 1',
+          mnemonic: realMnemonic,
+          createdAt: '2026-01-01T00:00:00.000Z',
+        },
+      ],
+      activeAccountId: 'acc-1',
+    });
+    mockStore[WALLET_KEY] = sensitiveBlob;
+
+    // The legacy path never registers the in-flight map, so concurrent callers
+    // each strip inline (idempotent). Every result is mnemonic-free.
+    const results = await Promise.all([
+      MultiAccountWalletService.getCurrentWallet(),
+      MultiAccountWalletService.getCurrentWallet(),
+    ]);
+    for (const w of results) {
+      if (!w) throw new Error('expected a wallet');
+      expect(firstStandard(w).mnemonic).toBe('');
+    }
+    // Storage ended up sanitized regardless of interleaving.
+    expect(mockStore[WALLET_KEY]).not.toContain(realMnemonic);
+  });
+
+  it('(h) a secret on a MISTYPED / non-STANDARD account is still detected, scrubbed, and never cached (type-agnostic, fail-closed)', async () => {
+    const account = algosdk.generateAccount();
+    const leakedMnemonic = algosdk.secretKeyToMnemonic(account.sk);
+    // A corrupt/legacy/tampered blob: a WATCH account (which should never carry
+    // key material) with a mnemonic AND a stray privateKey. A type-gated check
+    // (type === STANDARD) would miss this; the type-agnostic detector must catch
+    // it so the secret-bearing raw string never becomes a cache/in-flight key.
+    const corruptBlob = JSON.stringify({
+      id: 'wallet-1',
+      version: '1.0',
+      createdAt: '2026-01-01T00:00:00.000Z',
+      accounts: [
+        {
+          id: 'acc-1',
+          address: account.addr.toString(),
+          publicKey: Buffer.from(account.sk.slice(32)).toString('hex'),
+          type: AccountType.WATCH,
+          label: 'Watch 1',
+          mnemonic: leakedMnemonic,
+          privateKey: Buffer.from(account.sk).toString('hex'),
+        },
+      ],
+      activeAccountId: 'acc-1',
+    });
+    mockStore[WALLET_KEY] = corruptBlob;
+
+    const w1 = await MultiAccountWalletService.getCurrentWallet();
+    if (!w1) throw new Error('expected a wallet');
+
+    // The secret fields are gone from the returned object...
+    const acc0 = w1.accounts[0] as unknown as Record<string, unknown>;
+    expect(acc0.mnemonic).toBeUndefined();
+    expect(acc0.privateKey).toBeUndefined();
+    // ...and storage was rewritten with neither secret present.
+    expect(mockStore[WALLET_KEY]).not.toContain(leakedMnemonic);
+    expect(mockStore[WALLET_KEY]).not.toContain(
+      Buffer.from(account.sk).toString('hex')
+    );
+
+    // And it was NOT memoized: re-seed the corrupt blob and read again; a cached
+    // secret-bearing string would fast-path hit and skip the re-store.
+    mockStore[WALLET_KEY] = corruptBlob;
+    (storage.setItem as jest.Mock).mockClear();
+    const w2 = await MultiAccountWalletService.getCurrentWallet();
+    if (!w2) throw new Error('expected a wallet');
+    expect((storage.setItem as jest.Mock).mock.calls.length).toBeGreaterThan(0);
+  });
+});

--- a/src/services/wallet/index.ts
+++ b/src/services/wallet/index.ts
@@ -38,6 +38,51 @@ import { ledgerAlgorandService } from '@/services/ledger/algorand';
 import { NetworkService } from '@/services/network';
 import type { LedgerAccountDerivation } from '@/services/ledger/algorand';
 
+/**
+ * F-22 (TASK-179) — getCurrentWallet() memoization.
+ *
+ * getCurrentWallet() sits on the cold-boot path AND every signing/key-retrieval
+ * and WalletConnect flow (43 call sites). Each call re-parsed the whole wallet
+ * blob, scanned every account for a legacy mnemonic, ran algosdk.isValidAddress
+ * (base32 decode + SHA-512/256 checksum) on every account, and merged settings —
+ * identical work on an unchanged blob (~40-50 checksum hashes per cold boot).
+ *
+ * This memo caches ONLY the parsed/healed/validated Wallet, keyed on the exact
+ * raw stored string. Because this feeds signing (a stale wallet after a
+ * restore/reset/rekey must NEVER be signed), it holds to these invariants:
+ *   1. The current stored raw string is read on EVERY call (never cached), so
+ *      external wipes/rewrites that bypass this service — restore clearAllData()
+ *      removes voi_wallet_metadata directly (backup/restorers.ts), and
+ *      migrateLegacyValue rewrites it — are always observed. A null read busts
+ *      the memo and returns null (no stale wallet survives a reset).
+ *   2. Cache HIT only when the raw string is byte-identical to the cached key;
+ *      any change (including removal) re-parses.
+ *   3. Every return is a DEEP CLONE — callers mutate the returned wallet in place
+ *      before persisting, so a shared reference would corrupt the cache.
+ *   4. The legacy/unsanitized read (a blob still carrying a per-account mnemonic)
+ *      is NEVER memoized: its raw string would become the cache key and retain a
+ *      secret. Only the sanitized path is cached (persisted blobs are
+ *      mnemonic-stripped at write time), so the memo holds no key material.
+ *   5. Concurrent cold-boot loads of the same raw string collapse into one parse
+ *      via in-flight promise dedup (mirrors walletStore's balanceLoadsInFlight).
+ */
+let cachedWalletRawString: string | null = null;
+let cachedWallet: Wallet | null = null;
+const getCurrentWalletParsesInFlight = new Map<
+  string,
+  Promise<Wallet | null>
+>();
+
+/**
+ * Account fields that carry key material and must NEVER be retained in the module
+ * memo or become a cache/in-flight key. `mnemonic` is the persisted schema's only
+ * secret (StandardAccountMetadata); `privateKey` is checked as defense-in-depth
+ * against a corrupt/legacy/tampered blob that carries key material on a mistyped
+ * or malformed account object — a type-gated check would miss it, so detection is
+ * type-AGNOSTIC and fails closed on ANY account.
+ */
+const SECRET_ACCOUNT_FIELDS = ['mnemonic', 'privateKey'] as const;
+
 export class MultiAccountWalletService {
   private static readonly STORAGE_PREFIX = 'voi_account_';
   private static readonly WALLET_KEY = 'voi_wallet_metadata';
@@ -686,84 +731,208 @@ export class MultiAccountWalletService {
   // Wallet Management
   static async getCurrentWallet(): Promise<Wallet | null> {
     try {
+      // (1) ALWAYS read the current stored raw string. This read is intentionally
+      // NOT memoized: external wipes/rewrites that bypass this service (restore
+      // clearAllData() removing voi_wallet_metadata directly, migrateLegacyValue
+      // rewriting it) must be observed on every call so signing never sees a
+      // stale wallet.
       const walletData = await this.getStoredValue(this.WALLET_KEY);
+
       if (!walletData) {
+        // Removed key busts the memo and returns null — no stale wallet survives
+        // a restore/reset.
+        cachedWalletRawString = null;
+        cachedWallet = null;
         return null;
       }
-      const wallet = JSON.parse(walletData) as Wallet;
 
-      const hasSensitiveMnemonic = wallet.accounts.some(
-        (acc) =>
-          acc.type === AccountType.STANDARD &&
-          !!(acc as StandardAccountMetadata).mnemonic
+      // (2) Cache hit: byte-identical raw string. Skip the JSON.parse +
+      // legacy-mnemonic scan + per-account algosdk.isValidAddress checksum
+      // hashing + settings merge; hand back a deep clone so the caller can mutate
+      // its copy freely.
+      if (walletData === cachedWalletRawString && cachedWallet) {
+        return this.deepCloneWallet(cachedWallet);
+      }
+
+      // Parse once to classify the blob. JSON.parse is synchronous (it never
+      // yields), so a concurrent caller cannot interleave between here and the
+      // memo write below: the first caller to finish a sanitized load populates
+      // the memo, and overlapping callers then take the fast path (2) or join the
+      // in-flight load (4). Secret detection is type-AGNOSTIC (see
+      // SECRET_ACCOUNT_FIELDS): a mnemonic/privateKey on ANY account object —
+      // even one with a wrong or malformed `type` — is caught so its raw string
+      // can never become a cache/in-flight key.
+      const parsed = JSON.parse(walletData) as Wallet;
+      const hasSecretMaterial = parsed.accounts.some((acc) =>
+        this.accountHasSecretMaterial(acc)
       );
 
-      if (hasSensitiveMnemonic) {
-        wallet.accounts = wallet.accounts.map((acc) => {
-          if (acc.type === AccountType.STANDARD) {
-            const { mnemonic: _mnemonic, ...rest } =
-              acc as StandardAccountMetadata;
-            return {
-              ...rest,
-              mnemonic: '',
-            } as StandardAccountMetadata;
-          }
-          return acc;
-        });
+      // (3) Legacy/unsanitized path: the raw string still carries plaintext key
+      // material. It is handled ENTIRELY inline and is NEVER placed in the module
+      // cache OR the in-flight map — its raw string is a secret and must never
+      // become a module-level key (invariant #4). This is a one-time legacy
+      // migration; concurrent double-execution is idempotent (both strip to the
+      // same sanitized blob), so it needs no dedup.
+      if (hasSecretMaterial) {
+        parsed.accounts = parsed.accounts.map((acc) =>
+          this.stripAccountSecrets(acc)
+        );
 
-        await this.storeWallet(wallet);
+        await this.storeWallet(parsed);
+
+        const sanitized = await this.mergeSettingsAndHeal(parsed);
+        return this.deepCloneWallet(sanitized);
       }
 
-      const defaultSettings = this.getDefaultWalletSettings();
-      const persistedSettings = wallet.settings ?? {};
-      wallet.settings = {
-        ...defaultSettings,
-        ...persistedSettings,
-        numberLocale:
-          persistedSettings.numberLocale !== undefined
-            ? persistedSettings.numberLocale
-            : defaultSettings.numberLocale,
-      };
+      // (4) Sanitized path: the raw string carries no secret, so it is safe to
+      // use as both the in-flight dedup key and the cache key. Collapse
+      // concurrent cold-boot loads of the same raw string into one heal/validate
+      // pass; every caller still receives its own deep clone.
+      const inFlight = getCurrentWalletParsesInFlight.get(walletData);
+      if (inFlight) {
+        const shared = await inFlight;
+        return shared ? this.deepCloneWallet(shared) : null;
+      }
 
-      // Heal-on-read: repair invalid, missing, or non-base32 (e.g. a persisted
-      // algosdk `Address` object serialized to `{"publicKey":{...}}`) addresses
-      // by re-deriving them from the stored hex public key. This only ever
-      // rewrites to a freshly derived, checksum-valid base32 address obtained
-      // from an exactly-32-byte public key; it never weakens validation.
-      let modified = false;
-      wallet.accounts = wallet.accounts.map((acc) => {
-        const rawAddress = acc.address as unknown;
-        const currentAddress = typeof rawAddress === 'string' ? rawAddress : '';
-        if (!currentAddress || !algosdk.isValidAddress(currentAddress)) {
-          try {
-            const rawPublicKey = acc.publicKey as unknown;
-            const hexPublicKey =
-              typeof rawPublicKey === 'string' ? rawPublicKey : '';
-            if (hexPublicKey && /^[0-9a-fA-F]+$/.test(hexPublicKey)) {
-              const pubBytes = new Uint8Array(
-                hexPublicKey.match(/.{1,2}/g)!.map((b) => parseInt(b, 16))
-              );
-              if (pubBytes.length === 32) {
-                const derived = algosdk.encodeAddress(pubBytes);
-                if (algosdk.isValidAddress(derived)) {
-                  modified = true;
-                  return { ...acc, address: derived } as AccountMetadata;
-                }
-              }
-            }
-          } catch {}
+      const loadPromise = (async () => {
+        const wallet = await this.mergeSettingsAndHeal(parsed);
+        // Fail-closed: only memoize a wallet whose accounts hold NO secret
+        // material, keyed on a secret-free raw string. hasSecretMaterial already
+        // guaranteed this above; re-checking the healed result keeps the
+        // invariant local to the write so a future refactor cannot silently cache
+        // key material. (If heal-on-read re-stored a repaired address the stored
+        // string also changed, so this entry is simply superseded on the next
+        // read — never served stale, since every read compares the live string.)
+        if (
+          !wallet.accounts.some((acc) => this.accountHasSecretMaterial(acc))
+        ) {
+          cachedWalletRawString = walletData;
+          cachedWallet = wallet;
         }
-        return acc;
-      });
-
-      if (modified) {
-        await this.storeWallet(wallet);
+        return wallet;
+      })();
+      getCurrentWalletParsesInFlight.set(walletData, loadPromise);
+      try {
+        const wallet = await loadPromise;
+        return this.deepCloneWallet(wallet);
+      } finally {
+        getCurrentWalletParsesInFlight.delete(walletData);
       }
-      return wallet;
     } catch (error) {
       console.error('Failed to get current wallet:', error);
       return null;
     }
+  }
+
+  /**
+   * Applies the default-settings merge and heal-on-read address repair to an
+   * already-parsed, mnemonic-free wallet, persisting only when a repair actually
+   * ran. Shared by both getCurrentWallet() load paths and free of any caching
+   * side effect — the caller decides whether the result is memoized, so a
+   * mnemonic-bearing blob (handled inline in getCurrentWallet before it is
+   * stripped) can never be routed through the memo.
+   */
+  private static async mergeSettingsAndHeal(wallet: Wallet): Promise<Wallet> {
+    const defaultSettings = this.getDefaultWalletSettings();
+    const persistedSettings = wallet.settings ?? {};
+    wallet.settings = {
+      ...defaultSettings,
+      ...persistedSettings,
+      numberLocale:
+        persistedSettings.numberLocale !== undefined
+          ? persistedSettings.numberLocale
+          : defaultSettings.numberLocale,
+    };
+
+    // Heal-on-read: repair invalid, missing, or non-base32 (e.g. a persisted
+    // algosdk `Address` object serialized to `{"publicKey":{...}}`) addresses
+    // by re-deriving them from the stored hex public key. This only ever
+    // rewrites to a freshly derived, checksum-valid base32 address obtained
+    // from an exactly-32-byte public key; it never weakens validation.
+    let modified = false;
+    wallet.accounts = wallet.accounts.map((acc) => {
+      const rawAddress = acc.address as unknown;
+      const currentAddress = typeof rawAddress === 'string' ? rawAddress : '';
+      if (!currentAddress || !algosdk.isValidAddress(currentAddress)) {
+        try {
+          const rawPublicKey = acc.publicKey as unknown;
+          const hexPublicKey =
+            typeof rawPublicKey === 'string' ? rawPublicKey : '';
+          if (hexPublicKey && /^[0-9a-fA-F]+$/.test(hexPublicKey)) {
+            const pubBytes = new Uint8Array(
+              hexPublicKey.match(/.{1,2}/g)!.map((b) => parseInt(b, 16))
+            );
+            if (pubBytes.length === 32) {
+              const derived = algosdk.encodeAddress(pubBytes);
+              if (algosdk.isValidAddress(derived)) {
+                modified = true;
+                return { ...acc, address: derived } as AccountMetadata;
+              }
+            }
+          }
+        } catch {}
+      }
+      return acc;
+    });
+
+    if (modified) {
+      await this.storeWallet(wallet);
+    }
+
+    return wallet;
+  }
+
+  /**
+   * Deep clone via JSON round-trip. The Wallet is fully JSON-serializable (it is
+   * parsed from and persisted as JSON), so this produces a fully independent copy
+   * with no shared nested references. Required because getCurrentWallet()'s
+   * consumers mutate the returned object in place (e.g. wallet.accounts[i] = ...
+   * then storeWallet); handing out the cached reference would corrupt the memo.
+   */
+  private static deepCloneWallet(wallet: Wallet): Wallet {
+    return JSON.parse(JSON.stringify(wallet)) as Wallet;
+  }
+
+  /**
+   * Type-agnostic secret detector. Returns true if an account object carries key
+   * material in any SECRET_ACCOUNT_FIELDS entry, regardless of its declared
+   * `type`. Empty strings and absent fields are NOT secrets; any non-empty string
+   * (a mnemonic phrase / private key hex) or any unexpected non-string presence
+   * in a secret field fails closed as a secret. Used to keep the module memo free
+   * of key material even for corrupt/mistyped legacy blobs.
+   */
+  private static accountHasSecretMaterial(acc: unknown): boolean {
+    if (!acc || typeof acc !== 'object') {
+      return false;
+    }
+    const record = acc as Record<string, unknown>;
+    return SECRET_ACCOUNT_FIELDS.some((field) => {
+      const value = record[field];
+      if (value == null) {
+        return false;
+      }
+      return typeof value === 'string' ? value.length > 0 : true;
+    });
+  }
+
+  /**
+   * Removes every SECRET_ACCOUNT_FIELDS entry from an account object (any type),
+   * then restores the persisted-schema shape: a STANDARD account always carries
+   * an explicit empty `mnemonic` (matching sanitizeWalletForPersistence). Used on
+   * the inline legacy path so a mnemonic-bearing blob is fully scrubbed before it
+   * is re-stored or returned — and never memoized.
+   */
+  private static stripAccountSecrets(acc: AccountMetadata): AccountMetadata {
+    const record: Record<string, unknown> = {
+      ...(acc as unknown as Record<string, unknown>),
+    };
+    for (const field of SECRET_ACCOUNT_FIELDS) {
+      delete record[field];
+    }
+    if (record.type === AccountType.STANDARD) {
+      record.mnemonic = '';
+    }
+    return record as unknown as AccountMetadata;
   }
 
   static async createWallet(


### PR DESCRIPTION
## What & why

`getCurrentWallet()` (src/services/wallet/index.ts) is on the cold-boot path **and** every signing/key-retrieval and WalletConnect flow — 43 call sites. Each call re-parsed the whole wallet blob, scanned every account for a legacy mnemonic, ran `algosdk.isValidAddress` (base32 decode + SHA-512/256 checksum) on every account, and merged settings — identical work on an unchanged blob (~40-50 checksum hashes per cold boot; the send/sign critical path re-validates the same blob across several layers).

This PR memoizes **only** the parsed/healed/validated `Wallet`, keyed on the exact raw stored string. It implements the crypto-signed-off **safe-memo** design (TASK-179 comments; rejected the persistent write-invalidated cache because a cross-module writer bypasses invalidation).

Perf: on a cache hit the expensive JSON.parse + legacy-mnemonic scan + per-account `isValidAddress` checksum hashing + settings merge collapse to a single deep-clone; the native storage read is deliberately kept (see guarantee 1).

## Ref

- TASK-179 (Perf Audit II finding **F-22**, P2).
- Follow-up filed: **TASK-212** — pre-existing heal/strip write-vs-external-wipe resurrection race (see Codex verdict + Manual verification).

## Safe-memo design & guarantees

1. **Always reads current storage** — the raw string is read via the existing `getStoredValue(WALLET_KEY)` path on *every* call and is never cached, so external wipes/rewrites that bypass the service are always observed: restore `clearAllData()` removes `voi_wallet_metadata` directly (backup/restorers.ts:87-94), `migrateLegacyValue` rewrites it. A null read busts the memo and returns null — **no stale wallet survives a restore/reset**.
2. **Raw-string keying** — cache HIT only when the current raw string is byte-identical to the cached key; any change (including removal) re-parses.
3. **Deep clone on every return** — via JSON round-trip. Callers mutate the returned wallet in place before persisting (index.ts:677-681, 892-893); a shared reference would corrupt the cache.
4. **No legacy-blob caching / no secret retained** — a blob still carrying key material is routed **entirely inline** (stripped, re-stored, returned) and never touches the module cache *or* the in-flight map, so a mnemonic-bearing raw string can never become a module-level key. Detection is **type-agnostic** (`SECRET_ACCOUNT_FIELDS` = mnemonic/privateKey via `accountHasSecretMaterial`) so a secret on a mistyped/malformed account is still caught (fail-closed), and the cache write is guarded by a fail-closed re-check. The persisted blob is mnemonic-stripped by `sanitizeWalletForPersistence` (account.mnemonic === '').
5. **In-flight promise dedup** — concurrent cold-boot loads of the same (sanitized) raw string collapse into one heal/validate pass (mirrors walletStore's `balanceLoadsInFlight`); every caller still receives its own deep clone.

## Gates

- `npm run typecheck` — **0 errors**.
- `npm run lint` — **0 errors** (675 pre-existing warnings unchanged; exit 0).
- `npm test -- --ci` — **57 suites / 1015 tests pass**, including **9 new** tests in `getCurrentWallet.memo.test.ts`:
  - (a) two reads of an unchanged wallet are deep-EQUAL but not same-reference (nested too)
  - (a2) storage is re-read on every call (never caches the read)
  - (b) mutating a returned wallet does not affect the next read
  - (c) a change to the stored string busts the cache
  - (d) removal of the stored key returns null (no stale wallet)
  - (e) legacy mnemonic blob stripped, re-stored sanitized, never memoized
  - (f) concurrent cold-boot reads collapse and return independent clones
  - (g) concurrent legacy-mnemonic reads handled inline, no leak
  - (h) secret on a mistyped/non-STANDARD account is detected, scrubbed, never cached (type-agnostic, fail-closed)

## Codex self-review (crypto)

3 rounds (read-only). Round 1 flagged the in-flight Map transiently keying on a mnemonic-bearing blob; round 2 flagged the classifier being type-gated (a secret on a mistyped account could slip into the key). Both fixed (inline routing + type-agnostic fail-closed detection). **Round 3 verdict: CLEAN** — verified no secret reaches the cache or in-flight key on any path, no stale wallet served into signing after restore/reset/rekey, deep clones on all return paths, no secret logging, address validation/heal unchanged.

Codex also noted (PRE-EXISTING, not a blocker): the heal-on-read/legacy-strip `storeWallet()` can race an external wipe and re-persist older metadata. This predates the memo and is **not** served by the memo without matching current storage. Filed as **TASK-212**.

## Manual verification needed

Please exercise on-device (crypto/signing hot paths the memo feeds):
- **Send / sign** a transaction (standard account) — correct account + address signed.
- **WalletConnect** request handling (`getAllAccounts` path) — account enumeration correct.
- **Account switch** (`setActiveAccount`) then send — active account reflects immediately.
- **Backup restore, then read** — after restore/reset the next wallet read reflects the restored/empty state (no stale wallet); confirm no resurrection under TASK-212 flows.
