### PR TITLE
perf(ledger): lazy-init Ledger transport + connect-scoped health monitoring (F-24, TASK-180)

### DIFF
--- a/src/navigation/AppNavigator.tsx
+++ b/src/navigation/AppNavigator.tsx
@@ -1498,13 +1498,27 @@ export default function AppNavigator() {
         }
 
         // --- Branch: Ledger transport (useful in BOTH modes) ---
+        // F-24: only eagerly initialize the Ledger transport at boot when the
+        // user has a previously paired Ledger persisted. This loads that
+        // device's metadata into the in-memory map so rekey/signing
+        // getDevices() consumers (keyManager) see it, WITHOUT pulling
+        // ble-plx/rxjs into the cold-boot eval graph or starting a permanent
+        // 15s health-check interval for the ~100% of users who never use a
+        // Ledger. Users with no persisted device defer init to the first Ledger
+        // screen (DeviceDiscovery) / first signing attempt (keyManager), which
+        // call initialize() themselves.
         const initLedger = async () => {
           try {
-            await ledgerTransportService.initialize({
-              enableBle: true,
-              enableUsb: true,
-            });
-            console.log('Ledger transport service initialized');
+            const initialized =
+              await ledgerTransportService.initializeIfPersistedDevices({
+                enableBle: true,
+                enableUsb: true,
+              });
+            console.log(
+              initialized
+                ? 'Ledger transport service initialized'
+                : 'Ledger transport init deferred (no persisted devices)'
+            );
           } catch (error) {
             console.warn(
               'Failed to initialize Ledger transport service:',

--- a/src/services/ledger/__tests__/transport.test.ts
+++ b/src/services/ledger/__tests__/transport.test.ts
@@ -1,0 +1,283 @@
+/**
+ * TASK-180 (F-24) — Ledger transport lazy-init + connect-scoped health
+ * monitoring.
+ *
+ * These tests pin the perf/lifecycle contract, NOT hardware behavior:
+ *   (a) Boot: with NO persisted Ledger devices the transport does not initialize
+ *       — no 15s health-check interval starts and the heavy BLE/HID transport
+ *       modules are never eagerly evaluated. With persisted devices, boot init
+ *       loads their metadata into getDevices() (for rekey/signing consumers)
+ *       WITHOUT evaluating the transport modules or starting the interval.
+ *   (b) Health monitoring starts only on a successful connect() and stops on
+ *       BOTH the explicit disconnect() path and the transport 'disconnect' event
+ *       — a CONNECTED transport is never left unmonitored, a disconnected one
+ *       never keeps the interval alive.
+ *   (c) The 5s APDU race timeout is cleared once the race settles (APDU win),
+ *       so no stray self-expiring timer is leaked per check.
+ *
+ * CLAUDE.md (key/signing surface): no key material is involved here — the only
+ * mocked surface is the two Ledger transport leaves (so their native ble-plx /
+ * HID deps never enter the jest graph) and AsyncStorage. Real hardware BLE/USB
+ * paths are out of scope (verified on-device — HT).
+ */
+
+import { Buffer } from 'buffer';
+
+// --- The two Ledger transport leaves. Mocking them keeps react-native-ble-plx
+// + rxjs and the HID native module out of the jest module graph AND lets us
+// count how many times each is evaluated (the factory runs on first require,
+// i.e. the first dynamic import() the code under test performs). ----------------
+const mockBleTransport = {
+  isSupported: jest.fn().mockResolvedValue(true),
+  listen: jest.fn(),
+  open: jest.fn(),
+};
+const mockHidTransport = {
+  isSupported: jest.fn().mockResolvedValue(true),
+  listen: jest.fn(),
+  open: jest.fn(),
+};
+const mockBleEval = { count: 0 };
+const mockHidEval = { count: 0 };
+
+jest.mock('@ledgerhq/react-native-hw-transport-ble', () => {
+  mockBleEval.count += 1;
+  return { __esModule: true, default: mockBleTransport };
+});
+jest.mock('@ledgerhq/react-native-hid', () => {
+  mockHidEval.count += 1;
+  return { __esModule: true, default: mockHidTransport };
+});
+
+// AsyncStorage — force the community jest mock so the storage layer resolves.
+jest.mock('@react-native-async-storage/async-storage', () =>
+  require('@react-native-async-storage/async-storage/jest/async-storage-mock')
+);
+
+import { LedgerTransportService } from '../transport';
+import { ledgerDeviceStorage } from '../storage';
+import type { PersistedLedgerDevice } from '../storage';
+
+// A single persisted USB device. USB is used for the connect() tests because it
+// takes the direct openUsbTransport path (no BLE discovery / waitForDevice), so
+// connect() resolves deterministically from an in-memory record.
+const USB_DEVICE_ID = '1:2';
+const persistedUsbDevice: PersistedLedgerDevice = {
+  id: USB_DEVICE_ID,
+  name: 'Ledger USB',
+  type: 'usb',
+  vendorId: 1,
+  productId: 2,
+  lastSeen: new Date('2026-07-20T00:00:00.000Z').toISOString(),
+};
+
+/** A fake opened transport with the event/close/send surface the service uses. */
+function makeFakeTransport() {
+  return {
+    on: jest.fn(),
+    off: jest.fn(),
+    close: jest.fn().mockResolvedValue(undefined),
+    send: jest.fn().mockResolvedValue(Buffer.from([0x90, 0x00])),
+  };
+}
+
+/** Pull the 'disconnect' handler the service registered via transport.on(). */
+function getDisconnectHandler(
+  fakeTransport: ReturnType<typeof makeFakeTransport>
+): () => void {
+  const call = fakeTransport.on.mock.calls.find((c) => c[0] === 'disconnect');
+  if (!call) {
+    throw new Error('service did not register a disconnect handler');
+  }
+  return call[1] as () => void;
+}
+
+let service: LedgerTransportService;
+
+beforeEach(() => {
+  jest.useFakeTimers();
+  // Fresh singleton per test so private lifecycle state never leaks across.
+  (LedgerTransportService as unknown as { instance?: unknown }).instance =
+    undefined;
+  service = LedgerTransportService.getInstance();
+
+  mockBleEval.count = 0;
+  mockHidEval.count = 0;
+  mockBleTransport.open.mockReset();
+  mockHidTransport.open.mockReset();
+
+  // Storage is stubbed at the instance level so no test touches AsyncStorage
+  // directly; each test sets loadDevices/hasPersistedDevices as needed.
+  jest.spyOn(ledgerDeviceStorage, 'saveDevice').mockResolvedValue(undefined);
+  jest
+    .spyOn(ledgerDeviceStorage, 'updateLastConnected')
+    .mockResolvedValue(undefined);
+
+  jest.spyOn(console, 'log').mockImplementation(() => {});
+  jest.spyOn(console, 'warn').mockImplementation(() => {});
+  jest.spyOn(console, 'error').mockImplementation(() => {});
+});
+
+afterEach(() => {
+  service.stopConnectionHealthMonitoring();
+  jest.clearAllTimers();
+  jest.useRealTimers();
+  jest.restoreAllMocks();
+});
+
+// ===========================================================================
+// (a) Boot-time gate: no interval, no eager transport-module evaluation
+// ===========================================================================
+
+describe('boot-time initialization gate (F-24)', () => {
+  it('does NOT init, start the interval, or evaluate transport modules when no device is persisted', async () => {
+    jest
+      .spyOn(ledgerDeviceStorage, 'hasPersistedDevices')
+      .mockResolvedValue(false);
+    const loadSpy = jest.spyOn(ledgerDeviceStorage, 'loadDevices');
+    const bleBefore = mockBleEval.count;
+    const hidBefore = mockHidEval.count;
+
+    const didInit = await service.initializeIfPersistedDevices({
+      enableBle: true,
+      enableUsb: true,
+    });
+
+    expect(didInit).toBe(false);
+    // No populate read ran and the map stayed empty (nothing to load).
+    expect(loadSpy).not.toHaveBeenCalled();
+    expect(service.getDevices()).toEqual([]);
+    // The permanent 15s health-check interval is NOT started at boot.
+    expect(service.isHealthMonitoringActive()).toBe(false);
+    // The heavy BLE/HID modules were never dynamically imported.
+    expect(mockBleEval.count).toBe(bleBefore);
+    expect(mockHidEval.count).toBe(hidBefore);
+  });
+
+  it('with a persisted device, boot init loads metadata for getDevices() WITHOUT evaluating transport modules or starting the interval', async () => {
+    jest
+      .spyOn(ledgerDeviceStorage, 'hasPersistedDevices')
+      .mockResolvedValue(true);
+    jest
+      .spyOn(ledgerDeviceStorage, 'loadDevices')
+      .mockResolvedValue([persistedUsbDevice]);
+    const bleBefore = mockBleEval.count;
+    const hidBefore = mockHidEval.count;
+
+    const didInit = await service.initializeIfPersistedDevices({
+      enableBle: true,
+      enableUsb: true,
+    });
+
+    expect(didInit).toBe(true);
+    // Persisted-device metadata is available to getDevices() consumers
+    // (rekey/signing via keyManager) BEFORE any discovery/connect happens.
+    const devices = service.getDevices();
+    expect(devices).toHaveLength(1);
+    expect(devices[0]).toMatchObject({
+      id: USB_DEVICE_ID,
+      type: 'usb',
+      connected: false,
+    });
+    // Loading metadata must NOT pull in ble-plx/rxjs or the HID native module.
+    expect(mockBleEval.count).toBe(bleBefore);
+    expect(mockHidEval.count).toBe(hidBefore);
+    // Still no interval — monitoring is scoped to a live connection, not boot.
+    expect(service.isHealthMonitoringActive()).toBe(false);
+  });
+
+  it('initialize() itself never starts the health-check interval', async () => {
+    jest
+      .spyOn(ledgerDeviceStorage, 'loadDevices')
+      .mockResolvedValue([persistedUsbDevice]);
+
+    await service.initialize({ enableBle: true, enableUsb: true });
+
+    expect(service.isHealthMonitoringActive()).toBe(false);
+  });
+});
+
+// ===========================================================================
+// (b) Health monitoring: starts on connect, stops on BOTH disconnect paths
+// ===========================================================================
+
+describe('connect-scoped health monitoring (F-24)', () => {
+  async function connectUsb() {
+    jest
+      .spyOn(ledgerDeviceStorage, 'loadDevices')
+      .mockResolvedValue([persistedUsbDevice]);
+    await service.initialize({ enableBle: true, enableUsb: true });
+
+    const fakeTransport = makeFakeTransport();
+    mockHidTransport.open.mockResolvedValue(fakeTransport);
+
+    const transport = await service.connect(USB_DEVICE_ID, {
+      transportType: 'usb',
+    });
+    expect(transport).toBe(fakeTransport);
+    return fakeTransport;
+  }
+
+  it('starts monitoring only after a successful connect() (and evaluates only the HID module)', async () => {
+    expect(service.isHealthMonitoringActive()).toBe(false);
+
+    await connectUsb();
+
+    // A CONNECTED transport is monitored.
+    expect(service.isHealthMonitoringActive()).toBe(true);
+    // USB connect must not drag in the BLE module.
+    expect(mockBleEval.count).toBe(0);
+    expect(mockHidEval.count).toBe(1);
+  });
+
+  it('stops monitoring on the explicit disconnect() path', async () => {
+    const fakeTransport = await connectUsb();
+    expect(service.isHealthMonitoringActive()).toBe(true);
+
+    await service.disconnect();
+
+    expect(fakeTransport.close).toHaveBeenCalled();
+    expect(service.isHealthMonitoringActive()).toBe(false);
+  });
+
+  it('stops monitoring on the transport-initiated disconnect event', async () => {
+    const fakeTransport = await connectUsb();
+    expect(service.isHealthMonitoringActive()).toBe(true);
+
+    // Simulate the transport firing its own 'disconnect' (cable pulled / BLE drop).
+    const handler = getDisconnectHandler(fakeTransport);
+    handler();
+
+    expect(service.isHealthMonitoringActive()).toBe(false);
+  });
+});
+
+// ===========================================================================
+// (c) The 5s APDU race timeout is cleared when the APDU wins
+// ===========================================================================
+
+describe('checkConnectionHealth race-timer cleanup (F-24)', () => {
+  it('clears the 5s timeout once the APDU wins the race (no leaked timer)', async () => {
+    const send = jest.fn().mockResolvedValue(Buffer.from([0x90, 0x00]));
+    // Drive checkConnectionHealth directly with a connected transport.
+    (
+      service as unknown as {
+        currentTransport: unknown;
+        currentDeviceId: string;
+      }
+    ).currentTransport = { send };
+    (service as unknown as { currentDeviceId: string }).currentDeviceId = 'dev';
+
+    // No timers pending before the check.
+    expect(jest.getTimerCount()).toBe(0);
+
+    await (
+      service as unknown as { checkConnectionHealth: () => Promise<void> }
+    ).checkConnectionHealth();
+
+    // The APDU resolved and won the race; the 5s timeout must be cleared, so no
+    // self-expiring timer is left behind. (Before the fix this would be 1.)
+    expect(send).toHaveBeenCalledWith(0xb0, 0x01, 0x00, 0x00);
+    expect(jest.getTimerCount()).toBe(0);
+  });
+});

--- a/src/services/ledger/storage.ts
+++ b/src/services/ledger/storage.ts
@@ -80,6 +80,17 @@ export class LedgerDeviceStorage {
   }
 
   /**
+   * Whether any valid Ledger device is persisted. Used as the boot-time gate
+   * (F-24) for eagerly initializing the transport: a user who has never paired a
+   * Ledger returns false and skips transport init entirely. A single AsyncStorage
+   * read; validation matches loadDevices() so an invalid-only store reads false.
+   */
+  async hasPersistedDevices(): Promise<boolean> {
+    const devices = await this.loadDevices();
+    return devices.length > 0;
+  }
+
+  /**
    * Save device information to storage
    */
   async saveDevice(deviceInfo: LedgerDeviceInfo): Promise<void> {

--- a/src/services/ledger/transport.ts
+++ b/src/services/ledger/transport.ts
@@ -1,8 +1,6 @@
 import { Platform, PermissionsAndroid } from 'react-native';
 import type { Permission, PermissionStatus } from 'react-native';
-import TransportBLE from '@ledgerhq/react-native-hw-transport-ble';
-import TransportHID from '@ledgerhq/react-native-hid';
-import Transport from '@ledgerhq/hw-transport';
+import type Transport from '@ledgerhq/hw-transport';
 import type { Subscription as TransportSubscription } from '@ledgerhq/hw-transport';
 import type { Device as BleDevice } from 'react-native-ble-plx';
 import type { DeviceModelId } from '@ledgerhq/devices';
@@ -13,6 +11,44 @@ import {
 } from '@/types/wallet';
 import { ledgerDeviceStorage, LedgerDeviceStorage } from './storage';
 import { isLedgerSigningInProgress } from '@/services/ledger/signingState';
+
+// F-24: Lazy transport-module loaders. The BLE transport pulls in
+// react-native-ble-plx + rxjs and the HID transport its own native deps; both
+// are only needed once discovery/connect actually runs. Loading them via
+// dynamic import (instead of a static top-of-file import) keeps them out of the
+// cold-boot eval graph for the ~100% of sessions that never touch a Ledger.
+// The resolved module is cached; a failed load resets the cache so a later
+// attempt can retry rather than being poisoned by a stale rejection.
+type TransportBLEModule =
+  typeof import('@ledgerhq/react-native-hw-transport-ble').default;
+type TransportHIDModule = typeof import('@ledgerhq/react-native-hid').default;
+
+let transportBlePromise: Promise<TransportBLEModule> | null = null;
+let transportHidPromise: Promise<TransportHIDModule> | null = null;
+
+async function loadTransportBLE(): Promise<TransportBLEModule> {
+  if (!transportBlePromise) {
+    transportBlePromise = import('@ledgerhq/react-native-hw-transport-ble')
+      .then((mod) => mod.default)
+      .catch((error) => {
+        transportBlePromise = null;
+        throw error;
+      });
+  }
+  return transportBlePromise;
+}
+
+async function loadTransportHID(): Promise<TransportHIDModule> {
+  if (!transportHidPromise) {
+    transportHidPromise = import('@ledgerhq/react-native-hid')
+      .then((mod) => mod.default)
+      .catch((error) => {
+        transportHidPromise = null;
+        throw error;
+      });
+  }
+  return transportHidPromise;
+}
 
 export type LedgerTransportType = 'ble' | 'usb';
 
@@ -138,6 +174,26 @@ export class LedgerTransportService {
     };
   }
 
+  /**
+   * Boot-time initialization gate (F-24). Only eagerly initialize the transport
+   * when the user has a previously paired Ledger persisted in storage; a user
+   * who has never used a Ledger skips transport init entirely, so the BLE/HID
+   * modules stay out of the cold-boot eval graph and no health-check interval is
+   * started. When persisted devices DO exist we still initialize so their
+   * metadata is loaded into the in-memory map BEFORE any getDevices() consumer
+   * (rekey/signing via keyManager) reads it. Returns whether init actually ran.
+   */
+  async initializeIfPersistedDevices(
+    options: InitializeOptions = {}
+  ): Promise<boolean> {
+    const hasPersisted = await ledgerDeviceStorage.hasPersistedDevices();
+    if (!hasPersisted) {
+      return false;
+    }
+    await this.initialize(options);
+    return true;
+  }
+
   async initialize(options: InitializeOptions = {}): Promise<void> {
     const {
       enableBle = true,
@@ -148,7 +204,9 @@ export class LedgerTransportService {
     this.bleEnabled = enableBle;
     this.usbEnabled = enableUsb;
 
-    // Load previously discovered devices from storage
+    // Load previously discovered devices from storage. This populates the
+    // in-memory device map (metadata only, no live descriptor) so getDevices()
+    // consumers see previously paired Ledgers even before discovery/connect.
     await this.loadPersistedDevices();
 
     if (!enableBle) {
@@ -166,8 +224,20 @@ export class LedgerTransportService {
       });
     }
 
-    // Begin passive connection health monitoring
-    this.startConnectionHealthMonitoring();
+    // NOTE (F-24): health monitoring is intentionally NOT started here. It is a
+    // no-op whenever no transport is connected, so a permanent boot-time
+    // interval just burns a foreground JS wakeup every 15s for every user. It is
+    // now started on a successful connect() and stopped on every disconnect
+    // path, so a CONNECTED transport is always monitored and nothing else is.
+  }
+
+  /**
+   * Whether the periodic connection health-check interval is currently running.
+   * Exposed so callers/tests can assert monitoring is scoped to a live
+   * connection (started on connect, stopped on disconnect).
+   */
+  isHealthMonitoringActive(): boolean {
+    return this.healthCheckTimer !== null;
   }
 
   getConnectedDevice(): LedgerDeviceInfo | null {
@@ -333,6 +403,14 @@ export class LedgerTransportService {
           this.connectingDeviceId = null;
           this.isConnecting = false;
 
+          // F-24: begin health monitoring only now that a transport is actually
+          // connected. Every path that clears currentTransport (explicit
+          // disconnect, transport 'disconnect' event, discovery-removed, and the
+          // health check's own serious-error disconnect) stops it again, so a
+          // CONNECTED transport is never left unmonitored and a disconnected one
+          // never keeps the interval alive.
+          this.startConnectionHealthMonitoring();
+
           this.markDeviceConnected(deviceId);
           console.log('Ledger Connection Complete');
           return transport;
@@ -429,6 +507,9 @@ export class LedgerTransportService {
     } finally {
       this.currentTransport = null;
       this.currentDeviceId = null;
+      // F-24: no transport is connected anymore — stop the health-check interval
+      // (explicit-disconnect path).
+      this.stopConnectionHealthMonitoring();
       this.markDeviceDisconnected(deviceId);
     }
   }
@@ -504,6 +585,7 @@ export class LedgerTransportService {
       return;
     }
 
+    const TransportBLE = await loadTransportBLE();
     const supported = await TransportBLE.isSupported().catch((error) => {
       console.log('Ledger BLE support check failed', error);
       return false;
@@ -562,6 +644,9 @@ export class LedgerTransportService {
           if (this.currentDeviceId === descriptor.id) {
             this.currentDeviceId = null;
             this.currentTransport = null;
+            // F-24: the connected device went away during discovery — stop the
+            // health-check interval along with the transport it monitored.
+            this.stopConnectionHealthMonitoring();
           }
           this.emit('deviceRemoved', { id: descriptor.id });
         }
@@ -629,6 +714,7 @@ export class LedgerTransportService {
       return;
     }
 
+    const TransportHID = await loadTransportHID();
     const supported = await TransportHID.isSupported().catch(() => false);
     this.updatePermissionsStatus({ usbAuthorized: supported });
     if (!supported) {
@@ -685,6 +771,9 @@ export class LedgerTransportService {
           if (this.currentDeviceId === id) {
             this.currentDeviceId = null;
             this.currentTransport = null;
+            // F-24: the connected device went away during discovery — stop the
+            // health-check interval along with the transport it monitored.
+            this.stopConnectionHealthMonitoring();
           }
           this.emit('deviceRemoved', { id });
         }
@@ -781,6 +870,7 @@ export class LedgerTransportService {
       if (this.cancelRequested) {
         throw new Error('Connection cancelled');
       }
+      const TransportBLE = await loadTransportBLE();
       // Prefer an up-to-date descriptor when available; fallback to deviceId
       const transport = await TransportBLE.open(descriptor ?? deviceId);
       if (this.cancelRequested) {
@@ -812,6 +902,7 @@ export class LedgerTransportService {
     }
 
     try {
+      const TransportHID = await loadTransportHID();
       const transport = await TransportHID.open(usbDescriptor);
       return transport;
     } catch (error) {
@@ -867,6 +958,9 @@ export class LedgerTransportService {
       if (this.currentDeviceId === deviceId) {
         this.currentTransport = null;
         this.currentDeviceId = null;
+        // F-24: transport-initiated disconnect — stop health monitoring so the
+        // interval never outlives the connection it was scoped to.
+        this.stopConnectionHealthMonitoring();
       }
       this.markDeviceDisconnected(deviceId);
     };
@@ -1111,12 +1205,19 @@ export class LedgerTransportService {
       return;
     }
 
+    // F-24: the 5s race timeout must be cleared once the race settles. If the
+    // APDU wins, the timer would otherwise self-expire ~5s later — a stray,
+    // uncollected timer per check (4/min) for the whole connected session.
+    let raceTimer: ReturnType<typeof setTimeout> | undefined;
     try {
       // APDU: get app and version (same as used by Algorand app service)
       // Use shorter timeout for health checks to avoid blocking
-      const timeout = new Promise((_, reject) =>
-        setTimeout(() => reject(new Error('Health check timeout')), 5000)
-      );
+      const timeout = new Promise((_, reject) => {
+        raceTimer = setTimeout(
+          () => reject(new Error('Health check timeout')),
+          5000
+        );
+      });
 
       const healthCheck = this.currentTransport.send(0xb0, 0x01, 0x00, 0x00);
 
@@ -1143,6 +1244,9 @@ export class LedgerTransportService {
         const deviceId = this.currentDeviceId;
         this.currentTransport = null;
         this.currentDeviceId = null;
+        // F-24: this check just disconnected the transport it was monitoring —
+        // stop the interval so it does not keep waking on a dead connection.
+        this.stopConnectionHealthMonitoring();
         if (deviceId) {
           this.markDeviceDisconnected(deviceId);
         }
@@ -1151,6 +1255,12 @@ export class LedgerTransportService {
         console.log(
           'Ledger Health Check: Temporary communication issue, not disconnecting'
         );
+      }
+    } finally {
+      // F-24: always clear the race timeout, whether the APDU won (timer still
+      // pending) or the timeout itself fired (already settled — a no-op).
+      if (raceTimer) {
+        clearTimeout(raceTimer);
       }
     }
   }


### PR DESCRIPTION
## What & why

Voi Wallet Perf Audit II finding **F-24** (TASK-180, P2): the Ledger transport was initialized unconditionally at boot for **every** user — including signer mode — which meant:

1. A permanent **15s `setInterval` health check** ran for the app's whole foreground lifetime. For the ~100% of sessions with no connected Ledger, `checkConnectionHealth()` early-returns, so it's a pure JS wakeup 4×/min forever (battery, prevents JS idle).
2. One **wasted `AsyncStorage` read** per boot.
3. During a connected Ledger session, each health check created a 5s timeout that was **never cleared** when the APDU won the `Promise.race` — a stray self-expiring timer per check.
4. Static `TransportBLE` / `TransportHID` imports pulled **react-native-ble-plx 3.4.0 + rxjs 7.8.2** into the cold-boot eval graph (expo metro default `inlineRequires:false`), for hardware-wallet functionality most sessions never use.

## Changes

- **Boot gate** (`AppNavigator` → `ledgerTransportService.initializeIfPersistedDevices()`): only eagerly initialize when a Ledger was previously paired (persisted devices exist). A user who never used a Ledger skips transport init entirely. Users **with** a persisted device still load its metadata into the in-memory map so `getDevices()` consumers (rekey/signing via `keyManager.ts:436-482`) see it **before** any discovery/connect — metadata load never touches the transport modules. New `LedgerDeviceStorage.hasPersistedDevices()` backs the gate.
- **Connect-scoped health monitoring**: removed from `initialize()`; started only on a successful `connect()` and stopped on **every** path that clears a connected transport — explicit `disconnect()`, the transport `'disconnect'` event, discovery-`remove`, and the health check's own serious-error auto-disconnect. A CONNECTED transport is never left unmonitored; a disconnected one never keeps the interval alive.
- **APDU race timer**: `clearTimeout` in a `finally` so no stray 5s timer leaks when the APDU wins.
- **Lazy transport modules**: static `TransportBLE`/`TransportHID` imports → cached lazy `import()` inside discovery/connect, so ble-plx/rxjs leave the startup eval graph. `import Transport` narrowed to `import type`. Signer-mode / remote-signer / rekey / txn-signing are unaffected — they reach the transport only via `connect()`.

## Tests

New `src/services/ledger/__tests__/transport.test.ts` (7 tests): boot gate starts no interval and does not eval the transport modules (with and without persisted devices); monitoring starts on connect and stops on **both** disconnect paths; the 5s APDU race timer is cleared on APDU win.

## Gate results

- `npm run typecheck`: **0 errors**
- `npm run lint`: **0 errors** (675 pre-existing warnings unchanged)
- `npm test -- --ci`: **1049 passed / 62 suites**, incl. the 7 new F-24 tests

## Codex verdict

`codex exec` read-only self-review (5 hunts: unmonitored-connected-transport, lazy-import breaking signer/remote-signer/rekey/txn-signing, persisted metadata ordering vs keyManager, uncleared APDU timer, key/signature/Algorand-compat regression): **CLEAN** (round 1, no findings). Codex also independently confirmed `npm run typecheck` passed.

## On-device verification REQUIRED (real Ledger hardware)

Codex/CI cannot exercise real BLE/USB. Before merge, on a physical Ledger:

1. **Pair + connect** a Ledger (BLE and/or USB) from a fresh install (no persisted device) — confirm the first Ledger screen initializes the transport on demand and discovery/connect works.
2. **Sign a transaction** on-device and confirm it broadcasts (real Ed25519 signature, Algorand-compatible).
3. **Rekey to Ledger** and sign a rekeyed txn (auth address ≠ sender) — confirm `sgnr` handling still works.
4. **Disconnect** (explicit and by powering off / pulling cable) — confirm the 15s health monitoring **stops** (no wakeups after disconnect).
5. **Reconnect** — confirm monitoring resumes and a subsequent sign works.
6. Confirm a **no-Ledger** user gets **no 15s timer** at boot (the perf win).

Do **not** merge until the above hardware checks pass.
