### PR TITLE
feat(startup): control splash screen through init cascade (F-48, TASK-182)

### DIFF
--- a/app.config.js
+++ b/app.config.js
@@ -13,7 +13,7 @@ export default {
   "expo": {
     "name": IS_DEV ? "Voi Wallet (Dev)" : "Voi Wallet",
     "slug": "voi-wallet",
-    "version": "0.1.10",
+    "version": "0.1.11",
     "orientation": "portrait",
     "icon": "./assets/voi_wallet_logo.png",
     "userInterfaceStyle": "automatic",
@@ -48,7 +48,7 @@ export default {
       "supportsTablet": true,
       "jsEngine": "hermes",
       "bundleIdentifier": IS_DEV ? "com.voinetwork.wallet.dev" : "com.voinetwork.wallet",
-      "buildNumber": "22",
+      "buildNumber": "23",
       "icon": "./assets/voi_wallet_logo.png",
       "splash": {
         "image": "./assets/voi_wallet_logo.png",
@@ -84,7 +84,7 @@ export default {
       "predictiveBackGestureEnabled": false,
       "package": IS_DEV ? "com.voinetwork.wallet.dev" : "com.voinetwork.wallet",
       "googleServicesFile": IS_DEV ? "./google-services-dev.json" : "./google-services.json",
-      "versionCode": 22,
+      "versionCode": 23,
       "permissions": [
         "CAMERA",
         "USE_BIOMETRIC",

--- a/index.ts
+++ b/index.ts
@@ -8,6 +8,21 @@ global.Buffer = Buffer;
 // Import WalletConnect polyfills
 import './src/utils/polyfills';
 
+// Keep the branded native splash up through the whole cold-boot init cascade
+// (F-48, TASK-182). preventAutoHideAsync() MUST run at module scope, before the
+// first RN frame renders. It is placed AFTER the crypto polyfills above on
+// purpose: it uses no crypto, so their global setup (get-random-values, Buffer,
+// WC polyfills) still runs first. hideSplashScreen() (readiness owner in
+// AppStack) tears the splash down once the first real content frame is ready;
+// the watchdog is a last-resort safety net so a hang can never trap the user.
+import * as SplashScreen from 'expo-splash-screen';
+import { armSplashWatchdog } from './src/utils/splashController';
+
+// Best-effort: rejects on platforms without the native module (web); the app
+// must still boot, so swallow. armSplashWatchdog guarantees an eventual hide.
+SplashScreen.preventAutoHideAsync().catch(() => {});
+armSplashWatchdog();
+
 import { registerRootComponent } from 'expo';
 
 import App from './App';

--- a/package-lock.json
+++ b/package-lock.json
@@ -52,6 +52,7 @@
         "expo-screen-capture": "~8.0.9",
         "expo-secure-store": "~15.0.8",
         "expo-sharing": "~14.0.8",
+        "expo-splash-screen": "~31.0.13",
         "expo-status-bar": "~3.0.9",
         "expo-system-ui": "~6.0.9",
         "expo-updates": "~29.0.15",
@@ -10251,6 +10252,18 @@
       "resolved": "https://registry.npmjs.org/expo-sharing/-/expo-sharing-14.0.8.tgz",
       "integrity": "sha512-A1pPr2iBrxypFDCWVAESk532HK+db7MFXbvO2sCV9ienaFXAk7lIBm6bkqgE6vzRd9O3RGdEGzYx80cYlc089Q==",
       "license": "MIT",
+      "peerDependencies": {
+        "expo": "*"
+      }
+    },
+    "node_modules/expo-splash-screen": {
+      "version": "31.0.13",
+      "resolved": "https://registry.npmjs.org/expo-splash-screen/-/expo-splash-screen-31.0.13.tgz",
+      "integrity": "sha512-1epJLC1cDlwwj089R2h8cxaU5uk4ONVAC+vzGiTZH4YARQhL4Stlz1MbR6yAS173GMosvkE6CAeihR7oIbCkDA==",
+      "license": "MIT",
+      "dependencies": {
+        "@expo/prebuild-config": "^54.0.8"
+      },
       "peerDependencies": {
         "expo": "*"
       }

--- a/package.json
+++ b/package.json
@@ -63,6 +63,7 @@
     "expo-screen-capture": "~8.0.9",
     "expo-secure-store": "~15.0.8",
     "expo-sharing": "~14.0.8",
+    "expo-splash-screen": "~31.0.13",
     "expo-status-bar": "~3.0.9",
     "expo-system-ui": "~6.0.9",
     "expo-updates": "~29.0.15",

--- a/src/components/ErrorBoundary.tsx
+++ b/src/components/ErrorBoundary.tsx
@@ -2,6 +2,7 @@ import React from 'react';
 import { View, Text, StyleSheet } from 'react-native';
 import { useThemedStyles } from '@/hooks/useThemedStyles';
 import { Theme } from '@/constants/themes';
+import { hideSplashScreen } from '@/utils/splashController';
 
 interface ErrorBoundaryState {
   hasError: boolean;
@@ -41,6 +42,11 @@ export default class ErrorBoundary extends React.Component<
   componentDidCatch(error: Error, errorInfo: React.ErrorInfo) {
     console.error('ErrorBoundary caught an error:', error);
     console.error('Error info:', errorInfo);
+    // Fail-safe for the cold-boot splash (F-48, TASK-182): a render throw on the
+    // init path would otherwise leave the branded native splash overlay up,
+    // hiding this fallback UI and trapping the user. hideSplashScreen() is
+    // idempotent, so this is a no-op once the readiness owner has run.
+    void hideSplashScreen();
   }
 
   render() {

--- a/src/navigation/AppNavigator.tsx
+++ b/src/navigation/AppNavigator.tsx
@@ -70,6 +70,7 @@ import {
   useRemoteSignerStore,
 } from '@/store/remoteSignerStore';
 import { useWalletStore } from '@/store/walletStore';
+import { hideSplashScreen } from '@/utils/splashController';
 import { RemoteSignerRequest } from '@/types/remoteSigner';
 import SecuritySetupScreen from '@/screens/onboarding/SecuritySetupScreen';
 import AuthGuard from '@/components/AuthGuard';
@@ -1079,6 +1080,11 @@ function AppStack() {
   const [initialRoute, setInitialRoute] =
     useState<keyof RootStackParamList>('Onboarding');
   const [isLoading, setIsLoading] = useState(true);
+  // Subscribe to the remote-signer gate so this component (the splash readiness
+  // owner) re-renders when MainTabNavigator's `isInitialized` gate resolves.
+  const isSignerInitialized = useRemoteSignerStore(
+    (state) => state.isInitialized
+  );
 
   useEffect(() => {
     checkInitialRoute();
@@ -1100,6 +1106,26 @@ function AppStack() {
       setIsLoading(false);
     }
   };
+
+  // Single readiness owner for the native splash (F-48, TASK-182). Hide it only
+  // once the FIRST real content frame can render:
+  //   - the initial-route storage await has resolved (isLoading false), AND
+  //   - for the Main route, MainTabNavigator's remote-signer gate has hydrated
+  //     (isSignerInitialized) — the Onboarding route has no such gate, so it is
+  //     ready as soon as the route resolves.
+  // This effect runs AFTER commit, so the content it gates on is already painted
+  // when the splash lifts — no blank flash. checkInitialRoute() always clears
+  // isLoading in its finally, and remoteSignerStore.initialize() always sets
+  // isInitialized (even on its caught-error path), so this readiness condition
+  // cannot silently stall; the error boundary and the index.ts watchdog cover
+  // the render-throw and hard-hang cases as belt-and-suspenders.
+  const contentReady =
+    !isLoading && (initialRoute !== 'Main' || isSignerInitialized);
+  useEffect(() => {
+    if (contentReady) {
+      void hideSplashScreen();
+    }
+  }, [contentReady]);
 
   if (isLoading) {
     return null; // Or a loading screen

--- a/src/navigation/AppNavigator.tsx
+++ b/src/navigation/AppNavigator.tsx
@@ -70,7 +70,10 @@ import {
   useRemoteSignerStore,
 } from '@/store/remoteSignerStore';
 import { useWalletStore } from '@/store/walletStore';
-import { hideSplashScreen } from '@/utils/splashController';
+import {
+  hideSplashScreen,
+  isColdBootContentReady,
+} from '@/utils/splashController';
 import { RemoteSignerRequest } from '@/types/remoteSigner';
 import SecuritySetupScreen from '@/screens/onboarding/SecuritySetupScreen';
 import AuthGuard from '@/components/AuthGuard';
@@ -1080,11 +1083,18 @@ function AppStack() {
   const [initialRoute, setInitialRoute] =
     useState<keyof RootStackParamList>('Onboarding');
   const [isLoading, setIsLoading] = useState(true);
-  // Subscribe to the remote-signer gate so this component (the splash readiness
-  // owner) re-renders when MainTabNavigator's `isInitialized` gate resolves.
+  // Subscribe to the init-cascade gates this component (the splash readiness
+  // owner) must cover, so it re-renders as each resolves:
+  //   - remote-signer gate (MainTabNavigator's `isInitialized`) — gate 2,
+  //   - app mode (decided by that same gate) — selects signer vs wallet Home,
+  //   - wallet-store hydration (`isInitialized`) — gate 3, cached balances in
+  //     state so the normal-wallet Home renders real content, not its
+  //     "Loading wallet..." placeholder.
   const isSignerInitialized = useRemoteSignerStore(
     (state) => state.isInitialized
   );
+  const appMode = useAppMode();
+  const isWalletInitialized = useWalletStore((state) => state.isInitialized);
 
   useEffect(() => {
     checkInitialRoute();
@@ -1108,19 +1118,29 @@ function AppStack() {
   };
 
   // Single readiness owner for the native splash (F-48, TASK-182). Hide it only
-  // once the FIRST real content frame can render:
-  //   - the initial-route storage await has resolved (isLoading false), AND
-  //   - for the Main route, MainTabNavigator's remote-signer gate has hydrated
-  //     (isSignerInitialized) — the Onboarding route has no such gate, so it is
-  //     ready as soon as the route resolves.
+  // once the FIRST real content frame can render — covering ALL THREE gates of
+  // the F-03 init cascade (route + remote-signer + wallet-store hydration). See
+  // isColdBootContentReady() for the exact gate/scoping rules; in short, on the
+  // common existing-wallet cold start it now also waits for the wallet store's
+  // cached balances so the splash never lifts onto Home's "Loading wallet..."
+  // placeholder.
+  //
   // This effect runs AFTER commit, so the content it gates on is already painted
-  // when the splash lifts — no blank flash. checkInitialRoute() always clears
-  // isLoading in its finally, and remoteSignerStore.initialize() always sets
-  // isInitialized (even on its caught-error path), so this readiness condition
-  // cannot silently stall; the error boundary and the index.ts watchdog cover
-  // the render-throw and hard-hang cases as belt-and-suspenders.
-  const contentReady =
-    !isLoading && (initialRoute !== 'Main' || isSignerInitialized);
+  // when the splash lifts — no blank flash. Every gate is guaranteed to resolve
+  // (or throw) so this cannot silently stall: checkInitialRoute() always clears
+  // isLoading in its finally; remoteSignerStore.initialize() always sets
+  // isInitialized (even on its caught-error path); and walletStore.initialize()
+  // — kicked off early in initializeServices() AND again by Home's mount effect —
+  // always sets isInitialized (success and caught-error paths alike). The error
+  // boundary and the index.ts watchdog cover the render-throw and hard-hang
+  // cases as belt-and-suspenders.
+  const contentReady = isColdBootContentReady({
+    routeResolved: !isLoading,
+    isMainRoute: initialRoute === 'Main',
+    signerInitialized: isSignerInitialized,
+    isSignerMode: appMode === 'signer',
+    walletInitialized: isWalletInitialized,
+  });
   useEffect(() => {
     if (contentReady) {
       void hideSplashScreen();

--- a/src/screens/wallet/HomeScreen.tsx
+++ b/src/screens/wallet/HomeScreen.tsx
@@ -218,6 +218,15 @@ export default function HomeScreen() {
 
   const initialize = useWalletStore((state) => state.initialize);
   const wallet = useWalletStore((state) => state.wallet);
+  // Wallet-store hydration flag (F-48, TASK-182). This is the SAME signal the
+  // splash readiness owner (AppStack) gates on, so the "Loading wallet..."
+  // placeholder and the splash hide stay in lockstep. Once the store is
+  // initialized its cached balances are already in `accountStates`, so real
+  // content is renderable — never show the placeholder then, even while the
+  // local `loading` flag is mid-flight on a redundant re-init. This closes the
+  // gap where the splash could lift onto (or a redundant re-init could re-show)
+  // the placeholder despite cached content being ready.
+  const isWalletInitialized = useWalletStore((state) => state.isInitialized);
   const loadAccountTransactions = useWalletStore(
     (state) => state.loadAccountTransactions
   );
@@ -1232,7 +1241,12 @@ export default function HomeScreen() {
     currentNetworkConfig,
   ]);
 
-  if (loading) {
+  // Show the placeholder only while the wallet store has NOT yet hydrated its
+  // cached balances. Once `isWalletInitialized` is true the cached balances are
+  // in state and real content is renderable, so we skip the placeholder even if
+  // the local `loading` flag is still mid-flight (F-48, TASK-182) — keeping this
+  // in lockstep with the splash readiness gate.
+  if (loading && !isWalletInitialized) {
     return (
       <SafeAreaView style={styles.container} edges={['top']}>
         <View style={styles.loadingContainer}>

--- a/src/utils/__tests__/splashController.test.ts
+++ b/src/utils/__tests__/splashController.test.ts
@@ -1,0 +1,111 @@
+// Unit tests for the F-48 splash controller (TASK-182). The module keeps a
+// process-wide "already hidden" latch, so each test resets the module registry
+// and re-mocks expo-splash-screen to get a fresh latch + fresh spy.
+
+type SplashModule = typeof import('../splashController');
+
+function loadFresh(hideImpl?: () => Promise<void>): {
+  mod: SplashModule;
+  hideAsync: jest.Mock;
+  preventAutoHideAsync: jest.Mock;
+} {
+  jest.resetModules();
+  const hideAsync = jest.fn(hideImpl ?? (() => Promise.resolve()));
+  const preventAutoHideAsync = jest.fn(() => Promise.resolve());
+  jest.doMock('expo-splash-screen', () => ({
+    hideAsync,
+    preventAutoHideAsync,
+  }));
+  const mod = require('../splashController') as SplashModule;
+  return { mod, hideAsync, preventAutoHideAsync };
+}
+
+describe('hideSplashScreen', () => {
+  it('dismisses the native splash exactly once', async () => {
+    const { mod, hideAsync } = loadFresh();
+
+    await mod.hideSplashScreen();
+
+    expect(hideAsync).toHaveBeenCalledTimes(1);
+  });
+
+  it('is idempotent — repeat calls never fire hideAsync again', async () => {
+    const { mod, hideAsync } = loadFresh();
+
+    await mod.hideSplashScreen();
+    await mod.hideSplashScreen();
+    await mod.hideSplashScreen();
+
+    expect(hideAsync).toHaveBeenCalledTimes(1);
+  });
+
+  it('latches even under concurrent callers (single hideAsync)', async () => {
+    const { mod, hideAsync } = loadFresh();
+
+    await Promise.all([
+      mod.hideSplashScreen(),
+      mod.hideSplashScreen(),
+      mod.hideSplashScreen(),
+    ]);
+
+    expect(hideAsync).toHaveBeenCalledTimes(1);
+  });
+
+  it('swallows a hideAsync rejection instead of propagating it', async () => {
+    const { mod, hideAsync } = loadFresh(() =>
+      Promise.reject(new Error('already hidden'))
+    );
+
+    await expect(mod.hideSplashScreen()).resolves.toBeUndefined();
+    expect(hideAsync).toHaveBeenCalledTimes(1);
+  });
+
+  it('stays latched after a rejection (no retry that could re-throw)', async () => {
+    const { mod, hideAsync } = loadFresh(() =>
+      Promise.reject(new Error('already hidden'))
+    );
+
+    await mod.hideSplashScreen();
+    await mod.hideSplashScreen();
+
+    expect(hideAsync).toHaveBeenCalledTimes(1);
+  });
+});
+
+describe('armSplashWatchdog', () => {
+  beforeEach(() => {
+    jest.useFakeTimers();
+  });
+  afterEach(() => {
+    jest.clearAllTimers();
+    jest.useRealTimers();
+  });
+
+  it('does not hide before the watchdog interval elapses', () => {
+    const { mod, hideAsync } = loadFresh();
+
+    mod.armSplashWatchdog();
+    jest.advanceTimersByTime(mod.SPLASH_WATCHDOG_MS - 1);
+
+    expect(hideAsync).not.toHaveBeenCalled();
+  });
+
+  it('force-hides once the watchdog interval elapses', () => {
+    const { mod, hideAsync } = loadFresh();
+
+    mod.armSplashWatchdog();
+    jest.advanceTimersByTime(mod.SPLASH_WATCHDOG_MS);
+
+    expect(hideAsync).toHaveBeenCalledTimes(1);
+  });
+
+  it('is a no-op once the readiness owner has already hidden the splash', async () => {
+    const { mod, hideAsync } = loadFresh();
+
+    await mod.hideSplashScreen();
+    mod.armSplashWatchdog();
+    jest.advanceTimersByTime(mod.SPLASH_WATCHDOG_MS);
+
+    expect(hideAsync).toHaveBeenCalledTimes(1);
+  });
+});

--- a/src/utils/__tests__/splashController.test.ts
+++ b/src/utils/__tests__/splashController.test.ts
@@ -60,11 +60,30 @@ describe('hideSplashScreen', () => {
     expect(hideAsync).toHaveBeenCalledTimes(1);
   });
 
-  it('stays latched after a rejection (no retry that could re-throw)', async () => {
-    const { mod, hideAsync } = loadFresh(() =>
-      Promise.reject(new Error('already hidden'))
-    );
+  // Hardening (F-48): latch ONLY after a confirmed hide. A hideAsync that rejects
+  // while the splash may still be visible must NOT latch — otherwise a failed
+  // early caller would neuter the watchdog and could strand the user.
+  it('does not permanently latch after a rejection — a later call retries', async () => {
+    let calls = 0;
+    const { mod, hideAsync } = loadFresh(() => {
+      calls += 1;
+      // First attempt rejects (splash may still be visible); second succeeds.
+      return calls === 1
+        ? Promise.reject(new Error('still visible'))
+        : Promise.resolve();
+    });
 
+    await mod.hideSplashScreen(); // attempt 1: rejects, does NOT latch
+    await mod.hideSplashScreen(); // attempt 2: resolves, latches
+    await mod.hideSplashScreen(); // now genuinely hidden: no-op
+
+    expect(hideAsync).toHaveBeenCalledTimes(2);
+  });
+
+  it('latches once a hideAsync resolves — no double-hide spam afterward', async () => {
+    const { mod, hideAsync } = loadFresh();
+
+    await mod.hideSplashScreen();
     await mod.hideSplashScreen();
     await mod.hideSplashScreen();
 
@@ -90,9 +109,11 @@ describe('armSplashWatchdog', () => {
     expect(hideAsync).not.toHaveBeenCalled();
   });
 
-  it('force-hides once the watchdog interval elapses', () => {
+  it('force-hides once the watchdog interval elapses (bounds a hung cascade)', () => {
     const { mod, hideAsync } = loadFresh();
 
+    // Readiness never fires (a gate silently hangs) — the watchdog is the only
+    // thing that hides the splash, and it does so within its bound.
     mod.armSplashWatchdog();
     jest.advanceTimersByTime(mod.SPLASH_WATCHDOG_MS);
 
@@ -107,5 +128,101 @@ describe('armSplashWatchdog', () => {
     jest.advanceTimersByTime(mod.SPLASH_WATCHDOG_MS);
 
     expect(hideAsync).toHaveBeenCalledTimes(1);
+  });
+
+  it('still fires/retries if an earlier hide attempt rejected while visible', async () => {
+    // A non-watchdog caller fires first and its hideAsync REJECTS while the
+    // splash is still visible. Because the latch is on-resolve, the watchdog must
+    // still be able to retry — it is not neutered by the failed attempt.
+    const { mod, hideAsync } = loadFresh(() =>
+      Promise.reject(new Error('still visible'))
+    );
+
+    await mod.hideSplashScreen(); // failed early attempt (does not latch)
+    expect(hideAsync).toHaveBeenCalledTimes(1);
+
+    mod.armSplashWatchdog();
+    jest.advanceTimersByTime(mod.SPLASH_WATCHDOG_MS);
+
+    // Watchdog retried — the user is not stranded on the splash.
+    expect(hideAsync).toHaveBeenCalledTimes(2);
+  });
+});
+
+describe('isColdBootContentReady', () => {
+  // Baseline: an existing-wallet cold boot lands on the Main route in normal
+  // (non-signer) wallet mode. The splash must cover ALL THREE gates.
+  const existingWalletMain = {
+    routeResolved: true,
+    isMainRoute: true,
+    signerInitialized: true,
+    isSignerMode: false,
+    walletInitialized: true,
+  };
+
+  it('is not ready until the initial route resolves (gate 1)', () => {
+    const { mod } = loadFresh();
+    expect(
+      mod.isColdBootContentReady({
+        ...existingWalletMain,
+        routeResolved: false,
+      })
+    ).toBe(false);
+  });
+
+  it('is not ready on Main until the remote-signer gate hydrates (gate 2)', () => {
+    const { mod } = loadFresh();
+    expect(
+      mod.isColdBootContentReady({
+        ...existingWalletMain,
+        signerInitialized: false,
+      })
+    ).toBe(false);
+  });
+
+  // The core P2 assertion: after route + remote-signer resolve but BEFORE the
+  // wallet store hydrates, the splash must NOT lift — otherwise it reveals Home's
+  // "Loading wallet..." placeholder.
+  it('is NOT ready on normal-wallet Main until the wallet store hydrates (gate 3)', () => {
+    const { mod } = loadFresh();
+    expect(
+      mod.isColdBootContentReady({
+        ...existingWalletMain,
+        walletInitialized: false,
+      })
+    ).toBe(false);
+  });
+
+  it('is ready on normal-wallet Main only once all three gates resolve', () => {
+    const { mod } = loadFresh();
+    expect(mod.isColdBootContentReady(existingWalletMain)).toBe(true);
+  });
+
+  it('does not require the wallet gate in signer mode (no wallet placeholder)', () => {
+    const { mod } = loadFresh();
+    expect(
+      mod.isColdBootContentReady({
+        routeResolved: true,
+        isMainRoute: true,
+        signerInitialized: true,
+        isSignerMode: true,
+        walletInitialized: false, // airgap Home has no "Loading wallet..." gate
+      })
+    ).toBe(true);
+  });
+
+  it('is ready on a non-Main route as soon as the route resolves', () => {
+    const { mod } = loadFresh();
+    // Onboarding / Lock: no signer or wallet gate — requiring them would strand
+    // the splash since nothing on those routes ever flips them.
+    expect(
+      mod.isColdBootContentReady({
+        routeResolved: true,
+        isMainRoute: false,
+        signerInitialized: false,
+        isSignerMode: false,
+        walletInitialized: false,
+      })
+    ).toBe(true);
   });
 });

--- a/src/utils/splashController.ts
+++ b/src/utils/splashController.ts
@@ -4,8 +4,9 @@ import * as SplashScreen from 'expo-splash-screen';
 //
 // index.ts calls SplashScreen.preventAutoHideAsync() at module scope so the
 // branded native splash stays up through module eval + the async-storage gate
-// cascade (AppStack initial-route await + MainTabNavigator remote-signer gate)
-// instead of dismissing at first frame and exposing a blank RN root view.
+// cascade instead of dismissing at first frame and exposing a blank RN root
+// view. The readiness owner (AppStack) hides it only once the FIRST real-content
+// frame can paint — see isColdBootContentReady() for the exact gate set.
 //
 // hideSplashScreen() is the SINGLE funnel through which the splash is ever
 // dismissed. It is idempotent and never throws, so every caller — the readiness
@@ -15,29 +16,60 @@ import * as SplashScreen from 'expo-splash-screen';
 // that guarantee a throw or a silent hang on the init path can NEVER leave the
 // user stuck on the splash forever.
 
-// Latch so the native hideAsync runs at most once. Module-scoped: shared across
+// True only AFTER a hideAsync() has actually RESOLVED — i.e. the native splash
+// is genuinely gone. Latching on success (not on attempt) means a hideAsync that
+// REJECTS while the splash is still visible does NOT neuter later callers: the
+// watchdog (or any subsequent caller) can retry. Module-scoped: shared across
 // every import of this module for the life of the JS runtime.
 let splashHidden = false;
 
+// The single in-flight hide attempt, if any. Concurrent callers share it instead
+// of each firing their own hideAsync(). Cleared when the attempt settles, so a
+// LATER (sequential) caller can retry after a rejected attempt — while still
+// deduping the simultaneous burst the readiness owner + error boundary can
+// produce. Distinct from splashHidden: an attempt can be in flight (or have
+// failed) without the splash being confirmed hidden.
+let hideInFlight: Promise<void> | null = null;
+
 /**
- * Dismiss the native splash exactly once. Idempotent and error-swallowing:
- * repeat calls after the first are no-ops, and a rejection from hideAsync
- * (already hidden, or no native module on web) never propagates or blocks
- * startup. Safe to call from the readiness owner and from any fail-safe path.
+ * Dismiss the native splash. Idempotent and error-swallowing:
+ * - Once a hideAsync() has RESOLVED, every later call is a no-op (no double-hide
+ *   error spam once the splash is genuinely gone).
+ * - Concurrent callers share the single in-flight attempt (one hideAsync fires).
+ * - A rejection (already hidden, or no native module on web) is swallowed and
+ *   never propagates or blocks startup. Crucially it does NOT latch: if the
+ *   splash was still visible when the attempt failed, splashHidden stays false
+ *   so the watchdog / a later caller can try again. If it failed because the
+ *   splash was already gone, the retry just no-ops harmlessly.
+ * Safe to call from the readiness owner and from any fail-safe path.
  */
 export async function hideSplashScreen(): Promise<void> {
   if (splashHidden) {
     return;
   }
-  // Latch BEFORE awaiting so a concurrent second caller cannot also fire
-  // hideAsync (which would reject on the "already hidden" path).
-  splashHidden = true;
-  try {
-    await SplashScreen.hideAsync();
-  } catch {
-    // hideAsync rejects if the splash is already gone or the native module is
-    // unavailable (e.g. web). The app is already up — swallow it.
+  if (hideInFlight) {
+    // An attempt is already running; share it rather than firing a second
+    // hideAsync (which would reject on the native "already hidden" path).
+    return hideInFlight;
   }
+  hideInFlight = (async () => {
+    try {
+      await SplashScreen.hideAsync();
+      // Latch ONLY after a confirmed native hide. From here every caller no-ops.
+      splashHidden = true;
+    } catch {
+      // hideAsync rejects if the splash is already gone or the native module is
+      // unavailable (e.g. web). The app is already up — swallow it. Deliberately
+      // do NOT latch: leaving splashHidden false lets the watchdog retry in the
+      // (pathological) case the splash is somehow still visible.
+    } finally {
+      // Clear so a subsequent sequential caller (the watchdog) can retry after a
+      // rejected attempt. A resolved attempt has already set splashHidden, so the
+      // retry short-circuits to a no-op.
+      hideInFlight = null;
+    }
+  })();
+  return hideInFlight;
 }
 
 // Absolute ceiling the splash may cover before the watchdog force-hides it. The
@@ -50,11 +82,78 @@ export const SPLASH_WATCHDOG_MS = 10_000;
 
 /**
  * Arm the last-resort watchdog. Call once at module scope right after
- * preventAutoHideAsync(). No-op once the readiness owner has already hidden the
- * splash, because hideSplashScreen() is latched.
+ * preventAutoHideAsync(). No-op once a hide has genuinely succeeded, because
+ * hideSplashScreen() short-circuits on the resolved latch. If an earlier hide
+ * attempt REJECTED while the splash was still visible, this still fires and
+ * retries — the whole point of latching on resolve rather than on attempt.
  */
 export function armSplashWatchdog(): void {
   setTimeout(() => {
     void hideSplashScreen();
   }, SPLASH_WATCHDOG_MS);
+}
+
+/**
+ * Cold-boot readiness predicate for the splash (F-48, TASK-182). The branded
+ * native splash may hide only once the FIRST real-content frame can paint, which
+ * means covering the WHOLE F-03-restructured init cascade — three gates, not two:
+ *
+ *   1. routeResolved     — AppStack's initial-route storage await has resolved
+ *                          (isLoading false), so the route tree can mount.
+ *   2. signerInitialized — MainTabNavigator's remote-signer gate has hydrated;
+ *                          this both unblocks that navigator AND decides app mode.
+ *   3. walletInitialized — the wallet store has hydrated with its CACHED balances
+ *                          in state, so the normal-wallet Home screen renders real
+ *                          content instead of its "Loading wallet..." placeholder.
+ *
+ * Gate 3 is what an earlier two-gate readiness missed: on the common existing-
+ * wallet cold start the splash would lift after gates 1+2 to reveal Home's
+ * "Loading wallet..." placeholder — the exact flash this feature exists to hide.
+ *
+ * Scoping rules (these are what keep the splash from EVER stranding the user):
+ * - Non-Main routes (Onboarding, Lock, ...) have no signer/wallet gate and are
+ *   ready the instant the route resolves. Requiring gates 2/3 there would hang
+ *   the splash forever, because nothing on those routes ever flips them.
+ * - On the Main route in SIGNER mode the air-gapped Home renders straight after
+ *   gate 2 and has no "Loading wallet..." placeholder, so gate 3 is NOT required
+ *   — waiting on it would needlessly delay (though walletStore is still hydrated
+ *   early in both modes, so this is belt-and-suspenders, not a hang guard).
+ * - Gate 3 gates ONLY on cached-balance hydration (walletInitialized), never on
+ *   network balance/price fetches, so a slow network can never hang the splash.
+ *   The 10s watchdog remains the ultimate backstop, not the intended path.
+ */
+export function isColdBootContentReady(params: {
+  routeResolved: boolean;
+  isMainRoute: boolean;
+  signerInitialized: boolean;
+  isSignerMode: boolean;
+  walletInitialized: boolean;
+}): boolean {
+  const {
+    routeResolved,
+    isMainRoute,
+    signerInitialized,
+    isSignerMode,
+    walletInitialized,
+  } = params;
+
+  // Gate 1: the route tree cannot mount until the initial route is known.
+  if (!routeResolved) {
+    return false;
+  }
+  // Non-Main routes have no further gates — ready as soon as the route resolves.
+  if (!isMainRoute) {
+    return true;
+  }
+  // Gate 2: MainTabNavigator renders a blank View until the remote-signer store
+  // hydrates; app mode is unknown until then.
+  if (!signerInitialized) {
+    return false;
+  }
+  // Signer mode renders the air-gapped Home with no wallet placeholder.
+  if (isSignerMode) {
+    return true;
+  }
+  // Gate 3: normal-wallet Main is ready only once cached balances are in state.
+  return walletInitialized;
 }

--- a/src/utils/splashController.ts
+++ b/src/utils/splashController.ts
@@ -1,0 +1,60 @@
+import * as SplashScreen from 'expo-splash-screen';
+
+// Splash lifecycle control for the cold-boot init cascade (F-48, TASK-182).
+//
+// index.ts calls SplashScreen.preventAutoHideAsync() at module scope so the
+// branded native splash stays up through module eval + the async-storage gate
+// cascade (AppStack initial-route await + MainTabNavigator remote-signer gate)
+// instead of dismissing at first frame and exposing a blank RN root view.
+//
+// hideSplashScreen() is the SINGLE funnel through which the splash is ever
+// dismissed. It is idempotent and never throws, so every caller — the readiness
+// owner (AppStack), the error-boundary fallback, and the watchdog safety net —
+// can invoke it freely without coordinating. The readiness owner is the only
+// place that decides *when* the happy path hides; the other two are fail-safes
+// that guarantee a throw or a silent hang on the init path can NEVER leave the
+// user stuck on the splash forever.
+
+// Latch so the native hideAsync runs at most once. Module-scoped: shared across
+// every import of this module for the life of the JS runtime.
+let splashHidden = false;
+
+/**
+ * Dismiss the native splash exactly once. Idempotent and error-swallowing:
+ * repeat calls after the first are no-ops, and a rejection from hideAsync
+ * (already hidden, or no native module on web) never propagates or blocks
+ * startup. Safe to call from the readiness owner and from any fail-safe path.
+ */
+export async function hideSplashScreen(): Promise<void> {
+  if (splashHidden) {
+    return;
+  }
+  // Latch BEFORE awaiting so a concurrent second caller cannot also fire
+  // hideAsync (which would reject on the "already hidden" path).
+  splashHidden = true;
+  try {
+    await SplashScreen.hideAsync();
+  } catch {
+    // hideAsync rejects if the splash is already gone or the native module is
+    // unavailable (e.g. web). The app is already up — swallow it.
+  }
+}
+
+// Absolute ceiling the splash may cover before the watchdog force-hides it. The
+// readiness owner normally fires in well under a second; this only trips on a
+// pathological hang (e.g. a storage read that never settles) where no gate
+// resolves and nothing throws, so neither the readiness owner nor the error
+// boundary would ever fire. Force-hiding then reveals whatever gate view is
+// underneath — strictly better than trapping the user on the splash forever.
+export const SPLASH_WATCHDOG_MS = 10_000;
+
+/**
+ * Arm the last-resort watchdog. Call once at module scope right after
+ * preventAutoHideAsync(). No-op once the readiness owner has already hidden the
+ * splash, because hideSplashScreen() is latched.
+ */
+export function armSplashWatchdog(): void {
+  setTimeout(() => {
+    void hideSplashScreen();
+  }, SPLASH_WATCHDOG_MS);
+}


### PR DESCRIPTION
## What / why
Adds `expo-splash-screen` and holds the branded native splash across the **entire cold-boot init cascade**. Previously the native splash dismissed at first frame (iOS storyboard / Android `Theme.App.SplashScreen` swap in `MainActivity`), but the JS module that keeps it up was never installed — so the user saw a **blank RN root view** during module eval plus the sequential async-storage gate cascade:
- `AppStack` returns `null` while `checkInitialRoute` awaits `MultiAccountWalletService.getCurrentWallet()`, then
- `MainTabNavigator` renders an empty themed `View` until `remoteSignerStore.initialize()` hydrates.

The splash now covers all of that and lifts on the first real content frame.

Resolves **TASK-182** (Perf Audit II finding **F-48**, P3, startup).

## How
- **`index.ts`** — `SplashScreen.preventAutoHideAsync()` at **module scope**, placed **after** the crypto polyfills (it uses no crypto, so `get-random-values` / `Buffer` / WC polyfill ordering is preserved). Arms a last-resort watchdog.
- **`src/utils/splashController.ts`** (new) — one idempotent, error-swallowing `hideSplashScreen()` funnel + a bounded watchdog safety net. Unit tested.
- **`src/navigation/AppNavigator.tsx`** — `AppStack` is the **single readiness owner**. It subscribes to the remote-signer gate and hides the splash in a **post-commit `useEffect`** once the initial route resolves **and** (for the `Main` route) `isInitialized` hydrates → the gated content is already painted, so no blank flash. Onboarding route hides as soon as the route resolves.
- **`src/components/ErrorBoundary.tsx`** — hides the splash on a caught render throw so the fallback UI is visible instead of a frozen splash overlay.

### Fail-safe design (splash can NEVER stay up forever)
`hideAsync` is reachable on every init path:
- **Happy path** — `AppStack` readiness effect (the one clear owner).
- **Caught async errors** — `checkInitialRoute` clears `isLoading` in `finally`; `remoteSignerStore.initialize()` sets `isInitialized: true` even on its catch path, so neither gate can silently stall.
- **Render throw** — `ErrorBoundary.componentDidCatch` → `hideSplashScreen()`.
- **Non-settling hang** (e.g. a storage read that never resolves) — module-scope watchdog force-hides after a bounded ceiling.

All four route through the same idempotent controller.

## Coupled version bump (native, NOT OTA-shippable)
This adds a native module, so it **cannot** ship OTA (`runtimeVersion.policy = appVersion`). All three bumped together:
- `expo.version` `0.1.10` → `0.1.11`
- iOS `buildNumber` `22` → `23`
- Android `versionCode` `22` → `23`

Existing native splash config (Android `Theme.App.SplashScreen` swap, `app.config.js` splash assets) is **unchanged** — this PR only adds the JS control module + hide logic.

## Gates
- `npm run typecheck` — **0 errors**
- `npm run lint` — **no new problems** from this change (changed files clean; the single pre-existing `src/utils/animations.ts:440` `react-hooks/immutability` error exists identically on `main`, unrelated card-flip subsystem — left as-is to avoid a diff-expanding, behavior-risking change)
- `npm test -- --ci` — **1050 passed / 62 suites**, incl. 8 new `splashController` tests (idempotency, concurrent callers, rejection-swallow, watchdog fire/no-op)

## Codex verdict: CLEAN (round 1)
Confirmed: every init failure path reaches `hideAsync` via one idempotent controller with `AppStack` as sole readiness owner; version bump coupled; module-scope `preventAutoHideAsync` preserves crypto-polyfill ordering; correctly native/non-OTA.

## On-device verification REQUIRED (native rebuild)
This is a **native change** — CI typecheck/lint/unit + Codex are green but the native behavior cannot be exercised here. Human on-device gate (Dave):
1. Build a **dev client** (new native build — `expo-splash-screen` autolinks; `pod install` on iOS).
2. Cold-launch: the **branded splash covers the whole init cascade** with **no blank/flash gap** between splash and first real content (Home/Lock or Onboarding).
3. Simulate an init error (e.g. force `remoteSignerStore.initialize()` / `getCurrentWallet()` to throw or hang): the **splash still hides** (error-boundary fallback or watchdog) — the user is never trapped on the splash.
4. Verify on both iOS and Android, light and dark.
