### PR TITLE
perf(startup): enable Metro inlineRequires + code-split rarely-used screens (F-01, TASK-176)

### DIFF
--- a/metro.config.js
+++ b/metro.config.js
@@ -1,4 +1,5 @@
 const { getDefaultConfig } = require('expo/metro-config');
+const { NON_INLINED_REQUIRES } = require('./metro.inlineRequires');
 
 const config = getDefaultConfig(__dirname);
 
@@ -11,5 +12,26 @@ config.resolver.alias = {
 
 // Ensure these modules are resolved
 config.resolver.platforms = ['native', 'web', 'default'];
+
+// F-01 (TASK-176): enable Metro inline requires so per-module factories evaluate
+// on first use instead of eagerly at cold boot, cutting time-to-first-frame.
+// Expo SDK 54 ships this OFF (inlineRequires:false, ExpoMetroConfig.js:319-323);
+// experimentalImportSupport is already ON in Expo's default, so we preserve it
+// and flip inlineRequires on.
+//
+// CRITICAL: inlineRequires must NOT defer bootstrap side-effect modules whose
+// evaluation order is load-bearing — index.ts installs the crypto polyfills
+// BEFORE anything that touches algosdk, and client.ts side-effect-imports
+// @walletconnect/react-native-compat. `nonInlinedRequires` pins those eager.
+// NOTE: supplying this array REPLACES Metro's built-in default ignore list, so
+// NON_INLINED_REQUIRES re-includes Metro's base entries (React/react-native/…).
+// See ./metro.inlineRequires.js for the allowlist + rationale.
+config.transformer.getTransformOptions = async () => ({
+  transform: {
+    experimentalImportSupport: true,
+    inlineRequires: true,
+    nonInlinedRequires: NON_INLINED_REQUIRES,
+  },
+});
 
 module.exports = config;

--- a/metro.inlineRequires.js
+++ b/metro.inlineRequires.js
@@ -1,0 +1,45 @@
+// F-01 (TASK-176) — inlineRequires side-effect allowlist.
+//
+// When metro.config.js supplies `transform.nonInlinedRequires`, it REPLACES
+// Metro's built-in default list (metro/src/lib/transformHelpers.js
+// `baseIgnoredInlineRequires`) rather than extending it. So this array must
+// re-include Metro's base entries AND add the app's bootstrap side-effect
+// modules that must never be deferred.
+//
+// Shared between metro.config.js (the real bundler config) and its regression
+// test so the two can never drift.
+
+// Metro's own defaults — re-listed because supplying nonInlinedRequires drops
+// them. React/react-native are referenced from nearly every module and must not
+// be inline-deferred.
+const METRO_BASE_NON_INLINED = [
+  'React',
+  'react',
+  'react/jsx-dev-runtime',
+  'react/jsx-runtime',
+  'react-compiler-runtime',
+  'react-native',
+];
+
+// Bootstrap / side-effect polyfill modules whose evaluation ORDER is
+// load-bearing. index.ts installs the crypto polyfills BEFORE anything that
+// touches algosdk; @walletconnect/react-native-compat installs WC globals.
+// inlineRequires must keep these eager so require-time side effects still run in
+// source order. See index.ts (2/3/9) and src/services/walletconnect/client.ts:3.
+const BOOTSTRAP_SIDE_EFFECT_MODULES = [
+  'react-native-get-random-values', // index.ts:2 — crypto.getRandomValues polyfill
+  'buffer', // index.ts:3 — global.Buffer for algosdk
+  './src/utils/polyfills', // index.ts:9 — atob/btoa/TextEncoder/streams/url polyfills
+  '@walletconnect/react-native-compat', // client.ts:3 — WalletConnect RN globals
+];
+
+const NON_INLINED_REQUIRES = [
+  ...METRO_BASE_NON_INLINED,
+  ...BOOTSTRAP_SIDE_EFFECT_MODULES,
+];
+
+module.exports = {
+  NON_INLINED_REQUIRES,
+  METRO_BASE_NON_INLINED,
+  BOOTSTRAP_SIDE_EFFECT_MODULES,
+};

--- a/src/config/__tests__/metroInlineRequires.test.ts
+++ b/src/config/__tests__/metroInlineRequires.test.ts
@@ -1,0 +1,58 @@
+/**
+ * F-01 (TASK-176) regression guard for the Metro inlineRequires side-effect
+ * allowlist. inlineRequires must never defer the bootstrap polyfill modules that
+ * index.ts relies on running in source order (crypto polyfills BEFORE algosdk),
+ * nor @walletconnect/react-native-compat. This test fails if the allowlist loses
+ * a bootstrap module, or if metro.config.js stops wiring it into inlineRequires.
+ */
+import { readFileSync } from 'fs';
+import { resolve } from 'path';
+
+// Plain-CJS module shared with metro.config.js. require() keeps tsc from needing
+// a declaration file for the root config module.
+// eslint-disable-next-line @typescript-eslint/no-require-imports
+const inlineRequiresConfig = require('../../../metro.inlineRequires') as {
+  NON_INLINED_REQUIRES: string[];
+  METRO_BASE_NON_INLINED: string[];
+  BOOTSTRAP_SIDE_EFFECT_MODULES: string[];
+};
+const {
+  NON_INLINED_REQUIRES,
+  METRO_BASE_NON_INLINED,
+  BOOTSTRAP_SIDE_EFFECT_MODULES,
+} = inlineRequiresConfig;
+
+describe('Metro inlineRequires allowlist (F-01)', () => {
+  it('pins every bootstrap side-effect module eager', () => {
+    // These are the modules whose require-time side effects are order-sensitive.
+    // Losing any one from the allowlist risks inlineRequires deferring it and
+    // breaking index.ts crypto-before-algosdk ordering.
+    for (const mod of [
+      'react-native-get-random-values',
+      'buffer',
+      './src/utils/polyfills',
+      '@walletconnect/react-native-compat',
+    ]) {
+      expect(BOOTSTRAP_SIDE_EFFECT_MODULES).toContain(mod);
+      expect(NON_INLINED_REQUIRES).toContain(mod);
+    }
+  });
+
+  it("re-includes Metro's base ignore list (supplying nonInlinedRequires replaces it)", () => {
+    // Supplying transform.nonInlinedRequires REPLACES Metro's built-in default
+    // list, so React/react-native must be re-listed or they'd become deferrable.
+    for (const mod of ['React', 'react', 'react-native']) {
+      expect(METRO_BASE_NON_INLINED).toContain(mod);
+      expect(NON_INLINED_REQUIRES).toContain(mod);
+    }
+  });
+
+  it('is wired into metro.config.js with inlineRequires enabled', () => {
+    const configSource = readFileSync(
+      resolve(__dirname, '../../../metro.config.js'),
+      'utf8'
+    );
+    expect(configSource).toContain('inlineRequires: true');
+    expect(configSource).toContain('nonInlinedRequires: NON_INLINED_REQUIRES');
+  });
+});

--- a/src/navigation/AppNavigator.tsx
+++ b/src/navigation/AppNavigator.tsx
@@ -1,4 +1,10 @@
-import React, { useEffect, useState, useRef, useCallback } from 'react';
+import React, {
+  useEffect,
+  useState,
+  useRef,
+  useCallback,
+  Suspense,
+} from 'react';
 import {
   NavigationContainer,
   StackActions,
@@ -29,14 +35,10 @@ import MultiNetworkAssetScreen from '@/screens/wallet/MultiNetworkAssetScreen';
 import TransactionDetailScreen from '@/screens/wallet/TransactionDetailScreen';
 import WebViewScreen from '@/screens/wallet/WebViewScreen';
 import SendScreen from '@/screens/wallet/SendScreen';
-import SwapScreen from '@/screens/wallet/SwapScreen';
 import TransactionConfirmationScreen from '@/screens/wallet/TransactionConfirmationScreen';
 import TransactionResultScreen from '@/screens/wallet/TransactionResultScreen';
 import UniversalTransactionSigningScreen from '@/screens/wallet/UniversalTransactionSigningScreen';
 import ReceiveScreen from '@/screens/wallet/ReceiveScreen';
-import ClaimableTokensScreen from '@/screens/wallet/ClaimableTokensScreen';
-import ClaimTokenScreen from '@/screens/wallet/ClaimTokenScreen';
-import ClaimAllConfirmationScreen from '@/screens/wallet/ClaimAllConfirmationScreen';
 import DiscoverScreen from '@/screens/wallet/DiscoverScreen';
 import NFTScreen from '@/screens/wallet/NFTScreen';
 import NFTDetailScreen from '@/screens/wallet/NFTDetailScreen';
@@ -55,27 +57,9 @@ import CreateAccountScreen from '@/screens/account/CreateAccountScreen';
 import MnemonicImportScreen from '@/screens/account/MnemonicImportScreen';
 import RekeyAccountScreen from '@/screens/wallet/RekeyAccountScreen';
 import OnboardingScreen from '@/screens/onboarding/OnboardingScreen';
-import SessionProposalScreen from '@/screens/walletconnect/SessionProposalScreen';
-import SessionsScreen from '@/screens/walletconnect/SessionsScreen';
-import TransactionRequestScreen from '@/screens/walletconnect/TransactionRequestScreen';
-import QRScannerScreen from '@/screens/walletconnect/QRScannerScreen';
-import WalletConnectPairingScreen from '@/screens/walletconnect/WalletConnectPairingScreen';
-import WalletConnectErrorScreen from '@/screens/walletconnect/WalletConnectErrorScreen';
 import QRAccountImportScreen from '@/screens/account/QRAccountImportScreen';
 import AccountImportPreviewScreen from '@/screens/account/AccountImportPreviewScreen';
-import LedgerAccountImportScreen from '@/screens/account/LedgerAccountImportScreen';
 import CreateWalletScreen from '@/screens/onboarding/CreateWalletScreen';
-// Remote Signer screens
-import {
-  AirgapHomeScreen,
-  ExportAccountsScreen,
-  ImportRemoteSignerScreen,
-  RemoteSignerSettingsScreen,
-  SignRequestScannerScreen,
-  TransactionReviewScreen,
-  SignatureDisplayScreen,
-  ImportFromOnlineWalletScreen,
-} from '@/screens/remoteSigner';
 // ARC-0090 transaction screens
 import KeyregConfirmScreen from '@/screens/transaction/KeyregConfirmScreen';
 import AppCallConfirmScreen from '@/screens/transaction/AppCallConfirmScreen';
@@ -98,7 +82,6 @@ import { ledgerTransportService } from '@/services/ledger/transport';
 import { isWalletConnectUri } from '@/services/walletconnect/utils';
 import { useNetworkStore } from '@/store/networkStore';
 import { notificationService } from '@/services/notifications';
-import { realtimeService } from '@/services/realtime';
 import { NetworkId } from '@/types/network';
 import { TransactionInfo, WalletAccount } from '@/types/wallet';
 import { ScannedAccount } from '@/utils/accountQRParser';
@@ -121,6 +104,108 @@ import MyProfileScreen from '@/screens/social/MyProfileScreen';
 import MessagesInboxScreen from '@/screens/social/MessagesInboxScreen';
 import NewMessageScreen from '@/screens/social/NewMessageScreen';
 import ChatScreen from '@/screens/social/ChatScreen';
+
+// ---------------------------------------------------------------------------
+// Code-split rarely-used screen clusters (F-01, TASK-176)
+//
+// These clusters pull in the heaviest / least-used slices of the module graph
+// (WalletConnect ↔ @walletconnect, Swap ↔ @txnlab/deflex, remote-signer,
+// Ledger import, claim flows). Loading them with React.lazy defers their module
+// factories to first navigation instead of evaluating them at cold boot, which
+// is the module-graph cost F-01 targets. HomeScreen + core navigation stay
+// eager. NOTE: this defers the SCREEN modules only; the ledger transport service
+// (imported at module scope below) and the realtime singleton (pulled via
+// walletStore) are deferred by separate tasks (TASK-180 / realtime scoping).
+//
+// Each lazy screen needs its own Suspense boundary: native-stack does not
+// provide one, and a suspended component without a boundary throws. The split
+// module resolves from the already-loaded production bundle within ~a frame, so
+// a neutral transparent fallback avoids a visible flash without theme coupling.
+function LazyScreenFallback() {
+  return <View style={{ flex: 1 }} />;
+}
+
+// Return type is intentionally inferred as a function component: annotating it as
+// React.ComponentType<P> would union in ComponentClass<P>, which fails React
+// Navigation's ScreenComponentType variance check for screens that take a
+// required `navigation` prop without `route`.
+function lazyScreen<P extends object>(
+  factory: () => Promise<{ default: React.ComponentType<P> }>
+) {
+  const LazyComponent = React.lazy(factory);
+  return function SuspendedScreen(props: P) {
+    return (
+      <Suspense fallback={<LazyScreenFallback />}>
+        <LazyComponent {...props} />
+      </Suspense>
+    );
+  };
+}
+
+// Swap (→ services/swap → @txnlab/deflex)
+const SwapScreen = lazyScreen(() => import('@/screens/wallet/SwapScreen'));
+
+// Claim flows
+const ClaimableTokensScreen = lazyScreen(
+  () => import('@/screens/wallet/ClaimableTokensScreen')
+);
+const ClaimTokenScreen = lazyScreen(
+  () => import('@/screens/wallet/ClaimTokenScreen')
+);
+const ClaimAllConfirmationScreen = lazyScreen(
+  () => import('@/screens/wallet/ClaimAllConfirmationScreen')
+);
+
+// WalletConnect screens (→ @walletconnect/*)
+const SessionProposalScreen = lazyScreen(
+  () => import('@/screens/walletconnect/SessionProposalScreen')
+);
+const SessionsScreen = lazyScreen(
+  () => import('@/screens/walletconnect/SessionsScreen')
+);
+const TransactionRequestScreen = lazyScreen(
+  () => import('@/screens/walletconnect/TransactionRequestScreen')
+);
+const QRScannerScreen = lazyScreen(
+  () => import('@/screens/walletconnect/QRScannerScreen')
+);
+const WalletConnectPairingScreen = lazyScreen(
+  () => import('@/screens/walletconnect/WalletConnectPairingScreen')
+);
+const WalletConnectErrorScreen = lazyScreen(
+  () => import('@/screens/walletconnect/WalletConnectErrorScreen')
+);
+
+// Ledger import screen (screen module only; transport service import is TASK-180)
+const LedgerAccountImportScreen = lazyScreen(
+  () => import('@/screens/account/LedgerAccountImportScreen')
+);
+
+// Remote Signer screens
+const AirgapHomeScreen = lazyScreen(
+  () => import('@/screens/remoteSigner/AirgapHomeScreen')
+);
+const ExportAccountsScreen = lazyScreen(
+  () => import('@/screens/remoteSigner/ExportAccountsScreen')
+);
+const ImportRemoteSignerScreen = lazyScreen(
+  () => import('@/screens/remoteSigner/ImportRemoteSignerScreen')
+);
+const RemoteSignerSettingsScreen = lazyScreen(
+  () => import('@/screens/remoteSigner/RemoteSignerSettingsScreen')
+);
+const SignRequestScannerScreen = lazyScreen(
+  () => import('@/screens/remoteSigner/SignRequestScannerScreen')
+);
+const TransactionReviewScreen = lazyScreen(
+  () => import('@/screens/remoteSigner/TransactionReviewScreen')
+);
+const SignatureDisplayScreen = lazyScreen(
+  () => import('@/screens/remoteSigner/SignatureDisplayScreen')
+);
+const ImportFromOnlineWalletScreen = lazyScreen(
+  () => import('@/screens/remoteSigner/ImportFromOnlineWalletScreen')
+);
 
 export type RootStackParamList = {
   Main: NavigatorScreenParams<MainTabParamList> | undefined;


### PR DESCRIPTION
## What / why

Reduces cold-boot **module-graph evaluation** cost (F-01, **TASK-176** — P1, startup, OTA-shippable). Today Expo SDK 54 ships `inlineRequires: false`, and `AppNavigator.tsx` statically imports ~60 screen modules plus the heaviest deps in the tree (@walletconnect, algosdk, @supabase, @ledgerhq), so every module factory executes on the JS thread at every cold boot — before the first frame — including features most sessions never touch.

Two complementary changes:

1. **Enable Metro `inlineRequires`** in `metro.config.js` so per-module factories evaluate on first use instead of eagerly at require time. `experimentalImportSupport` is already ON in Expo's default; we preserve it and flip `inlineRequires` on.
2. **Code-split rarely-used screen clusters** with `React.lazy(() => import(...))` + a per-screen `<Suspense>` boundary: WalletConnect screens, remote-signer screens, Swap, the Ledger-import screen, and claim flows. HomeScreen + core navigation stay eager.

Plus: delete the dead `realtimeService` import in `AppNavigator.tsx`.

## `nonInlinedRequires` allowlist rationale (the risky bit)

`inlineRequires` must **not** defer bootstrap side-effect modules whose evaluation **order** is load-bearing — `index.ts` installs the crypto polyfills **before** anything touches algosdk, and `client.ts` side-effect-imports `@walletconnect/react-native-compat`. A `nonInlinedRequires` allowlist pins those eager:

- `react-native-get-random-values` (index.ts:2 — `crypto.getRandomValues`)
- `buffer` (index.ts:3 — `global.Buffer` for algosdk)
- `./src/utils/polyfills` (index.ts:9 — atob/btoa/TextEncoder/streams/url)
- `@walletconnect/react-native-compat` (client.ts:3 — WalletConnect RN globals)

Important Metro detail: supplying `transform.nonInlinedRequires` **replaces** Metro's built-in default ignore list rather than extending it, so the shared allowlist also re-includes Metro's base entries (`React`, `react`, `react-native`, jsx runtimes, `react-compiler-runtime`). The allowlist lives in `metro.inlineRequires.js` (shared with a regression test so config + test can't drift).

`index.ts` polyfill ordering is preserved exactly (unchanged file).

## Files changed

- `metro.config.js` — enable `inlineRequires` + wire the allowlist.
- `metro.inlineRequires.js` (new) — shared, documented allowlist.
- `src/navigation/AppNavigator.tsx` — `React.lazy` + `<Suspense>` for the 5 clusters; delete dead `realtimeService` import.
- `src/config/__tests__/metroInlineRequires.test.ts` (new) — regression guard for the allowlist + `inlineRequires` wiring.

## Lazily-loaded screen clusters

- **WalletConnect:** SessionProposal, Sessions, TransactionRequest, QRScanner, WalletConnectPairing, WalletConnectError
- **Remote-signer:** AirgapHome, ExportAccounts, ImportRemoteSigner, RemoteSignerSettings, SignRequestScanner, TransactionReview, SignatureDisplay, ImportFromOnlineWallet
- **Swap:** SwapScreen
- **Ledger import:** LedgerAccountImportScreen (screen module only — the `ledgerTransportService` import is intentionally left for **TASK-180**)
- **Claim flows:** ClaimableTokens, ClaimToken, ClaimAllConfirmation

Note: deleting the dead `realtimeService` import is cleanliness only — the realtime singleton is still pulled transitively via `HomeScreen → walletStore`, so this is **not** claimed as the perf win (scoped separately).

## Gate results

| Gate | Result |
| --- | --- |
| `npm run typecheck` | 0 errors |
| `npm run lint` | 0 errors (676 pre-existing baseline warnings, unchanged) |
| `npm test -- --ci` | 61 suites / **1042 tests pass** (incl. 3 new allowlist tests) |
| **iOS production bundle smoke** (`expo export --platform ios`) | **PASS** — `Bundled index.ts (3591 modules)`, 15 MB Hermes bytecode bundle emitted, no bundling/resolution error |

The bundle-smoke gate is the key check for this task: it catches require-ordering / module-resolution / cycle breakage that `inlineRequires` + dynamic `import()` can introduce, without a device.

## Codex self-review verdict: **CLEAN**

> - Bootstrap side-effect modules are covered or bare imports (not inlineable); crypto polyfills execute before `App`.
> - Lazy screens each have local `Suspense`; default exports and navigation typing pass `tsc --noEmit`.
> - No new runtime cycle found across WalletConnect, signing, or remote-signer boundaries.
> - Removing the direct realtime import does not change initialization: `walletStore` still imports the singleton.

## On-device verification REQUIRED before merge

This is the riskiest task in the plan (inlineRequires can reorder polyfill/side-effect evaluation). Automated gates + bundle-smoke are green, but the following must be verified in a **fresh process** on-device before merging:

- [ ] **Cold boot + first frame** renders correctly.
- [ ] **Sign a transaction** — confirms crypto/polyfill ordering is intact (algosdk sees `getRandomValues`/`Buffer`).
- [ ] **WalletConnect** pairing + a transaction request round-trip.
- [ ] **Remote-signer mode** (airgap): enter signer mode, scan/sign a request.
- [ ] Navigate into each **lazily-loaded cluster** and confirm it loads without a stuck fallback: WalletConnect screens, Swap, Ledger import, claim flows.

Do **not** merge until the above are checked.
