### PR TITLE
fix(startup): cache network health check off cold-boot critical path (F-04, TASK-178)

### DIFF
--- a/src/screens/wallet/HomeScreen.tsx
+++ b/src/screens/wallet/HomeScreen.tsx
@@ -364,13 +364,23 @@ export default function HomeScreen() {
       const currentViewMode = isMultiNetworkView;
 
       try {
-        const [networkHealth] = await Promise.allSettled([
-          VoiNetworkService.checkNetworkHealth(),
-        ]);
-
-        if (networkHealth.status === 'fulfilled') {
-          setNetworkStatus(networkHealth.value);
-        }
+        // Kick the health check off CONCURRENTLY with the mappings/balance load
+        // instead of awaiting it first. The service dedups/caches by NetworkId
+        // within a short TTL, so on cold boot this reuses the status networkStore
+        // already fetched during init (or shares its in-flight probe) rather than
+        // issuing a duplicate ~15s request, and never delays the first balance.
+        const networkHealthPromise = VoiNetworkService.checkNetworkHealth()
+          .then((status) => {
+            if (
+              viewModeRef.current === currentViewMode &&
+              activeAccountIdRef.current === accountId
+            ) {
+              setNetworkStatus(status);
+            }
+          })
+          .catch((error) => {
+            console.warn('[HomeScreen] Network health check failed:', error);
+          });
 
         // Check if view mode or account changed while loading
         if (
@@ -418,6 +428,9 @@ export default function HomeScreen() {
         await Promise.all([
           loadAccountTransactions(accountId),
           loadEnvoiName(accountId),
+          // Already running concurrently (self-handles state + errors); await it
+          // here only so it settles within loadData rather than dangling.
+          networkHealthPromise,
         ]);
       } catch (error) {
         console.error('Failed to load account data:', error);
@@ -880,7 +893,9 @@ export default function HomeScreen() {
 
     try {
       const [networkHealth] = await Promise.allSettled([
-        VoiNetworkService.checkNetworkHealth(),
+        // Explicit refresh (pull-to-refresh) must reflect current connectivity,
+        // so bypass the short-TTL cache.
+        VoiNetworkService.checkNetworkHealth({ force: true }),
       ]);
 
       if (networkHealth.status === 'fulfilled') {

--- a/src/services/network/__tests__/checkNetworkHealth.cache.test.ts
+++ b/src/services/network/__tests__/checkNetworkHealth.cache.test.ts
@@ -1,0 +1,120 @@
+import { NetworkService } from '../index';
+import { NetworkId, NetworkStatus } from '@/types/network';
+
+// A completed, healthy probe result. performNetworkHealthCheck is stubbed so
+// these tests exercise the TTL/in-flight wrapper (F-04) without real HTTP.
+const HEALTHY: NetworkStatus = {
+  isConnected: true,
+  lastSync: 0,
+  algodHeight: 100,
+  indexerHealth: true,
+};
+
+describe('NetworkService.checkNetworkHealth TTL cache + dedup (F-04, TASK-178)', () => {
+  afterEach(() => {
+    jest.restoreAllMocks();
+  });
+
+  it('dedupes concurrent health checks into a single underlying probe (in-flight)', async () => {
+    const service = NetworkService.getInstance(NetworkId.ALGORAND_MAINNET);
+    (service as any).healthCheckCache.clear();
+    (service as any).healthCheckInFlight.clear();
+
+    let resolveProbe!: (status: NetworkStatus) => void;
+    const spy = jest
+      .spyOn(service as any, 'performNetworkHealthCheck')
+      .mockImplementation(
+        () =>
+          new Promise<NetworkStatus>((resolve) => {
+            resolveProbe = resolve;
+          })
+      );
+
+    // Two callers race in the same tick; the second must reuse the first's
+    // in-flight probe rather than issuing its own.
+    const p1 = service.checkNetworkHealth();
+    const p2 = service.checkNetworkHealth();
+
+    expect(spy).toHaveBeenCalledTimes(1);
+
+    resolveProbe(HEALTHY);
+    const [r1, r2] = await Promise.all([p1, p2]);
+
+    expect(r1.isConnected).toBe(true);
+    expect(r2.isConnected).toBe(true);
+    expect(spy).toHaveBeenCalledTimes(1);
+  });
+
+  it('serves the cached status within the TTL and re-probes once it expires (or is forced)', async () => {
+    const service = NetworkService.getInstance(NetworkId.ALGORAND_MAINNET);
+    (service as any).healthCheckCache.clear();
+    (service as any).healthCheckInFlight.clear();
+
+    const spy = jest
+      .spyOn(service as any, 'performNetworkHealthCheck')
+      .mockResolvedValue(HEALTHY);
+
+    await service.checkNetworkHealth();
+    await service.checkNetworkHealth();
+    // Second call is served from the TTL cache — no new probe.
+    expect(spy).toHaveBeenCalledTimes(1);
+
+    // Expire the cached entry and confirm the next call re-probes.
+    const key = (service as any).currentNetworkId as NetworkId;
+    const entry = (service as any).healthCheckCache.get(key);
+    entry.timestamp =
+      Date.now() - ((NetworkService as any).HEALTH_CHECK_TTL_MS + 1);
+
+    await service.checkNetworkHealth();
+    expect(spy).toHaveBeenCalledTimes(2);
+
+    // force:true always re-probes, even within the TTL.
+    await service.checkNetworkHealth({ force: true });
+    expect(spy).toHaveBeenCalledTimes(3);
+  });
+
+  it('invalidates the health-check cache on switchNetwork', async () => {
+    const service = NetworkService.getInstance(NetworkId.VOI_MAINNET);
+    (service as any).healthCheckCache.clear();
+    (service as any).healthCheckInFlight.clear();
+
+    jest
+      .spyOn(service as any, 'performNetworkHealthCheck')
+      .mockResolvedValue(HEALTHY);
+
+    await service.checkNetworkHealth();
+    expect((service as any).healthCheckCache.has(NetworkId.VOI_MAINNET)).toBe(
+      true
+    );
+
+    await service.switchNetwork(NetworkId.ALGORAND_MAINNET);
+
+    // The pre-switch entry (keyed by the old network) must be gone so the
+    // switched-to network can never be served a stale result.
+    expect((service as any).healthCheckCache.has(NetworkId.VOI_MAINNET)).toBe(
+      false
+    );
+    expect(service.getCurrentNetworkId()).toBe(NetworkId.ALGORAND_MAINNET);
+
+    // Let the fire-and-forget post-switch probe settle to avoid dangling work.
+    await new Promise((resolve) => setImmediate(resolve));
+  });
+
+  it('does not block switchNetwork (cold launch to a non-default network) on a hung health probe', async () => {
+    const service = NetworkService.getInstance(NetworkId.VOI_MAINNET);
+    (service as any).healthCheckCache.clear();
+    (service as any).healthCheckInFlight.clear();
+
+    // Simulate an unavailable/hung node: the probe never settles.
+    jest
+      .spyOn(service as any, 'performNetworkHealthCheck')
+      .mockImplementation(() => new Promise<NetworkStatus>(() => {}));
+
+    // The switch performs client reconfiguration synchronously and must resolve
+    // WITHOUT awaiting the health probe — otherwise a slow node stalls cold boot.
+    await expect(
+      service.switchNetwork(NetworkId.ALGORAND_MAINNET)
+    ).resolves.toBeUndefined();
+    expect(service.getCurrentNetworkId()).toBe(NetworkId.ALGORAND_MAINNET);
+  });
+});

--- a/src/services/network/__tests__/checkNetworkHealth.cache.test.ts
+++ b/src/services/network/__tests__/checkNetworkHealth.cache.test.ts
@@ -100,6 +100,53 @@ describe('NetworkService.checkNetworkHealth TTL cache + dedup (F-04, TASK-178)',
     await new Promise((resolve) => setImmediate(resolve));
   });
 
+  it('discards a post-switch stale probe (does not clobber status or re-add the cache)', async () => {
+    const service = NetworkService.getInstance(NetworkId.VOI_MAINNET);
+    (service as any).healthCheckCache.clear();
+    (service as any).healthCheckInFlight.clear();
+
+    const baseline: NetworkStatus = {
+      isConnected: false,
+      lastSync: 111,
+      algodHeight: 0,
+      indexerHealth: false,
+    };
+    (service as any).networkStatus = { ...baseline };
+
+    // Deferred raw algod client so the probe can settle AFTER we simulate a
+    // switch. Exercises the REAL performNetworkHealthCheck (not a stub).
+    let resolveAlgod!: (v: unknown) => void;
+    (service as any).algodClient = {
+      status: () => ({
+        do: () =>
+          new Promise((resolve) => {
+            resolveAlgod = resolve;
+          }),
+      }),
+    };
+    (service as any).indexerClient = {
+      makeHealthCheck: () => ({ do: async () => ({}) }),
+    };
+
+    // Probe starts on VOI, capturing the current generation.
+    const probe = service.checkNetworkHealth();
+
+    // Simulate switchNetwork's invalidation while the probe is in flight.
+    (service as any).healthCheckCache.clear();
+    (service as any).healthCheckInFlight.clear();
+    (service as any).healthCheckGeneration++;
+
+    resolveAlgod({ lastRound: 42 });
+    await probe;
+
+    // The stale (previous-network) result must neither overwrite the current
+    // shared status nor re-populate the cache switchNetwork deliberately cleared.
+    expect((service as any).networkStatus).toEqual(baseline);
+    expect((service as any).healthCheckCache.has(NetworkId.VOI_MAINNET)).toBe(
+      false
+    );
+  });
+
   it('does not block switchNetwork (cold launch to a non-default network) on a hung health probe', async () => {
     const service = NetworkService.getInstance(NetworkId.VOI_MAINNET);
     (service as any).healthCheckCache.clear();

--- a/src/services/network/__tests__/checkNetworkHealth.cache.test.ts
+++ b/src/services/network/__tests__/checkNetworkHealth.cache.test.ts
@@ -153,7 +153,7 @@ describe('NetworkService.checkNetworkHealth TTL cache + dedup (F-04, TASK-178)',
     (service as any).healthCheckInFlight.clear();
 
     // Each algod probe gets its own deferred so we control settle order.
-    const algodResolvers: Array<(v: unknown) => void> = [];
+    const algodResolvers: ((v: unknown) => void)[] = [];
     (service as any).algodClient = {
       status: () => ({
         do: () =>

--- a/src/services/network/__tests__/checkNetworkHealth.cache.test.ts
+++ b/src/services/network/__tests__/checkNetworkHealth.cache.test.ts
@@ -147,6 +147,46 @@ describe('NetworkService.checkNetworkHealth TTL cache + dedup (F-04, TASK-178)',
     );
   });
 
+  it('lets the latest-issued probe win: a forced refresh is not overwritten by an older concurrent probe settling later', async () => {
+    const service = NetworkService.getInstance(NetworkId.VOI_MAINNET);
+    (service as any).healthCheckCache.clear();
+    (service as any).healthCheckInFlight.clear();
+
+    // Each algod probe gets its own deferred so we control settle order.
+    const algodResolvers: Array<(v: unknown) => void> = [];
+    (service as any).algodClient = {
+      status: () => ({
+        do: () =>
+          new Promise((resolve) => {
+            algodResolvers.push(resolve);
+          }),
+      }),
+    };
+    (service as any).indexerClient = {
+      makeHealthCheck: () => ({ do: async () => ({}) }),
+    };
+
+    const older = service.checkNetworkHealth(); // seq 1
+    const forced = service.checkNetworkHealth({ force: true }); // seq 2 (bypasses dedup)
+
+    // Two independent probes are in flight.
+    expect(algodResolvers.length).toBe(2);
+
+    // Settle the NEWER (forced) probe first with height 2, then the OLDER with 1.
+    algodResolvers[1]({ lastRound: 2 });
+    await forced;
+    algodResolvers[0]({ lastRound: 1 });
+    await older;
+
+    const key = (service as any).currentNetworkId as NetworkId;
+    // The forced (latest-issued) result must win, despite the older probe
+    // settling last.
+    expect((service as any).networkStatus.algodHeight).toBe(2);
+    expect((service as any).healthCheckCache.get(key).status.algodHeight).toBe(
+      2
+    );
+  });
+
   it('does not block switchNetwork (cold launch to a non-default network) on a hung health probe', async () => {
     const service = NetworkService.getInstance(NetworkId.VOI_MAINNET);
     (service as any).healthCheckCache.clear();

--- a/src/services/network/index.ts
+++ b/src/services/network/index.ts
@@ -75,6 +75,21 @@ export class NetworkService {
   // another network's decimals.
   private assetCacheGeneration = 0;
 
+  // Short-TTL cache + in-flight dedup for checkNetworkHealth, KEYED BY
+  // NetworkId. On cold boot the store's init refresh and HomeScreen's account
+  // load both probe health within the same window; without this each call
+  // issued 2 fresh HTTP requests (~15s worst case each). Keying by NetworkId
+  // stops a stale result from one network being served for another;
+  // switchNetwork clears both maps so a switched-to network never reuses
+  // pre-switch data.
+  private static readonly HEALTH_CHECK_TTL_MS = 5000;
+  private healthCheckCache: Map<
+    NetworkId,
+    { status: NetworkStatus; timestamp: number }
+  > = new Map();
+  private healthCheckInFlight: Map<NetworkId, Promise<NetworkStatus>> =
+    new Map();
+
   private constructor(networkId: NetworkId = DEFAULT_NETWORK_ID) {
     this.currentNetworkId = networkId;
     this.config = getNetworkConfig(networkId);
@@ -184,8 +199,18 @@ export class NetworkService {
         envoiHealth: undefined,
       };
 
-      // Perform initial health check
-      await this.checkNetworkHealth();
+      // Invalidate the health-check TTL/in-flight caches so the switched-to
+      // network can never be served a status probed before the switch.
+      this.healthCheckCache.clear();
+      this.healthCheckInFlight.clear();
+
+      // Kick off an initial health check but do NOT block the switch on it: the
+      // client reconfiguration above is the only real prerequisite for callers
+      // (cold-boot WalletConnect startup + queued txn-request navigation), and
+      // every caller re-refreshes status right after this returns. Awaiting a
+      // ~15s-timeout probe here stalled cold boot on a slow/unavailable node.
+      // checkNetworkHealth never rejects, so this is safe to leave unawaited.
+      void this.checkNetworkHealth();
 
       // Cache this instance under the new network ID and mark it active
       NetworkService.instances.set(networkId, this);
@@ -255,7 +280,53 @@ export class NetworkService {
     ) as Promise<T>;
   }
 
-  async checkNetworkHealth(): Promise<NetworkStatus> {
+  /**
+   * Health check with a short-TTL cache + in-flight dedup, keyed by the current
+   * NetworkId. Within HEALTH_CHECK_TTL_MS a completed result is reused and
+   * concurrent callers share a single in-flight probe, so the cold-boot burst
+   * (store init refresh + HomeScreen account load) issues ONE round-trip
+   * instead of several. Pass { force: true } to bypass the cache (e.g. an
+   * explicit pull-to-refresh that must reflect current connectivity).
+   */
+  async checkNetworkHealth(options?: {
+    force?: boolean;
+  }): Promise<NetworkStatus> {
+    const networkId = this.currentNetworkId;
+
+    if (!options?.force) {
+      const cached = this.healthCheckCache.get(networkId);
+      if (
+        cached &&
+        Date.now() - cached.timestamp < NetworkService.HEALTH_CHECK_TTL_MS
+      ) {
+        return { ...cached.status };
+      }
+
+      const inFlight = this.healthCheckInFlight.get(networkId);
+      if (inFlight) {
+        return inFlight;
+      }
+    }
+
+    const request = (async () => {
+      const status = await this.performNetworkHealthCheck();
+      this.healthCheckCache.set(networkId, { status, timestamp: Date.now() });
+      return status;
+    })();
+
+    this.healthCheckInFlight.set(networkId, request);
+    try {
+      return await request;
+    } finally {
+      // Only clear the entry if it is still ours — a concurrent force refresh or
+      // a switchNetwork()-triggered clear may have replaced/removed it.
+      if (this.healthCheckInFlight.get(networkId) === request) {
+        this.healthCheckInFlight.delete(networkId);
+      }
+    }
+  }
+
+  private async performNetworkHealthCheck(): Promise<NetworkStatus> {
     try {
       const [algodStatus, indexerHealth] = await Promise.allSettled([
         this.withTimeout(this.algodClient.status().do(), 'algod status'),

--- a/src/services/network/index.ts
+++ b/src/services/network/index.ts
@@ -90,6 +90,13 @@ export class NetworkService {
   private healthCheckInFlight: Map<NetworkId, Promise<NetworkStatus>> =
     new Map();
 
+  // Bumped on every switchNetwork. A probe captures this before its (up to
+  // ~15s) requests; on settle it commits to networkStatus/cache only if the
+  // generation is unchanged. This instance is mutated in place across switches,
+  // so a late-settling probe for a previous network must not clobber the
+  // current network's status or re-populate the cache switchNetwork cleared.
+  private healthCheckGeneration = 0;
+
   private constructor(networkId: NetworkId = DEFAULT_NETWORK_ID) {
     this.currentNetworkId = networkId;
     this.config = getNetworkConfig(networkId);
@@ -200,9 +207,12 @@ export class NetworkService {
       };
 
       // Invalidate the health-check TTL/in-flight caches so the switched-to
-      // network can never be served a status probed before the switch.
+      // network can never be served a status probed before the switch, and bump
+      // the generation so any probe already in flight for the previous network
+      // discards its result instead of clobbering the new network's status.
       this.healthCheckCache.clear();
       this.healthCheckInFlight.clear();
+      this.healthCheckGeneration++;
 
       // Kick off an initial health check but do NOT block the switch on it: the
       // client reconfiguration above is the only real prerequisite for callers
@@ -292,6 +302,7 @@ export class NetworkService {
     force?: boolean;
   }): Promise<NetworkStatus> {
     const networkId = this.currentNetworkId;
+    const generation = this.healthCheckGeneration;
 
     if (!options?.force) {
       const cached = this.healthCheckCache.get(networkId);
@@ -309,8 +320,13 @@ export class NetworkService {
     }
 
     const request = (async () => {
-      const status = await this.performNetworkHealthCheck();
-      this.healthCheckCache.set(networkId, { status, timestamp: Date.now() });
+      const status = await this.performNetworkHealthCheck(generation);
+      // Only repopulate the cache if we haven't switched networks since this
+      // probe started; otherwise switchNetwork deliberately cleared it and this
+      // result is for a network we've left.
+      if (this.healthCheckGeneration === generation) {
+        this.healthCheckCache.set(networkId, { status, timestamp: Date.now() });
+      }
       return status;
     })();
 
@@ -326,7 +342,9 @@ export class NetworkService {
     }
   }
 
-  private async performNetworkHealthCheck(): Promise<NetworkStatus> {
+  private async performNetworkHealthCheck(
+    generation: number
+  ): Promise<NetworkStatus> {
     try {
       const [algodStatus, indexerHealth] = await Promise.allSettled([
         this.withTimeout(this.algodClient.status().do(), 'algod status'),
@@ -339,23 +357,34 @@ export class NetworkService {
       const isAlgodHealthy = algodStatus.status === 'fulfilled';
       const isIndexerHealthy = indexerHealth.status === 'fulfilled';
 
-      this.networkStatus = {
+      const status: NetworkStatus = {
         isConnected: isAlgodHealthy && isIndexerHealthy,
         lastSync: Date.now(),
         algodHeight: isAlgodHealthy ? Number(algodStatus.value.lastRound) : 0,
         indexerHealth: isIndexerHealthy,
       };
 
-      return this.networkStatus;
+      // Don't let a probe for a network we've since switched away from clobber
+      // the current network's status (this instance is reused across switches).
+      if (this.healthCheckGeneration === generation) {
+        this.networkStatus = status;
+      }
+
+      return status;
     } catch (error) {
       console.error('Network health check failed:', error);
-      this.networkStatus = {
+      const status: NetworkStatus = {
         isConnected: false,
         lastSync: Date.now(),
         algodHeight: 0,
         indexerHealth: false,
       };
-      return this.networkStatus;
+
+      if (this.healthCheckGeneration === generation) {
+        this.networkStatus = status;
+      }
+
+      return status;
     }
   }
 

--- a/src/services/network/index.ts
+++ b/src/services/network/index.ts
@@ -97,6 +97,12 @@ export class NetworkService {
   // current network's status or re-populate the cache switchNetwork cleared.
   private healthCheckGeneration = 0;
 
+  // Incremented for every ACTUAL probe (not cache/in-flight reuse). A probe
+  // commits only if it is still the latest issued — so a forced refresh that
+  // supersedes an older concurrent probe is never overwritten by that older
+  // probe settling later (last-issued wins, not last-settled).
+  private healthCheckSeq = 0;
+
   private constructor(networkId: NetworkId = DEFAULT_NETWORK_ID) {
     this.currentNetworkId = networkId;
     this.config = getNetworkConfig(networkId);
@@ -319,12 +325,19 @@ export class NetworkService {
       }
     }
 
+    const seq = ++this.healthCheckSeq;
     const request = (async () => {
-      const status = await this.performNetworkHealthCheck(generation);
-      // Only repopulate the cache if we haven't switched networks since this
-      // probe started; otherwise switchNetwork deliberately cleared it and this
-      // result is for a network we've left.
-      if (this.healthCheckGeneration === generation) {
+      const status = await this.performNetworkHealthCheck();
+      // Commit to the shared status + cache only if this probe is still current:
+      // no network switch since it started (generation), and no newer probe has
+      // superseded it (seq). Otherwise it's for a network we've left, or a stale
+      // result that a forced refresh already replaced — return it to our own
+      // caller but don't let it clobber current state or the just-cleared cache.
+      if (
+        this.healthCheckGeneration === generation &&
+        this.healthCheckSeq === seq
+      ) {
+        this.networkStatus = status;
         this.healthCheckCache.set(networkId, { status, timestamp: Date.now() });
       }
       return status;
@@ -342,9 +355,10 @@ export class NetworkService {
     }
   }
 
-  private async performNetworkHealthCheck(
-    generation: number
-  ): Promise<NetworkStatus> {
+  // Runs the raw algod/indexer probes and returns the computed status. Pure with
+  // respect to instance state: committing to networkStatus/cache is the
+  // caller's (checkNetworkHealth) job, gated on generation + seq.
+  private async performNetworkHealthCheck(): Promise<NetworkStatus> {
     try {
       const [algodStatus, indexerHealth] = await Promise.allSettled([
         this.withTimeout(this.algodClient.status().do(), 'algod status'),
@@ -357,34 +371,20 @@ export class NetworkService {
       const isAlgodHealthy = algodStatus.status === 'fulfilled';
       const isIndexerHealthy = indexerHealth.status === 'fulfilled';
 
-      const status: NetworkStatus = {
+      return {
         isConnected: isAlgodHealthy && isIndexerHealthy,
         lastSync: Date.now(),
         algodHeight: isAlgodHealthy ? Number(algodStatus.value.lastRound) : 0,
         indexerHealth: isIndexerHealthy,
       };
-
-      // Don't let a probe for a network we've since switched away from clobber
-      // the current network's status (this instance is reused across switches).
-      if (this.healthCheckGeneration === generation) {
-        this.networkStatus = status;
-      }
-
-      return status;
     } catch (error) {
       console.error('Network health check failed:', error);
-      const status: NetworkStatus = {
+      return {
         isConnected: false,
         lastSync: Date.now(),
         algodHeight: 0,
         indexerHealth: false,
       };
-
-      if (this.healthCheckGeneration === generation) {
-        this.networkStatus = status;
-      }
-
-      return status;
     }
   }
 

--- a/src/store/__tests__/initializeNetwork.nonblocking.test.ts
+++ b/src/store/__tests__/initializeNetwork.nonblocking.test.ts
@@ -1,0 +1,63 @@
+import { NetworkId } from '@/types/network';
+import {
+  AVAILABLE_NETWORKS,
+  DEFAULT_NETWORK_ID,
+} from '@/services/network/config';
+
+// The store's initializeNetwork must await the persisted-network selection +
+// switchNetwork (client reconfiguration) but NOT the post-selection health
+// refresh. Stub the dependencies so we can assert it resolves even when the
+// health probe never settles (F-04, TASK-178).
+jest.mock('@/utils/storage', () => ({
+  AppStorage: {
+    getSelectedNetwork: jest.fn(),
+    saveSelectedNetwork: jest.fn().mockResolvedValue(undefined),
+  },
+}));
+
+jest.mock('@/services/network', () => ({
+  NetworkService: { getInstance: jest.fn() },
+}));
+
+jest.mock('../walletStore', () => ({
+  useWalletStore: {
+    getState: () => ({
+      clearSingleNetworkCache: jest.fn().mockResolvedValue(undefined),
+    }),
+  },
+}));
+
+import { AppStorage } from '@/utils/storage';
+import { NetworkService } from '@/services/network';
+import { useNetworkStore } from '../networkStore';
+
+describe('networkStore.initializeNetwork (F-04 non-blocking health, TASK-178)', () => {
+  const NON_DEFAULT = AVAILABLE_NETWORKS.find(
+    (n) => n !== DEFAULT_NETWORK_ID
+  ) as NetworkId;
+
+  it('resolves without awaiting the post-selection health refresh on a non-default network', async () => {
+    (AppStorage.getSelectedNetwork as jest.Mock).mockResolvedValue(NON_DEFAULT);
+
+    let healthProbeStarted = false;
+    const fakeService = {
+      getCurrentNetworkId: jest.fn().mockReturnValue(DEFAULT_NETWORK_ID),
+      switchNetwork: jest.fn().mockResolvedValue(undefined),
+      // A hung/unavailable node: the health probe never settles.
+      checkNetworkHealth: jest.fn().mockImplementation(() => {
+        healthProbeStarted = true;
+        return new Promise<never>(() => {});
+      }),
+    };
+    (NetworkService.getInstance as jest.Mock).mockReturnValue(fakeService);
+
+    // If initializeNetwork awaited the health refresh, this would never resolve
+    // and Jest would time out. The persisted-network switch is still awaited.
+    await useNetworkStore.getState().initializeNetwork();
+
+    expect(fakeService.switchNetwork).toHaveBeenCalledWith(NON_DEFAULT);
+    expect(useNetworkStore.getState().currentNetwork).toBe(NON_DEFAULT);
+    // The refresh was still kicked off — just fired, not awaited.
+    expect(healthProbeStarted).toBe(true);
+  });
+});

--- a/src/store/__tests__/initializeNetwork.nonblocking.test.ts
+++ b/src/store/__tests__/initializeNetwork.nonblocking.test.ts
@@ -60,4 +60,47 @@ describe('networkStore.initializeNetwork (F-04 non-blocking health, TASK-178)', 
     // The refresh was still kicked off — just fired, not awaited.
     expect(healthProbeStarted).toBe(true);
   });
+
+  it('does not let a superseded (stale) refresh overwrite fresher status for the same network', async () => {
+    // Each refresh gets its own deferred probe so we can control settle order.
+    const resolvers: Array<(status: unknown) => void> = [];
+    const fakeService = {
+      getCurrentNetworkId: jest.fn().mockReturnValue(NON_DEFAULT),
+      switchNetwork: jest.fn().mockResolvedValue(undefined),
+      checkNetworkHealth: jest.fn().mockImplementation(
+        () =>
+          new Promise((resolve) => {
+            resolvers.push(resolve);
+          })
+      ),
+    };
+    (NetworkService.getInstance as jest.Mock).mockReturnValue(fakeService);
+
+    const store = useNetworkStore.getState();
+    const older = store.refreshNetworkStatus(NON_DEFAULT); // earlier refresh
+    const newer = store.refreshNetworkStatus(NON_DEFAULT); // later refresh
+    expect(resolvers).toHaveLength(2);
+
+    const fresh = {
+      isConnected: true,
+      lastSync: 2,
+      algodHeight: 2,
+      indexerHealth: true,
+    };
+    const stale = {
+      isConnected: false,
+      lastSync: 1,
+      algodHeight: 1,
+      indexerHealth: false,
+    };
+
+    // The later refresh settles first and publishes; the earlier one settles
+    // afterwards and must be dropped, not overwrite the fresher status.
+    resolvers[1](fresh);
+    await newer;
+    resolvers[0](stale);
+    await older;
+
+    expect(useNetworkStore.getState().status[NON_DEFAULT]).toEqual(fresh);
+  });
 });

--- a/src/store/__tests__/initializeNetwork.nonblocking.test.ts
+++ b/src/store/__tests__/initializeNetwork.nonblocking.test.ts
@@ -63,7 +63,7 @@ describe('networkStore.initializeNetwork (F-04 non-blocking health, TASK-178)', 
 
   it('does not let a superseded (stale) refresh overwrite fresher status for the same network', async () => {
     // Each refresh gets its own deferred probe so we can control settle order.
-    const resolvers: Array<(status: unknown) => void> = [];
+    const resolvers: ((status: unknown) => void)[] = [];
     const fakeService = {
       getCurrentNetworkId: jest.fn().mockReturnValue(NON_DEFAULT),
       switchNetwork: jest.fn().mockResolvedValue(undefined),

--- a/src/store/networkStore.ts
+++ b/src/store/networkStore.ts
@@ -27,6 +27,13 @@ interface NetworkStoreState extends NetworkState {
   isCurrentNetworkHealthy: boolean;
 }
 
+// Monotonic per-network refresh tokens. A refresh publishes its result only if
+// it is still the latest issued for that network — so a slow probe from an
+// earlier refresh (e.g. one left in flight across a rapid A→B→A switch, whose
+// service-level dedup no longer applies because it now runs on a different
+// per-network instance) can't overwrite fresher status for the same network.
+const refreshSeq: Partial<Record<NetworkId, number>> = {};
+
 export const useNetworkStore = create<NetworkStoreState>()(
   subscribeWithSelector((set, get) => ({
     // Initial state
@@ -162,9 +169,18 @@ export const useNetworkStore = create<NetworkStoreState>()(
     async refreshNetworkStatus(networkId?: NetworkId) {
       const targetNetworkId = networkId || get().currentNetwork;
 
+      // Claim the latest refresh token for this network before awaiting.
+      const seq = (refreshSeq[targetNetworkId] ?? 0) + 1;
+      refreshSeq[targetNetworkId] = seq;
+      const isLatest = () => refreshSeq[targetNetworkId] === seq;
+
       try {
         const networkService = NetworkService.getInstance(targetNetworkId);
         const networkStatus = await networkService.checkNetworkHealth();
+
+        // A newer refresh for this network started while we were probing — its
+        // (fresher) result must win, so drop ours instead of overwriting.
+        if (!isLatest()) return;
 
         set((state) => ({
           status: {
@@ -177,6 +193,8 @@ export const useNetworkStore = create<NetworkStoreState>()(
           `Failed to refresh network status for ${targetNetworkId}:`,
           error
         );
+
+        if (!isLatest()) return;
 
         // Set unhealthy status on error
         set((state) => ({

--- a/src/store/networkStore.ts
+++ b/src/store/networkStore.ts
@@ -85,8 +85,14 @@ export const useNetworkStore = create<NetworkStoreState>()(
 
         set({ currentNetwork: networkToUse });
 
-        // Perform initial health check
-        await get().refreshNetworkStatus(networkToUse);
+        // Fire the initial health check OFF the cold-boot critical path. The
+        // persisted-network read + switchNetwork (client reconfiguration) above
+        // are the only real prerequisites for downstream startup (WalletConnect
+        // restore, queued txn-request navigation); those ran the network against
+        // the correct clients already. Awaiting the ~15s-timeout health probe
+        // here stalled the whole service-init branch on a slow/unavailable node.
+        // refreshNetworkStatus swallows its own errors, so this never rejects.
+        void get().refreshNetworkStatus(networkToUse);
 
         console.log(`Network store initialized with: ${networkToUse}`);
       } catch (error) {


### PR DESCRIPTION
## What / Why

Every cold boot paid up to **4** uncached `checkNetworkHealth` round-trips (2 HTTP requests each, ~15s `withTimeout`), **serialized on the critical path**:

- `AppNavigator.initializeServices` awaits `initializeNetwork()` before the parallel WalletConnect/DeepLink/Notifications/Ledger branch and before queued transaction-request navigation.
- `networkStore.initializeNetwork` awaited `refreshNetworkStatus` (and a third probe inside `NetworkService.switchNetwork` when the persisted network differs).
- `HomeScreen.loadData` then re-awaited the same singleton's `checkNetworkHealth` **before** loading balance/mappings, duplicating the requests and delaying the first balance by up to another ~15s.

On a slow/unavailable node this stalled push registration / WC restore and the first balance load by up to ~15s each — exactly when responsiveness matters most.

## Changes

- **`NetworkService.checkNetworkHealth`** (`services/network/index.ts`): added a short-TTL (5s) cache **+ in-flight dedup, keyed by `NetworkId`**. Body split into a pure `performNetworkHealthCheck`; the wrapper owns all commits. Commits to `networkStatus`/cache are gated on a **switch generation** (bumped every `switchNetwork`) **and a per-probe seq** (latest-issued probe wins), so a post-switch or superseded probe can never clobber current status or re-populate the just-cleared cache. `switchNetwork` clears both maps (invalidate-on-switch) and **fires** its initial probe without awaiting — client reconfiguration stays synchronous/awaited.
- **`networkStore.initializeNetwork`** (`store/networkStore.ts`): keeps awaiting the persisted-network read **and** `switchNetwork` (client reconfiguration) per the Codex Phase-D constraint; fires the post-selection `refreshNetworkStatus` **without awaiting** (off the critical path). `refreshNetworkStatus` now claims a monotonic **per-network refresh token** before awaiting and publishes only if still latest (a stale probe across a rapid A→B→A switch can't overwrite fresher `status`).
- **`HomeScreen.loadData`** (`screens/wallet/HomeScreen.tsx`): runs the health check **concurrently** with the mappings/balance load (reusing the store's fresh status via the TTL/dedup) instead of serially before it. Pull-to-refresh (`loadAccountData`) passes `{ force: true }` so an explicit refresh reflects current connectivity.

Net: cold boot issues **1** health-check round-trip instead of 4, and network init never blocks on a slow/unavailable health probe. Selected-network resolution + client reconfiguration remain awaited, so WalletConnect startup and queued txn-request navigation always run against the correct network.

TASK-178 (Perf Audit II finding **F-04**, P1). OTA-shippable (pure JS).

## Gate results

- `npm run typecheck` — **0 errors**.
- `npm run lint` — **0 errors** (675 pre-existing baseline warnings; this diff adds 0 errors and 0 warnings).
- `npm test -- --ci` — **1014 passed, 58 suites**.

## Tests added

`services/network/__tests__/checkNetworkHealth.cache.test.ts` (6): in-flight dedup; TTL hit + expiry + `force`; `switchNetwork` invalidates the cache; post-switch stale probe doesn't clobber status/cache; **latest-issued probe wins** over an older concurrent one; cold launch to a non-default network doesn't block `switchNetwork` on a hung probe.

`store/__tests__/initializeNetwork.nonblocking.test.ts` (2): `initializeNetwork` resolves without awaiting the health refresh on a non-default network (switch still awaited); a superseded refresh doesn't overwrite fresher status.

## Codex self-review

Ran `codex exec` (read-only) over `main...HEAD` across 4 rounds. Findings fixed: (P2) post-switch stale probe clobbering shared status/cache → switch-generation guard; (P2) forced refresh overwritten by older concurrent probe → per-probe seq / latest-issued-wins; (P2) store publishing a stale probe result → per-network refresh-token guard. **Final verdict: CLEAN.** Startup ordering confirmed safe (client reconfiguration remains awaited before WC init and queued-request navigation).

## Manual verification needed

Codex is read-only (cannot run a device). Please verify the cold-boot flow on a real device:
- App launches **without a ~15s stall** of push registration / WalletConnect restore when the selected network's node is slow/unavailable (test on a throttled or unreachable network).
- First balance loads **without a duplicate health check** (HomeScreen reuses the store's status within the TTL).
- **Cold launch on a selected NON-default network** (Algorand) resolves promptly, and a **WalletConnect cold-start request** navigates against the correct network.
