### PR TITLE
perf(startup): parallelize cold-boot storage + auth probe chain (F-03, TASK-177)

### DIFF
--- a/src/contexts/AuthContext.tsx
+++ b/src/contexts/AuthContext.tsx
@@ -27,8 +27,13 @@ const checkBiometricAvailability = async (): Promise<{
   }
   try {
     const LocalAuthentication = require('expo-local-authentication');
-    const hasHardware = await LocalAuthentication.hasHardwareAsync();
-    const isEnrolled = await LocalAuthentication.isEnrolledAsync();
+    // hasHardwareAsync and isEnrolledAsync are independent native reads — run
+    // them concurrently (F-03) instead of serially. A rejection in either still
+    // rejects the Promise.all and is caught below (→ unavailable), unchanged.
+    const [hasHardware, isEnrolled] = await Promise.all([
+      LocalAuthentication.hasHardwareAsync(),
+      LocalAuthentication.isEnrolledAsync(),
+    ]);
     return { hasHardware, isEnrolled };
   } catch {
     return { hasHardware: false, isEnrolled: false };
@@ -162,12 +167,37 @@ export function AuthProvider({ children }: { children: React.ReactNode }) {
 
   const checkInitialAuthState = async () => {
     try {
-      const wallet = await MultiAccountWalletService.getCurrentWallet();
-      const hasPin = await AccountSecureStorage.hasPin();
-      const { hasHardware, isEnrolled } = await checkBiometricAvailability();
-      const biometricEnabled = await AccountSecureStorage.isBiometricEnabled();
+      // Parallelize the independent lock-determining probes (F-03). These five
+      // reads (wallet, PIN presence, biometric hardware/enrollment, biometric
+      // enabled flag, PIN timeout) do not depend on each other, so they run
+      // concurrently instead of as a 7-deep serial await chain. The lock state
+      // computed for every resolved-value input is IDENTICAL to the prior serial
+      // predicate below — only the I/O is parallelized.
+      //
+      // Promise.all, NOT Promise.allSettled: a probe that *rejects* still
+      // propagates to the catch below, leaving the app at its LOCKED default
+      // (isLocked: true / isAuthenticated: false) — exactly as the serial awaits
+      // did. Do NOT switch to allSettled: coercing a rejected hasPin to `false`
+      // would flip a rejecting read into the `!hasPin` unlocked setup state.
+      //
+      // NOTE — pre-existing fail-OPEN, out of scope for this I/O-only change:
+      // hasPin() and getCurrentWallet() catch their OWN storage errors and
+      // resolve falsy (false / null) rather than rejecting (AccountSecureStorage
+      // .hasPin, wallet/index.ts getCurrentWallet), so a storage read *failure*
+      // is indistinguishable here from "no PIN / no wallet" and lands in the
+      // unlocked setup state. That predates this diff and is unchanged by it;
+      // closing it would require an auth/lock SEMANTICS change (surfacing a read
+      // failure as a locked state) that needs human auth sign-off — see TASK-177.
+      const [wallet, hasPin, biometric, biometricEnabled, timeoutMinutes] =
+        await Promise.all([
+          MultiAccountWalletService.getCurrentWallet(),
+          AccountSecureStorage.hasPin(),
+          checkBiometricAvailability(),
+          AccountSecureStorage.isBiometricEnabled(),
+          AccountSecureStorage.getPinTimeout(),
+        ]);
+      const { hasHardware, isEnrolled } = biometric;
       const biometricAvailable = hasHardware && isEnrolled;
-      const timeoutMinutes = await AccountSecureStorage.getPinTimeout();
 
       if (!wallet || wallet.accounts.length === 0 || !hasPin) {
         // No wallet setup yet or no PIN set - allow access for setup

--- a/src/contexts/__tests__/AuthContext.test.tsx
+++ b/src/contexts/__tests__/AuthContext.test.tsx
@@ -204,6 +204,185 @@ describe('AuthContext — initial state', () => {
   });
 });
 
+// ---------------------------------------------------------------------------
+// F-03 (TASK-177): the initial lock-state probes are now parallelized with
+// Promise.all inside checkInitialAuthState. These tests pin the two invariants
+// the parallelization MUST preserve:
+//   (1) REJECTION FAIL-CLOSED — if a lock-determining read (esp. hasPin)
+//       *rejects*, the app stays LOCKED, never in the `!hasPin` unlocked setup
+//       state. Promise.all propagates the rejection to the catch (leaving the
+//       locked default); this guards against a regression to Promise.allSettled,
+//       which would coerce a rejected hasPin to a falsy default and slip into
+//       unlocked setup state.
+//       SCOPE: this is the rejection path ONLY. Production hasPin() /
+//       getCurrentWallet() swallow their OWN storage errors and resolve falsy
+//       (false / null), so a storage *failure* is treated as "no PIN / no
+//       wallet" = unlocked setup state — a PRE-EXISTING fail-open left unchanged
+//       by this I/O-only diff (see the TASK-177 auth-semantics fork). These
+//       tests therefore assert the layer's rejection handling, not an
+//       end-to-end fail-closed guarantee.
+//   (2) PARITY — for every resolved-value input, the computed lock state is
+//       identical to the prior serial logic
+//       (`!wallet || wallet.accounts.length === 0 || !hasPin` ⇒ unlocked setup).
+// ---------------------------------------------------------------------------
+describe('AuthContext — F-03 parallelized probes (rejection fail-closed + parity)', () => {
+  it('stays LOCKED (fail-closed) when the hasPin read REJECTS — never slips into unlocked setup state', async () => {
+    // A wallet-with-accounts is present, so if hasPin were coerced to `false`
+    // (the Promise.allSettled failure mode this guards against) the app would
+    // WRONGLY enter the `!hasPin` unlocked setup branch. The read instead
+    // rejects, so it MUST remain locked.
+    mockWallet.mockResolvedValue(WALLET_WITH_ACCOUNTS);
+    mockHasPin.mockRejectedValue(new Error('keychain read failed'));
+    const errorSpy = jest.spyOn(console, 'error').mockImplementation(() => {});
+
+    const { result } = await mountAuth();
+
+    // Left at the LOCKED default; the unlocked setup state was never entered.
+    expect(result.current.authState.isLocked).toBe(true);
+    expect(result.current.authState.isAuthenticated).toBe(false);
+    expect(errorSpy).toHaveBeenCalled();
+
+    errorSpy.mockRestore();
+  });
+
+  it('stays LOCKED (fail-closed) when the wallet read REJECTS', async () => {
+    mockWallet.mockRejectedValue(new Error('wallet store unavailable'));
+    mockHasPin.mockResolvedValue(true);
+    const errorSpy = jest.spyOn(console, 'error').mockImplementation(() => {});
+
+    const { result } = await mountAuth();
+
+    expect(result.current.authState.isLocked).toBe(true);
+    expect(result.current.authState.isAuthenticated).toBe(false);
+
+    errorSpy.mockRestore();
+  });
+
+  it('stays LOCKED (fail-closed) when the pin-timeout read REJECTS for a wallet-with-PIN', async () => {
+    mockWallet.mockResolvedValue(WALLET_WITH_ACCOUNTS);
+    mockHasPin.mockResolvedValue(true);
+    mockGetPinTimeout.mockRejectedValue(new Error('timeout read failed'));
+    const errorSpy = jest.spyOn(console, 'error').mockImplementation(() => {});
+
+    const { result } = await mountAuth();
+
+    expect(result.current.authState.isLocked).toBe(true);
+    expect(result.current.authState.isAuthenticated).toBe(false);
+
+    errorSpy.mockRestore();
+  });
+
+  it('computes LOCKED for a PIN/passphrase-protected wallet launch', async () => {
+    mockWallet.mockResolvedValue(WALLET_WITH_ACCOUNTS);
+    mockHasPin.mockResolvedValue(true);
+    mockGetPinTimeout.mockResolvedValue('never');
+
+    const { result } = await mountAuth();
+
+    expect(result.current.authState.isLocked).toBe(true);
+    expect(result.current.authState.isAuthenticated).toBe(false);
+    expect(result.current.authState.hasPin).toBe(true);
+    expect(result.current.authState.timeoutMinutes).toBe('never');
+  });
+
+  it('computes LOCKED on a biometric-invalidated launch (enrollment gone) — never unlocks, biometrics disabled', async () => {
+    // Wallet + PIN exist. Biometrics were enabled, but enrollment is now
+    // invalidated (isEnrolledAsync → false): the biometric probe outcome must
+    // NOT change the lock decision. Still LOCKED; biometricEnabled reported off.
+    mockWallet.mockResolvedValue(WALLET_WITH_ACCOUNTS);
+    mockHasPin.mockResolvedValue(true);
+    mockIsBiometricEnabled.mockResolvedValue(true);
+    // One-shot: this mount's single probe returns "not enrolled"; do NOT leak a
+    // persistent override into the biometric-unlock suite that follows.
+    (LocalAuthentication.isEnrolledAsync as jest.Mock).mockResolvedValueOnce(
+      false
+    );
+
+    const { result } = await mountAuth();
+
+    expect(result.current.authState.isLocked).toBe(true);
+    expect(result.current.authState.isAuthenticated).toBe(false);
+    expect(result.current.authState.biometricEnabled).toBe(false);
+  });
+
+  it('computes LOCKED even when the biometric availability probe THROWS (wallet+PIN)', async () => {
+    mockWallet.mockResolvedValue(WALLET_WITH_ACCOUNTS);
+    mockHasPin.mockResolvedValue(true);
+    // One-shot rejection (see above) so the throw does not bleed into later tests.
+    (LocalAuthentication.hasHardwareAsync as jest.Mock).mockRejectedValueOnce(
+      new Error('native biometric probe failed')
+    );
+
+    const { result } = await mountAuth();
+
+    // checkBiometricAvailability swallows the throw → unavailable; the lock
+    // decision is unaffected and stays LOCKED.
+    expect(result.current.authState.isLocked).toBe(true);
+    expect(result.current.authState.isAuthenticated).toBe(false);
+    expect(result.current.authState.biometricEnabled).toBe(false);
+  });
+
+  // Parity table: the parallelized probe chain must compute the SAME lock state
+  // as the documented serial predicate for representative input combinations.
+  const parityCases: {
+    name: string;
+    wallet: unknown;
+    hasPin: boolean;
+    expectedLocked: boolean;
+  }[] = [
+    {
+      name: 'wallet-with-accounts + PIN',
+      wallet: WALLET_WITH_ACCOUNTS,
+      hasPin: true,
+      expectedLocked: true,
+    },
+    {
+      name: 'wallet-with-accounts + no PIN',
+      wallet: WALLET_WITH_ACCOUNTS,
+      hasPin: false,
+      expectedLocked: false,
+    },
+    {
+      name: 'no wallet + PIN',
+      wallet: null,
+      hasPin: true,
+      expectedLocked: false,
+    },
+    {
+      name: 'no wallet + no PIN',
+      wallet: null,
+      hasPin: false,
+      expectedLocked: false,
+    },
+    {
+      name: 'wallet with EMPTY accounts + PIN',
+      wallet: { accounts: [] },
+      hasPin: true,
+      expectedLocked: false,
+    },
+  ];
+
+  it.each(parityCases)(
+    'parity: $name ⇒ locked=$expectedLocked (matches serial logic)',
+    async ({ wallet, hasPin, expectedLocked }) => {
+      mockWallet.mockResolvedValue(wallet as never);
+      mockHasPin.mockResolvedValue(hasPin);
+
+      const { result } = await mountAuth();
+
+      // Recompute the expected lock state from the ORIGINAL serial predicate and
+      // assert both against the hand-authored expectation and the parallel result.
+      const w = wallet as { accounts?: unknown[] } | null;
+      const serialUnlockedSetup =
+        !w || (w.accounts?.length ?? 0) === 0 || !hasPin;
+      expect(serialUnlockedSetup).toBe(!expectedLocked);
+
+      expect(result.current.authState.isLocked).toBe(expectedLocked);
+      expect(result.current.authState.isAuthenticated).toBe(!expectedLocked);
+    }
+  );
+});
+
 describe('AuthContext — PIN unlock', () => {
   it('unlocks with a valid PIN and populates the session vault + lock signal', async () => {
     const { result } = await mountAuth();

--- a/src/navigation/AppNavigator.tsx
+++ b/src/navigation/AppNavigator.tsx
@@ -85,6 +85,7 @@ import {
   getAppModeEarly,
   useRemoteSignerStore,
 } from '@/store/remoteSignerStore';
+import { useWalletStore } from '@/store/walletStore';
 import { RemoteSignerRequest } from '@/types/remoteSigner';
 import SecuritySetupScreen from '@/screens/onboarding/SecuritySetupScreen';
 import AuthGuard from '@/components/AuthGuard';
@@ -1197,6 +1198,17 @@ export default function AppNavigator() {
 
     const initializeServices = async () => {
       try {
+        // Kick off remote-signer store hydration EARLY (F-03 cross-stage
+        // parallelization). Previously it started only once MainTabNavigator
+        // mounted (behind the AppStack render gate), daisy-chaining it after the
+        // first frame. Starting it here runs it concurrently with AppStack's
+        // checkInitialRoute and the service init below. It reuses the same
+        // getAppModeEarly() promise awaited just below, and its initialize() is
+        // coalesced, so the later MainTabNavigator mount-effect call dedupes onto
+        // this in-flight pass rather than starting a second one. Fire-and-forget:
+        // it must not block service init.
+        void useRemoteSignerStore.getState().initialize();
+
         // Get app mode BEFORE initializing network services
         // This avoids a race condition with store hydration
         const appMode = await getAppModeEarly();
@@ -1204,6 +1216,16 @@ export default function AppNavigator() {
 
         // Initialize Network store (needed in both modes for basic config)
         await initializeNetwork();
+
+        // Kick off wallet store hydration EARLY too (F-03). It previously started
+        // only when HomeScreen/AirgapHomeScreen mounted — the last of three
+        // render gates. Starting it here (well ahead of that gate) lets the
+        // wallet/account list + persisted balance cache load during startup.
+        // It is kept AFTER initializeNetwork() on purpose: walletStore.initialize
+        // reads the ACTIVE network to key the balance cache, matching where the
+        // Home mount effect ran it (always post-network-init). Its initialize()
+        // coalescer dedupes the later Home mount-effect call. Fire-and-forget.
+        void useWalletStore.getState().initialize();
 
         // Variables for cleanup - only defined if services are initialized
         let wcService: WalletConnectService | null = null;

--- a/src/store/remoteSignerStore.ts
+++ b/src/store/remoteSignerStore.ts
@@ -23,6 +23,16 @@ const STORAGE_KEYS = {
 // Module-level promise for early mode detection (before store hydration)
 let appModePromise: Promise<AppMode> | null = null;
 
+// Coalescer for the remote-signer store initialize(): a single shared in-flight
+// promise so overlapping initialize() calls dedupe into ONE hydration pass. With
+// F-03 the store is kicked off early from AppNavigator's mount effect AND from
+// the MainTabNavigator / HomeScreen / RemoteSignerSettings mount effects; without
+// this guard those concurrent calls would each run a full read+set pass. Reset on
+// settle (see the finally below), so a later explicit initialize() still
+// re-hydrates. Module-level (not a store field) so it survives the store's own
+// state resets.
+let remoteSignerInitializationPromise: Promise<void> | null = null;
+
 // Bounded retry for the replay-guard persistence so a transient native write
 // failure (e.g. momentary disk pressure) does not silently drop a processed id.
 const PROCESSED_PERSIST_MAX_ATTEMPTS = 3;
@@ -203,23 +213,38 @@ export const useRemoteSignerStore = create<RemoteSignerState>()(
 
     // ============ Initialization ============
     initialize: async () => {
-      try {
-        // Load app mode
-        const storedMode = await AsyncStorage.getItem(STORAGE_KEYS.APP_MODE);
-        const appMode: AppMode = storedMode === 'signer' ? 'signer' : 'wallet';
+      // Coalesce concurrent initialize() calls into a single hydration pass (see
+      // the remoteSignerInitializationPromise comment above). Share the in-flight
+      // promise instead of starting a second full read+set pass.
+      if (remoteSignerInitializationPromise) {
+        return remoteSignerInitializationPromise;
+      }
 
-        // Load signer config (if exists)
-        const storedConfig = await AsyncStorage.getItem(
-          STORAGE_KEYS.SIGNER_CONFIG
-        );
+      let resolveInitialization: () => void = () => {};
+      remoteSignerInitializationPromise = new Promise<void>((resolve) => {
+        resolveInitialization = resolve;
+      });
+
+      try {
+        // Batch the independent cold-boot reads (F-03). APP_MODE reuses the
+        // promise getAppModeEarly() already cached at startup — AppNavigator
+        // awaits it before this store can mount — instead of re-reading the same
+        // key. The remaining three keys are mutually independent, so they load
+        // concurrently rather than in a 4-deep serial await chain.
+        const [appMode, storedConfig, storedSigners, storedProcessed] =
+          await Promise.all([
+            getAppModeEarly(),
+            AsyncStorage.getItem(STORAGE_KEYS.SIGNER_CONFIG),
+            AsyncStorage.getItem(STORAGE_KEYS.PAIRED_SIGNERS),
+            AsyncStorage.getItem(STORAGE_KEYS.PROCESSED_REQUESTS),
+          ]);
+
+        // Parse signer config (if exists)
         const signerConfig: SignerDeviceConfig | null = storedConfig
           ? JSON.parse(storedConfig)
           : null;
 
-        // Load paired signers
-        const storedSigners = await AsyncStorage.getItem(
-          STORAGE_KEYS.PAIRED_SIGNERS
-        );
+        // Parse paired signers
         const pairedSigners = new Map<string, SignerDeviceInfo>(
           storedSigners ? JSON.parse(storedSigners) : []
         );
@@ -227,11 +252,10 @@ export const useRemoteSignerStore = create<RemoteSignerState>()(
         // Load processed requests (for replay prevention in signer mode). UNION
         // with any ids already in memory rather than replacing: a
         // markRequestProcessed that lands during this async hydration must not
-        // be dropped (which would let that id replay). Union keeps both the
+        // be dropped (which would let that id replay). Reading the in-memory set
+        // AFTER the awaits above (unchanged from the serial version) is what
+        // captures a mark that landed while we were loading. Union keeps both the
         // persisted history and any just-marked id.
-        const storedProcessed = await AsyncStorage.getItem(
-          STORAGE_KEYS.PROCESSED_REQUESTS
-        );
         const inMemoryIds = get().processedRequestIds;
         const processedRequestIds = new Set<string>([
           ...inMemoryIds,
@@ -262,6 +286,11 @@ export const useRemoteSignerStore = create<RemoteSignerState>()(
       } catch (error) {
         console.error('[RemoteSignerStore] Failed to initialize:', error);
         set({ isInitialized: true });
+      } finally {
+        // Reset the coalescer on settle so a later explicit initialize()
+        // re-hydrates, and resolve the shared promise for any coalesced caller.
+        remoteSignerInitializationPromise = null;
+        resolveInitialization();
       }
     },
 

--- a/src/store/walletStore.ts
+++ b/src/store/walletStore.ts
@@ -469,27 +469,51 @@ export const useWalletStore = create<WalletState>()(
       try {
         set({ isLoading: true, lastError: null });
 
-        // Load persisted asset network filter
-        try {
-          const persistedFilter = await AsyncStorage.getItem(
-            '@wallet-asset-network-filter'
-          );
-          if (
-            persistedFilter &&
-            ['all', 'voi', 'algorand'].includes(persistedFilter)
-          ) {
-            set({
-              assetNetworkFilter: persistedFilter as 'all' | 'voi' | 'algorand',
-            });
-          }
-        } catch (error) {
-          console.warn('Failed to load persisted asset network filter:', error);
+        // Batch the three mutually-independent cold-boot reads (F-03): the asset
+        // network filter, the asset filter settings (which is itself internally a
+        // single Promise.all over its keys), and the current wallet. They gated
+        // each other only through serial awaits, so they run concurrently here.
+        //
+        // The filter/settings reads keep their ORIGINAL non-fatal semantics: a
+        // failure warns and falls back to defaults WITHOUT aborting wallet load.
+        // They are wrapped in `.catch(() => sentinel)` so they never reject the
+        // Promise.all. getCurrentWallet() is intentionally NOT wrapped, so its
+        // rejection still propagates to the outer catch (lastError), exactly as
+        // when it was the third serial await.
+        //
+        // Balance-cache loads remain STRICTLY AFTER this — they key into the
+        // resolved account list and depend on it, so they must not race ahead of
+        // getCurrentWallet.
+        const [persistedFilter, filterSettings, wallet] = await Promise.all([
+          AsyncStorage.getItem('@wallet-asset-network-filter').catch(
+            (error) => {
+              console.warn(
+                'Failed to load persisted asset network filter:',
+                error
+              );
+              return null;
+            }
+          ),
+          AssetFilterStorage.loadAssetFilterSettings().catch((error) => {
+            console.warn(
+              'Failed to load persisted asset filter settings:',
+              error
+            );
+            return null;
+          }),
+          MultiAccountWalletService.getCurrentWallet(),
+        ]);
+
+        if (
+          persistedFilter &&
+          ['all', 'voi', 'algorand'].includes(persistedFilter)
+        ) {
+          set({
+            assetNetworkFilter: persistedFilter as 'all' | 'voi' | 'algorand',
+          });
         }
 
-        // Load persisted asset filter settings
-        try {
-          const filterSettings =
-            await AssetFilterStorage.loadAssetFilterSettings();
+        if (filterSettings) {
           set({
             assetSortBy: filterSettings.sortBy,
             assetSortOrder: filterSettings.sortOrder,
@@ -497,14 +521,7 @@ export const useWalletStore = create<WalletState>()(
             assetFilterValueThreshold: filterSettings.valueThreshold,
             assetNativeTokensFirst: filterSettings.nativeTokensFirst,
           });
-        } catch (error) {
-          console.warn(
-            'Failed to load persisted asset filter settings:',
-            error
-          );
         }
-
-        const wallet = await MultiAccountWalletService.getCurrentWallet();
 
         if (wallet) {
           // Initialize account states


### PR DESCRIPTION
## What & why

Cold boot serialized ~9-12 storage/keychain round-trips across three never-overlapping render-gate stages before the first meaningful frame (F-03, TASK-177). This batches the independent reads into ~3 parallel groups and starts the store hydrations early, cutting ~100-300ms of avoidable blank-screen time on every cold boot. Pure JS / OTA-shippable. **Faithful I/O-only change: the lock state computed for every input is identical to the prior serial logic.**

### Changes
- **`remoteSignerStore.initialize`**: reuse `getAppModeEarly()`'s already-cached `appModePromise` for `APP_MODE` and `Promise.all` the other 3 independent `AsyncStorage` reads (was a 4-deep serial await chain). Added an in-flight coalescer (mirrors the existing `walletStore` one) so the new early kickoff dedupes with the `MainTabNavigator` / `HomeScreen` / `RemoteSignerSettings` mount-effect calls. The mid-hydration replay-guard union (read `get().processedRequestIds` **after** the awaits) is preserved exactly.
- **`walletStore.initialize`**: `Promise.all` the 3 genuinely-independent reads (asset network filter, asset filter settings, `getCurrentWallet`), each filter/settings read keeping its original **non-fatal** semantics via `.catch(() => sentinel)`; `getCurrentWallet` rejection still propagates to the outer catch (`lastError`) as before. Account-dependent balance-cache loads remain **strictly after** the resolved wallet/account list. The existing `initialize()` coalescer and `assetFilterStorage`'s internal `Promise.all` were left untouched.
- **`AuthContext.checkInitialAuthState`**: `Promise.all` the 5 independent probes (`getCurrentWallet`, `hasPin`, biometric hardware+enrollment, `isBiometricEnabled`, `getPinTimeout`) plus the 2 biometric probes inside `checkBiometricAvailability`, then compute lock state **atomically**. Lock decision (`!wallet || wallet.accounts.length === 0 || !hasPin`) is byte-identical to the prior serial code.
- **`AppNavigator` mount effect**: kick off `remoteSignerStore.initialize()` and `walletStore.initialize()` concurrently/early (fire-and-forget) instead of daisy-chaining each behind the prior render gate. `walletStore.initialize()` is kept **after** `initializeNetwork()` so the active-network balance-cache keying is unchanged. No serial network await reintroduced — F-04's non-blocking network init is untouched.

## Auth guarantee (what this PR actually provides)
`checkInitialAuthState` uses **`Promise.all`, never `Promise.allSettled`**: a probe that **rejects** still propagates to the existing `catch`, leaving the app at its **LOCKED** default — exactly as the serial `await`s did. The parallelization changes no lock/biometric state for any resolved-value input. **No biometric prompt was added** (it still lives only in `unlockWithBiometrics`).

## ⚠️ Pre-existing auth-semantics fork (NOT fixed here — needs human sign-off)
Codex review surfaced that production `hasPin()` (`AccountSecureStorage.ts`) and `getCurrentWallet()` (`services/wallet/index.ts`) **catch their own storage errors and resolve falsy** (`false` / `null`) rather than rejecting. So a genuine storage **read failure** is indistinguishable from "no PIN / no wallet" and lands in the **unlocked setup state** — a **fail-OPEN**. This predates this diff and is **unchanged** by it (the serial code did the identical thing). Closing it truly (surfacing a read failure as a *locked* state) is an **auth/lock semantics change**, which per the TASK-177 hard constraint I did **not** implement without human auth sign-off. Flagging for a decision/follow-up task. The tests below therefore assert this layer's **rejection** handling + serial parity, not an end-to-end fail-closed guarantee.

## Tests added (`AuthContext.test.tsx`, +8)
- Rejected `hasPin` read (wallet-with-accounts present) → stays **LOCKED**, never unlocked setup (guards against an `allSettled` regression).
- Rejected `getCurrentWallet` read → stays LOCKED.
- Rejected `getPinTimeout` read for a wallet-with-PIN → stays LOCKED.
- Locked PIN/passphrase launch → correct locked state (incl. `timeoutMinutes: 'never'`).
- Biometric-invalidated launch (enrollment gone) → stays LOCKED, biometrics reported off.
- Biometric availability probe throws → stays LOCKED.
- Serial-parity table (`it.each`): 5 representative `{wallet, hasPin}` inputs assert the parallel result matches the original serial predicate.

## Gate results
- `npm run typecheck` — **0 errors**
- `npm run lint` — **0 errors** (pre-existing warnings only)
- `npm test -- --ci` — **1039 passed / 60 suites** (AuthContext 32; remoteSignerStore 33 incl. re-hydration/replay through the new parallel path)

## Codex verdict
**CLEAN** (round 2). Round 1 raised the fail-open overclaim above; the code comment, test header, and commit message were reworded to accurately scope the rejection-path guarantee and flag the pre-existing fail-open. Codex is read-only (no tsc/jest) — gates above are authoritative.

## Manual verification needed
Cold boot into each and confirm the correct lock screen appears and the first frame is faster:
- Fresh install (no wallet) → Onboarding / unlocked setup.
- Locked-with-PIN wallet → Lock screen (PIN/passphrase).
- Biometric-enabled wallet → Lock screen offers biometrics (prompt only on user action, not at boot).
- Remote-signer mode → Airgap home renders with the correct mode.
