### PR TITLE
fix(auth): fail closed on secure-storage read failure at boot (TASK-213)

### DIFF
--- a/src/components/AuthGuard.tsx
+++ b/src/components/AuthGuard.tsx
@@ -2,13 +2,23 @@ import React from 'react';
 import { View, StyleSheet } from 'react-native';
 import { useAuth } from '@/contexts/AuthContext';
 import LockScreen from '@/screens/auth/LockScreen';
+import SecureStorageUnavailableScreen from '@/screens/auth/SecureStorageUnavailableScreen';
 
 interface AuthGuardProps {
   children: React.ReactNode;
 }
 
 export default function AuthGuard({ children }: AuthGuardProps) {
-  const { authState } = useAuth();
+  const { authState, recheckAuthState } = useAuth();
+
+  // Fail-closed recovery (TASK-213): when the strict boot reads found secure
+  // storage unreadable, render ONLY the recovery screen — no children, no lock
+  // screen — so the app grants ZERO wallet access until the check recovers. This
+  // takes priority over the normal lock so a broken store never falls through to
+  // the PIN pad (which cannot unlock a store it can't read) or to the wallet.
+  if (authState.securityUnavailable) {
+    return <SecureStorageUnavailableScreen onRetry={recheckAuthState} />;
+  }
 
   const showLock = authState.isLocked || !authState.isAuthenticated;
 

--- a/src/contexts/AuthContext.tsx
+++ b/src/contexts/AuthContext.tsx
@@ -378,12 +378,21 @@ export function AuthProvider({ children }: { children: React.ReactNode }) {
       // keystore break to SecuritySetup (a lock-takeover fail-OPEN). This is the
       // "clear whenever the strict PIN read confirms a PIN exists" guarantee;
       // hasPinStrict is kept a pure read, so the clear lives here at the sole read
-      // site. Fire-and-forget: the breadcrumb is only ever read at the NEXT boot,
-      // and a killed clear is retried on the next readable-PIN boot; the primary
-      // durable clear is in setupPin. When hasPin is true the key-bearing guard
-      // below cannot fire, so this never races the breadcrumb READ.
+      // site. AWAITED (not fire-and-forget) so the breadcrumb is DURABLY gone
+      // before this boot's verdict — closing the window where a killed
+      // fire-and-forget clear could leave it for a later keystore-break boot. The
+      // primary clear is still in setupPin; this is the belt-and-suspenders that
+      // makes lingering impossible for realistic failure modes. Bounded by
+      // withTimeout so a wedged removeItem cannot stall boot, and its result is
+      // swallowed (best-effort) so it never perturbs the lock verdict. When hasPin
+      // is true the key-bearing guard below cannot fire, so this never races the
+      // breadcrumb READ.
       if (hasPin) {
-        void clearPinSetupPending();
+        await withTimeout(
+          clearPinSetupPending(),
+          STRICT_READ_TIMEOUT_MS,
+          'pin_setup_pending self-heal clear'
+        ).catch(() => {});
       }
 
       if (hasKeyBearingAccount && !hasPin) {
@@ -404,7 +413,15 @@ export function AuthProvider({ children }: { children: React.ReactNode }) {
         //
         // isPinSetupPending fails CLOSED (a breadcrumb read error resolves absent),
         // so an unreadable breadcrumb takes the recovery path, never SecuritySetup.
-        const restoreInProgress = await isPinSetupPending();
+        // Bounded by withTimeout so a HUNG breadcrumb read (a promise that never
+        // settles) cannot strand boot here after the strict probes succeeded — a
+        // timeout resolves to `false` (fail CLOSED to recovery), never a hang and
+        // never a wrongful resume.
+        const restoreInProgress = await withTimeout(
+          isPinSetupPending(),
+          STRICT_READ_TIMEOUT_MS,
+          'pin_setup_pending read'
+        ).catch(() => false);
         if (restoreInProgress) {
           // Resume PIN setup. isLocked/isAuthenticated are set to the FAIL-CLOSED
           // pair (locked, not authenticated) as defense in depth: the navigator

--- a/src/contexts/AuthContext.tsx
+++ b/src/contexts/AuthContext.tsx
@@ -56,6 +56,12 @@ export interface AuthState {
   // grants ZERO wallet access: it is neither the unlocked setup state nor the
   // normal PIN-lock. It is never set for genuine absence or a readable wallet.
   securityUnavailable: boolean;
+  // True once checkInitialAuthState has produced its FIRST verdict (any branch:
+  // recovery, unlocked-setup, or locked). Consumers that render UN-guarded routes
+  // (the navigator's Onboarding branch, TASK-213) wait on this so a pending
+  // storage FAILURE resolves to the recovery screen instead of briefly exposing
+  // the unauthenticated setup flow. Starts false; only ever transitions to true.
+  authChecked: boolean;
 }
 
 export interface AuthContextType {
@@ -99,6 +105,7 @@ export function AuthProvider({ children }: { children: React.ReactNode }) {
     timeoutMinutes: 5,
     hasPin: false,
     securityUnavailable: false,
+    authChecked: false,
   });
 
   const activityTimer = useRef<NodeJS.Timeout | undefined>(undefined);
@@ -260,6 +267,7 @@ export function AuthProvider({ children }: { children: React.ReactNode }) {
           isLocked: true,
           isAuthenticated: false,
           securityUnavailable: true,
+          authChecked: true,
           biometricEnabled: false,
           backgroundedAt: null,
         }));
@@ -277,6 +285,7 @@ export function AuthProvider({ children }: { children: React.ReactNode }) {
           isLocked: false,
           isAuthenticated: true,
           securityUnavailable: false,
+          authChecked: true,
           biometricEnabled: biometricEnabled && biometricAvailable,
           backgroundedAt: null,
           timeoutMinutes,
@@ -291,6 +300,7 @@ export function AuthProvider({ children }: { children: React.ReactNode }) {
         isLocked: true,
         isAuthenticated: false,
         securityUnavailable: false,
+        authChecked: true,
         biometricEnabled: biometricEnabled && biometricAvailable,
         backgroundedAt: null,
         timeoutMinutes,
@@ -309,6 +319,7 @@ export function AuthProvider({ children }: { children: React.ReactNode }) {
         isLocked: true,
         isAuthenticated: false,
         securityUnavailable: true,
+        authChecked: true,
         biometricEnabled: false,
         backgroundedAt: null,
       }));

--- a/src/contexts/AuthContext.tsx
+++ b/src/contexts/AuthContext.tsx
@@ -8,6 +8,10 @@ import React, {
 import { AppState, Platform, AppStateStatus } from 'react-native';
 import { MultiAccountWalletService } from '@/services/wallet';
 import { AccountSecureStorage } from '@/services/secure';
+import {
+  isPinSetupPending,
+  clearPinSetupPending,
+} from '@/services/secure/pinSetupPending';
 import { SessionKeyVault } from '@/services/secure/SessionKeyVault';
 import type { SecretSource } from '@/services/secure/SessionKeyVault';
 import { unlockVaultWithBiometrics } from '@/services/secure/biometricUnlock';
@@ -69,6 +73,15 @@ export interface AuthState {
   // must not expose the unguarded setup flow after a recovery/transient blip).
   // Meaningful only once authChecked is true and securityUnavailable is false.
   hasWallet: boolean;
+  // Resume-PIN-setup flag (TASK-213 restore-before-PIN fix). True ONLY when the
+  // boot verdict found a key-bearing account with no readable PIN AND the durable
+  // pin_setup_pending breadcrumb was set — i.e. a restore-from-backup persisted
+  // STANDARD accounts and was cold-killed before the user set a PIN. The navigator
+  // routes its initial route to SecuritySetup(source:'restore') so the user
+  // RESUMES PIN setup instead of hitting the recovery screen (whose Reset would
+  // wipe the just-restored wallet). Without the breadcrumb the SAME key-bearing/
+  // no-PIN state is a genuine keystore break and stays fail-closed to recovery.
+  pinSetupResume: boolean;
 }
 
 export interface AuthContextType {
@@ -155,6 +168,7 @@ export function AuthProvider({ children }: { children: React.ReactNode }) {
     securityUnavailable: false,
     authChecked: false,
     hasWallet: false,
+    pinSetupResume: false,
   });
 
   const activityTimer = useRef<NodeJS.Timeout | undefined>(undefined);
@@ -342,6 +356,7 @@ export function AuthProvider({ children }: { children: React.ReactNode }) {
           isAuthenticated: false,
           securityUnavailable: true,
           authChecked: true,
+          pinSetupResume: false,
           biometricEnabled: false,
           backgroundedAt: null,
         }));
@@ -350,17 +365,59 @@ export function AuthProvider({ children }: { children: React.ReactNode }) {
 
       const { hasWallet, hasPin, hasKeyBearingAccount } = lockState;
 
+      // SELF-HEAL (TASK-213, anti-fail-open): a readable PIN proves setup
+      // completed, so any lingering pin_setup_pending breadcrumb is stale. Clear
+      // it on EVERY readable-PIN boot so it can never later route a genuine
+      // keystore break to SecuritySetup (a lock-takeover fail-OPEN). This is the
+      // "clear whenever the strict PIN read confirms a PIN exists" guarantee;
+      // hasPinStrict is kept a pure read, so the clear lives here at the sole read
+      // site. Fire-and-forget: the breadcrumb is only ever read at the NEXT boot,
+      // and a killed clear is retried on the next readable-PIN boot; the primary
+      // durable clear is in setupPin. When hasPin is true the key-bearing guard
+      // below cannot fire, so this never races the breadcrumb READ.
+      if (hasPin) {
+        void clearPinSetupPending();
+      }
+
       if (hasKeyBearingAccount && !hasPin) {
-        // FAIL CLOSED (TASK-213 Codex round-4): a locally-key-bearing (STANDARD)
-        // account CANNOT exist without a PIN — setupPin always precedes the key
-        // import and the key is wrapped under the secret. So "key-bearing account
-        // present, PIN absent" is an IMPOSSIBLE genuine state: the PIN read was an
-        // Android swallow-to-null failure that the per-key presence sentinel could
-        // not catch (a pre-sentinel install whose keystore broke on its first boot
-        // after upgrade). Falling into the `!hasPin` setup branch here would be the
-        // exact fail-OPEN this task closes (offering to set a NEW PIN over a real
-        // wallet — a lock-takeover). Enter recovery instead. The wallet-metadata
-        // signal is read from plaintext AsyncStorage, unaffected by keystore desync.
+        // A locally-key-bearing (STANDARD) account with NO readable PIN. Two very
+        // different causes, disambiguated by the durable plaintext breadcrumb:
+        //
+        //  (1) RESTORE-BEFORE-PIN (breadcrumb SET): restore-from-backup persists
+        //      STANDARD accounts BEFORE the user sets a PIN, then routes to
+        //      SecuritySetup. A cold-kill in that window leaves this exact on-disk
+        //      state on a HEALTHY wallet. Route to SecuritySetup to RESUME PIN
+        //      setup — NOT recovery, whose Reset would wipe the restored wallet.
+        //
+        //  (2) GENUINE KEYSTORE BREAK (breadcrumb ABSENT): an Android
+        //      swallow-to-null PIN read on a wallet whose keystore desynced. Here
+        //      "key-bearing + no PIN" is an IMPOSSIBLE genuine state and falling
+        //      into the setup branch would be a fail-OPEN (offering a NEW PIN over
+        //      a real wallet). Fail CLOSED to recovery.
+        //
+        // isPinSetupPending fails CLOSED (a breadcrumb read error resolves absent),
+        // so an unreadable breadcrumb takes the recovery path, never SecuritySetup.
+        const restoreInProgress = await isPinSetupPending();
+        if (restoreInProgress) {
+          // Resume PIN setup. isLocked/isAuthenticated are set to the FAIL-CLOSED
+          // pair (locked, not authenticated) as defense in depth: the navigator
+          // routes the initial route to SecuritySetup (never Main) off
+          // pinSetupResume, and Main stays lock-guarded even if it were reached
+          // before a PIN is set. hasWallet reflects the on-disk reality (true).
+          setAuthState((prev) => ({
+            ...prev,
+            isLocked: true,
+            isAuthenticated: false,
+            securityUnavailable: false,
+            authChecked: true,
+            pinSetupResume: true,
+            hasWallet: true,
+            hasPin: false,
+            biometricEnabled: false,
+            backgroundedAt: null,
+          }));
+          return;
+        }
         console.error(
           'Key-bearing account present but PIN read resolved absent — treating as a ' +
             'secure-storage read failure and failing closed to recovery.'
@@ -371,6 +428,7 @@ export function AuthProvider({ children }: { children: React.ReactNode }) {
           isAuthenticated: false,
           securityUnavailable: true,
           authChecked: true,
+          pinSetupResume: false,
           biometricEnabled: false,
           backgroundedAt: null,
         }));
@@ -387,6 +445,7 @@ export function AuthProvider({ children }: { children: React.ReactNode }) {
           isAuthenticated: true,
           securityUnavailable: false,
           authChecked: true,
+          pinSetupResume: false,
           hasWallet,
           biometricEnabled: biometricEnabled && biometricAvailable,
           backgroundedAt: null,
@@ -403,6 +462,7 @@ export function AuthProvider({ children }: { children: React.ReactNode }) {
         isAuthenticated: false,
         securityUnavailable: false,
         authChecked: true,
+        pinSetupResume: false,
         hasWallet,
         biometricEnabled: biometricEnabled && biometricAvailable,
         backgroundedAt: null,
@@ -423,6 +483,7 @@ export function AuthProvider({ children }: { children: React.ReactNode }) {
         isAuthenticated: false,
         securityUnavailable: true,
         authChecked: true,
+        pinSetupResume: false,
         biometricEnabled: false,
         backgroundedAt: null,
       }));

--- a/src/contexts/AuthContext.tsx
+++ b/src/contexts/AuthContext.tsx
@@ -97,9 +97,50 @@ const BACKGROUND_GRACE_PERIOD = 60 * 1000; // 60 seconds
 const STRICT_READ_MAX_ATTEMPTS = 3;
 const STRICT_READ_BACKOFF_MS = 200;
 
+// TASK-213 (no-stuck): per-read timeout so a HUNG storage read (a promise that
+// never resolves OR rejects — e.g. a wedged native bridge) cannot strand the
+// boot. Without it, an awaited read that never settles means checkInitialAuthState
+// never reaches a terminal setAuthState, authChecked stays false forever, the
+// navigator renders null under the splash, and the 10s splash watchdog only
+// force-HIDES the splash to reveal a blank screen with no recovery UI. Wrapping
+// each read in a timeout converts a hang into a REJECTION, which the strict-read
+// retry loop already handles: it retries, then fails CLOSED to the recovery
+// screen (which now offers Retry AND a reset escape hatch). The bound is chosen
+// so even the worst case — the non-critical reads hang, then all 3 strict
+// attempts hang (2000 + 2000+200 + 2000+400 + 2000 = 8600 ms) — still settles
+// UNDER the 10s splash watchdog, so recovery paints before the splash is torn
+// down onto a blank frame.
+const STRICT_READ_TIMEOUT_MS = 2000;
+
 // Web-safe delay. Used only for the bounded strict-read backoff above.
 const delay = (ms: number): Promise<void> =>
   new Promise((resolve) => setTimeout(resolve, ms));
+
+// Reject if `promise` has not settled within `ms`. On timeout the underlying
+// read is abandoned (its eventual settlement is ignored) and a labelled Error is
+// thrown so the caller can retry / fail closed. The timer is always cleared so no
+// stray handle survives once the promise settles first.
+const withTimeout = <T,>(
+  promise: Promise<T>,
+  ms: number,
+  label: string
+): Promise<T> => {
+  return new Promise<T>((resolve, reject) => {
+    const timer = setTimeout(() => {
+      reject(new Error(`${label} timed out after ${ms}ms`));
+    }, ms);
+    promise.then(
+      (value) => {
+        clearTimeout(timer);
+        resolve(value);
+      },
+      (error) => {
+        clearTimeout(timer);
+        reject(error);
+      }
+    );
+  });
+};
 
 export function AuthProvider({ children }: { children: React.ReactNode }) {
   const [authState, setAuthState] = useState<AuthState>({
@@ -211,11 +252,19 @@ export function AuthProvider({ children }: { children: React.ReactNode }) {
       let biometricAvailable = false;
       let timeoutMinutes: number | 'never' = 5;
       try {
-        const [biometric, isBiometricEnabled, pinTimeout] = await Promise.all([
-          checkBiometricAvailability(),
-          AccountSecureStorage.isBiometricEnabled(),
-          AccountSecureStorage.getPinTimeout(),
-        ]);
+        // Wrapped in a timeout (no-stuck): these non-critical reads are NEWLY on
+        // the app-render-gating path, so a hang here would stall boot just like a
+        // strict-read hang. On timeout the catch below falls back to safe display
+        // defaults — it NEVER drives the lock decision.
+        const [biometric, isBiometricEnabled, pinTimeout] = await withTimeout(
+          Promise.all([
+            checkBiometricAvailability(),
+            AccountSecureStorage.isBiometricEnabled(),
+            AccountSecureStorage.getPinTimeout(),
+          ]),
+          STRICT_READ_TIMEOUT_MS,
+          'Non-critical auth-init reads'
+        );
         biometricAvailable = biometric.hasHardware && biometric.isEnrolled;
         biometricEnabled = isBiometricEnabled;
         timeoutMinutes = pinTimeout;
@@ -241,15 +290,32 @@ export function AuthProvider({ children }: { children: React.ReactNode }) {
       // pair so the loop can RETRY it. A retry happens ONLY on a read FAILURE —
       // a genuine ABSENCE resolves `false` and is never retried. The short
       // backoff tolerates transient cold-boot keychain/keystore unavailability.
-      let lockState: { hasWallet: boolean; hasPin: boolean } | null = null;
+      let lockState: {
+        hasWallet: boolean;
+        hasPin: boolean;
+        hasKeyBearingAccount: boolean;
+      } | null = null;
       let lastError: unknown;
       for (let attempt = 1; attempt <= STRICT_READ_MAX_ATTEMPTS; attempt += 1) {
         try {
-          const [hasWallet, hasPin] = await Promise.all([
-            MultiAccountWalletService.hasWalletWithAccountsStrict(),
-            AccountSecureStorage.hasPinStrict(),
-          ]);
-          lockState = { hasWallet, hasPin };
+          // Timeout-wrapped (no-stuck): a strict read that HANGS (never settles)
+          // is converted into a rejection so this loop retries and, if it never
+          // recovers, fails CLOSED to the recovery screen — instead of leaving
+          // authChecked false forever behind the splash.
+          //
+          // hasKeyBearingAccount is read from the SAME strict pass so the
+          // Android-swallow-to-null guard below (Codex round-4) can act on the
+          // durable, keystore-independent signal it needs.
+          const [hasWallet, hasPin, hasKeyBearingAccount] = await withTimeout(
+            Promise.all([
+              MultiAccountWalletService.hasWalletWithAccountsStrict(),
+              AccountSecureStorage.hasPinStrict(),
+              MultiAccountWalletService.hasKeyBearingAccountStrict(),
+            ]),
+            STRICT_READ_TIMEOUT_MS,
+            'Strict lock-determining auth reads'
+          );
+          lockState = { hasWallet, hasPin, hasKeyBearingAccount };
           break;
         } catch (error) {
           lastError = error;
@@ -282,7 +348,34 @@ export function AuthProvider({ children }: { children: React.ReactNode }) {
         return;
       }
 
-      const { hasWallet, hasPin } = lockState;
+      const { hasWallet, hasPin, hasKeyBearingAccount } = lockState;
+
+      if (hasKeyBearingAccount && !hasPin) {
+        // FAIL CLOSED (TASK-213 Codex round-4): a locally-key-bearing (STANDARD)
+        // account CANNOT exist without a PIN — setupPin always precedes the key
+        // import and the key is wrapped under the secret. So "key-bearing account
+        // present, PIN absent" is an IMPOSSIBLE genuine state: the PIN read was an
+        // Android swallow-to-null failure that the per-key presence sentinel could
+        // not catch (a pre-sentinel install whose keystore broke on its first boot
+        // after upgrade). Falling into the `!hasPin` setup branch here would be the
+        // exact fail-OPEN this task closes (offering to set a NEW PIN over a real
+        // wallet — a lock-takeover). Enter recovery instead. The wallet-metadata
+        // signal is read from plaintext AsyncStorage, unaffected by keystore desync.
+        console.error(
+          'Key-bearing account present but PIN read resolved absent — treating as a ' +
+            'secure-storage read failure and failing closed to recovery.'
+        );
+        setAuthState((prev) => ({
+          ...prev,
+          isLocked: true,
+          isAuthenticated: false,
+          securityUnavailable: true,
+          authChecked: true,
+          biometricEnabled: false,
+          backgroundedAt: null,
+        }));
+        return;
+      }
 
       if (!hasWallet || !hasPin) {
         // Genuine ABSENCE of a wallet or PIN — allow access for setup (UNCHANGED

--- a/src/contexts/AuthContext.tsx
+++ b/src/contexts/AuthContext.tsx
@@ -62,6 +62,13 @@ export interface AuthState {
   // storage FAILURE resolves to the recovery screen instead of briefly exposing
   // the unauthenticated setup flow. Starts false; only ever transitions to true.
   authChecked: boolean;
+  // Authoritative "a wallet with ≥1 account exists", from the SAME strict boot
+  // read that decides the lock state (TASK-213). The navigator derives its
+  // initial route (Main vs Onboarding) from this single source of truth so the
+  // route can never diverge from the fail-closed auth verdict (a stale route
+  // must not expose the unguarded setup flow after a recovery/transient blip).
+  // Meaningful only once authChecked is true and securityUnavailable is false.
+  hasWallet: boolean;
 }
 
 export interface AuthContextType {
@@ -106,6 +113,7 @@ export function AuthProvider({ children }: { children: React.ReactNode }) {
     hasPin: false,
     securityUnavailable: false,
     authChecked: false,
+    hasWallet: false,
   });
 
   const activityTimer = useRef<NodeJS.Timeout | undefined>(undefined);
@@ -286,6 +294,7 @@ export function AuthProvider({ children }: { children: React.ReactNode }) {
           isAuthenticated: true,
           securityUnavailable: false,
           authChecked: true,
+          hasWallet,
           biometricEnabled: biometricEnabled && biometricAvailable,
           backgroundedAt: null,
           timeoutMinutes,
@@ -301,6 +310,7 @@ export function AuthProvider({ children }: { children: React.ReactNode }) {
         isAuthenticated: false,
         securityUnavailable: false,
         authChecked: true,
+        hasWallet,
         biometricEnabled: biometricEnabled && biometricAvailable,
         backgroundedAt: null,
         timeoutMinutes,

--- a/src/contexts/AuthContext.tsx
+++ b/src/contexts/AuthContext.tsx
@@ -120,10 +120,17 @@ const STRICT_READ_BACKOFF_MS = 200;
 // retry loop already handles: it retries, then fails CLOSED to the recovery
 // screen (which now offers Retry AND a reset escape hatch). The bound is chosen
 // so even the worst case — the non-critical reads hang, then all 3 strict
-// attempts hang (2000 + 2000+200 + 2000+400 + 2000 = 8600 ms) — still settles
-// UNDER the 10s splash watchdog, so recovery paints before the splash is torn
-// down onto a blank frame.
-const STRICT_READ_TIMEOUT_MS = 2000;
+// attempts hang — still settles COMFORTABLY under the 10s splash watchdog, so
+// recovery paints before the splash is torn down onto a blank frame.
+//
+// TASK-213 (P3, watchdog margin): trimmed 2000 → 1500 ms. The worst case is now
+// 1500 (non-critical) + 1500+200 + 1500+400 + 1500 = 6600 ms, leaving ~3.4 s of
+// slack under the 10 s watchdog (was only ~1.4 s at 2000 ms) so cold-boot timer/
+// scheduling drift can't push the settle past the watchdog and force it to hide
+// onto a blank frame before recovery renders. 1500 ms is still far above a normal
+// keychain/keystore read (<100 ms), so it never trips on a healthy-but-slow read;
+// a genuinely wedged read still times out → retries → fails CLOSED to recovery.
+const STRICT_READ_TIMEOUT_MS = 1500;
 
 // Web-safe delay. Used only for the bounded strict-read backoff above.
 const delay = (ms: number): Promise<void> =>

--- a/src/contexts/AuthContext.tsx
+++ b/src/contexts/AuthContext.tsx
@@ -411,8 +411,16 @@ export function AuthProvider({ children }: { children: React.ReactNode }) {
         //      into the setup branch would be a fail-OPEN (offering a NEW PIN over
         //      a real wallet). Fail CLOSED to recovery.
         //
-        // isPinSetupPending fails CLOSED (a breadcrumb read error resolves absent),
-        // so an unreadable breadcrumb takes the recovery path, never SecuritySetup.
+        // WHY A STALE BREADCRUMB CANNOT FAIL OPEN HERE (see pinSetupPending.ts):
+        //  - This branch is reached only when the strict PIN read RESOLVED false.
+        //    A PIN committed via secureStorage records a durable presence sentinel,
+        //    so a later keystore break makes that read THROW (present-but-unreadable)
+        //    → the `!lockState` recovery path above, NOT this guard. So reaching
+        //    here means no such committed-PIN sentinel exists (genuine absence or a
+        //    pre-sentinel install with no PIN of its own) — a resume is correct.
+        //  - isPinSetupPending fails CLOSED (a breadcrumb read error resolves
+        //    absent), so a broken store — the only state where a stale marker could
+        //    survive un-cleared — takes the RECOVERY path, never a resume.
         // Bounded by withTimeout so a HUNG breadcrumb read (a promise that never
         // settles) cannot strand boot here after the strict probes succeeded — a
         // timeout resolves to `false` (fail CLOSED to recovery), never a hang and

--- a/src/contexts/AuthContext.tsx
+++ b/src/contexts/AuthContext.tsx
@@ -49,6 +49,13 @@ export interface AuthState {
   backgroundedAt: number | null;
   timeoutMinutes: number | 'never';
   hasPin: boolean;
+  // Fail-closed recovery flag (TASK-213). True ONLY when the strict, lock-
+  // determining secure-storage reads at boot STILL fail after bounded retry —
+  // i.e. secure storage is genuinely unreadable. When true the app shows the
+  // "secure storage unavailable" recovery screen (Retry re-runs the check) and
+  // grants ZERO wallet access: it is neither the unlocked setup state nor the
+  // normal PIN-lock. It is never set for genuine absence or a readable wallet.
+  securityUnavailable: boolean;
 }
 
 export interface AuthContextType {
@@ -69,6 +76,18 @@ const DEFAULT_SESSION_TIMEOUT = 5 * 60 * 1000; // 5 minutes default
 const ACTIVITY_CHECK_INTERVAL = 30 * 1000; // 30 seconds
 const BACKGROUND_GRACE_PERIOD = 60 * 1000; // 60 seconds
 
+// TASK-213: bounded retry for the STRICT, lock-determining secure-storage reads
+// at boot. A transient keychain/keystore unavailability (common at cold boot) is
+// retried a few times with a short linear backoff before the app fails CLOSED to
+// the recovery state — so a transient hiccup recovers silently and never strands
+// a legitimate user, while a persistent failure never falls open to setup state.
+const STRICT_READ_MAX_ATTEMPTS = 3;
+const STRICT_READ_BACKOFF_MS = 200;
+
+// Web-safe delay. Used only for the bounded strict-read backoff above.
+const delay = (ms: number): Promise<void> =>
+  new Promise((resolve) => setTimeout(resolve, ms));
+
 export function AuthProvider({ children }: { children: React.ReactNode }) {
   const [authState, setAuthState] = useState<AuthState>({
     isLocked: true,
@@ -79,6 +98,7 @@ export function AuthProvider({ children }: { children: React.ReactNode }) {
     backgroundedAt: null,
     timeoutMinutes: 5,
     hasPin: false,
+    securityUnavailable: false,
   });
 
   const activityTimer = useRef<NodeJS.Timeout | undefined>(undefined);
@@ -167,44 +187,96 @@ export function AuthProvider({ children }: { children: React.ReactNode }) {
 
   const checkInitialAuthState = async () => {
     try {
-      // Parallelize the independent lock-determining probes (F-03). These five
-      // reads (wallet, PIN presence, biometric hardware/enrollment, biometric
-      // enabled flag, PIN timeout) do not depend on each other, so they run
-      // concurrently instead of as a 7-deep serial await chain. The lock state
-      // computed for every resolved-value input is IDENTICAL to the prior serial
-      // predicate below — only the I/O is parallelized.
-      //
-      // Promise.all, NOT Promise.allSettled: a probe that *rejects* still
-      // propagates to the catch below, leaving the app at its LOCKED default
-      // (isLocked: true / isAuthenticated: false) — exactly as the serial awaits
-      // did. Do NOT switch to allSettled: coercing a rejected hasPin to `false`
-      // would flip a rejecting read into the `!hasPin` unlocked setup state.
-      //
-      // NOTE — pre-existing fail-OPEN, out of scope for this I/O-only change:
-      // hasPin() and getCurrentWallet() catch their OWN storage errors and
-      // resolve falsy (false / null) rather than rejecting (AccountSecureStorage
-      // .hasPin, wallet/index.ts getCurrentWallet), so a storage read *failure*
-      // is indistinguishable here from "no PIN / no wallet" and lands in the
-      // unlocked setup state. That predates this diff and is unchanged by it;
-      // closing it would require an auth/lock SEMANTICS change (surfacing a read
-      // failure as a locked state) that needs human auth sign-off — see TASK-177.
-      const [wallet, hasPin, biometric, biometricEnabled, timeoutMinutes] =
-        await Promise.all([
-          MultiAccountWalletService.getCurrentWallet(),
-          AccountSecureStorage.hasPin(),
+      // ── Non-lock-determining reads (display/config only) ───────────────────
+      // Biometric availability, the biometric-enabled flag, and the PIN timeout
+      // do NOT gate wallet access, so a failure here falls back to safe display
+      // defaults (no biometrics, 5-min timeout) and NEVER drives the lock
+      // decision. Only the STRICT reads below decide locked/unlocked/recovery.
+      let biometricEnabled = false;
+      let biometricAvailable = false;
+      let timeoutMinutes: number | 'never' = 5;
+      try {
+        const [biometric, isBiometricEnabled, pinTimeout] = await Promise.all([
           checkBiometricAvailability(),
           AccountSecureStorage.isBiometricEnabled(),
           AccountSecureStorage.getPinTimeout(),
         ]);
-      const { hasHardware, isEnrolled } = biometric;
-      const biometricAvailable = hasHardware && isEnrolled;
+        biometricAvailable = biometric.hasHardware && biometric.isEnrolled;
+        biometricEnabled = isBiometricEnabled;
+        timeoutMinutes = pinTimeout;
+      } catch (error) {
+        // Non-security-critical — this must NOT affect the fail-closed lock
+        // decision, so keep the safe display defaults and continue.
+        console.warn(
+          'Non-critical auth-init reads failed; using display defaults',
+          error
+        );
+      }
 
-      if (!wallet || wallet.accounts.length === 0 || !hasPin) {
-        // No wallet setup yet or no PIN set - allow access for setup
+      // ── Lock-determining reads (STRICT, bounded retry, fail-closed) ─────────
+      // TASK-213: the STRICT variants THROW on a genuine secure-storage read/
+      // decrypt FAILURE and resolve falsy ONLY for genuine ABSENCE. That is what
+      // lets boot fail CLOSED: a read failure can no longer masquerade as "no
+      // wallet / no PIN" and slip into the unlocked setup state (the fail-OPEN
+      // this closes). The prior code used the error-SWALLOWING getCurrentWallet()
+      // / hasPin(), which resolved falsy on failure and dropped straight into the
+      // `!hasPin` unlocked branch.
+      //
+      // Promise.all (NOT allSettled): a throw in EITHER strict read rejects the
+      // pair so the loop can RETRY it. A retry happens ONLY on a read FAILURE —
+      // a genuine ABSENCE resolves `false` and is never retried. The short
+      // backoff tolerates transient cold-boot keychain/keystore unavailability.
+      let lockState: { hasWallet: boolean; hasPin: boolean } | null = null;
+      let lastError: unknown;
+      for (let attempt = 1; attempt <= STRICT_READ_MAX_ATTEMPTS; attempt += 1) {
+        try {
+          const [hasWallet, hasPin] = await Promise.all([
+            MultiAccountWalletService.hasWalletWithAccountsStrict(),
+            AccountSecureStorage.hasPinStrict(),
+          ]);
+          lockState = { hasWallet, hasPin };
+          break;
+        } catch (error) {
+          lastError = error;
+          // Back off briefly, then retry. No delay after the final attempt.
+          if (attempt < STRICT_READ_MAX_ATTEMPTS) {
+            await delay(STRICT_READ_BACKOFF_MS * attempt);
+          }
+        }
+      }
+
+      if (!lockState) {
+        // FAIL CLOSED (TASK-213): the strict lock-determining reads STILL failed
+        // after retry, so secure storage is genuinely unreadable. Do NOT grant
+        // setup access and do NOT show the normal PIN lock (which cannot recover
+        // a broken store). Enter the recovery state — zero wallet access; its
+        // Retry re-runs this check and recovers if storage becomes readable.
+        console.error(
+          'Secure storage unavailable at auth init after retries:',
+          lastError
+        );
+        setAuthState((prev) => ({
+          ...prev,
+          isLocked: true,
+          isAuthenticated: false,
+          securityUnavailable: true,
+          biometricEnabled: false,
+          backgroundedAt: null,
+        }));
+        return;
+      }
+
+      const { hasWallet, hasPin } = lockState;
+
+      if (!hasWallet || !hasPin) {
+        // Genuine ABSENCE of a wallet or PIN — allow access for setup (UNCHANGED
+        // behavior). securityUnavailable is cleared: a transient failure that
+        // recovered on retry lands here and never shows the recovery screen.
         setAuthState((prev) => ({
           ...prev,
           isLocked: false,
           isAuthenticated: true,
+          securityUnavailable: false,
           biometricEnabled: biometricEnabled && biometricAvailable,
           backgroundedAt: null,
           timeoutMinutes,
@@ -213,18 +285,33 @@ export function AuthProvider({ children }: { children: React.ReactNode }) {
         return;
       }
 
-      // Wallet exists and has PIN - require authentication
+      // Wallet exists and has a PIN — require authentication (UNCHANGED).
       setAuthState((prev) => ({
         ...prev,
         isLocked: true,
         isAuthenticated: false,
+        securityUnavailable: false,
         biometricEnabled: biometricEnabled && biometricAvailable,
         backgroundedAt: null,
         timeoutMinutes,
         hasPin,
       }));
     } catch (error) {
-      console.error('Failed to check initial auth state:', error);
+      // Defensive: any UNEXPECTED failure in the auth-init path fails CLOSED to
+      // the recovery state rather than leaving the app indeterminate (possibly
+      // unlocked). Retry re-runs this check.
+      console.error(
+        'Unexpected failure during auth init; failing closed:',
+        error
+      );
+      setAuthState((prev) => ({
+        ...prev,
+        isLocked: true,
+        isAuthenticated: false,
+        securityUnavailable: true,
+        biometricEnabled: false,
+        backgroundedAt: null,
+      }));
     }
   };
 

--- a/src/contexts/__tests__/AuthContext.test.tsx
+++ b/src/contexts/__tests__/AuthContext.test.tsx
@@ -631,6 +631,59 @@ describe('AuthContext — TASK-213 fail-closed recovery on storage read failure'
     expect(result.current.authState.isAuthenticated).toBe(true);
   });
 
+  it('(m) a HUNG breadcrumb read does NOT stall boot — times out and fails CLOSED to recovery', async () => {
+    // No-stuck (Codex round-5 finding 2): isPinSetupPending is on the boot path in
+    // the key-bearing guard. A read that never settles must NOT leave boot awaiting
+    // forever (authChecked false behind the splash). withTimeout converts the hang
+    // into `false` ⇒ the guard falls through to RECOVERY (fail-closed), never a
+    // wrongful resume and never a stall.
+    mockHasWalletStrict.mockResolvedValue(true);
+    mockHasPinStrict.mockResolvedValue(false);
+    mockHasKeyBearing.mockResolvedValue(true);
+    mockIsPinSetupPending.mockReturnValue(new Promise<boolean>(() => {})); // hangs
+    const errorSpy = jest.spyOn(console, 'error').mockImplementation(() => {});
+
+    const rendered = renderHook(() => useAuth(), { wrapper });
+    await act(async () => {
+      for (let i = 0; i < 20; i += 1) {
+        await Promise.resolve();
+        jest.advanceTimersByTime(1000);
+        await Promise.resolve();
+      }
+    });
+
+    expect(rendered.result.current.authState.authChecked).toBe(true);
+    expect(rendered.result.current.authState.securityUnavailable).toBe(true);
+    expect(rendered.result.current.authState.pinSetupResume).toBe(false);
+    expect(rendered.result.current.authState.isAuthenticated).toBe(false);
+
+    errorSpy.mockRestore();
+  });
+
+  it('(n) a HUNG self-heal clear does NOT stall boot — the verdict still settles (LOCKED)', async () => {
+    // The readable-PIN self-heal clear is AWAITED (durable) but bounded, so a
+    // wedged removeItem cannot strand boot. It times out and the lock verdict
+    // still resolves.
+    mockHasWalletStrict.mockResolvedValue(true);
+    mockHasPinStrict.mockResolvedValue(true);
+    mockHasKeyBearing.mockResolvedValue(false);
+    mockIsPinSetupPending.mockResolvedValue(true);
+    mockClearPinSetupPending.mockReturnValue(new Promise<void>(() => {})); // hangs
+
+    const rendered = renderHook(() => useAuth(), { wrapper });
+    await act(async () => {
+      for (let i = 0; i < 20; i += 1) {
+        await Promise.resolve();
+        jest.advanceTimersByTime(1000);
+        await Promise.resolve();
+      }
+    });
+
+    expect(rendered.result.current.authState.authChecked).toBe(true);
+    expect(rendered.result.current.authState.isLocked).toBe(true);
+    expect(rendered.result.current.authState.securityUnavailable).toBe(false);
+  });
+
   it('never RETRIES a genuine absence — a false-resolving strict read reads exactly once', async () => {
     // Absence must NOT be retried (only failures are). One attempt, no backoff.
     mockHasWalletStrict.mockResolvedValue(false);

--- a/src/contexts/__tests__/AuthContext.test.tsx
+++ b/src/contexts/__tests__/AuthContext.test.tsx
@@ -27,6 +27,10 @@ import { SessionKeyVault } from '@/services/secure/SessionKeyVault';
 import { unlockVaultWithBiometrics } from '@/services/secure/biometricUnlock';
 import { enterLockedState } from '@/services/secure/sessionTeardown';
 import { AppLockSignal } from '@/services/secure/appLockState';
+import {
+  isPinSetupPending,
+  clearPinSetupPending,
+} from '@/services/secure/pinSetupPending';
 import * as LocalAuthentication from 'expo-local-authentication';
 
 // --- Mocks: wallet + every secure-store leaf, vault, teardown, lock signal. ---
@@ -57,6 +61,15 @@ jest.mock('@/services/secure', () => ({
     setBiometricEnabled: jest.fn(),
     clearBiometricSecret: jest.fn(),
   },
+}));
+
+// TASK-213 restore-before-PIN breadcrumb. Separate submodule path (NOT the
+// mocked @/services/secure barrel), so it needs its own mock. Defaults are set in
+// beforeEach: ABSENT breadcrumb + a no-op clear, so the key-bearing guard behaves
+// EXACTLY as before unless a test opts into a restore-in-progress state.
+jest.mock('@/services/secure/pinSetupPending', () => ({
+  isPinSetupPending: jest.fn(),
+  clearPinSetupPending: jest.fn(),
 }));
 
 jest.mock('@/services/secure/SessionKeyVault', () => ({
@@ -113,6 +126,8 @@ const mockMigrate = AccountSecureStorage.migrateAllAccountsToV2 as jest.Mock;
 const mockVaultSet = SessionKeyVault.set as jest.Mock;
 const mockBiometricUnlock = unlockVaultWithBiometrics as jest.Mock;
 const mockEnterLocked = enterLockedState as jest.Mock;
+const mockIsPinSetupPending = isPinSetupPending as jest.Mock;
+const mockClearPinSetupPending = clearPinSetupPending as jest.Mock;
 const mockSetUnlocked = AppLockSignal.setUnlocked as jest.Mock;
 
 // A non-empty account list so checkInitialAuthState treats the wallet as
@@ -211,6 +226,10 @@ beforeEach(() => {
   mockGetCredentialSource.mockResolvedValue('pin');
   mockMigrate.mockResolvedValue(undefined);
   mockBiometricUnlock.mockResolvedValue({ status: 'unlocked' });
+  // TASK-213: default to NO restore-in-progress breadcrumb so the key-bearing
+  // guard stays fail-closed (recovery) exactly as before; opt-in per test.
+  mockIsPinSetupPending.mockResolvedValue(false);
+  mockClearPinSetupPending.mockResolvedValue(undefined);
 });
 
 afterEach(() => {
@@ -512,6 +531,104 @@ describe('AuthContext — TASK-213 fail-closed recovery on storage read failure'
     expect(result.current.authState.isLocked).toBe(false);
     expect(result.current.authState.isAuthenticated).toBe(true);
     expect(result.current.authState.hasPin).toBe(false);
+  });
+
+  // -------------------------------------------------------------------------
+  // TASK-213 restore-before-PIN: the pin_setup_pending breadcrumb disambiguates
+  // "key-bearing account + no readable PIN" between a genuine keystore break
+  // (fail CLOSED to recovery) and a restore that persisted STANDARD accounts
+  // before the PIN (route to SecuritySetup RESUME). The breadcrumb must NEVER
+  // reopen the Android fail-open: a real, readable PIN self-heals any stale
+  // breadcrumb, and an absent breadcrumb still routes a genuine break to recovery.
+  // -------------------------------------------------------------------------
+  it('(j) restore-before-PIN: key-bearing + no PIN + breadcrumb SET ⇒ resume SecuritySetup, NOT recovery/unlocked', async () => {
+    mockHasWalletStrict.mockResolvedValue(true);
+    mockHasPinStrict.mockResolvedValue(false); // no PIN yet (restore not finished)
+    mockHasKeyBearing.mockResolvedValue(true); // restore persisted STANDARD accounts
+    mockIsPinSetupPending.mockResolvedValue(true); // durable breadcrumb present
+
+    const { result } = await mountAuth();
+
+    // Routes to SecuritySetup resume — never the recovery screen (whose Reset
+    // would wipe the just-restored wallet).
+    expect(result.current.authState.pinSetupResume).toBe(true);
+    expect(result.current.authState.securityUnavailable).toBe(false);
+    expect(result.current.authState.authChecked).toBe(true);
+    // AND still grants ZERO wallet access before the PIN is set (defense in depth:
+    // the navigator routes to SecuritySetup, and Main stays lock-guarded).
+    expect(result.current.authState.isAuthenticated).toBe(false);
+    expect(result.current.authState.isLocked).toBe(true);
+    expect(result.current.authState.hasWallet).toBe(true);
+    expect(result.current.authState.hasPin).toBe(false);
+  });
+
+  it('(j2) genuine keystore break: key-bearing + no PIN + NO breadcrumb ⇒ RECOVERY (fail-closed, unchanged)', async () => {
+    // The exact Android swallow-to-null scenario, breadcrumb ABSENT (default). Must
+    // stay fail-closed — the breadcrumb fix must not weaken this.
+    mockHasWalletStrict.mockResolvedValue(true);
+    mockHasPinStrict.mockResolvedValue(false);
+    mockHasKeyBearing.mockResolvedValue(true);
+    mockIsPinSetupPending.mockResolvedValue(false);
+    const errorSpy = jest.spyOn(console, 'error').mockImplementation(() => {});
+
+    const { result } = await mountAuth();
+
+    expect(result.current.authState.securityUnavailable).toBe(true);
+    expect(result.current.authState.pinSetupResume).toBe(false);
+    expect(result.current.authState.isAuthenticated).toBe(false);
+
+    errorSpy.mockRestore();
+  });
+
+  it('(k) anti-fail-open: a STALE breadcrumb + key-bearing wallet WITH a readable PIN ⇒ LOCKED (not resume), breadcrumb self-healed', async () => {
+    // The dangerous case: a PIN was set (setupPin should have cleared it) but a
+    // stale breadcrumb lingers. A readable PIN means the guard does NOT fire and
+    // the self-heal clears the stale breadcrumb — so a LATER keystore break can
+    // never later route to SecuritySetup over this protected wallet.
+    mockHasWalletStrict.mockResolvedValue(true);
+    mockHasPinStrict.mockResolvedValue(true); // PIN is readable
+    mockHasKeyBearing.mockResolvedValue(true);
+    mockIsPinSetupPending.mockResolvedValue(true); // stale breadcrumb
+
+    const { result } = await mountAuth();
+
+    // Normal locked boot — NOT resume, NOT recovery.
+    expect(result.current.authState.pinSetupResume).toBe(false);
+    expect(result.current.authState.securityUnavailable).toBe(false);
+    expect(result.current.authState.isLocked).toBe(true);
+    expect(result.current.authState.isAuthenticated).toBe(false);
+    expect(result.current.authState.hasPin).toBe(true);
+    // Self-heal fired: the stale breadcrumb was cleared on this readable-PIN boot.
+    expect(mockClearPinSetupPending).toHaveBeenCalled();
+  });
+
+  it('(k2) self-heal on a normal wallet+PIN boot: a stale breadcrumb is cleared even without a key-bearing account', async () => {
+    mockHasWalletStrict.mockResolvedValue(true);
+    mockHasPinStrict.mockResolvedValue(true);
+    mockHasKeyBearing.mockResolvedValue(false);
+    mockIsPinSetupPending.mockResolvedValue(true);
+
+    const { result } = await mountAuth();
+
+    expect(result.current.authState.isLocked).toBe(true);
+    expect(result.current.authState.pinSetupResume).toBe(false);
+    expect(mockClearPinSetupPending).toHaveBeenCalled();
+  });
+
+  it('(l) breadcrumb does NOT perturb genuine absence: no wallet + breadcrumb SET ⇒ unlocked setup, not resume', async () => {
+    // The guard requires a key-bearing account; a breadcrumb alone must never
+    // force the resume/recovery path on a genuinely empty install.
+    mockHasWalletStrict.mockResolvedValue(false);
+    mockHasPinStrict.mockResolvedValue(false);
+    mockHasKeyBearing.mockResolvedValue(false);
+    mockIsPinSetupPending.mockResolvedValue(true);
+
+    const { result } = await mountAuth();
+
+    expect(result.current.authState.securityUnavailable).toBe(false);
+    expect(result.current.authState.pinSetupResume).toBe(false);
+    expect(result.current.authState.isLocked).toBe(false);
+    expect(result.current.authState.isAuthenticated).toBe(true);
   });
 
   it('never RETRIES a genuine absence — a false-resolving strict read reads exactly once', async () => {

--- a/src/contexts/__tests__/AuthContext.test.tsx
+++ b/src/contexts/__tests__/AuthContext.test.tsx
@@ -281,7 +281,9 @@ describe('AuthContext — TASK-213 fail-closed recovery on storage read failure'
   });
 
   it('(b) enters RECOVERY when the strict WALLET read FAILS at boot', async () => {
-    mockHasWalletStrict.mockRejectedValue(new Error('wallet store unavailable'));
+    mockHasWalletStrict.mockRejectedValue(
+      new Error('wallet store unavailable')
+    );
     mockHasPinStrict.mockResolvedValue(true);
     const errorSpy = jest.spyOn(console, 'error').mockImplementation(() => {});
 
@@ -315,6 +317,9 @@ describe('AuthContext — TASK-213 fail-closed recovery on storage read failure'
     expect(result.current.authState.isLocked).toBe(false);
     expect(result.current.authState.isAuthenticated).toBe(true);
     expect(result.current.authState.hasPin).toBe(false);
+    // Route derives from hasWallet — a wallet exists here ⇒ Main (not Onboarding).
+    expect(result.current.authState.hasWallet).toBe(true);
+    expect(result.current.authState.authChecked).toBe(true);
   });
 
   it('(d) genuine wallet+PIN ⇒ locked, NOT recovery (unchanged)', async () => {
@@ -327,6 +332,8 @@ describe('AuthContext — TASK-213 fail-closed recovery on storage read failure'
     expect(result.current.authState.isLocked).toBe(true);
     expect(result.current.authState.isAuthenticated).toBe(false);
     expect(result.current.authState.hasPin).toBe(true);
+    expect(result.current.authState.hasWallet).toBe(true);
+    expect(result.current.authState.authChecked).toBe(true);
   });
 
   it('(e) a TRANSIENT strict-read failure that SUCCEEDS on retry proceeds normally (LOCKED) — no recovery screen', async () => {
@@ -387,6 +394,10 @@ describe('AuthContext — TASK-213 fail-closed recovery on storage read failure'
     expect(result.current.authState.securityUnavailable).toBe(false);
     expect(result.current.authState.isLocked).toBe(true);
     expect(result.current.authState.isAuthenticated).toBe(false);
+    // Codex round-2 guard: after recovery the AUTHORITATIVE hasWallet is correct
+    // (true ⇒ the navigator derives route=Main, never a stale unguarded
+    // Onboarding). The route is a single source of truth = this verdict.
+    expect(result.current.authState.hasWallet).toBe(true);
 
     errorSpy.mockRestore();
   });

--- a/src/contexts/__tests__/AuthContext.test.tsx
+++ b/src/contexts/__tests__/AuthContext.test.tsx
@@ -229,7 +229,7 @@ beforeEach(() => {
   // TASK-213: default to NO restore-in-progress breadcrumb so the key-bearing
   // guard stays fail-closed (recovery) exactly as before; opt-in per test.
   mockIsPinSetupPending.mockResolvedValue(false);
-  mockClearPinSetupPending.mockResolvedValue(undefined);
+  mockClearPinSetupPending.mockResolvedValue(true);
 });
 
 afterEach(() => {

--- a/src/contexts/__tests__/AuthContext.test.tsx
+++ b/src/contexts/__tests__/AuthContext.test.tsx
@@ -36,6 +36,9 @@ jest.mock('@/services/wallet', () => ({
     // TASK-213: the STRICT, boot-only wallet-presence probe the auth-init path
     // now uses (throws on read FAILURE, resolves false only on genuine absence).
     hasWalletWithAccountsStrict: jest.fn(),
+    // TASK-213 Codex round-4: does a persisted wallet hold ≥1 locally-key-bearing
+    // (STANDARD) account? Used to close the Android swallow-to-null fail-open.
+    hasKeyBearingAccountStrict: jest.fn(),
   },
 }));
 
@@ -96,6 +99,8 @@ const mockWallet = MultiAccountWalletService.getCurrentWallet as jest.Mock;
 // STRICT boot probes (TASK-213) — these are what checkInitialAuthState reads now.
 const mockHasWalletStrict =
   MultiAccountWalletService.hasWalletWithAccountsStrict as jest.Mock;
+const mockHasKeyBearing =
+  MultiAccountWalletService.hasKeyBearingAccountStrict as jest.Mock;
 const mockHasPinStrict = AccountSecureStorage.hasPinStrict as jest.Mock;
 const mockHasPin = AccountSecureStorage.hasPin as jest.Mock;
 const mockIsBiometricEnabled =
@@ -193,6 +198,11 @@ beforeEach(() => {
   // mocked for any incidental callers but no longer gate the initial lock state.
   mockHasWalletStrict.mockResolvedValue(true);
   mockHasPinStrict.mockResolvedValue(true);
+  // Default to NO key-bearing account so the Codex round-4 guard
+  // (hasKeyBearingAccount && !hasPin ⇒ recovery) never fires unless a test opts
+  // in — the guard only matters for the wallet+no-PIN cases, which the existing
+  // suite treats as legit watch-only/absence states.
+  mockHasKeyBearing.mockResolvedValue(false);
   mockWallet.mockResolvedValue(WALLET_WITH_ACCOUNTS);
   mockHasPin.mockResolvedValue(true);
   mockIsBiometricEnabled.mockResolvedValue(true);
@@ -400,6 +410,108 @@ describe('AuthContext — TASK-213 fail-closed recovery on storage read failure'
     expect(result.current.authState.hasWallet).toBe(true);
 
     errorSpy.mockRestore();
+  });
+
+  it('(g) a HUNG strict read (never settles) TIMES OUT, retries, and fails CLOSED to recovery — never stuck behind the splash', async () => {
+    // No-stuck regression (TASK-213 Codex round-4 P2): a strict read that never
+    // resolves NOR rejects. Without a per-read timeout, checkInitialAuthState
+    // would never reach a terminal setAuthState — authChecked stays false, the
+    // navigator renders null under the splash forever, and the 10s watchdog only
+    // hides the splash onto a BLANK screen. The timeout converts the hang into a
+    // rejection the retry loop already handles, so boot fails CLOSED to recovery.
+    mockHasWalletStrict.mockResolvedValue(true);
+    // A promise that never settles, returned on every attempt.
+    const neverSettles = new Promise<boolean>(() => {});
+    mockHasPinStrict.mockReturnValue(neverSettles);
+    const errorSpy = jest.spyOn(console, 'error').mockImplementation(() => {});
+
+    const rendered = renderHook(() => useAuth(), { wrapper });
+    // Pump fake timers well past 3 attempts × (2000ms per-read timeout + backoff)
+    // ≈ 6.6s worst case.
+    await act(async () => {
+      for (let i = 0; i < 20; i += 1) {
+        await Promise.resolve();
+        jest.advanceTimersByTime(1000);
+        await Promise.resolve();
+      }
+    });
+
+    // Settled into recovery (NOT left indeterminate behind the splash).
+    expect(rendered.result.current.authState.authChecked).toBe(true);
+    expect(rendered.result.current.authState.securityUnavailable).toBe(true);
+    expect(rendered.result.current.authState.isAuthenticated).toBe(false);
+    expect(rendered.result.current.authState.isLocked).toBe(true);
+    // Retried (the hang was surfaced as a failure on each attempt).
+    expect(mockHasPinStrict.mock.calls.length).toBeGreaterThan(1);
+    expect(errorSpy).toHaveBeenCalled();
+
+    errorSpy.mockRestore();
+  });
+
+  it('(h) a HUNG non-critical read (biometric/timeout) does NOT stall boot — falls back to defaults and still computes the lock verdict', async () => {
+    // The non-critical biometric/isBiometricEnabled/getPinTimeout reads are on the
+    // render-gating path now; a hang there must not strand boot. It times out to
+    // the safe display defaults and the strict lock verdict still resolves.
+    mockHasWalletStrict.mockResolvedValue(true);
+    mockHasPinStrict.mockResolvedValue(true);
+    mockGetPinTimeout.mockReturnValue(new Promise<number>(() => {})); // hangs
+    const warnSpy = jest.spyOn(console, 'warn').mockImplementation(() => {});
+
+    const rendered = renderHook(() => useAuth(), { wrapper });
+    await act(async () => {
+      for (let i = 0; i < 12; i += 1) {
+        await Promise.resolve();
+        jest.advanceTimersByTime(1000);
+        await Promise.resolve();
+      }
+    });
+
+    // Boot still reached a verdict (LOCKED wallet+PIN), NOT recovery, with the
+    // default 5-min timeout after the non-critical read timed out.
+    expect(rendered.result.current.authState.authChecked).toBe(true);
+    expect(rendered.result.current.authState.securityUnavailable).toBe(false);
+    expect(rendered.result.current.authState.isLocked).toBe(true);
+    expect(rendered.result.current.authState.timeoutMinutes).toBe(5);
+    expect(warnSpy).toHaveBeenCalled();
+
+    warnSpy.mockRestore();
+  });
+
+  it('(i) Android swallow-to-null closure: a KEY-BEARING account + absent PIN ⇒ RECOVERY, never unlocked setup', async () => {
+    // Codex round-4 P1: a pre-sentinel Android install whose keystore breaks on
+    // its first post-upgrade boot has no presence sentinel, so hasPinStrict reads
+    // the swallowed-to-null PIN as genuine ABSENCE (false). But a locally-key-
+    // bearing (STANDARD) account CANNOT exist without a PIN, so this state is
+    // impossible-genuine and must be a read failure ⇒ fail CLOSED to recovery
+    // (NOT the unlocked setup branch that would offer to set a NEW PIN).
+    mockHasWalletStrict.mockResolvedValue(true);
+    mockHasPinStrict.mockResolvedValue(false); // swallowed-to-null on Android
+    mockHasKeyBearing.mockResolvedValue(true); // durable, keystore-independent
+    const errorSpy = jest.spyOn(console, 'error').mockImplementation(() => {});
+
+    const { result } = await mountAuth();
+
+    expect(result.current.authState.securityUnavailable).toBe(true);
+    expect(result.current.authState.isAuthenticated).toBe(false);
+    expect(result.current.authState.isLocked).toBe(true);
+    expect(errorSpy).toHaveBeenCalled();
+
+    errorSpy.mockRestore();
+  });
+
+  it('(i2) a PIN-less wallet with NO key-bearing account (watch-only) ⇒ unlocked setup, NOT recovery', async () => {
+    // The guard must NOT over-fire: a genuinely PIN-less watch-only wallet is a
+    // legitimate boot state and must still reach the setup branch.
+    mockHasWalletStrict.mockResolvedValue(true);
+    mockHasPinStrict.mockResolvedValue(false);
+    mockHasKeyBearing.mockResolvedValue(false);
+
+    const { result } = await mountAuth();
+
+    expect(result.current.authState.securityUnavailable).toBe(false);
+    expect(result.current.authState.isLocked).toBe(false);
+    expect(result.current.authState.isAuthenticated).toBe(true);
+    expect(result.current.authState.hasPin).toBe(false);
   });
 
   it('never RETRIES a genuine absence — a false-resolving strict read reads exactly once', async () => {

--- a/src/contexts/__tests__/AuthContext.test.tsx
+++ b/src/contexts/__tests__/AuthContext.test.tsx
@@ -33,12 +33,17 @@ import * as LocalAuthentication from 'expo-local-authentication';
 jest.mock('@/services/wallet', () => ({
   MultiAccountWalletService: {
     getCurrentWallet: jest.fn(),
+    // TASK-213: the STRICT, boot-only wallet-presence probe the auth-init path
+    // now uses (throws on read FAILURE, resolves false only on genuine absence).
+    hasWalletWithAccountsStrict: jest.fn(),
   },
 }));
 
 jest.mock('@/services/secure', () => ({
   AccountSecureStorage: {
     hasPin: jest.fn(),
+    // TASK-213: the STRICT, boot-only PIN-presence probe (see wallet mock above).
+    hasPinStrict: jest.fn(),
     isBiometricEnabled: jest.fn(),
     getPinTimeout: jest.fn(),
     verifyPin: jest.fn(),
@@ -88,6 +93,10 @@ jest.mock('expo-local-authentication', () => ({
 
 // Typed handles to the mocked members we drive per-test.
 const mockWallet = MultiAccountWalletService.getCurrentWallet as jest.Mock;
+// STRICT boot probes (TASK-213) — these are what checkInitialAuthState reads now.
+const mockHasWalletStrict =
+  MultiAccountWalletService.hasWalletWithAccountsStrict as jest.Mock;
+const mockHasPinStrict = AccountSecureStorage.hasPinStrict as jest.Mock;
 const mockHasPin = AccountSecureStorage.hasPin as jest.Mock;
 const mockIsBiometricEnabled =
   AccountSecureStorage.isBiometricEnabled as jest.Mock;
@@ -130,12 +139,36 @@ const flush = async () => {
   });
 };
 
+// TASK-213: the strict-read retry path awaits a real setTimeout backoff between
+// attempts, which never resolves under fake timers on microtask flushing alone.
+// This helper interleaves microtask flushes with fake-timer advances so the
+// bounded retry loop (≤3 attempts, 200ms + 400ms backoffs) can run to
+// completion — used by the recovery / transient-recovery tests.
+const flushWithRetries = async () => {
+  await act(async () => {
+    for (let i = 0; i < 12; i += 1) {
+      await Promise.resolve();
+      jest.advanceTimersByTime(1000);
+      await Promise.resolve();
+    }
+  });
+};
+
 const mountAuth = async () => {
   // renderHook manages its own act(); wrapping it in an outer act() leaves the
   // renderer looking unmounted. Render directly, then flush the mount effects'
   // async checkInitialAuthState chain.
   const rendered = renderHook(() => useAuth(), { wrapper });
   await flush();
+  return rendered;
+};
+
+// Like mountAuth but pumps the fake-timer backoff so a mount whose strict reads
+// FAIL (and therefore retry) settles into its final state (recovery or, for a
+// transient failure, the recovered lock state).
+const mountAuthWithRetries = async () => {
+  const rendered = renderHook(() => useAuth(), { wrapper });
+  await flushWithRetries();
   return rendered;
 };
 
@@ -154,7 +187,12 @@ beforeEach(() => {
     );
 
   // Default baseline: a wallet that exists, has a PIN, 5-min timeout, biometrics
-  // available + enabled. Individual tests override as needed.
+  // available + enabled. Individual tests override as needed. The STRICT boot
+  // probes (TASK-213) drive the lock decision now, so their baseline resolves to
+  // a wallet-with-accounts + PIN (⇒ LOCKED). getCurrentWallet/hasPin are kept
+  // mocked for any incidental callers but no longer gate the initial lock state.
+  mockHasWalletStrict.mockResolvedValue(true);
+  mockHasPinStrict.mockResolvedValue(true);
   mockWallet.mockResolvedValue(WALLET_WITH_ACCOUNTS);
   mockHasPin.mockResolvedValue(true);
   mockIsBiometricEnabled.mockResolvedValue(true);
@@ -183,14 +221,15 @@ describe('AuthContext — initial state', () => {
   });
 
   it('starts UNLOCKED (setup mode) when no wallet / no PIN exists', async () => {
-    mockWallet.mockResolvedValue(null);
-    mockHasPin.mockResolvedValue(false);
+    mockHasWalletStrict.mockResolvedValue(false);
+    mockHasPinStrict.mockResolvedValue(false);
 
     const { result } = await mountAuth();
 
     expect(result.current.authState.isLocked).toBe(false);
     expect(result.current.authState.isAuthenticated).toBe(true);
     expect(result.current.authState.hasPin).toBe(false);
+    expect(result.current.authState.securityUnavailable).toBe(false);
   });
 
   it('reports biometricEnabled=false when hardware is unavailable even if the flag is on', async () => {
@@ -205,95 +244,199 @@ describe('AuthContext — initial state', () => {
 });
 
 // ---------------------------------------------------------------------------
-// F-03 (TASK-177): the initial lock-state probes are now parallelized with
-// Promise.all inside checkInitialAuthState. These tests pin the two invariants
-// the parallelization MUST preserve:
-//   (1) REJECTION FAIL-CLOSED — if a lock-determining read (esp. hasPin)
-//       *rejects*, the app stays LOCKED, never in the `!hasPin` unlocked setup
-//       state. Promise.all propagates the rejection to the catch (leaving the
-//       locked default); this guards against a regression to Promise.allSettled,
-//       which would coerce a rejected hasPin to a falsy default and slip into
-//       unlocked setup state.
-//       SCOPE: this is the rejection path ONLY. Production hasPin() /
-//       getCurrentWallet() swallow their OWN storage errors and resolve falsy
-//       (false / null), so a storage *failure* is treated as "no PIN / no
-//       wallet" = unlocked setup state — a PRE-EXISTING fail-open left unchanged
-//       by this I/O-only diff (see the TASK-177 auth-semantics fork). These
-//       tests therefore assert the layer's rejection handling, not an
-//       end-to-end fail-closed guarantee.
-//   (2) PARITY — for every resolved-value input, the computed lock state is
-//       identical to the prior serial logic
-//       (`!wallet || wallet.accounts.length === 0 || !hasPin` ⇒ unlocked setup).
+// TASK-213: FAIL-CLOSED recovery on a secure-storage READ FAILURE at boot.
+//
+// checkInitialAuthState now reads the lock-determining state through the STRICT
+// probes (MultiAccountWalletService.hasWalletWithAccountsStrict +
+// AccountSecureStorage.hasPinStrict), which THROW on a genuine secure-storage
+// read/decrypt FAILURE and resolve falsy ONLY for genuine ABSENCE. A read
+// failure is therefore no longer indistinguishable from "no wallet / no PIN":
+//   - a persistent strict-read FAILURE (after bounded retry) ⇒ RECOVERY state
+//     (authState.securityUnavailable === true) — NOT unlocked setup, NOT the
+//     normal PIN lock, ZERO wallet access;
+//   - genuine ABSENCE ⇒ unlocked setup (UNCHANGED);
+//   - genuine wallet+PIN ⇒ locked (UNCHANGED);
+//   - a TRANSIENT failure that succeeds on retry ⇒ proceeds to its normal state
+//     and NEVER shows the recovery screen.
+// This closes the pre-existing fail-OPEN documented on the former F-03 tests.
 // ---------------------------------------------------------------------------
-describe('AuthContext — F-03 parallelized probes (rejection fail-closed + parity)', () => {
-  it('stays LOCKED (fail-closed) when the hasPin read REJECTS — never slips into unlocked setup state', async () => {
-    // A wallet-with-accounts is present, so if hasPin were coerced to `false`
-    // (the Promise.allSettled failure mode this guards against) the app would
-    // WRONGLY enter the `!hasPin` unlocked setup branch. The read instead
-    // rejects, so it MUST remain locked.
-    mockWallet.mockResolvedValue(WALLET_WITH_ACCOUNTS);
-    mockHasPin.mockRejectedValue(new Error('keychain read failed'));
+describe('AuthContext — TASK-213 fail-closed recovery on storage read failure', () => {
+  it('(a) enters RECOVERY (securityUnavailable) when the strict PIN read FAILS at boot — never unlocked, never normal-locked', async () => {
+    // A wallet is present and the PIN read throws (keychain unreadable). The old
+    // behavior swallowed this to `hasPin=false` and slipped into unlocked setup;
+    // now the strict read throws, bounded retry exhausts, and we fail CLOSED.
+    mockHasWalletStrict.mockResolvedValue(true);
+    mockHasPinStrict.mockRejectedValue(new Error('keychain read failed'));
     const errorSpy = jest.spyOn(console, 'error').mockImplementation(() => {});
 
-    const { result } = await mountAuth();
+    const { result } = await mountAuthWithRetries();
 
-    // Left at the LOCKED default; the unlocked setup state was never entered.
-    expect(result.current.authState.isLocked).toBe(true);
+    expect(result.current.authState.securityUnavailable).toBe(true);
+    // Zero wallet access: not authenticated, and NOT the unlocked setup state.
     expect(result.current.authState.isAuthenticated).toBe(false);
+    expect(result.current.authState.isLocked).toBe(true);
     expect(errorSpy).toHaveBeenCalled();
 
     errorSpy.mockRestore();
   });
 
-  it('stays LOCKED (fail-closed) when the wallet read REJECTS', async () => {
-    mockWallet.mockRejectedValue(new Error('wallet store unavailable'));
-    mockHasPin.mockResolvedValue(true);
+  it('(b) enters RECOVERY when the strict WALLET read FAILS at boot', async () => {
+    mockHasWalletStrict.mockRejectedValue(new Error('wallet store unavailable'));
+    mockHasPinStrict.mockResolvedValue(true);
     const errorSpy = jest.spyOn(console, 'error').mockImplementation(() => {});
+
+    const { result } = await mountAuthWithRetries();
+
+    expect(result.current.authState.securityUnavailable).toBe(true);
+    expect(result.current.authState.isAuthenticated).toBe(false);
+    expect(result.current.authState.isLocked).toBe(true);
+
+    errorSpy.mockRestore();
+  });
+
+  it('(c) genuine ABSENCE (no wallet / no PIN) ⇒ unlocked setup, NOT recovery (unchanged)', async () => {
+    mockHasWalletStrict.mockResolvedValue(false);
+    mockHasPinStrict.mockResolvedValue(false);
 
     const { result } = await mountAuth();
 
+    expect(result.current.authState.securityUnavailable).toBe(false);
+    expect(result.current.authState.isLocked).toBe(false);
+    expect(result.current.authState.isAuthenticated).toBe(true);
+  });
+
+  it('(c2) genuine wallet present but no PIN ⇒ unlocked setup, NOT recovery', async () => {
+    mockHasWalletStrict.mockResolvedValue(true);
+    mockHasPinStrict.mockResolvedValue(false);
+
+    const { result } = await mountAuth();
+
+    expect(result.current.authState.securityUnavailable).toBe(false);
+    expect(result.current.authState.isLocked).toBe(false);
+    expect(result.current.authState.isAuthenticated).toBe(true);
+    expect(result.current.authState.hasPin).toBe(false);
+  });
+
+  it('(d) genuine wallet+PIN ⇒ locked, NOT recovery (unchanged)', async () => {
+    mockHasWalletStrict.mockResolvedValue(true);
+    mockHasPinStrict.mockResolvedValue(true);
+
+    const { result } = await mountAuth();
+
+    expect(result.current.authState.securityUnavailable).toBe(false);
+    expect(result.current.authState.isLocked).toBe(true);
+    expect(result.current.authState.isAuthenticated).toBe(false);
+    expect(result.current.authState.hasPin).toBe(true);
+  });
+
+  it('(e) a TRANSIENT strict-read failure that SUCCEEDS on retry proceeds normally (LOCKED) — no recovery screen', async () => {
+    // First attempt: the PIN read throws; the retry then succeeds. The app must
+    // recover to its true state (wallet+PIN ⇒ LOCKED) and NEVER show recovery.
+    mockHasWalletStrict.mockResolvedValue(true);
+    mockHasPinStrict
+      .mockRejectedValueOnce(new Error('transient keychain unavailability'))
+      .mockResolvedValue(true);
+    const errorSpy = jest.spyOn(console, 'error').mockImplementation(() => {});
+
+    const { result } = await mountAuthWithRetries();
+
+    expect(result.current.authState.securityUnavailable).toBe(false);
+    expect(result.current.authState.isLocked).toBe(true);
+    expect(result.current.authState.isAuthenticated).toBe(false);
+    // Retry actually happened (more than one strict-read attempt).
+    expect(mockHasPinStrict.mock.calls.length).toBeGreaterThan(1);
+    // A transient, recovered failure logs nothing at error level.
+    expect(errorSpy).not.toHaveBeenCalled();
+
+    errorSpy.mockRestore();
+  });
+
+  it('(e2) a TRANSIENT failure that recovers into genuine ABSENCE ⇒ unlocked setup, no recovery', async () => {
+    mockHasWalletStrict
+      .mockRejectedValueOnce(new Error('transient wallet-store hiccup'))
+      .mockResolvedValue(false);
+    mockHasPinStrict.mockResolvedValue(false);
+
+    const { result } = await mountAuthWithRetries();
+
+    expect(result.current.authState.securityUnavailable).toBe(false);
+    expect(result.current.authState.isLocked).toBe(false);
+    expect(result.current.authState.isAuthenticated).toBe(true);
+  });
+
+  it('(f) recovery Retry (recheckAuthState) re-runs the check and RECOVERS when storage becomes readable', async () => {
+    // Boot into recovery via a persistent failure.
+    mockHasWalletStrict.mockResolvedValue(true);
+    mockHasPinStrict.mockRejectedValue(new Error('keychain unreadable'));
+    const errorSpy = jest.spyOn(console, 'error').mockImplementation(() => {});
+
+    const { result } = await mountAuthWithRetries();
+    expect(result.current.authState.securityUnavailable).toBe(true);
+
+    // Storage becomes readable; the Retry button calls recheckAuthState.
+    mockHasPinStrict.mockReset();
+    mockHasPinStrict.mockResolvedValue(true);
+
+    await act(async () => {
+      await result.current.recheckAuthState();
+    });
+    await flushWithRetries();
+
+    // Recovered: no longer securityUnavailable, and now correctly LOCKED
+    // (wallet+PIN). The recovery state is never permanently stuck.
+    expect(result.current.authState.securityUnavailable).toBe(false);
     expect(result.current.authState.isLocked).toBe(true);
     expect(result.current.authState.isAuthenticated).toBe(false);
 
     errorSpy.mockRestore();
   });
 
-  it('stays LOCKED (fail-closed) when the pin-timeout read REJECTS for a wallet-with-PIN', async () => {
-    mockWallet.mockResolvedValue(WALLET_WITH_ACCOUNTS);
-    mockHasPin.mockResolvedValue(true);
-    mockGetPinTimeout.mockRejectedValue(new Error('timeout read failed'));
-    const errorSpy = jest.spyOn(console, 'error').mockImplementation(() => {});
+  it('never RETRIES a genuine absence — a false-resolving strict read reads exactly once', async () => {
+    // Absence must NOT be retried (only failures are). One attempt, no backoff.
+    mockHasWalletStrict.mockResolvedValue(false);
+    mockHasPinStrict.mockResolvedValue(false);
 
-    const { result } = await mountAuth();
+    await mountAuth();
 
-    expect(result.current.authState.isLocked).toBe(true);
-    expect(result.current.authState.isAuthenticated).toBe(false);
-
-    errorSpy.mockRestore();
+    expect(mockHasWalletStrict).toHaveBeenCalledTimes(1);
+    expect(mockHasPinStrict).toHaveBeenCalledTimes(1);
   });
 
-  it('computes LOCKED for a PIN/passphrase-protected wallet launch', async () => {
-    mockWallet.mockResolvedValue(WALLET_WITH_ACCOUNTS);
-    mockHasPin.mockResolvedValue(true);
+  it('computes LOCKED for a passphrase-protected wallet launch (timeout=never)', async () => {
+    mockHasWalletStrict.mockResolvedValue(true);
+    mockHasPinStrict.mockResolvedValue(true);
     mockGetPinTimeout.mockResolvedValue('never');
 
     const { result } = await mountAuth();
 
     expect(result.current.authState.isLocked).toBe(true);
-    expect(result.current.authState.isAuthenticated).toBe(false);
     expect(result.current.authState.hasPin).toBe(true);
     expect(result.current.authState.timeoutMinutes).toBe('never');
+    expect(result.current.authState.securityUnavailable).toBe(false);
+  });
+
+  it('stays LOCKED (not recovery) when a NON-critical read (pin-timeout) fails for a wallet+PIN', async () => {
+    // getPinTimeout is display/config only: its failure must fall back to the
+    // 5-min default and NOT drive the lock/recovery decision.
+    mockHasWalletStrict.mockResolvedValue(true);
+    mockHasPinStrict.mockResolvedValue(true);
+    mockGetPinTimeout.mockRejectedValue(new Error('timeout read failed'));
+    const warnSpy = jest.spyOn(console, 'warn').mockImplementation(() => {});
+
+    const { result } = await mountAuth();
+
+    expect(result.current.authState.securityUnavailable).toBe(false);
+    expect(result.current.authState.isLocked).toBe(true);
+    expect(result.current.authState.isAuthenticated).toBe(false);
+    expect(result.current.authState.timeoutMinutes).toBe(5);
+
+    warnSpy.mockRestore();
   });
 
   it('computes LOCKED on a biometric-invalidated launch (enrollment gone) — never unlocks, biometrics disabled', async () => {
-    // Wallet + PIN exist. Biometrics were enabled, but enrollment is now
-    // invalidated (isEnrolledAsync → false): the biometric probe outcome must
-    // NOT change the lock decision. Still LOCKED; biometricEnabled reported off.
-    mockWallet.mockResolvedValue(WALLET_WITH_ACCOUNTS);
-    mockHasPin.mockResolvedValue(true);
+    mockHasWalletStrict.mockResolvedValue(true);
+    mockHasPinStrict.mockResolvedValue(true);
     mockIsBiometricEnabled.mockResolvedValue(true);
-    // One-shot: this mount's single probe returns "not enrolled"; do NOT leak a
-    // persistent override into the biometric-unlock suite that follows.
     (LocalAuthentication.isEnrolledAsync as jest.Mock).mockResolvedValueOnce(
       false
     );
@@ -303,82 +446,77 @@ describe('AuthContext — F-03 parallelized probes (rejection fail-closed + pari
     expect(result.current.authState.isLocked).toBe(true);
     expect(result.current.authState.isAuthenticated).toBe(false);
     expect(result.current.authState.biometricEnabled).toBe(false);
+    expect(result.current.authState.securityUnavailable).toBe(false);
   });
 
   it('computes LOCKED even when the biometric availability probe THROWS (wallet+PIN)', async () => {
-    mockWallet.mockResolvedValue(WALLET_WITH_ACCOUNTS);
-    mockHasPin.mockResolvedValue(true);
-    // One-shot rejection (see above) so the throw does not bleed into later tests.
+    mockHasWalletStrict.mockResolvedValue(true);
+    mockHasPinStrict.mockResolvedValue(true);
     (LocalAuthentication.hasHardwareAsync as jest.Mock).mockRejectedValueOnce(
       new Error('native biometric probe failed')
     );
+    const warnSpy = jest.spyOn(console, 'warn').mockImplementation(() => {});
 
     const { result } = await mountAuth();
 
-    // checkBiometricAvailability swallows the throw → unavailable; the lock
-    // decision is unaffected and stays LOCKED.
+    // The biometric probe throw is swallowed to "unavailable"; it does NOT
+    // trigger recovery (only the strict lock-determining reads can).
     expect(result.current.authState.isLocked).toBe(true);
     expect(result.current.authState.isAuthenticated).toBe(false);
     expect(result.current.authState.biometricEnabled).toBe(false);
+    expect(result.current.authState.securityUnavailable).toBe(false);
+
+    warnSpy.mockRestore();
   });
 
-  // Parity table: the parallelized probe chain must compute the SAME lock state
-  // as the documented serial predicate for representative input combinations.
+  // Parity table: the strict probe chain computes the SAME locked/unlocked
+  // decision as `!hasWallet || !hasPin` ⇒ unlocked setup, and never recovery.
   const parityCases: {
     name: string;
-    wallet: unknown;
+    hasWallet: boolean;
     hasPin: boolean;
     expectedLocked: boolean;
   }[] = [
     {
-      name: 'wallet-with-accounts + PIN',
-      wallet: WALLET_WITH_ACCOUNTS,
+      name: 'wallet + PIN',
+      hasWallet: true,
       hasPin: true,
       expectedLocked: true,
     },
     {
-      name: 'wallet-with-accounts + no PIN',
-      wallet: WALLET_WITH_ACCOUNTS,
+      name: 'wallet + no PIN',
+      hasWallet: true,
       hasPin: false,
       expectedLocked: false,
     },
     {
       name: 'no wallet + PIN',
-      wallet: null,
+      hasWallet: false,
       hasPin: true,
       expectedLocked: false,
     },
     {
       name: 'no wallet + no PIN',
-      wallet: null,
+      hasWallet: false,
       hasPin: false,
-      expectedLocked: false,
-    },
-    {
-      name: 'wallet with EMPTY accounts + PIN',
-      wallet: { accounts: [] },
-      hasPin: true,
       expectedLocked: false,
     },
   ];
 
   it.each(parityCases)(
-    'parity: $name ⇒ locked=$expectedLocked (matches serial logic)',
-    async ({ wallet, hasPin, expectedLocked }) => {
-      mockWallet.mockResolvedValue(wallet as never);
-      mockHasPin.mockResolvedValue(hasPin);
+    'parity: $name ⇒ locked=$expectedLocked, recovery=false',
+    async ({ hasWallet, hasPin, expectedLocked }) => {
+      mockHasWalletStrict.mockResolvedValue(hasWallet);
+      mockHasPinStrict.mockResolvedValue(hasPin);
 
       const { result } = await mountAuth();
 
-      // Recompute the expected lock state from the ORIGINAL serial predicate and
-      // assert both against the hand-authored expectation and the parallel result.
-      const w = wallet as { accounts?: unknown[] } | null;
-      const serialUnlockedSetup =
-        !w || (w.accounts?.length ?? 0) === 0 || !hasPin;
-      expect(serialUnlockedSetup).toBe(!expectedLocked);
+      const unlockedSetup = !hasWallet || !hasPin;
+      expect(unlockedSetup).toBe(!expectedLocked);
 
       expect(result.current.authState.isLocked).toBe(expectedLocked);
       expect(result.current.authState.isAuthenticated).toBe(!expectedLocked);
+      expect(result.current.authState.securityUnavailable).toBe(false);
     }
   );
 });

--- a/src/navigation/AppNavigator.tsx
+++ b/src/navigation/AppNavigator.tsx
@@ -1,10 +1,4 @@
-import React, {
-  useEffect,
-  useState,
-  useRef,
-  useCallback,
-  Suspense,
-} from 'react';
+import React, { useEffect, useRef, useCallback, Suspense } from 'react';
 import {
   NavigationContainer,
   StackActions,
@@ -1081,9 +1075,6 @@ function MainTabNavigator() {
 }
 
 function AppStack() {
-  const [initialRoute, setInitialRoute] =
-    useState<keyof RootStackParamList>('Onboarding');
-  const [isLoading, setIsLoading] = useState(true);
   // Subscribe to the init-cascade gates this component (the splash readiness
   // owner) must cover, so it re-renders as each resolves:
   //   - remote-signer gate (MainTabNavigator's `isInitialized`) — gate 2,
@@ -1096,67 +1087,44 @@ function AppStack() {
   );
   const appMode = useAppMode();
   const isWalletInitialized = useWalletStore((state) => state.isInitialized);
-  // TASK-213: the initial route is chosen by the error-SWALLOWING
-  // getCurrentWallet() below, which returns null on a storage read FAILURE and
-  // would route to the UN-guarded Onboarding flow (AuthGuard only wraps `Main`).
-  // AuthContext.checkInitialAuthState performs the authoritative, fail-closed
-  // determination (with bounded retry); when it finds secure storage unreadable
-  // it sets securityUnavailable, and we render the recovery screen OVER the whole
-  // navigator — so a storage failure can never expose onboarding/create/import.
+  // TASK-213: derive the initial route from the SINGLE authoritative auth verdict
+  // (AuthContext.checkInitialAuthState) instead of a second, error-SWALLOWING
+  // wallet read. That verdict distinguishes a storage read FAILURE (→ recovery,
+  // below) from genuine absence (→ Onboarding) and presence (→ Main) with bounded
+  // retry, so the route can NEVER diverge from the fail-closed lock state — e.g.
+  // a stale Onboarding route can no longer expose the UN-guarded setup flow after
+  // a recovery Retry or a transient blip (AuthGuard only wraps `Main`). hasWallet
+  // is meaningful only once authChecked is true, which gates the render below.
   const { authState, recheckAuthState } = useAuth();
-
-  useEffect(() => {
-    checkInitialRoute();
-  }, []);
-
-  const checkInitialRoute = async () => {
-    try {
-      const wallet = await MultiAccountWalletService.getCurrentWallet();
-
-      if (wallet && wallet.accounts.length > 0) {
-        setInitialRoute('Main');
-      } else {
-        setInitialRoute('Onboarding');
-      }
-    } catch (error) {
-      console.error('Failed to check initial route:', error);
-      setInitialRoute('Onboarding');
-    } finally {
-      setIsLoading(false);
-    }
-  };
+  const initialRoute: keyof RootStackParamList = authState.hasWallet
+    ? 'Main'
+    : 'Onboarding';
 
   // Single readiness owner for the native splash (F-48, TASK-182). Hide it only
-  // once the FIRST real content frame can render — covering ALL THREE gates of
-  // the F-03 init cascade (route + remote-signer + wallet-store hydration). See
+  // once the FIRST real content frame can render — covering ALL gates of the init
+  // cascade (auth verdict + remote-signer + wallet-store hydration). See
   // isColdBootContentReady() for the exact gate/scoping rules; in short, on the
-  // common existing-wallet cold start it now also waits for the wallet store's
-  // cached balances so the splash never lifts onto Home's "Loading wallet..."
-  // placeholder.
+  // common existing-wallet cold start it also waits for the wallet store's cached
+  // balances so the splash never lifts onto Home's "Loading wallet..." placeholder.
   //
   // This effect runs AFTER commit, so the content it gates on is already painted
   // when the splash lifts — no blank flash. Every gate is guaranteed to resolve
-  // (or throw) so this cannot silently stall: checkInitialRoute() always clears
-  // isLoading in its finally; remoteSignerStore.initialize() always sets
-  // isInitialized (even on its caught-error path); and walletStore.initialize()
-  // — kicked off early in initializeServices() AND again by Home's mount effect —
-  // always sets isInitialized (success and caught-error paths alike). The error
-  // boundary and the index.ts watchdog cover the render-throw and hard-hang
-  // cases as belt-and-suspenders.
-  // TASK-213: for a non-Main (Onboarding) initial route, hold the splash until
-  // the auth-init verdict is in (authChecked) so a pending storage FAILURE
-  // resolves to the recovery screen below instead of briefly exposing the
-  // unguarded onboarding flow. `Main` is unchanged (AuthGuard gates it), so its
-  // splash-readiness timing is unaffected.
-  const routeReady =
-    !isLoading && (initialRoute === 'Main' || authState.authChecked);
+  // (or throw) so this cannot silently stall: checkInitialAuthState() always
+  // reaches a terminal setAuthState that sets authChecked (locked, unlocked-setup,
+  // recovery, and the defensive catch alike); remoteSignerStore.initialize()
+  // always sets isInitialized (even on its caught-error path); and
+  // walletStore.initialize() — kicked off early in initializeServices() AND again
+  // by Home's mount effect — always sets isInitialized (success and caught-error
+  // paths alike). The error boundary and the index.ts watchdog cover the
+  // render-throw and hard-hang cases as belt-and-suspenders.
+  //
   // The recovery screen is real, ready-to-paint content — lift the splash for it
   // regardless of the route's normal gates (e.g. a Main route whose signer/wallet
   // stores haven't hydrated must not keep the splash over the recovery screen).
   const contentReady =
     authState.securityUnavailable ||
     isColdBootContentReady({
-      routeResolved: routeReady,
+      routeResolved: authState.authChecked,
       isMainRoute: initialRoute === 'Main',
       signerInitialized: isSignerInitialized,
       isSignerMode: appMode === 'signer',
@@ -1175,8 +1143,13 @@ function AppStack() {
     return <SecureStorageUnavailableScreen onRetry={recheckAuthState} />;
   }
 
-  if (!routeReady) {
-    return null; // Or a loading screen
+  // Wait for the auth-init verdict before mounting ANY route: the navigator's
+  // Onboarding branch is UN-guarded, so it must not mount until authChecked has
+  // resolved whether this is genuine absence (→ Onboarding) or a failure
+  // (→ recovery, above). initialRouteName is honored only at this first mount, so
+  // gating here guarantees the mounted route matches the settled auth verdict.
+  if (!authState.authChecked) {
+    return null; // Native splash stays up until the first content frame.
   }
 
   return (

--- a/src/navigation/AppNavigator.tsx
+++ b/src/navigation/AppNavigator.tsx
@@ -57,6 +57,7 @@ import CreateAccountScreen from '@/screens/account/CreateAccountScreen';
 import MnemonicImportScreen from '@/screens/account/MnemonicImportScreen';
 import RekeyAccountScreen from '@/screens/wallet/RekeyAccountScreen';
 import OnboardingScreen from '@/screens/onboarding/OnboardingScreen';
+import SecureStorageUnavailableScreen from '@/screens/auth/SecureStorageUnavailableScreen';
 import QRAccountImportScreen from '@/screens/account/QRAccountImportScreen';
 import AccountImportPreviewScreen from '@/screens/account/AccountImportPreviewScreen';
 import CreateWalletScreen from '@/screens/onboarding/CreateWalletScreen';
@@ -1095,6 +1096,14 @@ function AppStack() {
   );
   const appMode = useAppMode();
   const isWalletInitialized = useWalletStore((state) => state.isInitialized);
+  // TASK-213: the initial route is chosen by the error-SWALLOWING
+  // getCurrentWallet() below, which returns null on a storage read FAILURE and
+  // would route to the UN-guarded Onboarding flow (AuthGuard only wraps `Main`).
+  // AuthContext.checkInitialAuthState performs the authoritative, fail-closed
+  // determination (with bounded retry); when it finds secure storage unreadable
+  // it sets securityUnavailable, and we render the recovery screen OVER the whole
+  // navigator — so a storage failure can never expose onboarding/create/import.
+  const { authState, recheckAuthState } = useAuth();
 
   useEffect(() => {
     checkInitialRoute();
@@ -1134,20 +1143,39 @@ function AppStack() {
   // always sets isInitialized (success and caught-error paths alike). The error
   // boundary and the index.ts watchdog cover the render-throw and hard-hang
   // cases as belt-and-suspenders.
-  const contentReady = isColdBootContentReady({
-    routeResolved: !isLoading,
-    isMainRoute: initialRoute === 'Main',
-    signerInitialized: isSignerInitialized,
-    isSignerMode: appMode === 'signer',
-    walletInitialized: isWalletInitialized,
-  });
+  // TASK-213: for a non-Main (Onboarding) initial route, hold the splash until
+  // the auth-init verdict is in (authChecked) so a pending storage FAILURE
+  // resolves to the recovery screen below instead of briefly exposing the
+  // unguarded onboarding flow. `Main` is unchanged (AuthGuard gates it), so its
+  // splash-readiness timing is unaffected.
+  const routeReady =
+    !isLoading && (initialRoute === 'Main' || authState.authChecked);
+  // The recovery screen is real, ready-to-paint content — lift the splash for it
+  // regardless of the route's normal gates (e.g. a Main route whose signer/wallet
+  // stores haven't hydrated must not keep the splash over the recovery screen).
+  const contentReady =
+    authState.securityUnavailable ||
+    isColdBootContentReady({
+      routeResolved: routeReady,
+      isMainRoute: initialRoute === 'Main',
+      signerInitialized: isSignerInitialized,
+      isSignerMode: appMode === 'signer',
+      walletInitialized: isWalletInitialized,
+    });
   useEffect(() => {
     if (contentReady) {
       void hideSplashScreen();
     }
   }, [contentReady]);
 
-  if (isLoading) {
+  // Fail-closed recovery (TASK-213): secure storage was found unreadable at boot.
+  // Render ONLY the recovery screen — over every route, including the unguarded
+  // onboarding flow — so the app grants ZERO wallet access until it recovers.
+  if (authState.securityUnavailable) {
+    return <SecureStorageUnavailableScreen onRetry={recheckAuthState} />;
+  }
+
+  if (!routeReady) {
     return null; // Or a loading screen
   }
 

--- a/src/navigation/AppNavigator.tsx
+++ b/src/navigation/AppNavigator.tsx
@@ -213,7 +213,10 @@ export type RootStackParamList = {
   SecuritySetup: {
     mnemonic?: string;
     accounts?: ScannedAccount[];
-    source?: 'create' | 'qr' | 'watch' | 'mnemonic' | 'ledger';
+    // 'restore' = post-restore PIN setup (no import branch runs; setupPin only).
+    // RestoreWalletScreen already navigates with it via CommonActions.reset, and
+    // TASK-213's cold-boot resume routes here with it as the initial param.
+    source?: 'create' | 'qr' | 'watch' | 'mnemonic' | 'ledger' | 'restore';
     accountLabel?: string;
   };
   MnemonicImport: { isOnboarding?: boolean } | undefined;
@@ -1096,9 +1099,18 @@ function AppStack() {
   // a recovery Retry or a transient blip (AuthGuard only wraps `Main`). hasWallet
   // is meaningful only once authChecked is true, which gates the render below.
   const { authState, recheckAuthState } = useAuth();
-  const initialRoute: keyof RootStackParamList = authState.hasWallet
-    ? 'Main'
-    : 'Onboarding';
+  // TASK-213 (restore-before-PIN): when the boot verdict is "resume PIN setup"
+  // (a restore persisted key-bearing accounts but was cold-killed before the PIN),
+  // the initial route is SecuritySetup(source:'restore') — NOT Main and NOT the
+  // recovery screen. This must take precedence over the hasWallet→Main derivation
+  // (a restored wallet HAS accounts, so hasWallet is true here). SecuritySetup is
+  // an unguarded route; Main is only ever reached from it AFTER setupPin succeeds
+  // (which sets a PIN and clears the breadcrumb), so this never exposes the wallet.
+  const initialRoute: keyof RootStackParamList = authState.pinSetupResume
+    ? 'SecuritySetup'
+    : authState.hasWallet
+      ? 'Main'
+      : 'Onboarding';
 
   // Single readiness owner for the native splash (F-48, TASK-182). Hide it only
   // once the FIRST real content frame can render — covering ALL gates of the init
@@ -1164,7 +1176,17 @@ function AppStack() {
     >
       <Stack.Screen name="Onboarding" component={OnboardingScreen} />
       <Stack.Screen name="CreateWallet" component={CreateWalletScreen} />
-      <Stack.Screen name="SecuritySetup" component={SecuritySetupScreen} />
+      <Stack.Screen
+        name="SecuritySetup"
+        component={SecuritySetupScreen}
+        // TASK-213: when SecuritySetup is the INITIAL route (the restore-before-PIN
+        // resume), it is mounted without navigation params, so seed source:'restore'
+        // here. Harmless otherwise — an explicit navigate() (create/import/ledger)
+        // provides its own params, which override these initial defaults.
+        initialParams={
+          authState.pinSetupResume ? { source: 'restore' } : undefined
+        }
+      />
       <Stack.Screen name="MnemonicImport" component={MnemonicImportScreen} />
       <Stack.Screen name="AddWatchAccount" component={AddWatchAccountScreen} />
       <Stack.Screen name="Main" component={MainTabNavigator} />

--- a/src/platform/__tests__/mobileSecureStorage.setItemWithAuth.test.ts
+++ b/src/platform/__tests__/mobileSecureStorage.setItemWithAuth.test.ts
@@ -13,6 +13,18 @@ jest.mock('expo-secure-store', () => ({
   deleteItemAsync: jest.fn(async () => {}),
 }));
 
+// The adapter now imports AsyncStorage (TASK-213 Android presence sentinel); its
+// native module is null under jest, so provide an in-memory mock. This test runs
+// the non-sentinel write paths, but the top-level import must still resolve.
+jest.mock('@react-native-async-storage/async-storage', () => ({
+  __esModule: true,
+  default: {
+    getItem: jest.fn(async () => null),
+    setItem: jest.fn(async () => {}),
+    removeItem: jest.fn(async () => {}),
+  },
+}));
+
 import * as SecureStore from 'expo-secure-store';
 import { MobileSecureStorageAdapter } from '../mobile/secureStorage';
 

--- a/src/platform/extension/__tests__/secureStorageFailClosed.test.ts
+++ b/src/platform/extension/__tests__/secureStorageFailClosed.test.ts
@@ -1,0 +1,82 @@
+// Unit tests for TASK-213 (Codex round-3 P0): ExtensionSecureStorageAdapter must
+// THROW on a present-but-undecryptable item (a genuine decrypt FAILURE) and
+// resolve null ONLY for genuine ABSENCE — so the auth-init strict reads can fail
+// CLOSED on the extension. Previously a decrypt error was swallowed to null,
+// indistinguishable from "no value" (a fail-OPEN at auth init).
+//
+// SECURITY NOTE: no real secret material is used; ciphertext is a throwaway blob.
+
+jest.mock('../storage', () => ({
+  extensionStorage: {
+    getItem: jest.fn(),
+    setItem: jest.fn(async () => {}),
+    removeItem: jest.fn(async () => {}),
+  },
+}));
+
+jest.mock('../crypto', () => ({
+  extensionCrypto: {
+    getRandomBytes: jest.fn(async (n: number) => new Uint8Array(n)),
+  },
+}));
+
+import { extensionStorage } from '../storage';
+import { ExtensionSecureStorageAdapter } from '../secureStorage';
+
+const mockGet = extensionStorage.getItem as jest.Mock;
+
+// Stub WebCrypto so key derivation succeeds but decrypt REJECTS (models a
+// corrupt/undecryptable item) without depending on the env's real crypto.subtle.
+const realCrypto = (globalThis as { crypto?: unknown }).crypto;
+
+beforeAll(() => {
+  Object.defineProperty(globalThis, 'crypto', {
+    configurable: true,
+    value: {
+      subtle: {
+        importKey: jest.fn(async () => ({})),
+        deriveKey: jest.fn(async () => ({})),
+        decrypt: jest.fn(async () => {
+          throw new Error('AES-GCM authentication tag mismatch');
+        }),
+      },
+    },
+  });
+});
+
+afterAll(() => {
+  Object.defineProperty(globalThis, 'crypto', {
+    configurable: true,
+    value: realCrypto,
+  });
+});
+
+describe('ExtensionSecureStorageAdapter.getItem — decrypt failure vs absence (TASK-213)', () => {
+  beforeEach(() => {
+    jest.clearAllMocks();
+  });
+
+  it('resolves NULL for genuine absence (no stored item) — no decrypt attempted', async () => {
+    mockGet.mockResolvedValue(null);
+    const adapter = new ExtensionSecureStorageAdapter();
+    await expect(adapter.getItem('pin')).resolves.toBeNull();
+  });
+
+  it('THROWS (fails closed) when a PRESENT item cannot be decrypted — never coerced to null', async () => {
+    // Truthy for every key: the encryption-key material read AND the secure item
+    // read both return a value, so decrypt is reached and (stubbed) rejects.
+    mockGet.mockResolvedValue('cipherblobcipherblob');
+    const adapter = new ExtensionSecureStorageAdapter();
+    await expect(adapter.getItem('pin')).rejects.toThrow(
+      'Secure storage decrypt failed'
+    );
+  });
+
+  it('propagates a THROW from the underlying store read (failure, not absence)', async () => {
+    mockGet.mockRejectedValue(new Error('chrome storage read failed'));
+    const adapter = new ExtensionSecureStorageAdapter();
+    await expect(adapter.getItem('pin')).rejects.toThrow(
+      'chrome storage read failed'
+    );
+  });
+});

--- a/src/platform/extension/__tests__/storageFailClosed.test.ts
+++ b/src/platform/extension/__tests__/storageFailClosed.test.ts
@@ -1,0 +1,60 @@
+// Unit tests for TASK-213 (Codex round-3 P0): the EXTENSION storage adapter must
+// distinguish a genuine read FAILURE (throw) from genuine ABSENCE (resolve null),
+// so the auth-init strict reads can fail CLOSED on the extension too. Previously
+// a chrome.runtime.lastError read error was swallowed and resolved null —
+// indistinguishable from "no value", letting a storage failure masquerade as
+// absence (a fail-OPEN at auth init).
+//
+// SECURITY NOTE: no real secret material is used.
+
+type GetCb = (result: Record<string, unknown>) => void;
+
+// `hasChromeStorage` in storage.ts is captured at MODULE LOAD, so `chrome` must
+// exist BEFORE the adapter is required. Install a mutable chrome shim first, then
+// require the module (require, not import, so this ordering is guaranteed).
+let currentGet: (keys: string[], cb: GetCb) => void = (_keys, cb) => cb({});
+let currentLastError: { message: string } | undefined;
+
+(globalThis as { chrome?: unknown }).chrome = {
+  storage: {
+    local: {
+      get: (keys: string[], cb: GetCb) => currentGet(keys, cb),
+    },
+  },
+  runtime: {
+    get lastError() {
+      return currentLastError;
+    },
+  },
+};
+
+// eslint-disable-next-line @typescript-eslint/no-require-imports
+const { ExtensionStorageAdapter } = require('../storage');
+
+describe('ExtensionStorageAdapter.getItem — failure vs absence (TASK-213)', () => {
+  let adapter: InstanceType<typeof ExtensionStorageAdapter>;
+
+  beforeEach(() => {
+    adapter = new ExtensionStorageAdapter();
+    currentLastError = undefined;
+    currentGet = (_keys, cb) => cb({});
+  });
+
+  it('resolves the stored VALUE when present (no error)', async () => {
+    currentGet = (keys, cb) => cb({ [keys[0]]: 'stored-value' });
+    await expect(adapter.getItem('k')).resolves.toBe('stored-value');
+  });
+
+  it('resolves NULL for genuine absence (key missing, no error)', async () => {
+    currentGet = (_keys, cb) => cb({});
+    await expect(adapter.getItem('k')).resolves.toBeNull();
+  });
+
+  it('THROWS (fails closed) when chrome.runtime.lastError is set — a read FAILURE, not absence', async () => {
+    currentLastError = { message: 'chrome storage read failed' };
+    currentGet = (_keys, cb) => cb({});
+    await expect(adapter.getItem('k')).rejects.toThrow(
+      'chrome storage read failed'
+    );
+  });
+});

--- a/src/platform/extension/secureStorage.ts
+++ b/src/platform/extension/secureStorage.ts
@@ -129,14 +129,21 @@ export class ExtensionSecureStorageAdapter implements SecureStorageAdapter {
   async getItem(key: string): Promise<string | null> {
     const encrypted = await extensionStorage.getItem(`${SECURE_PREFIX}${key}`);
     if (!encrypted) {
+      // Genuine ABSENCE (no stored item) — resolve null. A read FAILURE from the
+      // underlying store already threw above and propagates.
       return null;
     }
 
     try {
       return await this.decrypt(encrypted);
-    } catch (error) {
-      console.error('Failed to decrypt secure storage item:', error);
-      return null;
+    } catch {
+      // A PRESENT-but-undecryptable item is a genuine read/decrypt FAILURE, NOT
+      // absence. THROW so fail-closed callers (auth-init strict reads, TASK-213)
+      // can distinguish it from "no value"; the error-swallowing callers
+      // (hasPin/getCurrentWallet/...) still catch and resolve falsy, so their
+      // contract is unchanged. Never log the ciphertext or decrypted plaintext.
+      console.error('Failed to decrypt secure storage item');
+      throw new Error('Secure storage decrypt failed');
     }
   }
 

--- a/src/platform/extension/storage.ts
+++ b/src/platform/extension/storage.ts
@@ -13,16 +13,23 @@ const hasChromeStorage =
 export class ExtensionStorageAdapter implements StorageAdapter {
   async getItem(key: string): Promise<string | null> {
     if (!hasChromeStorage) {
-      // Fallback to localStorage for web builds
-      try {
-        return localStorage.getItem(key);
-      } catch {
-        return null;
-      }
+      // Fallback to localStorage for web builds. localStorage.getItem returns
+      // null for a genuinely-absent key and only throws on a real access
+      // FAILURE (storage disabled/blocked) — rethrow so fail-closed callers
+      // (auth-init strict reads, TASK-213) can tell failure from absence.
+      return localStorage.getItem(key);
     }
 
-    return new Promise((resolve) => {
+    return new Promise((resolve, reject) => {
       chrome.storage.local.get([key], (result) => {
+        // Distinguish a genuine read FAILURE (chrome API error) from ABSENCE:
+        // a swallowed lastError previously made both resolve `null`, which let a
+        // storage failure masquerade as "no value" (a fail-OPEN at auth init).
+        // Mirrors the setItem/removeItem lastError handling in this adapter.
+        if (chrome.runtime.lastError) {
+          reject(new Error(chrome.runtime.lastError.message));
+          return;
+        }
         resolve(result[key] ?? null);
       });
     });

--- a/src/platform/mobile/__tests__/secureStorageFailClosed.test.ts
+++ b/src/platform/mobile/__tests__/secureStorageFailClosed.test.ts
@@ -1,0 +1,244 @@
+// Regression tests for TASK-213 (Codex round-4 P1): the MOBILE secure-storage
+// adapter must fail CLOSED on Android, where expo-secure-store SWALLOWS a
+// decrypt/keystore read FAILURE to `null` — indistinguishable from genuine
+// ABSENCE — for the keystore-desync classes this guards (missing KeyStore key
+// after reinstall/restore, KeyPermanentlyInvalidatedException, BadPadding / AEAD
+// tag mismatch). Two of those native paths ALSO delete the item, which without a
+// guard makes the fail-OPEN permanent (Retry sees genuine absence and the app
+// offers to set a NEW PIN — a lock-takeover vector).
+//
+// The adapter keeps a PLAINTEXT presence sentinel (key NAMES only) in AsyncStorage
+// so a value that was written and not deleted, yet now reads back `null`, is
+// surfaced as a THROW (a read FAILURE) rather than absence. iOS throws natively,
+// so this reconstruction is Android-only and iOS behavior is pass-through.
+//
+// SECURITY NOTE: no real secret material — opaque marker strings only.
+//
+// The shared control/state below is `mock`-prefixed so the jest.mock factories
+// (hoisted above imports) may legally reference it.
+
+// In-memory backing for the two stores the adapter touches.
+const mockSecureBacking = new Map<string, string>();
+const mockAsyncBacking = new Map<string, string>();
+
+// Models the Android native read: healthy -> returns the stored value; broken ->
+// swallows to null (like KeyPermanentlyInvalidated) and, when
+// `mockDeleteOnDecryptFailure` is set, ALSO deletes the item (like the BadPadding
+// / missing-KeyStore-key paths that call deleteItemImpl).
+const mockCtl = {
+  keystoreHealthy: true,
+  deleteOnDecryptFailure: true,
+  // For the iOS pass-through test: make the native read THROW (iOS raises a
+  // KeyChainException on any status other than errSecItemNotFound).
+  iosNativeThrows: false,
+  // Make the AsyncStorage sentinel read THROW (models AsyncStorage genuinely
+  // unavailable). Driven through the shared control object rather than a
+  // per-instance mockRejectedValueOnce because the adapter is loaded under
+  // jest.isolateModules and thus holds its OWN jest.fn instance.
+  asyncGetThrows: false,
+  // Make the native delete THROW (a broken keystore can make deletion fail).
+  nativeDeleteThrows: false,
+};
+
+jest.mock('expo-secure-store', () => ({
+  WHEN_UNLOCKED_THIS_DEVICE_ONLY: 'whenUnlockedThisDeviceOnly',
+  getItemAsync: jest.fn(async (key: string) => {
+    if (mockCtl.iosNativeThrows) {
+      throw new Error('KeyChainException: keychain unreadable');
+    }
+    if (!mockSecureBacking.has(key)) {
+      return null; // genuine absence
+    }
+    if (mockCtl.keystoreHealthy) {
+      return mockSecureBacking.get(key)!;
+    }
+    if (mockCtl.deleteOnDecryptFailure) {
+      mockSecureBacking.delete(key); // mimic deleteItemImpl on BadPadding/missing-key
+    }
+    return null; // Android swallow-to-null
+  }),
+  setItemAsync: jest.fn(async (key: string, value: string) => {
+    mockSecureBacking.set(key, value);
+  }),
+  deleteItemAsync: jest.fn(async (key: string) => {
+    if (mockCtl.nativeDeleteThrows) {
+      throw new Error('native delete failed (broken keystore)');
+    }
+    mockSecureBacking.delete(key);
+  }),
+}));
+
+jest.mock('@react-native-async-storage/async-storage', () => ({
+  __esModule: true,
+  default: {
+    getItem: jest.fn(async (k: string) => {
+      if (mockCtl.asyncGetThrows) {
+        throw new Error('AsyncStorage unavailable');
+      }
+      return mockAsyncBacking.has(k) ? mockAsyncBacking.get(k)! : null;
+    }),
+    setItem: jest.fn(async (k: string, v: string) => {
+      mockAsyncBacking.set(k, v);
+    }),
+    removeItem: jest.fn(async (k: string) => {
+      mockAsyncBacking.delete(k);
+    }),
+  },
+}));
+
+const PIN_KEY = 'voi_wallet_pin';
+const SENTINEL = '__voi_ss_present__' + PIN_KEY;
+
+// Load a FRESH adapter instance bound to a chosen Platform.OS. The adapter reads
+// Platform.OS at module-eval time, so the platform mock must be installed before
+// the module is required — hence isolateModules + doMock per load.
+function loadAdapter(os: 'android' | 'ios') {
+  let AdapterClass: typeof import('../secureStorage').MobileSecureStorageAdapter;
+  jest.isolateModules(() => {
+    jest.doMock('react-native', () => ({ Platform: { OS: os } }));
+    AdapterClass = require('../secureStorage').MobileSecureStorageAdapter;
+  });
+  // @ts-expect-error assigned inside isolateModules
+  return new AdapterClass();
+}
+
+beforeEach(() => {
+  mockSecureBacking.clear();
+  mockAsyncBacking.clear();
+  mockCtl.keystoreHealthy = true;
+  mockCtl.deleteOnDecryptFailure = true;
+  mockCtl.iosNativeThrows = false;
+  mockCtl.asyncGetThrows = false;
+  mockCtl.nativeDeleteThrows = false;
+  jest.clearAllMocks();
+});
+
+describe('MobileSecureStorageAdapter — Android fail-closed (TASK-213)', () => {
+  it('resolves NULL for genuine absence (no stored item, no sentinel)', async () => {
+    const adapter = loadAdapter('android');
+    await expect(adapter.getItem(PIN_KEY)).resolves.toBeNull();
+  });
+
+  it('resolves the value AND self-heals the presence sentinel on a healthy read', async () => {
+    // Pre-existing item written by an older build (no sentinel yet).
+    mockSecureBacking.set(PIN_KEY, 'opaque-credential');
+    const adapter = loadAdapter('android');
+
+    await expect(adapter.getItem(PIN_KEY)).resolves.toBe('opaque-credential');
+    // The sentinel was written so the NEXT boot is protected.
+    expect(mockAsyncBacking.get(SENTINEL)).toBe('1');
+  });
+
+  it('THROWS (fails closed) when a written item later reads back null — the Android swallow-to-null', async () => {
+    const adapter = loadAdapter('android');
+    // A value is written (sentinel recorded)...
+    await adapter.setItem(PIN_KEY, 'opaque-credential');
+    expect(mockAsyncBacking.get(SENTINEL)).toBe('1');
+
+    // ...then the keystore desyncs: native returns null (and deletes the item).
+    mockCtl.keystoreHealthy = false;
+
+    await expect(adapter.getItem(PIN_KEY)).rejects.toThrow(
+      /secure storage read failed/i
+    );
+  });
+
+  it('STAYS failed closed on the NEXT read after the native path deleted the item (no permanent fail-open)', async () => {
+    const adapter = loadAdapter('android');
+    await adapter.setItem(PIN_KEY, 'opaque-credential');
+
+    // First failing read: native swallows to null AND deletes the encrypted item.
+    mockCtl.keystoreHealthy = false;
+    await expect(adapter.getItem(PIN_KEY)).rejects.toThrow();
+    expect(mockSecureBacking.has(PIN_KEY)).toBe(false); // native deleted it
+
+    // Second read: the item is genuinely gone from secure store, but the sentinel
+    // persists — so the adapter STILL throws rather than reporting a fake absence
+    // (which is what let a NEW PIN be set — the lock-takeover the guard closes).
+    await expect(adapter.getItem(PIN_KEY)).rejects.toThrow(
+      /secure storage read failed/i
+    );
+  });
+
+  it('an EXPLICIT delete clears the sentinel so the next read is genuine ABSENCE (reset escape hatch)', async () => {
+    const adapter = loadAdapter('android');
+    await adapter.setItem(PIN_KEY, 'opaque-credential');
+
+    // Break the keystore, then delete (models clearAll() during a reset).
+    mockCtl.keystoreHealthy = false;
+    await adapter.deleteItem(PIN_KEY);
+    expect(mockAsyncBacking.has(SENTINEL)).toBe(false);
+
+    // After the intentional wipe the read must resolve null (absence), NOT throw —
+    // this is what routes the recovery-screen reset back into Onboarding.
+    await expect(adapter.getItem(PIN_KEY)).resolves.toBeNull();
+  });
+
+  it('clears the sentinel EVEN WHEN the native delete throws (Codex round-4 P2 — reset never stranded)', async () => {
+    const adapter = loadAdapter('android');
+    await adapter.setItem(PIN_KEY, 'opaque-credential');
+
+    // Broken keystore: native delete throws AND the item still reads back null.
+    mockCtl.keystoreHealthy = false;
+    mockCtl.nativeDeleteThrows = true;
+
+    // clearAll() swallows the deleteItem rejection, so we mirror that here: the
+    // native error propagates, but the sentinel MUST already be cleared.
+    await expect(adapter.deleteItem(PIN_KEY)).rejects.toThrow(
+      'native delete failed'
+    );
+    expect(mockAsyncBacking.has(SENTINEL)).toBe(false);
+
+    // With the sentinel gone, the next strict read resolves genuine ABSENCE (not a
+    // fail-closed throw), so recovery's reset can reach Onboarding.
+    await expect(adapter.getItem(PIN_KEY)).resolves.toBeNull();
+  });
+
+  it('a self-healed item is protected on the FOLLOWING boot even if it was written by an older build', async () => {
+    // Older build wrote the value with no sentinel.
+    mockSecureBacking.set(PIN_KEY, 'opaque-credential');
+    const adapter = loadAdapter('android');
+
+    // First successful boot self-heals the sentinel.
+    await expect(adapter.getItem(PIN_KEY)).resolves.toBe('opaque-credential');
+
+    // Now the keystore breaks — the (now-recorded) sentinel makes it fail closed.
+    mockCtl.keystoreHealthy = false;
+    await expect(adapter.getItem(PIN_KEY)).rejects.toThrow(
+      /secure storage read failed/i
+    );
+  });
+
+  it('propagates an AsyncStorage sentinel-read failure (fail closed, never coerced to absence)', async () => {
+    const adapter = loadAdapter('android');
+    await adapter.setItem(PIN_KEY, 'opaque-credential');
+    mockCtl.keystoreHealthy = false;
+    // Native read yields null; the sentinel read then fails — the failure must
+    // PROPAGATE (fail closed), never be coerced to absence.
+    mockCtl.asyncGetThrows = true;
+
+    await expect(adapter.getItem(PIN_KEY)).rejects.toThrow(
+      'AsyncStorage unavailable'
+    );
+  });
+});
+
+describe('MobileSecureStorageAdapter — iOS is pass-through (unchanged)', () => {
+  it('propagates a native THROW (iOS raises on keychain failure) — no sentinel involved', async () => {
+    mockSecureBacking.set(PIN_KEY, 'opaque-credential');
+    mockCtl.iosNativeThrows = true;
+    const adapter = loadAdapter('ios');
+
+    await expect(adapter.getItem(PIN_KEY)).rejects.toThrow('KeyChainException');
+  });
+
+  it('resolves null for absence and does NOT write a sentinel on iOS', async () => {
+    const adapter = loadAdapter('ios');
+
+    await expect(adapter.getItem(PIN_KEY)).resolves.toBeNull();
+    await adapter.setItem(PIN_KEY, 'opaque-credential');
+    // No Android sentinel bookkeeping on iOS.
+    expect(mockAsyncBacking.size).toBe(0);
+    await expect(adapter.getItem(PIN_KEY)).resolves.toBe('opaque-credential');
+  });
+});

--- a/src/platform/mobile/secureStorage.ts
+++ b/src/platform/mobile/secureStorage.ts
@@ -6,6 +6,7 @@
 import * as SecureStore from 'expo-secure-store';
 import type { SecureStoreOptions } from 'expo-secure-store';
 import { Platform } from 'react-native';
+import AsyncStorage from '@react-native-async-storage/async-storage';
 import type { SecureStorageAdapter } from '../types';
 
 const SECURE_STORE_OPTIONS: SecureStoreOptions =
@@ -13,23 +14,116 @@ const SECURE_STORE_OPTIONS: SecureStoreOptions =
     ? { keychainAccessible: SecureStore.WHEN_UNLOCKED_THIS_DEVICE_ONLY }
     : {};
 
+// TASK-213 (Android fail-closed): on Android, expo-secure-store SWALLOWS a
+// decrypt/keystore read FAILURE to `null` — indistinguishable from genuine
+// ABSENCE — for the exact keystore-desync classes this guards against: a missing
+// KeyStore key after reinstall/restore (deleteItemImpl + return null), a
+// KeyPermanentlyInvalidatedException (return null), and a BadPaddingException /
+// AEAD auth-tag mismatch = corruption (deleteItemImpl + return null). See
+// node_modules/expo-secure-store/android/.../SecureStoreModule.kt readJSONEncodedItem.
+// Two of those paths ALSO delete the item, which (without this guard) makes the
+// fail-OPEN permanent: the next boot sees genuine absence and the app offers to
+// set a NEW PIN — a lock-takeover vector on an unlocked device. iOS THROWS a
+// KeyChainException on any keychain status other than errSecItemNotFound, so a
+// `null` there is already unambiguous absence; this reconstruction is Android-only.
+//
+// Mechanism: a PLAINTEXT presence sentinel in AsyncStorage records which secure
+// keys currently hold a value. It stores KEY NAMES ONLY (never a value — a key
+// name like `voi_wallet_pin` is not secret) so a key that was written and not
+// deleted through this adapter is known to be present. If the native read then
+// yields `null` for a sentinel-present key, that `null` is a read FAILURE (not
+// absence) — surface it as a THROW so the fail-closed auth-init strict probes
+// (hasPinStrict, TASK-213) enter the recovery state instead of the unlocked setup
+// state. Genuine absence (no sentinel) still resolves `null`, unchanged. On a
+// HEALTHY keystore the native read always returns the value, so the throw branch
+// is never reached — the happy path is byte-for-byte unchanged.
+const IS_ANDROID = Platform.OS === 'android';
+const PRESENCE_SENTINEL_PREFIX = '__voi_ss_present__';
+
 export class MobileSecureStorageAdapter implements SecureStorageAdapter {
+  private sentinelKey(key: string): string {
+    return `${PRESENCE_SENTINEL_PREFIX}${key}`;
+  }
+
+  private async wasPresent(key: string): Promise<boolean> {
+    // A throw here (AsyncStorage genuinely unavailable) PROPAGATES — that is
+    // itself a read failure and must fail closed, not silently resolve absence.
+    return (await AsyncStorage.getItem(this.sentinelKey(key))) !== null;
+  }
+
   async setItem(key: string, value: string): Promise<void> {
+    // Write the secure value FIRST, THEN record presence. Ordering matters: if
+    // the native write throws, no sentinel is left behind (a dangling sentinel
+    // would later masquerade as a decrypt failure); if the sentinel write throws,
+    // it surfaces to the caller and the item is simply re-writable.
     await SecureStore.setItemAsync(key, value, SECURE_STORE_OPTIONS);
+    if (IS_ANDROID) {
+      await AsyncStorage.setItem(this.sentinelKey(key), '1');
+    }
   }
 
   async getItem(key: string): Promise<string | null> {
-    return await SecureStore.getItemAsync(key, SECURE_STORE_OPTIONS);
+    const value = await SecureStore.getItemAsync(key, SECURE_STORE_OPTIONS);
+    if (!IS_ANDROID) {
+      // iOS getItemAsync throws on any keychain failure other than
+      // errSecItemNotFound, so `null` here is already unambiguous absence.
+      return value;
+    }
+    if (value !== null) {
+      // Present AND decryptable. Self-heal the sentinel for a pre-sentinel install
+      // (an item written by an older build, or the first successful read after
+      // upgrade) so the NEXT boot is fail-closed. Read-then-write keeps the common
+      // steady-state read path write-free (the sentinel already exists). This is
+      // BEST-EFFORT: a sentinel bookkeeping hiccup must NEVER turn a good secure
+      // read into a failure — the value was read fine, so return it regardless.
+      try {
+        if (!(await this.wasPresent(key))) {
+          await AsyncStorage.setItem(this.sentinelKey(key), '1');
+        }
+      } catch (error) {
+        console.warn('Secure-store presence sentinel self-heal failed', error);
+      }
+      return value;
+    }
+    // Android returned `null`: genuine absence OR a swallowed decrypt/keystore
+    // failure that expo-secure-store collapsed (and possibly deleted). A value we
+    // recorded but can no longer read is a FAILURE, not absence — fail closed.
+    if (await this.wasPresent(key)) {
+      throw new Error(
+        'Secure storage read failed: a stored item is present but unreadable ' +
+          '(keystore desync / decrypt failure)'
+      );
+    }
+    return null;
   }
 
   async deleteItem(key: string): Promise<void> {
-    await SecureStore.deleteItemAsync(key);
+    try {
+      await SecureStore.deleteItemAsync(key);
+    } finally {
+      // Clear the sentinel in a `finally` so it runs EVEN IF the native delete
+      // threw (Codex round-4 P2): on a broken keystore the native delete can fail
+      // and clearAll() swallows that error, so without clearing here the sentinel
+      // would survive and the next strict read would still throw — permanently
+      // stranding the recovery-screen reset. The caller's INTENT is removal, so
+      // the next getItem must resolve genuine ABSENCE (→ Onboarding). Best-effort
+      // and isolated so it never masks the native error. (No fail-open risk: if
+      // the item is actually still readable, getItem's value!=null path returns it
+      // and self-heals the sentinel.)
+      if (IS_ANDROID) {
+        await AsyncStorage.removeItem(this.sentinelKey(key)).catch(() => {});
+      }
+    }
   }
 
   async getItemWithAuth(
     key: string,
     options: { prompt: string }
   ): Promise<string | null> {
+    // Intentionally NOT sentinel-guarded: the sole consumer is the biometric-
+    // convenience item, which is DESIGNED to be OS-invalidated on enrollment
+    // change / lock removal and must fall back to PIN entry (never the mnemonic).
+    // Coercing its invalidation into a throw would break that graceful fallback.
     return await SecureStore.getItemAsync(key, {
       ...SECURE_STORE_OPTIONS,
       requireAuthentication: true,

--- a/src/screens/auth/SecureStorageUnavailableScreen.tsx
+++ b/src/screens/auth/SecureStorageUnavailableScreen.tsx
@@ -1,0 +1,156 @@
+import React, { useEffect, useRef, useState } from 'react';
+import { View, Text, StyleSheet, TouchableOpacity } from 'react-native';
+import { SafeAreaView } from 'react-native-safe-area-context';
+import { Ionicons } from '@expo/vector-icons';
+import { useThemedStyles } from '@/hooks/useThemedStyles';
+import { useTheme } from '@/contexts/ThemeContext';
+import { Theme } from '@/constants/themes';
+
+interface SecureStorageUnavailableScreenProps {
+  /**
+   * Re-run the auth-init check. Wired to AuthContext.recheckAuthState so a
+   * transient keychain/keystore failure can recover WITHOUT a full app restart:
+   * if secure storage is readable again the check clears securityUnavailable and
+   * this screen unmounts; if it still fails, the recovery state is re-entered.
+   */
+  onRetry: () => Promise<void>;
+}
+
+/**
+ * Fail-closed recovery screen (TASK-213). Rendered ONLY when the strict,
+ * lock-determining secure-storage reads at boot still fail after bounded retry
+ * (authState.securityUnavailable === true) — i.e. secure storage is genuinely
+ * unreadable. It grants ZERO wallet access: it is neither the unlocked setup
+ * state nor the normal PIN lock, and it exposes no path into the wallet. The
+ * only actions are Retry (re-run the check) and the hint to restart the app.
+ */
+export default function SecureStorageUnavailableScreen({
+  onRetry,
+}: SecureStorageUnavailableScreenProps) {
+  const { theme } = useTheme();
+  const styles = useThemedStyles(createStyles);
+  const [isRetrying, setIsRetrying] = useState(false);
+  // Avoid a setState-after-unmount warning: on a SUCCESSFUL retry this screen
+  // unmounts (securityUnavailable cleared) before the handler resumes.
+  const mountedRef = useRef(true);
+  useEffect(() => {
+    return () => {
+      mountedRef.current = false;
+    };
+  }, []);
+
+  const handleRetry = async () => {
+    if (isRetrying) return;
+    setIsRetrying(true);
+    try {
+      await onRetry();
+    } catch (error) {
+      // recheckAuthState fails closed internally; nothing to surface here.
+      console.error('Retry of auth-init check failed:', error);
+    } finally {
+      if (mountedRef.current) {
+        setIsRetrying(false);
+      }
+    }
+  };
+
+  return (
+    <SafeAreaView style={styles.container} edges={['top', 'bottom']}>
+      <View style={styles.content}>
+        <View style={styles.header}>
+          <Ionicons
+            name="warning-outline"
+            size={48}
+            color={theme.colors.error}
+          />
+          <Text style={styles.title}>Secure storage unavailable</Text>
+          <Text style={styles.subtitle}>
+            Your device&apos;s secure storage could not be read, so the wallet
+            was kept locked to protect your accounts. This is usually temporary.
+          </Text>
+        </View>
+
+        <TouchableOpacity
+          style={[styles.retryButton, isRetrying && styles.retryButtonDisabled]}
+          onPress={handleRetry}
+          disabled={isRetrying}
+          accessibilityRole="button"
+          accessibilityLabel="Retry secure storage check"
+        >
+          <Ionicons
+            name="refresh-outline"
+            size={20}
+            color={theme.colors.buttonText}
+          />
+          <Text style={styles.retryButtonText}>
+            {isRetrying ? 'Checking…' : 'Retry'}
+          </Text>
+        </TouchableOpacity>
+
+        <Text style={styles.hint}>
+          If this keeps happening, fully close and reopen the app. Your wallet
+          data has not been lost.
+        </Text>
+      </View>
+    </SafeAreaView>
+  );
+}
+
+const createStyles = (theme: Theme) =>
+  StyleSheet.create({
+    container: {
+      flex: 1,
+      backgroundColor: theme.colors.background,
+    },
+    content: {
+      flex: 1,
+      paddingHorizontal: theme.spacing.lg,
+      justifyContent: 'center',
+      alignItems: 'center',
+    },
+    header: {
+      alignItems: 'center',
+      marginBottom: theme.spacing.xxl,
+    },
+    title: {
+      fontSize: 24,
+      fontWeight: 'bold',
+      color: theme.colors.text,
+      marginTop: theme.spacing.lg,
+      marginBottom: theme.spacing.sm,
+      textAlign: 'center',
+    },
+    subtitle: {
+      fontSize: 16,
+      color: theme.colors.textSecondary,
+      textAlign: 'center',
+      lineHeight: 22,
+    },
+    retryButton: {
+      flexDirection: 'row',
+      alignItems: 'center',
+      justifyContent: 'center',
+      backgroundColor: theme.colors.primary,
+      borderRadius: theme.borderRadius.lg,
+      paddingVertical: theme.spacing.md,
+      paddingHorizontal: theme.spacing.xxl,
+      gap: theme.spacing.sm,
+      minWidth: 180,
+    },
+    retryButtonDisabled: {
+      opacity: 0.6,
+    },
+    retryButtonText: {
+      color: theme.colors.buttonText,
+      fontSize: 16,
+      fontWeight: '600',
+    },
+    hint: {
+      fontSize: 13,
+      color: theme.colors.textMuted,
+      textAlign: 'center',
+      marginTop: theme.spacing.xl,
+      lineHeight: 18,
+      paddingHorizontal: theme.spacing.lg,
+    },
+  });

--- a/src/screens/auth/SecureStorageUnavailableScreen.tsx
+++ b/src/screens/auth/SecureStorageUnavailableScreen.tsx
@@ -220,14 +220,14 @@ export default function SecureStorageUnavailableScreen({
         </TouchableOpacity>
 
         <Text style={styles.hint}>
-          If retrying doesn&apos;t help, your device&apos;s secure storage may be
-          permanently reset (for example after changing your device passcode or
-          restoring your phone from a backup). Resetting erases ALL local wallet
-          data on this device. Only accounts you hold a recovery phrase for can be
-          restored — each from its own phrase. Watch-only, Ledger, and
-          remote-signer accounts, and account names, are not covered by a recovery
-          phrase and must be re-added manually. Make sure you have every recovery
-          phrase before continuing.
+          If retrying doesn&apos;t help, your device&apos;s secure storage may
+          be permanently reset (for example after changing your device passcode
+          or restoring your phone from a backup). Resetting erases ALL local
+          wallet data on this device. Only accounts you hold a recovery phrase
+          for can be restored — each from its own phrase. Watch-only, Ledger,
+          and remote-signer accounts, and account names, are not covered by a
+          recovery phrase and must be re-added manually. Make sure you have
+          every recovery phrase before continuing.
         </Text>
 
         <Text style={styles.resetPrompt}>
@@ -246,7 +246,10 @@ export default function SecureStorageUnavailableScreen({
         />
 
         {resetAttempted && !busy ? (
-          <Text style={styles.resetFailedNotice} accessibilityLiveRegion="polite">
+          <Text
+            style={styles.resetFailedNotice}
+            accessibilityLiveRegion="polite"
+          >
             Reset didn&apos;t resolve the problem. Fully restart your device and
             reopen the app. If it keeps happening, contact support.
           </Text>

--- a/src/screens/auth/SecureStorageUnavailableScreen.tsx
+++ b/src/screens/auth/SecureStorageUnavailableScreen.tsx
@@ -4,6 +4,7 @@ import {
   Text,
   StyleSheet,
   TouchableOpacity,
+  TextInput,
   Platform,
 } from 'react-native';
 import { SafeAreaView } from 'react-native-safe-area-context';
@@ -75,6 +76,19 @@ export default function SecureStorageUnavailableScreen({
   const styles = useThemedStyles(createStyles);
   const [isRetrying, setIsRetrying] = useState(false);
   const [isResetting, setIsResetting] = useState(false);
+  // Type-RESET friction (Dave's decision, TASK-213): the destructive wipe stays
+  // disabled until the user types the exact word RESET — stronger intent than a
+  // checkbox, ON TOP OF the existing double confirmation.
+  const [resetConfirmText, setResetConfirmText] = useState('');
+  // FIX 3(a): "reset didn't resolve it" signal. Set when a reset attempt starts.
+  // On a SUCCESSFUL reset the recheck clears securityUnavailable and this screen
+  // UNMOUNTS, destroying this state — so the message never shows. If the reset
+  // does NOT resolve the failure the screen stays mounted, this stays true, and
+  // the guidance renders (no silent loop). This survives-by-unmount design needs
+  // no fragile post-await timing check.
+  const [resetAttempted, setResetAttempted] = useState(false);
+  const RESET_CONFIRM_WORD = 'RESET';
+  const canReset = resetConfirmText === RESET_CONFIRM_WORD;
   // Avoid a setState-after-unmount warning: on a SUCCESSFUL retry/reset this
   // screen unmounts (securityUnavailable cleared) before the handler resumes.
   const mountedRef = useRef(true);
@@ -103,6 +117,10 @@ export default function SecureStorageUnavailableScreen({
 
   const performReset = async () => {
     setIsResetting(true);
+    // Mark the attempt BEFORE the wipe. A SUCCESSFUL reset unmounts this screen
+    // (securityUnavailable cleared), discarding this flag; if we stay mounted the
+    // reset did NOT resolve the failure and the guidance below renders.
+    setResetAttempted(true);
     try {
       // Best-effort local wipe. Each step is isolated so a throw in one (a broken
       // keystore can make key-material deletion fail) still lets the wallet-
@@ -124,13 +142,10 @@ export default function SecureStorageUnavailableScreen({
       // absence ⇒ unlocked setup ⇒ Onboarding (restore-from-recovery-phrase).
       await onRetry();
     } catch (error) {
+      // A throw here (or a recheck that re-lands on recovery without throwing)
+      // leaves this screen mounted; resetAttempted stays true and the inline
+      // "reset didn't resolve it" guidance renders — no silent loop.
       console.error('Reset of secure storage state failed:', error);
-      if (mountedRef.current) {
-        showAlert(
-          'Reset failed',
-          'The app could not reset its local data. Fully close and reopen the app, then try again.'
-        );
-      }
     } finally {
       if (mountedRef.current) {
         setIsResetting(false);
@@ -139,10 +154,12 @@ export default function SecureStorageUnavailableScreen({
   };
 
   const confirmReset = () => {
-    if (busy) return;
+    // Gate on both the typed-RESET word and the not-busy state, so this can never
+    // be triggered before the friction is satisfied.
+    if (busy || !canReset) return;
     showAlert(
       'Reset and start over?',
-      'This permanently deletes this device’s local wallet data. Your accounts stay safe on-chain and can be restored with your recovery phrase. Without your recovery phrase this cannot be undone.',
+      'This permanently erases ALL local wallet data on this device. Only accounts backed by a recovery phrase you personally hold can be restored — each from its own phrase. Watch-only, Ledger, and remote-signer accounts must be re-added manually. This cannot be undone.',
       [
         { text: 'Cancel', style: 'cancel' },
         {
@@ -151,7 +168,7 @@ export default function SecureStorageUnavailableScreen({
           onPress: () =>
             showAlert(
               'Are you sure?',
-              'Make sure you have your recovery phrase before continuing. All local wallet data will be erased.',
+              'Make sure you have EVERY recovery phrase before continuing. All local wallet data on this device will be permanently erased.',
               [
                 { text: 'Cancel', style: 'cancel' },
                 {
@@ -203,17 +220,47 @@ export default function SecureStorageUnavailableScreen({
         </TouchableOpacity>
 
         <Text style={styles.hint}>
-          If retrying doesn&apos;t help, your device&apos;s secure storage may
-          be permanently reset (for example after changing your device passcode
-          or restoring from a backup). You can reset this app and restore your
-          wallet from your recovery phrase — your funds remain safe on-chain.
+          If retrying doesn&apos;t help, your device&apos;s secure storage may be
+          permanently reset (for example after changing your device passcode or
+          restoring your phone from a backup). Resetting erases ALL local wallet
+          data on this device. Only accounts you hold a recovery phrase for can be
+          restored — each from its own phrase. Watch-only, Ledger, and
+          remote-signer accounts, and account names, are not covered by a recovery
+          phrase and must be re-added manually. Make sure you have every recovery
+          phrase before continuing.
         </Text>
 
+        <Text style={styles.resetPrompt}>
+          Type {RESET_CONFIRM_WORD} below to enable erasing all local data.
+        </Text>
+        <TextInput
+          style={styles.resetInput}
+          value={resetConfirmText}
+          onChangeText={setResetConfirmText}
+          editable={!busy}
+          autoCapitalize="characters"
+          autoCorrect={false}
+          placeholder={RESET_CONFIRM_WORD}
+          placeholderTextColor={theme.colors.textMuted}
+          accessibilityLabel="Type RESET to enable erasing all local data"
+        />
+
+        {resetAttempted && !busy ? (
+          <Text style={styles.resetFailedNotice} accessibilityLiveRegion="polite">
+            Reset didn&apos;t resolve the problem. Fully restart your device and
+            reopen the app. If it keeps happening, contact support.
+          </Text>
+        ) : null}
+
         <TouchableOpacity
-          style={[styles.resetButton, busy && styles.buttonDisabled]}
+          style={[
+            styles.resetButton,
+            (busy || !canReset) && styles.buttonDisabled,
+          ]}
           onPress={confirmReset}
-          disabled={busy}
+          disabled={busy || !canReset}
           accessibilityRole="button"
+          accessibilityState={{ disabled: busy || !canReset }}
           accessibilityLabel="Reset app and restore from recovery phrase"
         >
           <Ionicons name="trash-outline" size={18} color={theme.colors.error} />
@@ -301,5 +348,34 @@ const createStyles = (theme: Theme) =>
       color: theme.colors.error,
       fontSize: 14,
       fontWeight: '600',
+    },
+    resetPrompt: {
+      fontSize: 13,
+      color: theme.colors.textSecondary,
+      textAlign: 'center',
+      marginTop: theme.spacing.xl,
+      marginBottom: theme.spacing.sm,
+      paddingHorizontal: theme.spacing.lg,
+    },
+    resetInput: {
+      alignSelf: 'stretch',
+      borderWidth: 1,
+      borderColor: theme.colors.border,
+      borderRadius: theme.borderRadius.md,
+      paddingVertical: theme.spacing.sm,
+      paddingHorizontal: theme.spacing.md,
+      marginHorizontal: theme.spacing.lg,
+      color: theme.colors.text,
+      fontSize: 16,
+      textAlign: 'center',
+      letterSpacing: 2,
+    },
+    resetFailedNotice: {
+      fontSize: 13,
+      color: theme.colors.error,
+      textAlign: 'center',
+      marginTop: theme.spacing.lg,
+      lineHeight: 18,
+      paddingHorizontal: theme.spacing.lg,
     },
   });

--- a/src/screens/auth/SecureStorageUnavailableScreen.tsx
+++ b/src/screens/auth/SecureStorageUnavailableScreen.tsx
@@ -42,6 +42,34 @@ const showAlert = (
   }
 };
 
+// No-stuck bound for each reset step (TASK-213). A wedged native call — a hung
+// keystore deletion or a recheck that never settles — must not leave the button
+// pinned on "Resetting…" forever. On timeout the step is abandoned (best-effort)
+// so the flow proceeds to the recheck / the "reset didn't resolve it" guidance
+// instead of hanging. 8s comfortably exceeds any healthy local wipe.
+const RESET_STEP_TIMEOUT_MS = 8000;
+
+const withTimeout = <T,>(
+  promise: Promise<T>,
+  ms: number,
+  label: string
+): Promise<T> =>
+  new Promise<T>((resolve, reject) => {
+    const timer = setTimeout(() => {
+      reject(new Error(`${label} timed out after ${ms}ms`));
+    }, ms);
+    promise.then(
+      (value) => {
+        clearTimeout(timer);
+        resolve(value);
+      },
+      (error) => {
+        clearTimeout(timer);
+        reject(error);
+      }
+    );
+  });
+
 interface SecureStorageUnavailableScreenProps {
   /**
    * Re-run the auth-init check. Wired to AuthContext.recheckAuthState so a
@@ -129,18 +157,30 @@ export default function SecureStorageUnavailableScreen({
       // Android it also clears the secure-store presence sentinel so hasPinStrict
       // reads genuine ABSENCE (not a fail-closed throw) afterward.
       try {
-        await AccountSecureStorage.clearAll();
+        await withTimeout(
+          AccountSecureStorage.clearAll(),
+          RESET_STEP_TIMEOUT_MS,
+          'clearAll'
+        );
       } catch (error) {
-        console.error('Reset: clearAll failed (continuing):', error);
+        console.error('Reset: clearAll failed/timed out (continuing):', error);
       }
       try {
-        await MultiAccountWalletService.clearAllWallets();
+        await withTimeout(
+          MultiAccountWalletService.clearAllWallets(),
+          RESET_STEP_TIMEOUT_MS,
+          'clearAllWallets'
+        );
       } catch (error) {
-        console.error('Reset: clearAllWallets failed (continuing):', error);
+        console.error(
+          'Reset: clearAllWallets failed/timed out (continuing):',
+          error
+        );
       }
       // Re-run the auth check: with local data wiped it resolves to genuine
       // absence ⇒ unlocked setup ⇒ Onboarding (restore-from-recovery-phrase).
-      await onRetry();
+      // Bounded too, so a recheck that never settles can't strand "Resetting…".
+      await withTimeout(onRetry(), RESET_STEP_TIMEOUT_MS, 'recheck');
     } catch (error) {
       // A throw here (or a recheck that re-lands on recovery without throwing)
       // leaves this screen mounted; resetAttempted stays true and the inline

--- a/src/screens/auth/SecureStorageUnavailableScreen.tsx
+++ b/src/screens/auth/SecureStorageUnavailableScreen.tsx
@@ -1,10 +1,45 @@
 import React, { useEffect, useRef, useState } from 'react';
-import { View, Text, StyleSheet, TouchableOpacity } from 'react-native';
+import {
+  View,
+  Text,
+  StyleSheet,
+  TouchableOpacity,
+  Platform,
+} from 'react-native';
 import { SafeAreaView } from 'react-native-safe-area-context';
 import { Ionicons } from '@expo/vector-icons';
 import { useThemedStyles } from '@/hooks/useThemedStyles';
 import { useTheme } from '@/contexts/ThemeContext';
 import { Theme } from '@/constants/themes';
+import { AccountSecureStorage } from '@/services/secure';
+import { MultiAccountWalletService } from '@/services/wallet';
+
+// Cross-platform confirm dialog (mirrors LockScreen.showAlert): on web there is
+// no native Alert, so fall back to window.confirm for the multi-button
+// (destructive) case and window.alert otherwise.
+const showAlert = (
+  title: string,
+  message: string,
+  buttons?: { text: string; onPress?: () => void; style?: string }[]
+) => {
+  if (Platform.OS === 'web') {
+    if (buttons && buttons.length > 1) {
+      const confirmed = window.confirm(`${title}\n\n${message}`);
+      if (confirmed) {
+        const confirmButton =
+          buttons.find((b) => b.style === 'destructive') ||
+          buttons[buttons.length - 1];
+        confirmButton?.onPress?.();
+      }
+    } else {
+      window.alert(`${title}\n\n${message}`);
+      buttons?.[0]?.onPress?.();
+    }
+  } else {
+    const { Alert } = require('react-native');
+    Alert.alert(title, message, buttons);
+  }
+};
 
 interface SecureStorageUnavailableScreenProps {
   /**
@@ -21,8 +56,17 @@ interface SecureStorageUnavailableScreenProps {
  * lock-determining secure-storage reads at boot still fail after bounded retry
  * (authState.securityUnavailable === true) — i.e. secure storage is genuinely
  * unreadable. It grants ZERO wallet access: it is neither the unlocked setup
- * state nor the normal PIN lock, and it exposes no path into the wallet. The
- * only actions are Retry (re-run the check) and the hint to restart the app.
+ * state nor the normal PIN lock, and it exposes no path into the wallet.
+ *
+ * Two actions, in priority order:
+ *  - Retry: re-run the check. Recovers a TRANSIENT failure with no data loss.
+ *  - Reset & restore: the escape hatch for a PERSISTENT failure (a permanently
+ *    desynced keystore or an irrecoverably corrupt local blob) that Retry can
+ *    never clear. It wipes ONLY local data — the on-chain accounts are untouched
+ *    and are recoverable from the user's recovery phrase — then re-runs the check
+ *    so the app lands in Onboarding (restore-from-phrase). Without this the user
+ *    would be permanently stranded here (Retry re-failing forever). Guarded by a
+ *    double confirmation because it is destructive to un-backed-up local state.
  */
 export default function SecureStorageUnavailableScreen({
   onRetry,
@@ -30,8 +74,9 @@ export default function SecureStorageUnavailableScreen({
   const { theme } = useTheme();
   const styles = useThemedStyles(createStyles);
   const [isRetrying, setIsRetrying] = useState(false);
-  // Avoid a setState-after-unmount warning: on a SUCCESSFUL retry this screen
-  // unmounts (securityUnavailable cleared) before the handler resumes.
+  const [isResetting, setIsResetting] = useState(false);
+  // Avoid a setState-after-unmount warning: on a SUCCESSFUL retry/reset this
+  // screen unmounts (securityUnavailable cleared) before the handler resumes.
   const mountedRef = useRef(true);
   useEffect(() => {
     return () => {
@@ -39,8 +84,10 @@ export default function SecureStorageUnavailableScreen({
     };
   }, []);
 
+  const busy = isRetrying || isResetting;
+
   const handleRetry = async () => {
-    if (isRetrying) return;
+    if (busy) return;
     setIsRetrying(true);
     try {
       await onRetry();
@@ -52,6 +99,73 @@ export default function SecureStorageUnavailableScreen({
         setIsRetrying(false);
       }
     }
+  };
+
+  const performReset = async () => {
+    setIsResetting(true);
+    try {
+      // Best-effort local wipe. Each step is isolated so a throw in one (a broken
+      // keystore can make key-material deletion fail) still lets the wallet-
+      // metadata wipe run — that AsyncStorage removal is what makes the next
+      // strict boot read resolve "no wallet" and route to Onboarding, and on
+      // Android it also clears the secure-store presence sentinel so hasPinStrict
+      // reads genuine ABSENCE (not a fail-closed throw) afterward.
+      try {
+        await AccountSecureStorage.clearAll();
+      } catch (error) {
+        console.error('Reset: clearAll failed (continuing):', error);
+      }
+      try {
+        await MultiAccountWalletService.clearAllWallets();
+      } catch (error) {
+        console.error('Reset: clearAllWallets failed (continuing):', error);
+      }
+      // Re-run the auth check: with local data wiped it resolves to genuine
+      // absence ⇒ unlocked setup ⇒ Onboarding (restore-from-recovery-phrase).
+      await onRetry();
+    } catch (error) {
+      console.error('Reset of secure storage state failed:', error);
+      if (mountedRef.current) {
+        showAlert(
+          'Reset failed',
+          'The app could not reset its local data. Fully close and reopen the app, then try again.'
+        );
+      }
+    } finally {
+      if (mountedRef.current) {
+        setIsResetting(false);
+      }
+    }
+  };
+
+  const confirmReset = () => {
+    if (busy) return;
+    showAlert(
+      'Reset and start over?',
+      'This permanently deletes this device’s local wallet data. Your accounts stay safe on-chain and can be restored with your recovery phrase. Without your recovery phrase this cannot be undone.',
+      [
+        { text: 'Cancel', style: 'cancel' },
+        {
+          text: 'Continue',
+          style: 'destructive',
+          onPress: () =>
+            showAlert(
+              'Are you sure?',
+              'Make sure you have your recovery phrase before continuing. All local wallet data will be erased.',
+              [
+                { text: 'Cancel', style: 'cancel' },
+                {
+                  text: 'Erase and restore',
+                  style: 'destructive',
+                  onPress: () => {
+                    void performReset();
+                  },
+                },
+              ]
+            ),
+        },
+      ]
+    );
   };
 
   return (
@@ -66,14 +180,15 @@ export default function SecureStorageUnavailableScreen({
           <Text style={styles.title}>Secure storage unavailable</Text>
           <Text style={styles.subtitle}>
             Your device&apos;s secure storage could not be read, so the wallet
-            was kept locked to protect your accounts. This is usually temporary.
+            was kept locked to protect your accounts. This is often temporary —
+            try again first.
           </Text>
         </View>
 
         <TouchableOpacity
-          style={[styles.retryButton, isRetrying && styles.retryButtonDisabled]}
+          style={[styles.retryButton, busy && styles.buttonDisabled]}
           onPress={handleRetry}
-          disabled={isRetrying}
+          disabled={busy}
           accessibilityRole="button"
           accessibilityLabel="Retry secure storage check"
         >
@@ -88,9 +203,26 @@ export default function SecureStorageUnavailableScreen({
         </TouchableOpacity>
 
         <Text style={styles.hint}>
-          If this keeps happening, fully close and reopen the app. Your wallet
-          data has not been lost.
+          If retrying doesn&apos;t help, your device&apos;s secure storage may
+          be permanently reset (for example after changing your device passcode
+          or restoring from a backup). You can reset this app and restore your
+          wallet from your recovery phrase — your funds remain safe on-chain.
         </Text>
+
+        <TouchableOpacity
+          style={[styles.resetButton, busy && styles.buttonDisabled]}
+          onPress={confirmReset}
+          disabled={busy}
+          accessibilityRole="button"
+          accessibilityLabel="Reset app and restore from recovery phrase"
+        >
+          <Ionicons name="trash-outline" size={18} color={theme.colors.error} />
+          <Text style={styles.resetButtonText}>
+            {isResetting
+              ? 'Resetting…'
+              : 'Reset & restore from recovery phrase'}
+          </Text>
+        </TouchableOpacity>
       </View>
     </SafeAreaView>
   );
@@ -137,7 +269,7 @@ const createStyles = (theme: Theme) =>
       gap: theme.spacing.sm,
       minWidth: 180,
     },
-    retryButtonDisabled: {
+    buttonDisabled: {
       opacity: 0.6,
     },
     retryButtonText: {
@@ -152,5 +284,22 @@ const createStyles = (theme: Theme) =>
       marginTop: theme.spacing.xl,
       lineHeight: 18,
       paddingHorizontal: theme.spacing.lg,
+    },
+    resetButton: {
+      flexDirection: 'row',
+      alignItems: 'center',
+      justifyContent: 'center',
+      borderWidth: 1,
+      borderColor: theme.colors.error,
+      borderRadius: theme.borderRadius.lg,
+      paddingVertical: theme.spacing.sm,
+      paddingHorizontal: theme.spacing.lg,
+      gap: theme.spacing.sm,
+      marginTop: theme.spacing.lg,
+    },
+    resetButtonText: {
+      color: theme.colors.error,
+      fontSize: 14,
+      fontWeight: '600',
     },
   });

--- a/src/screens/auth/__tests__/SecureStorageUnavailableScreen.test.tsx
+++ b/src/screens/auth/__tests__/SecureStorageUnavailableScreen.test.tsx
@@ -1,0 +1,143 @@
+// Regression tests for TASK-213 (Codex round-4 P2): the fail-closed recovery
+// screen must offer an ESCAPE HATCH for a PERSISTENT failure. Retry alone leaves
+// a permanently-desynced keystore / irrecoverably-corrupt blob stranded forever
+// (Retry re-runs the identical, deterministically-failing reads). The screen adds
+// a guarded "Reset & restore" that wipes ONLY local data (on-chain accounts are
+// untouched, recoverable from the recovery phrase) then re-runs the auth check so
+// the app lands in Onboarding.
+//
+// SECURITY NOTE: no real secret material — the wipe services are mocked sinks.
+
+import React from 'react';
+import { Alert } from 'react-native';
+import { render, fireEvent, act } from '@testing-library/react-native';
+
+import SecureStorageUnavailableScreen from '../SecureStorageUnavailableScreen';
+import { AccountSecureStorage } from '@/services/secure';
+import { MultiAccountWalletService } from '@/services/wallet';
+
+jest.mock('@/services/secure', () => ({
+  AccountSecureStorage: { clearAll: jest.fn(async () => {}) },
+}));
+
+jest.mock('@/services/wallet', () => ({
+  MultiAccountWalletService: { clearAllWallets: jest.fn(async () => {}) },
+}));
+
+// Keep the render host-component-light: theme + native leaves are opaque.
+jest.mock('@/hooks/useThemedStyles', () => ({
+  useThemedStyles: () => ({}),
+}));
+
+jest.mock('@/contexts/ThemeContext', () => ({
+  useTheme: () => ({
+    theme: {
+      colors: {
+        error: '#f00',
+        buttonText: '#fff',
+        textMuted: '#999',
+        primary: '#00f',
+        text: '#000',
+        textSecondary: '#333',
+        background: '#fff',
+      },
+    },
+  }),
+}));
+
+jest.mock('@expo/vector-icons', () => ({ Ionicons: () => null }), {
+  virtual: true,
+});
+
+jest.mock('react-native-safe-area-context', () => ({
+  SafeAreaView: ({ children }: { children: React.ReactNode }) => children,
+}));
+
+const mockClearAll = AccountSecureStorage.clearAll as jest.Mock;
+const mockClearAllWallets =
+  MultiAccountWalletService.clearAllWallets as jest.Mock;
+
+beforeEach(() => {
+  jest.clearAllMocks();
+});
+
+// Auto-confirm every Alert by invoking its destructive (or last) button, so the
+// double confirmation chains straight through to performReset.
+function autoConfirmAlerts() {
+  return jest
+    .spyOn(Alert, 'alert')
+    .mockImplementation((_title, _msg, buttons) => {
+      const btn =
+        buttons?.find((b) => b.style === 'destructive') ??
+        buttons?.[(buttons?.length ?? 1) - 1];
+      btn?.onPress?.();
+    });
+}
+
+describe('SecureStorageUnavailableScreen — reset escape hatch (TASK-213)', () => {
+  it('exposes a Retry action wired to onRetry', async () => {
+    const onRetry = jest.fn(async () => {});
+    const { getByLabelText } = render(
+      <SecureStorageUnavailableScreen onRetry={onRetry} />
+    );
+
+    await act(async () => {
+      fireEvent.press(getByLabelText('Retry secure storage check'));
+    });
+
+    expect(onRetry).toHaveBeenCalledTimes(1);
+    // Retry must NOT wipe anything.
+    expect(mockClearAll).not.toHaveBeenCalled();
+    expect(mockClearAllWallets).not.toHaveBeenCalled();
+  });
+
+  it('the guarded Reset wipes local data (clearAll + clearAllWallets) then re-runs the check', async () => {
+    const alertSpy = autoConfirmAlerts();
+    const onRetry = jest.fn(async () => {});
+    const { getByLabelText } = render(
+      <SecureStorageUnavailableScreen onRetry={onRetry} />
+    );
+
+    await act(async () => {
+      fireEvent.press(
+        getByLabelText('Reset app and restore from recovery phrase')
+      );
+      await Promise.resolve();
+    });
+
+    // Double confirmation was shown (two nested alerts).
+    expect(alertSpy.mock.calls.length).toBeGreaterThanOrEqual(2);
+    // Local data wiped, THEN the auth check re-run (→ Onboarding on absence).
+    expect(mockClearAll).toHaveBeenCalledTimes(1);
+    expect(mockClearAllWallets).toHaveBeenCalledTimes(1);
+    expect(onRetry).toHaveBeenCalledTimes(1);
+
+    alertSpy.mockRestore();
+  });
+
+  it('still re-runs the check when clearAll throws (broken keystore) — best-effort wipe', async () => {
+    const alertSpy = autoConfirmAlerts();
+    mockClearAll.mockRejectedValueOnce(new Error('keystore delete failed'));
+    const errorSpy = jest.spyOn(console, 'error').mockImplementation(() => {});
+    const onRetry = jest.fn(async () => {});
+    const { getByLabelText } = render(
+      <SecureStorageUnavailableScreen onRetry={onRetry} />
+    );
+
+    await act(async () => {
+      fireEvent.press(
+        getByLabelText('Reset app and restore from recovery phrase')
+      );
+      await Promise.resolve();
+    });
+
+    // A clearAll failure must NOT abort the reset: the wallet-metadata wipe (the
+    // step that actually lets the next boot resolve "no wallet") still runs, and
+    // the check is still re-run.
+    expect(mockClearAllWallets).toHaveBeenCalledTimes(1);
+    expect(onRetry).toHaveBeenCalledTimes(1);
+
+    errorSpy.mockRestore();
+    alertSpy.mockRestore();
+  });
+});

--- a/src/screens/auth/__tests__/SecureStorageUnavailableScreen.test.tsx
+++ b/src/screens/auth/__tests__/SecureStorageUnavailableScreen.test.tsx
@@ -94,9 +94,12 @@ describe('SecureStorageUnavailableScreen — reset escape hatch (TASK-213)', () 
   it('the guarded Reset wipes local data (clearAll + clearAllWallets) then re-runs the check', async () => {
     const alertSpy = autoConfirmAlerts();
     const onRetry = jest.fn(async () => {});
-    const { getByLabelText } = render(
+    const { getByLabelText, getByPlaceholderText } = render(
       <SecureStorageUnavailableScreen onRetry={onRetry} />
     );
+
+    // Type-RESET friction (TASK-213): the wipe is gated until RESET is typed.
+    fireEvent.changeText(getByPlaceholderText('RESET'), 'RESET');
 
     await act(async () => {
       fireEvent.press(
@@ -120,9 +123,11 @@ describe('SecureStorageUnavailableScreen — reset escape hatch (TASK-213)', () 
     mockClearAll.mockRejectedValueOnce(new Error('keystore delete failed'));
     const errorSpy = jest.spyOn(console, 'error').mockImplementation(() => {});
     const onRetry = jest.fn(async () => {});
-    const { getByLabelText } = render(
+    const { getByLabelText, getByPlaceholderText } = render(
       <SecureStorageUnavailableScreen onRetry={onRetry} />
     );
+
+    fireEvent.changeText(getByPlaceholderText('RESET'), 'RESET');
 
     await act(async () => {
       fireEvent.press(
@@ -138,6 +143,105 @@ describe('SecureStorageUnavailableScreen — reset escape hatch (TASK-213)', () 
     expect(onRetry).toHaveBeenCalledTimes(1);
 
     errorSpy.mockRestore();
+    alertSpy.mockRestore();
+  });
+
+  it('the wipe stays DISABLED until the exact word RESET is typed (TASK-213)', async () => {
+    const alertSpy = autoConfirmAlerts();
+    const onRetry = jest.fn(async () => {});
+    const { getByLabelText, getByPlaceholderText } = render(
+      <SecureStorageUnavailableScreen onRetry={onRetry} />
+    );
+
+    // Pressing with NOTHING typed does nothing — no confirm dialog, no wipe.
+    await act(async () => {
+      fireEvent.press(
+        getByLabelText('Reset app and restore from recovery phrase')
+      );
+      await Promise.resolve();
+    });
+    expect(alertSpy).not.toHaveBeenCalled();
+    expect(mockClearAll).not.toHaveBeenCalled();
+
+    // A near-miss (wrong case) still does NOT enable it.
+    fireEvent.changeText(getByPlaceholderText('RESET'), 'reset');
+    await act(async () => {
+      fireEvent.press(
+        getByLabelText('Reset app and restore from recovery phrase')
+      );
+      await Promise.resolve();
+    });
+    expect(alertSpy).not.toHaveBeenCalled();
+    expect(mockClearAll).not.toHaveBeenCalled();
+
+    // Exact RESET enables it — now the confirm chain runs and the wipe fires.
+    fireEvent.changeText(getByPlaceholderText('RESET'), 'RESET');
+    await act(async () => {
+      fireEvent.press(
+        getByLabelText('Reset app and restore from recovery phrase')
+      );
+      await Promise.resolve();
+    });
+    expect(alertSpy).toHaveBeenCalled();
+    expect(mockClearAll).toHaveBeenCalledTimes(1);
+
+    alertSpy.mockRestore();
+  });
+
+  it('the reset confirmation copy is accurate — no single-recovery-phrase over-promise (TASK-213)', async () => {
+    const alertSpy = autoConfirmAlerts();
+    const onRetry = jest.fn(async () => {});
+    const { getByLabelText, getByPlaceholderText } = render(
+      <SecureStorageUnavailableScreen onRetry={onRetry} />
+    );
+
+    fireEvent.changeText(getByPlaceholderText('RESET'), 'RESET');
+    await act(async () => {
+      fireEvent.press(
+        getByLabelText('Reset app and restore from recovery phrase')
+      );
+      await Promise.resolve();
+    });
+
+    const messages = alertSpy.mock.calls.map((c) => String(c[1]));
+    const combined = messages.join('\n');
+    // Erases ALL local data — not just "a wallet" restorable from one phrase.
+    expect(combined).toMatch(/erases ALL local wallet data/i);
+    // Names the account kinds a single seed does NOT restore.
+    expect(combined).toMatch(/watch-only/i);
+    expect(combined).toMatch(/ledger/i);
+    expect(combined).toMatch(/remote-signer/i);
+    // Each phrase restores only its own accounts; requires EVERY phrase.
+    expect(combined).toMatch(/each from its own phrase/i);
+    expect(combined).toMatch(/every recovery phrase/i);
+
+    alertSpy.mockRestore();
+  });
+
+  it('FIX 3(a): shows a "reset didn\'t resolve it" message when the recheck stays on recovery', async () => {
+    // onRetry that resolves WITHOUT clearing the recovery state (e.g. AsyncStorage
+    // itself unwritable) leaves this screen mounted. Instead of silently looping,
+    // the guidance renders.
+    const alertSpy = autoConfirmAlerts();
+    const onRetry = jest.fn(async () => {}); // does not resolve the failure
+    const { getByLabelText, getByPlaceholderText, queryByText } = render(
+      <SecureStorageUnavailableScreen onRetry={onRetry} />
+    );
+
+    // No message before a reset attempt.
+    expect(queryByText(/resolve the problem/i)).toBeNull();
+
+    fireEvent.changeText(getByPlaceholderText('RESET'), 'RESET');
+    await act(async () => {
+      fireEvent.press(
+        getByLabelText('Reset app and restore from recovery phrase')
+      );
+      await Promise.resolve();
+    });
+
+    expect(onRetry).toHaveBeenCalledTimes(1);
+    expect(queryByText(/resolve the problem/i)).not.toBeNull();
+
     alertSpy.mockRestore();
   });
 });

--- a/src/screens/auth/__tests__/SecureStorageUnavailableScreen.test.tsx
+++ b/src/screens/auth/__tests__/SecureStorageUnavailableScreen.test.tsx
@@ -244,4 +244,44 @@ describe('SecureStorageUnavailableScreen — reset escape hatch (TASK-213)', () 
 
     alertSpy.mockRestore();
   });
+
+  it('FIX 3(b): a HUNG wipe step times out — the reset never sticks on "Resetting…"', async () => {
+    jest.useFakeTimers();
+    const alertSpy = autoConfirmAlerts();
+    // clearAll never settles (wedged native keystore deletion). Bounded reset
+    // steps must time out so the flow proceeds instead of hanging forever.
+    mockClearAll.mockReturnValue(new Promise(() => {}));
+    const onRetry = jest.fn(async () => {});
+    const errorSpy = jest.spyOn(console, 'error').mockImplementation(() => {});
+    const { getByLabelText, getByPlaceholderText, queryByText } = render(
+      <SecureStorageUnavailableScreen onRetry={onRetry} />
+    );
+
+    fireEvent.changeText(getByPlaceholderText('RESET'), 'RESET');
+    await act(async () => {
+      fireEvent.press(
+        getByLabelText('Reset app and restore from recovery phrase')
+      );
+      await Promise.resolve();
+    });
+
+    // Advance past the per-step timeout so the hung clearAll is abandoned and the
+    // flow continues to clearAllWallets + the recheck.
+    await act(async () => {
+      jest.advanceTimersByTime(8000);
+      for (let i = 0; i < 10; i += 1) {
+        await Promise.resolve();
+      }
+    });
+
+    // The recheck ran (flow did NOT hang on clearAll) and, since onRetry didn't
+    // resolve the failure, the "didn't resolve" guidance is shown (not a stuck
+    // spinner).
+    expect(onRetry).toHaveBeenCalledTimes(1);
+    expect(queryByText(/resolve the problem/i)).not.toBeNull();
+
+    errorSpy.mockRestore();
+    alertSpy.mockRestore();
+    jest.useRealTimers();
+  });
 });

--- a/src/screens/onboarding/SecuritySetupScreen.tsx
+++ b/src/screens/onboarding/SecuritySetupScreen.tsx
@@ -20,6 +20,7 @@ import {
   clearAccountSecrets,
 } from '@/utils/accountQRParser';
 import { useTheme } from '@/contexts/ThemeContext';
+import { useAuth } from '@/contexts/AuthContext';
 import { useThemedStyles } from '@/hooks/useThemedStyles';
 import { Theme } from '@/constants/themes';
 import KeyboardAwareScrollView from '@/components/common/KeyboardAwareScrollView';
@@ -50,6 +51,13 @@ interface Props {
 
 export default function SecuritySetupScreen({ navigation, route }: Props) {
   const { theme } = useTheme();
+  // TASK-213: set the PIN through AuthContext (not AccountSecureStorage directly)
+  // so authState.hasPin flips to true on success. Otherwise a wallet set up in this
+  // session — including the cold-restore RESUME path (pinSetupResume) — would keep
+  // hasPin=false in context, and lock()/inactivity/background auto-lock would no-op
+  // until the NEXT launch. AuthContext.setupPin delegates to the same atomic
+  // AccountSecureStorage.setupPin and then updates hasPin.
+  const { setupPin: authSetupPin } = useAuth();
   const styles = useThemedStyles(createStyles);
   const [mode, setMode] = useState<SecretSource>('pin');
   const [pin, setPin] = useState('');
@@ -117,7 +125,7 @@ export default function SecuritySetupScreen({ navigation, route }: Props) {
       // any pre-existing device-key accounts under the new secret before committing
       // the credential (verify-before-delete), so onboarding never strands keys.
       setSetupStep(`Setting up ${secretLabel}...`);
-      await AccountSecureStorage.setupPin(pin, mode);
+      await authSetupPin(pin, mode);
 
       // Store biometric preference. When the user opts into biometrics at
       // onboarding, capture the just-set PIN behind the write-time auth gate

--- a/src/services/backup/__tests__/restorePinSetupPending.test.ts
+++ b/src/services/backup/__tests__/restorePinSetupPending.test.ts
@@ -1,0 +1,112 @@
+// TASK-213 restore-before-PIN: performFullRestore must SET the pin_setup_pending
+// breadcrumb AFTER wiping old data and BEFORE persisting any key-bearing (STANDARD)
+// account — so a cold-kill in the restore window (accounts on disk, no PIN yet)
+// boots to SecuritySetup(resume), not the recovery screen whose Reset would wipe
+// the just-restored wallet. This asserts that ordering invariant.
+//
+// SECURITY NOTE: no real key material — algosdk + secure storage are mocked sinks;
+// the breadcrumb holds only the marker 'true', never a secret.
+
+const order: string[] = [];
+
+jest.mock('@/services/secure/pinSetupPending', () => ({
+  markPinSetupPending: jest.fn(async () => {
+    order.push('mark');
+  }),
+}));
+
+jest.mock('@/services/secure/AccountSecureStorage', () => ({
+  AccountSecureStorage: {
+    clearAll: jest.fn(async () => {
+      order.push('clearAll');
+    }),
+    storeAccount: jest.fn(async () => {
+      order.push('storeAccount');
+    }),
+    setBiometricEnabled: jest.fn(async () => {}),
+  },
+}));
+
+jest.mock('@/services/wallet', () => ({
+  MultiAccountWalletService: {
+    persistRestoredWallet: jest.fn(async () => {
+      order.push('persistList');
+    }),
+  },
+}));
+
+jest.mock('@/platform', () => ({
+  storage: {
+    removeItem: jest.fn(async () => {}),
+    setItem: jest.fn(async () => {}),
+  },
+}));
+
+jest.mock('@react-native-async-storage/async-storage', () => ({
+  __esModule: true,
+  default: {
+    getAllKeys: jest.fn(async () => []),
+    multiRemove: jest.fn(async () => {}),
+    multiSet: jest.fn(async () => {}),
+    setItem: jest.fn(async () => {}),
+  },
+}));
+
+jest.mock('algosdk', () => ({
+  __esModule: true,
+  default: {
+    mnemonicToSecretKey: jest.fn(() => ({
+      addr: { toString: () => 'RESTORED_ADDR' },
+      sk: new Uint8Array(64),
+    })),
+  },
+}));
+
+import { performFullRestore } from '../restorers';
+import { markPinSetupPending } from '@/services/secure/pinSetupPending';
+import { AccountType } from '@/types/wallet';
+import type { BackupAccountData, BackupSettings } from '../types';
+
+const mockMark = markPinSetupPending as jest.Mock;
+
+beforeEach(() => {
+  order.length = 0;
+  jest.clearAllMocks();
+});
+
+describe('performFullRestore — pin_setup_pending breadcrumb ordering (TASK-213)', () => {
+  it('sets the breadcrumb AFTER clearAllData and BEFORE the STANDARD account is persisted', async () => {
+    const standardAccount = {
+      id: 'restored-standard-1',
+      type: AccountType.STANDARD,
+      address: 'RESTORED_ADDR',
+      // Non-empty so the STANDARD branch does not skip; algosdk is mocked so the
+      // content is irrelevant (never a real phrase).
+      mnemonic: 'placeholder mnemonic not a real phrase',
+      label: 'Restored',
+      createdAt: new Date().toISOString(),
+    } as unknown as BackupAccountData;
+
+    // Minimal settings/experimental: the later restorers may reject on these, but
+    // the mark/clearAll/storeAccount ordering is already committed by then. Guard
+    // so a later rejection can't fail this ordering assertion.
+    try {
+      await performFullRestore(
+        [standardAccount],
+        {} as unknown as BackupSettings,
+        [],
+        {} as unknown as Parameters<typeof performFullRestore>[3]
+      );
+    } catch {
+      // ignore — ordering already captured above
+    }
+
+    expect(mockMark).toHaveBeenCalledTimes(1);
+    // Breadcrumb set after the wipe...
+    expect(order.indexOf('clearAll')).toBeGreaterThanOrEqual(0);
+    expect(order.indexOf('clearAll')).toBeLessThan(order.indexOf('mark'));
+    // ...and BEFORE any key-bearing account is written to disk.
+    expect(order.indexOf('storeAccount')).toBeGreaterThanOrEqual(0);
+    expect(order.indexOf('mark')).toBeLessThan(order.indexOf('storeAccount'));
+  });
+});

--- a/src/services/backup/restorers.ts
+++ b/src/services/backup/restorers.ts
@@ -11,6 +11,7 @@ import * as Crypto from 'expo-crypto';
 import { storage } from '@/platform';
 import { MultiAccountWalletService } from '@/services/wallet';
 import { AccountSecureStorage } from '@/services/secure/AccountSecureStorage';
+import { markPinSetupPending } from '@/services/secure/pinSetupPending';
 import {
   AccountType,
   StandardAccountMetadata,
@@ -644,6 +645,17 @@ export async function performFullRestore(
 ): Promise<RestoreResult> {
   // Clear all existing data first
   await clearAllData();
+
+  // TASK-213 (restore-before-PIN false-lockout fix): set the durable plaintext
+  // breadcrumb NOW — after the old PIN is wiped, BEFORE any key-bearing (STANDARD)
+  // account is persisted below. Restore writes STANDARD account key material with
+  // NO PIN yet (the user sets the PIN afterward on SecuritySetup). A cold-kill in
+  // that window would otherwise boot into the fail-closed recovery screen (whose
+  // Reset WIPES this just-restored wallet); the breadcrumb lets checkInitialAuthState
+  // route to SecuritySetup (resume PIN setup) instead. setupPin clears it on
+  // success. Placed BEFORE restoreAccounts so the breadcrumb can never be missing
+  // while a key-bearing account sits on disk without a PIN.
+  await markPinSetupPending();
 
   // Restore accounts
   const accountCounts = await restoreAccounts(accounts);

--- a/src/services/secure/AccountSecureStorage.ts
+++ b/src/services/secure/AccountSecureStorage.ts
@@ -2053,8 +2053,11 @@ export class AccountSecureStorage {
       // breadcrumb (if any) is stale. Clear it here — the PRIMARY clear point —
       // so a LATER keystore break fails CLOSED to recovery instead of routing to
       // SecuritySetup over this now-protected wallet (the fail-OPEN this guards).
-      // Best-effort (clearPinSetupPending never throws): a clear failure is
-      // self-healed by the readable-PIN boot clear in checkInitialAuthState.
+      // clearPinSetupPending is internally BOUNDED (per-op timeouts + bounded
+      // retries) and NEVER throws, so this await cannot hang the SecuritySetup
+      // submit; it verifies removal (retries) so the marker is durably gone on a
+      // functioning store, and any residual is self-healed by the readable-PIN
+      // boot clear in checkInitialAuthState.
       await clearPinSetupPending();
     } catch (error) {
       throw new AccountStorageError(

--- a/src/services/secure/AccountSecureStorage.ts
+++ b/src/services/secure/AccountSecureStorage.ts
@@ -2410,6 +2410,36 @@ export class AccountSecureStorage {
     }
   }
 
+  /**
+   * STRICT, boot-only PIN-presence probe (TASK-213). Unlike hasPin() — which
+   * swallows secure-storage read/decrypt errors and resolves `false`, making a
+   * genuine read FAILURE indistinguishable from genuine absence (the auth-init
+   * fail-OPEN) — this variant THROWS on a genuine secure-storage read/decrypt
+   * failure and resolves `false` ONLY for genuine ABSENCE (no credential stored
+   * in either the primary secure-store or the legacy AsyncStorage location).
+   *
+   * It is a pure read: no JSON parse, no legacy-migration WRITE, no cache
+   * mutation, and no secret material is ever returned or logged. Presence is
+   * decided purely on whether a raw credential value exists.
+   *
+   * Used EXCLUSIVELY by AuthContext.checkInitialAuthState so lock computation can
+   * fail CLOSED (the "secure storage unavailable" recovery state) on a storage
+   * read failure. Do NOT route other callers here: hasPin()'s error-swallowing
+   * contract (resolve falsy on failure) is relied on by its other call sites.
+   */
+  static async hasPinStrict(): Promise<boolean> {
+    // A throw from either getItem (keychain/keystore unavailable, decrypt error)
+    // PROPAGATES to the caller — it is never coerced to `false`. Presence in
+    // EITHER the secure store or the legacy AsyncStorage location counts as
+    // "PIN set"; both getItems return `null` (not throw) for genuine absence.
+    const secure = await secureStorage.getItem(this.PIN_KEY);
+    if (secure) {
+      return true;
+    }
+    const legacy = await storage.getItem(this.PIN_KEY);
+    return Boolean(legacy);
+  }
+
   static async changePin(
     currentPin: string,
     newPin: string,

--- a/src/services/secure/AccountSecureStorage.ts
+++ b/src/services/secure/AccountSecureStorage.ts
@@ -2038,6 +2038,24 @@ export class AccountSecureStorage {
   ): Promise<void> {
     try {
       this.validateSecret(newSecret, secretSource);
+      // TASK-213 (fail-OPEN closure): clear the restore-before-PIN breadcrumb —
+      // with CONFIRMED removal — BEFORE committing the PIN, not after. A PIN
+      // credential must never come to exist on disk while a live breadcrumb could
+      // still be read: otherwise a commit that partially fails (e.g. the Android
+      // presence-sentinel write fails, so a later keystore break makes the PIN read
+      // resolve absent) would let the stale breadcrumb route that wallet to
+      // SecuritySetup — a NEW PIN over a real wallet. Clearing FIRST makes every
+      // such race fail CLOSED (recovery), never open. If removal cannot be
+      // CONFIRMED (a wedged/unhealthy store), ABORT rather than commit a PIN into
+      // that ambiguous state — the caller simply retries. clearPinSetupPending is
+      // bounded + verifying + never-throwing; a no-op when no breadcrumb exists
+      // (normal onboarding) on a healthy store.
+      const breadcrumbCleared = await clearPinSetupPending();
+      if (!breadcrumbCleared) {
+        throw new Error(
+          'Could not clear the restore setup marker before establishing the PIN'
+        );
+      }
       // Acquire the GLOBAL key-mutation mutex, then run the atomic rewrap+commit
       // under it (P1-3: no verify/commit races). setupPin has no current secret
       // to verify (first-secret setup).
@@ -2049,16 +2067,6 @@ export class AccountSecureStorage {
         })
       );
       this.legacyCheckRequired = false;
-      // TASK-213: a PIN is now durably established, so the restore-before-PIN
-      // breadcrumb (if any) is stale. Clear it here — the PRIMARY clear point —
-      // so a LATER keystore break fails CLOSED to recovery instead of routing to
-      // SecuritySetup over this now-protected wallet (the fail-OPEN this guards).
-      // clearPinSetupPending is internally BOUNDED (per-op timeouts + bounded
-      // retries) and NEVER throws, so this await cannot hang the SecuritySetup
-      // submit; it verifies removal (retries) so the marker is durably gone on a
-      // functioning store, and any residual is self-healed by the readable-PIN
-      // boot clear in checkInitialAuthState.
-      await clearPinSetupPending();
     } catch (error) {
       throw new AccountStorageError(
         `Failed to set up PIN: ${error instanceof Error ? error.message : 'Unknown error'}`

--- a/src/services/secure/AccountSecureStorage.ts
+++ b/src/services/secure/AccountSecureStorage.ts
@@ -44,6 +44,7 @@ import {
 } from './envelopeV2';
 import { SessionKeyVault, VaultLockedError } from './SessionKeyVault';
 import type { SecretSource } from './SessionKeyVault';
+import { clearPinSetupPending } from './pinSetupPending';
 import { SECURITY_CONFIG } from '../../config/security';
 
 // ─────────────────────────────────────────────────────────────────────────────
@@ -2048,6 +2049,13 @@ export class AccountSecureStorage {
         })
       );
       this.legacyCheckRequired = false;
+      // TASK-213: a PIN is now durably established, so the restore-before-PIN
+      // breadcrumb (if any) is stale. Clear it here — the PRIMARY clear point —
+      // so a LATER keystore break fails CLOSED to recovery instead of routing to
+      // SecuritySetup over this now-protected wallet (the fail-OPEN this guards).
+      // Best-effort (clearPinSetupPending never throws): a clear failure is
+      // self-healed by the readable-PIN boot clear in checkInitialAuthState.
+      await clearPinSetupPending();
     } catch (error) {
       throw new AccountStorageError(
         `Failed to set up PIN: ${error instanceof Error ? error.message : 'Unknown error'}`

--- a/src/services/secure/__tests__/hasPinStrict.test.ts
+++ b/src/services/secure/__tests__/hasPinStrict.test.ts
@@ -1,0 +1,122 @@
+// Unit tests for TASK-213: AccountSecureStorage.hasPinStrict().
+//
+// The STRICT, boot-only PIN-presence probe AuthContext uses to fail CLOSED. It
+// MUST distinguish a genuine secure-storage read/decrypt FAILURE (throw /
+// propagate) from a genuine ABSENCE (resolve false), and must be a pure read —
+// no legacy-migration WRITE, no cache mutation, and it must NEVER coerce a read
+// failure to `false` the way the error-swallowing hasPin() does.
+//
+// SECURITY NOTE: no real PIN/secret material is used; values are opaque markers.
+
+const mockSecure = new Map<string, string>();
+const mockKv = new Map<string, string>();
+const mockSecureGetItem = jest.fn(async (k: string) =>
+  mockSecure.has(k) ? mockSecure.get(k)! : null
+);
+const mockSecureSetItem = jest.fn(async (k: string, v: string) => {
+  mockSecure.set(k, v);
+});
+const mockKvGetItem = jest.fn(async (k: string) =>
+  mockKv.has(k) ? mockKv.get(k)! : null
+);
+const mockKvRemoveItem = jest.fn(async (k: string) => {
+  mockKv.delete(k);
+});
+
+jest.mock('@/platform', () => {
+  const nodeCrypto = require('crypto');
+  return {
+    crypto: {
+      getRandomBytes: async (n: number): Promise<Uint8Array> =>
+        Uint8Array.from(nodeCrypto.randomBytes(n)),
+      sha256: async (input: string): Promise<string> =>
+        nodeCrypto.createHash('sha256').update(input).digest('hex'),
+      randomUUID: () => nodeCrypto.randomUUID(),
+    },
+    secureStorage: {
+      getItem: (k: string) => mockSecureGetItem(k),
+      setItem: (k: string, v: string) => mockSecureSetItem(k, v),
+      deleteItem: jest.fn(async () => {}),
+      getItemWithAuth: (k: string) => mockSecureGetItem(k),
+    },
+    storage: {
+      getItem: (k: string) => mockKvGetItem(k),
+      setItem: jest.fn(async () => {}),
+      removeItem: (k: string) => mockKvRemoveItem(k),
+      multiRemove: jest.fn(async () => {}),
+    },
+    biometrics: {
+      isAvailable: async () => false,
+      isEnrolled: async () => false,
+    },
+    deviceId: { getDeviceId: async () => 'has-pin-strict-test-device' },
+  };
+});
+
+import { AccountSecureStorage } from '../AccountSecureStorage';
+
+const PIN_KEY = 'voi_wallet_pin';
+
+beforeEach(() => {
+  mockSecure.clear();
+  mockKv.clear();
+  jest.clearAllMocks();
+});
+
+describe('hasPinStrict — absence vs failure (TASK-213)', () => {
+  it('resolves FALSE for genuine absence (no credential in either location)', async () => {
+    await expect(AccountSecureStorage.hasPinStrict()).resolves.toBe(false);
+  });
+
+  it('resolves TRUE when a credential is present in secure storage', async () => {
+    mockSecure.set(PIN_KEY, JSON.stringify({ hash: 'h', iterations: 100000 }));
+    await expect(AccountSecureStorage.hasPinStrict()).resolves.toBe(true);
+  });
+
+  it('resolves TRUE when the credential is only in the legacy AsyncStorage location', async () => {
+    mockKv.set(PIN_KEY, JSON.stringify({ hash: 'h', iterations: 100000 }));
+    await expect(AccountSecureStorage.hasPinStrict()).resolves.toBe(true);
+  });
+
+  it('THROWS (fails closed) when the secure-store read FAILS — never coerced to false', async () => {
+    mockSecureGetItem.mockImplementationOnce(async () => {
+      throw new Error('keychain/keystore unavailable');
+    });
+    await expect(AccountSecureStorage.hasPinStrict()).rejects.toThrow(
+      'keychain/keystore unavailable'
+    );
+  });
+
+  it('THROWS when the legacy AsyncStorage read FAILS (secure store empty)', async () => {
+    mockKvGetItem.mockImplementationOnce(async () => {
+      throw new Error('AsyncStorage read failed');
+    });
+    await expect(AccountSecureStorage.hasPinStrict()).rejects.toThrow(
+      'AsyncStorage read failed'
+    );
+  });
+
+  it('is a PURE read — performs no migration write and no cache mutation', async () => {
+    mockKv.set(PIN_KEY, JSON.stringify({ hash: 'h', iterations: 100000 }));
+    await AccountSecureStorage.hasPinStrict();
+    // Unlike getStoredPinData(), the strict probe must NOT migrate the legacy
+    // value into secure storage or delete it.
+    expect(mockSecureSetItem).not.toHaveBeenCalled();
+    expect(mockKvRemoveItem).not.toHaveBeenCalled();
+  });
+
+  it('contrast: the error-swallowing hasPin() still resolves FALSE on the same read failure', async () => {
+    // Guards the contract split: hasPin()'s other callers must keep getting a
+    // falsy resolve on failure; only hasPinStrict() surfaces the throw.
+    const warnSpy = jest.spyOn(console, 'warn').mockImplementation(() => {});
+    mockSecureGetItem.mockImplementation(async () => {
+      throw new Error('keychain unavailable');
+    });
+    // Legacy AsyncStorage read also fails, so getStoredPinData cannot fall back.
+    mockKvGetItem.mockImplementation(async () => {
+      throw new Error('AsyncStorage unavailable');
+    });
+    await expect(AccountSecureStorage.hasPin()).resolves.toBe(false);
+    warnSpy.mockRestore();
+  });
+});

--- a/src/services/secure/__tests__/keyWriterChangePin.test.ts
+++ b/src/services/secure/__tests__/keyWriterChangePin.test.ts
@@ -119,6 +119,12 @@ const mockPlatform = platform as unknown as {
     setItemWithAuth: jest.Mock;
     deleteItem: jest.Mock;
   };
+  storage: {
+    getItem: jest.Mock;
+    setItem: jest.Mock;
+    removeItem: jest.Mock;
+    multiRemove: jest.Mock;
+  };
 };
 
 // Reach the private statics the way the merged suites do (cast, no `any`).
@@ -409,17 +415,46 @@ describe('setupPin — first-secret device→v2 migration (§5.4)', () => {
     expect(await AccountSecureStorage.verifyPin('123456')).toBe(true);
   });
 
-  it('clears the pin_setup_pending breadcrumb on success (TASK-213 anti-fail-open)', async () => {
+  it('clears the pin_setup_pending breadcrumb BEFORE committing the PIN (TASK-213 anti-fail-open)', async () => {
     useFastWriter();
     // A restore-in-progress breadcrumb sits in plaintext AsyncStorage (restore
-    // sets it BEFORE the PIN). Establishing the PIN must clear it here — the
-    // PRIMARY clear — so a LATER keystore break fails CLOSED to recovery instead
-    // of routing to SecuritySetup over this now-protected wallet (the fail-OPEN).
+    // sets it BEFORE the PIN). Establishing the PIN must clear it — with confirmed
+    // removal, BEFORE the credential commits — so a PIN can never coexist on disk
+    // with a live breadcrumb (which a later keystore break could resume over).
     mockPlatform.__kv.set('pin_setup_pending', 'true');
 
     await AccountSecureStorage.setupPin('123456', 'pin');
 
     expect(mockPlatform.__kv.has('pin_setup_pending')).toBe(false);
+    // The PIN credential is committed and verifies (the clear did not block it).
+    expect(await AccountSecureStorage.verifyPin('123456')).toBe(true);
+  });
+
+  it('ABORTS setupPin (no PIN committed) when the breadcrumb removal cannot be confirmed', async () => {
+    useFastWriter();
+    mockPlatform.__kv.set('pin_setup_pending', 'true');
+    // Plaintext removal can never be confirmed → clearPinSetupPending returns
+    // false → setupPin MUST abort rather than commit a PIN alongside a live marker.
+    const originalRemove =
+      mockPlatform.storage.removeItem.getMockImplementation();
+    mockPlatform.storage.removeItem.mockRejectedValue(new Error('kv wedged'));
+    const warnSpy = jest.spyOn(console, 'warn').mockImplementation(() => {});
+    try {
+      await expect(
+        AccountSecureStorage.setupPin('123456', 'pin')
+      ).rejects.toThrow(/Failed to set up PIN/);
+      // No PIN credential was committed (fail-closed): nothing to verify against.
+      expect(await AccountSecureStorage.verifyPin('123456')).toBe(false);
+    } finally {
+      warnSpy.mockRestore();
+      // Restore the shared mock impl (clearMocks preserves impls across tests).
+      mockPlatform.storage.removeItem.mockImplementation(
+        originalRemove ??
+          (async (k: string) => {
+            mockPlatform.__kv.delete(k);
+          })
+      );
+    }
   });
 });
 

--- a/src/services/secure/__tests__/keyWriterChangePin.test.ts
+++ b/src/services/secure/__tests__/keyWriterChangePin.test.ts
@@ -408,6 +408,19 @@ describe('setupPin — first-secret device→v2 migration (§5.4)', () => {
     expect(mockPlatform.__secure.has(secretKey('acct-watch'))).toBe(false);
     expect(await AccountSecureStorage.verifyPin('123456')).toBe(true);
   });
+
+  it('clears the pin_setup_pending breadcrumb on success (TASK-213 anti-fail-open)', async () => {
+    useFastWriter();
+    // A restore-in-progress breadcrumb sits in plaintext AsyncStorage (restore
+    // sets it BEFORE the PIN). Establishing the PIN must clear it here — the
+    // PRIMARY clear — so a LATER keystore break fails CLOSED to recovery instead
+    // of routing to SecuritySetup over this now-protected wallet (the fail-OPEN).
+    mockPlatform.__kv.set('pin_setup_pending', 'true');
+
+    await AccountSecureStorage.setupPin('123456', 'pin');
+
+    expect(mockPlatform.__kv.has('pin_setup_pending')).toBe(false);
+  });
 });
 
 // ─────────────────────────────────────────────────────────────────────────────

--- a/src/services/secure/__tests__/pinSetupPending.test.ts
+++ b/src/services/secure/__tests__/pinSetupPending.test.ts
@@ -1,0 +1,79 @@
+// Unit tests for the pin_setup_pending breadcrumb (TASK-213 restore-before-PIN).
+//
+// The breadcrumb distinguishes restore-before-PIN (a healthy wallet mid-restore)
+// from a genuine keystore break in AuthContext's key-bearing guard. Its READ must
+// FAIL CLOSED (an unreadable breadcrumb ⇒ treated ABSENT ⇒ recovery, never the
+// SecuritySetup resume) and its CLEAR must never throw (so a clear failure can
+// never fail an otherwise-successful PIN setup). Backed by PLAINTEXT AsyncStorage
+// so it stays readable when the KEYSTORE is broken; it holds NO secret material.
+
+const store = new Map<string, string>();
+const mockGetItem = jest.fn(async (k: string) =>
+  store.has(k) ? store.get(k)! : null
+);
+const mockSetItem = jest.fn(async (k: string, v: string) => {
+  store.set(k, v);
+});
+const mockRemoveItem = jest.fn(async (k: string) => {
+  store.delete(k);
+});
+
+jest.mock('@/platform', () => ({
+  storage: {
+    getItem: (k: string) => mockGetItem(k),
+    setItem: (k: string, v: string) => mockSetItem(k, v),
+    removeItem: (k: string) => mockRemoveItem(k),
+  },
+}));
+
+import {
+  PIN_SETUP_PENDING_KEY,
+  markPinSetupPending,
+  clearPinSetupPending,
+  isPinSetupPending,
+} from '../pinSetupPending';
+
+beforeEach(() => {
+  store.clear();
+  jest.clearAllMocks();
+});
+
+describe('pinSetupPending breadcrumb (TASK-213)', () => {
+  it('mark writes the durable marker; isPending then resolves TRUE', async () => {
+    await markPinSetupPending();
+    expect(store.get(PIN_SETUP_PENDING_KEY)).toBe('true');
+    await expect(isPinSetupPending()).resolves.toBe(true);
+  });
+
+  it('isPending resolves FALSE for genuine absence', async () => {
+    await expect(isPinSetupPending()).resolves.toBe(false);
+  });
+
+  it('clear removes the marker; isPending then resolves FALSE', async () => {
+    await markPinSetupPending();
+    await clearPinSetupPending();
+    expect(store.has(PIN_SETUP_PENDING_KEY)).toBe(false);
+    await expect(isPinSetupPending()).resolves.toBe(false);
+  });
+
+  it('isPending FAILS CLOSED (resolves FALSE, never throws) on a read error', async () => {
+    // A breadcrumb that cannot be read must be treated as ABSENT so the
+    // key-bearing guard routes to RECOVERY, never the SecuritySetup resume.
+    const warnSpy = jest.spyOn(console, 'warn').mockImplementation(() => {});
+    mockGetItem.mockRejectedValueOnce(new Error('AsyncStorage read failed'));
+    await expect(isPinSetupPending()).resolves.toBe(false);
+    warnSpy.mockRestore();
+  });
+
+  it('isPending resolves FALSE for any value that is not the exact marker', async () => {
+    store.set(PIN_SETUP_PENDING_KEY, 'TRUE'); // wrong case / stray value
+    await expect(isPinSetupPending()).resolves.toBe(false);
+  });
+
+  it('clear NEVER throws even when removeItem rejects (best-effort, self-healed later)', async () => {
+    const warnSpy = jest.spyOn(console, 'warn').mockImplementation(() => {});
+    mockRemoveItem.mockRejectedValueOnce(new Error('AsyncStorage remove failed'));
+    await expect(clearPinSetupPending()).resolves.toBeUndefined();
+    warnSpy.mockRestore();
+  });
+});

--- a/src/services/secure/__tests__/pinSetupPending.test.ts
+++ b/src/services/secure/__tests__/pinSetupPending.test.ts
@@ -49,9 +49,14 @@ describe('pinSetupPending breadcrumb (TASK-213)', () => {
     await expect(isPinSetupPending()).resolves.toBe(false);
   });
 
-  it('clear removes the marker; isPending then resolves FALSE', async () => {
+  it('mark PROPAGATES a write failure (bounded) so restore fails fast, not hangs', async () => {
+    mockSetItem.mockRejectedValueOnce(new Error('AsyncStorage write failed'));
+    await expect(markPinSetupPending()).rejects.toThrow();
+  });
+
+  it('clear removes the marker and returns TRUE (confirmed); isPending then FALSE', async () => {
     await markPinSetupPending();
-    await clearPinSetupPending();
+    await expect(clearPinSetupPending()).resolves.toBe(true);
     expect(store.has(PIN_SETUP_PENDING_KEY)).toBe(false);
     await expect(isPinSetupPending()).resolves.toBe(false);
   });
@@ -70,25 +75,26 @@ describe('pinSetupPending breadcrumb (TASK-213)', () => {
     await expect(isPinSetupPending()).resolves.toBe(false);
   });
 
-  it('clear RETRIES a transient removeItem failure, then VERIFIES the marker is gone', async () => {
+  it('clear RETRIES a transient removeItem failure, VERIFIES removal, returns TRUE', async () => {
     await markPinSetupPending();
     // First removal attempt throws; the retry succeeds and removal is confirmed.
     mockRemoveItem.mockRejectedValueOnce(
       new Error('transient AsyncStorage remove failure')
     );
-    await clearPinSetupPending();
+    await expect(clearPinSetupPending()).resolves.toBe(true);
     expect(store.has(PIN_SETUP_PENDING_KEY)).toBe(false);
     // Retried the removal (more than one attempt).
     expect(mockRemoveItem.mock.calls.length).toBeGreaterThan(1);
   });
 
-  it('clear NEVER throws even when removeItem PERSISTENTLY rejects (fail-closed read makes it safe)', async () => {
-    // Even if removal can never succeed, clear must resolve (not throw) — a marker
-    // that cannot be removed also cannot be READ (isPending fails closed), so it
-    // can never cause a fail-open resume.
+  it('clear returns FALSE (never throws) when removal can NEVER be confirmed — the abort signal setupPin keys off', async () => {
+    // A marker that cannot be verifiably removed makes clear return FALSE so
+    // setupPin ABORTS rather than committing a PIN into an ambiguous state. It is
+    // still safe if a caller ignores the result: a marker that cannot be removed
+    // also cannot be READ (isPending fails closed), so it can never fail open.
     const warnSpy = jest.spyOn(console, 'warn').mockImplementation(() => {});
     mockRemoveItem.mockRejectedValue(new Error('AsyncStorage remove failed'));
-    await expect(clearPinSetupPending()).resolves.toBeUndefined();
+    await expect(clearPinSetupPending()).resolves.toBe(false);
     warnSpy.mockRestore();
   });
 });

--- a/src/services/secure/__tests__/pinSetupPending.test.ts
+++ b/src/services/secure/__tests__/pinSetupPending.test.ts
@@ -72,7 +72,9 @@ describe('pinSetupPending breadcrumb (TASK-213)', () => {
 
   it('clear NEVER throws even when removeItem rejects (best-effort, self-healed later)', async () => {
     const warnSpy = jest.spyOn(console, 'warn').mockImplementation(() => {});
-    mockRemoveItem.mockRejectedValueOnce(new Error('AsyncStorage remove failed'));
+    mockRemoveItem.mockRejectedValueOnce(
+      new Error('AsyncStorage remove failed')
+    );
     await expect(clearPinSetupPending()).resolves.toBeUndefined();
     warnSpy.mockRestore();
   });

--- a/src/services/secure/__tests__/pinSetupPending.test.ts
+++ b/src/services/secure/__tests__/pinSetupPending.test.ts
@@ -70,11 +70,24 @@ describe('pinSetupPending breadcrumb (TASK-213)', () => {
     await expect(isPinSetupPending()).resolves.toBe(false);
   });
 
-  it('clear NEVER throws even when removeItem rejects (best-effort, self-healed later)', async () => {
-    const warnSpy = jest.spyOn(console, 'warn').mockImplementation(() => {});
+  it('clear RETRIES a transient removeItem failure, then VERIFIES the marker is gone', async () => {
+    await markPinSetupPending();
+    // First removal attempt throws; the retry succeeds and removal is confirmed.
     mockRemoveItem.mockRejectedValueOnce(
-      new Error('AsyncStorage remove failed')
+      new Error('transient AsyncStorage remove failure')
     );
+    await clearPinSetupPending();
+    expect(store.has(PIN_SETUP_PENDING_KEY)).toBe(false);
+    // Retried the removal (more than one attempt).
+    expect(mockRemoveItem.mock.calls.length).toBeGreaterThan(1);
+  });
+
+  it('clear NEVER throws even when removeItem PERSISTENTLY rejects (fail-closed read makes it safe)', async () => {
+    // Even if removal can never succeed, clear must resolve (not throw) — a marker
+    // that cannot be removed also cannot be READ (isPending fails closed), so it
+    // can never cause a fail-open resume.
+    const warnSpy = jest.spyOn(console, 'warn').mockImplementation(() => {});
+    mockRemoveItem.mockRejectedValue(new Error('AsyncStorage remove failed'));
     await expect(clearPinSetupPending()).resolves.toBeUndefined();
     warnSpy.mockRestore();
   });

--- a/src/services/secure/pinSetupPending.ts
+++ b/src/services/secure/pinSetupPending.ts
@@ -14,13 +14,27 @@
 // account, so the key-bearing guard can route to SecuritySetup (resume PIN setup)
 // instead of recovery. A genuine keystore break has NO breadcrumb → still recovery.
 //
-// FAIL-OPEN SAFETY (this is the whole ballgame)
-// A stale / never-cleared breadcrumb would be a FAIL-OPEN: it would let someone set
-// a NEW PIN over a real, PIN-protected wallet whose keystore later broke. So the
-// breadcrumb is cleared the MOMENT a PIN is durably established (setupPin) AND
-// re-cleared on every boot that can read the PIN (checkInitialAuthState, when the
-// strict PIN read resolves present). A wallet that has ever had a readable PIN
-// therefore never carries a lingering breadcrumb.
+// FAIL-OPEN SAFETY — WHY A STALE MARKER CANNOT AUTHORIZE A NEW PIN OVER A WALLET
+// A stale marker would be a FAIL-OPEN only if it were READ (in the key-bearing
+// guard) while a PIN actually exists. Three independent properties prevent that:
+//
+//   1. FAIL-CLOSED READ. isPinSetupPending() resolves `false` on ANY read error
+//      (below). So if AsyncStorage is broken enough that a stale marker could not
+//      be removed, it also cannot be READ — the guard sees "absent" and routes to
+//      RECOVERY, never a resume. A marker can only be trusted when the store is
+//      healthy, and a healthy store can always remove it.
+//   2. VERIFYING, RETRYING CLEAR. clearPinSetupPending() re-reads to CONFIRM
+//      removal and retries, so on a healthy store it ESTABLISHES removal (it does
+//      not blindly swallow a failed removeItem). Called on setupPin success AND on
+//      every readable-PIN boot (self-heal), so a marker cannot survive a completed
+//      PIN setup on a functioning device.
+//   3. PRESENCE-SENTINEL BACKSTOP. A PIN committed through secureStorage.setItem
+//      records a durable plaintext presence sentinel (src/platform/.../secureStorage
+//      .ts). A later keystore break then makes the strict PIN read THROW (present-
+//      but-unreadable ⇒ read failure), so checkInitialAuthState fails closed to
+//      recovery WITHOUT reaching the breadcrumb guard at all. The guard is reached
+//      only when the strict read RESOLVES false (genuine absence / a pre-sentinel
+//      install with no PIN of its own), where a resume is the correct outcome.
 //
 // STORAGE CHOICE
 // PLAINTEXT AsyncStorage (`storage`), NOT the secure store — the whole point is
@@ -34,6 +48,35 @@ export const PIN_SETUP_PENDING_KEY = 'pin_setup_pending';
 
 const PENDING_VALUE = 'true';
 
+// Bounded, best-effort clear parameters. Each storage op is time-bounded so a
+// wedged AsyncStorage can never hang a caller (setupPin runs on the SecuritySetup
+// submit path; the boot self-heal runs on the render-gating path), and removal is
+// retried + verified so a transient hiccup does not leave a durable marker.
+// 2 attempts × (remove + verify), each bounded — worst case ≈ 4.8s on a fully
+// wedged store (vs. a normal ~20ms), so setupPin's submit is bounded, never hung.
+const CLEAR_MAX_ATTEMPTS = 2;
+const CLEAR_OP_TIMEOUT_MS = 1200;
+
+// Reject if `promise` has not settled within `ms` (no-stuck bound). The underlying
+// op is abandoned on timeout; the timer is always cleared so no handle survives.
+const withTimeout = <T>(promise: Promise<T>, ms: number): Promise<T> =>
+  new Promise<T>((resolve, reject) => {
+    const timer = setTimeout(
+      () => reject(new Error('storage op timed out')),
+      ms
+    );
+    promise.then(
+      (value) => {
+        clearTimeout(timer);
+        resolve(value);
+      },
+      (error) => {
+        clearTimeout(timer);
+        reject(error);
+      }
+    );
+  });
+
 /**
  * Set the breadcrumb. Called at the START of the restore flow (after the old PIN
  * is wiped, BEFORE any key-bearing account is persisted). Propagates on failure:
@@ -45,17 +88,38 @@ export async function markPinSetupPending(): Promise<void> {
 }
 
 /**
- * Clear the breadcrumb. Best-effort and NEVER throws — a clear failure must not
- * fail an otherwise-successful PIN setup. It is called from multiple points
- * (setupPin success + every readable-PIN boot), so any single failed clear is
- * self-healed by the next one. This is the anti-fail-open guarantee.
+ * Clear the breadcrumb — bounded, retrying, verifying, and NEVER-throwing.
+ *
+ * It re-reads to CONFIRM the marker is gone and retries a bounded number of times,
+ * so on a functioning store it ESTABLISHES removal rather than silently accepting
+ * a failed removeItem. Every op is time-bounded so a wedged store cannot hang the
+ * caller. It never throws: a persistent failure is SAFE because isPinSetupPending()
+ * fails closed (an unreadable/broken marker resolves absent ⇒ recovery, never a
+ * resume), so a marker that genuinely cannot be removed also cannot be read to
+ * cause a fail-open.
  */
 export async function clearPinSetupPending(): Promise<void> {
-  try {
-    await storage.removeItem(PIN_SETUP_PENDING_KEY);
-  } catch (error) {
-    console.warn('Failed to clear pin_setup_pending breadcrumb:', error);
+  for (let attempt = 0; attempt < CLEAR_MAX_ATTEMPTS; attempt += 1) {
+    try {
+      await withTimeout(
+        storage.removeItem(PIN_SETUP_PENDING_KEY),
+        CLEAR_OP_TIMEOUT_MS
+      );
+      // Verify removal: on a healthy store this reads back absent and we are done.
+      const remaining = await withTimeout(
+        storage.getItem(PIN_SETUP_PENDING_KEY),
+        CLEAR_OP_TIMEOUT_MS
+      );
+      if (remaining !== PENDING_VALUE) {
+        return; // confirmed gone (null) — or unreadable, which fails closed on read
+      }
+    } catch {
+      // Timeout or read/write error — retry. (Never rethrow: see the doc above.)
+    }
   }
+  console.warn(
+    'pin_setup_pending breadcrumb clear could not be confirmed after retries'
+  );
 }
 
 /**

--- a/src/services/secure/pinSetupPending.ts
+++ b/src/services/secure/pinSetupPending.ts
@@ -1,0 +1,73 @@
+// Durable "PIN setup is pending" breadcrumb (TASK-213 restore-before-PIN fix).
+//
+// WHY THIS EXISTS
+// AuthContext's key-bearing invariant treats "a locally-key-bearing (STANDARD)
+// account exists but no PIN is readable" as an IMPOSSIBLE genuine state and fails
+// CLOSED to the recovery screen (whose Reset WIPES local data). That invariant is
+// correct for a genuine keystore break — but restore-from-backup DELIBERATELY
+// persists STANDARD accounts BEFORE the user sets a PIN (restorers.ts wipes the
+// old PIN, writes the accounts, then routes to SecuritySetup). A cold-kill in that
+// durable on-disk window would otherwise strand a healthy just-restored wallet on
+// the recovery screen and let its Reset wipe it.
+//
+// This breadcrumb distinguishes the two: restore SETS it before persisting any
+// account, so the key-bearing guard can route to SecuritySetup (resume PIN setup)
+// instead of recovery. A genuine keystore break has NO breadcrumb → still recovery.
+//
+// FAIL-OPEN SAFETY (this is the whole ballgame)
+// A stale / never-cleared breadcrumb would be a FAIL-OPEN: it would let someone set
+// a NEW PIN over a real, PIN-protected wallet whose keystore later broke. So the
+// breadcrumb is cleared the MOMENT a PIN is durably established (setupPin) AND
+// re-cleared on every boot that can read the PIN (checkInitialAuthState, when the
+// strict PIN read resolves present). A wallet that has ever had a readable PIN
+// therefore never carries a lingering breadcrumb.
+//
+// STORAGE CHOICE
+// PLAINTEXT AsyncStorage (`storage`), NOT the secure store — the whole point is
+// that it stays readable when the KEYSTORE is broken. It holds NO secret material:
+// only the literal marker string 'true'.
+
+import { storage } from '../../platform';
+
+/** Plaintext AsyncStorage key for the restore-before-PIN breadcrumb. */
+export const PIN_SETUP_PENDING_KEY = 'pin_setup_pending';
+
+const PENDING_VALUE = 'true';
+
+/**
+ * Set the breadcrumb. Called at the START of the restore flow (after the old PIN
+ * is wiped, BEFORE any key-bearing account is persisted). Propagates on failure:
+ * if plaintext AsyncStorage cannot even be written, the restore itself is unsafe
+ * and should surface the error rather than proceed without the guard.
+ */
+export async function markPinSetupPending(): Promise<void> {
+  await storage.setItem(PIN_SETUP_PENDING_KEY, PENDING_VALUE);
+}
+
+/**
+ * Clear the breadcrumb. Best-effort and NEVER throws — a clear failure must not
+ * fail an otherwise-successful PIN setup. It is called from multiple points
+ * (setupPin success + every readable-PIN boot), so any single failed clear is
+ * self-healed by the next one. This is the anti-fail-open guarantee.
+ */
+export async function clearPinSetupPending(): Promise<void> {
+  try {
+    await storage.removeItem(PIN_SETUP_PENDING_KEY);
+  } catch (error) {
+    console.warn('Failed to clear pin_setup_pending breadcrumb:', error);
+  }
+}
+
+/**
+ * Read the breadcrumb. FAIL-CLOSED on a read error: a breadcrumb that cannot be
+ * read is treated as ABSENT, so the key-bearing guard routes to RECOVERY (never
+ * SecuritySetup). Never throws.
+ */
+export async function isPinSetupPending(): Promise<boolean> {
+  try {
+    return (await storage.getItem(PIN_SETUP_PENDING_KEY)) === PENDING_VALUE;
+  } catch (error) {
+    console.warn('Failed to read pin_setup_pending breadcrumb:', error);
+    return false;
+  }
+}

--- a/src/services/secure/pinSetupPending.ts
+++ b/src/services/secure/pinSetupPending.ts
@@ -84,21 +84,28 @@ const withTimeout = <T>(promise: Promise<T>, ms: number): Promise<T> =>
  * and should surface the error rather than proceed without the guard.
  */
 export async function markPinSetupPending(): Promise<void> {
-  await storage.setItem(PIN_SETUP_PENDING_KEY, PENDING_VALUE);
+  // Bounded so a wedged AsyncStorage write cannot permanently stall the restore
+  // submission before any account is restored. On timeout it THROWS, so restore
+  // fails fast and cleanly (a store that cannot take this write cannot take the
+  // account writes that follow either) rather than hanging.
+  await withTimeout(
+    storage.setItem(PIN_SETUP_PENDING_KEY, PENDING_VALUE),
+    CLEAR_OP_TIMEOUT_MS
+  );
 }
 
 /**
  * Clear the breadcrumb — bounded, retrying, verifying, and NEVER-throwing.
  *
- * It re-reads to CONFIRM the marker is gone and retries a bounded number of times,
- * so on a functioning store it ESTABLISHES removal rather than silently accepting
- * a failed removeItem. Every op is time-bounded so a wedged store cannot hang the
- * caller. It never throws: a persistent failure is SAFE because isPinSetupPending()
- * fails closed (an unreadable/broken marker resolves absent ⇒ recovery, never a
- * resume), so a marker that genuinely cannot be removed also cannot be read to
- * cause a fail-open.
+ * Returns TRUE only when removal is CONFIRMED by a re-read (the marker is gone),
+ * FALSE when removal could not be confirmed within the bounded retries. Callers
+ * that must NOT commit a PIN while a live breadcrumb could persist (setupPin) key
+ * off this: they abort on FALSE. It re-reads to confirm and retries, so on a
+ * functioning store it ESTABLISHES removal rather than silently accepting a failed
+ * removeItem. Every op is time-bounded so a wedged store cannot hang the caller.
+ * It never throws.
  */
-export async function clearPinSetupPending(): Promise<void> {
+export async function clearPinSetupPending(): Promise<boolean> {
   for (let attempt = 0; attempt < CLEAR_MAX_ATTEMPTS; attempt += 1) {
     try {
       await withTimeout(
@@ -111,7 +118,7 @@ export async function clearPinSetupPending(): Promise<void> {
         CLEAR_OP_TIMEOUT_MS
       );
       if (remaining !== PENDING_VALUE) {
-        return; // confirmed gone (null) — or unreadable, which fails closed on read
+        return true; // confirmed gone (null)
       }
     } catch {
       // Timeout or read/write error — retry. (Never rethrow: see the doc above.)
@@ -120,6 +127,7 @@ export async function clearPinSetupPending(): Promise<void> {
   console.warn(
     'pin_setup_pending breadcrumb clear could not be confirmed after retries'
   );
+  return false;
 }
 
 /**

--- a/src/services/wallet/__tests__/hasWalletWithAccountsStrict.test.ts
+++ b/src/services/wallet/__tests__/hasWalletWithAccountsStrict.test.ts
@@ -1,0 +1,117 @@
+// Unit tests for TASK-213: MultiAccountWalletService.hasWalletWithAccountsStrict().
+//
+// This STRICT, boot-only wallet-presence probe is what lets AuthContext fail
+// CLOSED at boot. It MUST distinguish a genuine secure-storage read FAILURE
+// (throw / propagate) from a genuine ABSENCE (resolve false), and it must be a
+// pure read — no migration WRITE, no cache mutation, no key material returned.
+//
+// SECURITY NOTE: no secret material is used; blobs are minimal throwaway JSON.
+
+// In-memory storage backing the platform mock. Prefixed `mock*` so jest's module
+// factory hoist allows referencing it (babel-plugin-jest-hoist rule).
+let mockStore: Record<string, string> = {};
+
+jest.mock('@/platform', () => ({
+  storage: {
+    getItem: jest.fn(async (k: string) =>
+      Object.prototype.hasOwnProperty.call(mockStore, k) ? mockStore[k] : null
+    ),
+    setItem: jest.fn(async (k: string, v: string) => {
+      mockStore[k] = v;
+    }),
+    removeItem: jest.fn(async (k: string) => {
+      delete mockStore[k];
+    }),
+  },
+  secureStorage: {
+    getItem: jest.fn(async () => null),
+    setItem: jest.fn(async () => {}),
+    deleteItem: jest.fn(async () => {}),
+  },
+}));
+
+// Mock the heavy/native side of the wallet dependency graph; the strict probe
+// only touches storage.
+jest.mock('@/services/ledger/transport', () => ({ ledgerTransportService: {} }));
+jest.mock('@/services/ledger/algorand', () => ({ ledgerAlgorandService: {} }));
+jest.mock('@/services/network', () => ({ NetworkService: {} }));
+jest.mock('../../secure/AccountSecureStorage', () => ({
+  AccountSecureStorage: {},
+}));
+
+import { storage, secureStorage } from '@/platform';
+import { MultiAccountWalletService } from '../index';
+
+const WALLET_KEY = 'voi_wallet_metadata';
+
+const mockStorageGet = storage.getItem as jest.Mock;
+const mockStorageSet = storage.setItem as jest.Mock;
+const mockSecureGet = secureStorage.getItem as jest.Mock;
+
+beforeEach(() => {
+  mockStore = {};
+  jest.clearAllMocks();
+  // Restore the default backed-by-mockStore implementations after clearAllMocks.
+  mockStorageGet.mockImplementation(async (k: string) =>
+    Object.prototype.hasOwnProperty.call(mockStore, k) ? mockStore[k] : null
+  );
+  mockStorageSet.mockImplementation(async (k: string, v: string) => {
+    mockStore[k] = v;
+  });
+  mockSecureGet.mockImplementation(async () => null);
+});
+
+describe('hasWalletWithAccountsStrict — absence vs failure (TASK-213)', () => {
+  it('resolves FALSE for genuine absence (no wallet blob anywhere)', async () => {
+    await expect(
+      MultiAccountWalletService.hasWalletWithAccountsStrict()
+    ).resolves.toBe(false);
+  });
+
+  it('resolves TRUE when a wallet with ≥1 account is present', async () => {
+    mockStore[WALLET_KEY] = JSON.stringify({ accounts: [{ id: 'a' }] });
+    await expect(
+      MultiAccountWalletService.hasWalletWithAccountsStrict()
+    ).resolves.toBe(true);
+  });
+
+  it('resolves FALSE for a present wallet with ZERO accounts (absence-like)', async () => {
+    mockStore[WALLET_KEY] = JSON.stringify({ accounts: [] });
+    await expect(
+      MultiAccountWalletService.hasWalletWithAccountsStrict()
+    ).resolves.toBe(false);
+  });
+
+  it('THROWS (fails closed) when the primary storage read FAILS', async () => {
+    mockStorageGet.mockImplementationOnce(async () => {
+      throw new Error('AsyncStorage unavailable');
+    });
+    await expect(
+      MultiAccountWalletService.hasWalletWithAccountsStrict()
+    ).rejects.toThrow('AsyncStorage unavailable');
+  });
+
+  it('THROWS when the legacy secure-store read FAILS (primary empty)', async () => {
+    // Primary returns null → probe consults the legacy secure-store location,
+    // whose read throws. That is a genuine failure and must propagate.
+    mockSecureGet.mockImplementationOnce(async () => {
+      throw new Error('keychain unavailable');
+    });
+    await expect(
+      MultiAccountWalletService.hasWalletWithAccountsStrict()
+    ).rejects.toThrow('keychain unavailable');
+  });
+
+  it('THROWS (fails closed) on a present-but-corrupt/unparseable blob — never treated as absence', async () => {
+    mockStore[WALLET_KEY] = '{not-valid-json';
+    await expect(
+      MultiAccountWalletService.hasWalletWithAccountsStrict()
+    ).rejects.toBeInstanceOf(SyntaxError);
+  });
+
+  it('is a PURE read — never writes (no migration/cache side effect)', async () => {
+    mockStore[WALLET_KEY] = JSON.stringify({ accounts: [{ id: 'a' }] });
+    await MultiAccountWalletService.hasWalletWithAccountsStrict();
+    expect(mockStorageSet).not.toHaveBeenCalled();
+  });
+});

--- a/src/services/wallet/__tests__/hasWalletWithAccountsStrict.test.ts
+++ b/src/services/wallet/__tests__/hasWalletWithAccountsStrict.test.ts
@@ -32,7 +32,9 @@ jest.mock('@/platform', () => ({
 
 // Mock the heavy/native side of the wallet dependency graph; the strict probe
 // only touches storage.
-jest.mock('@/services/ledger/transport', () => ({ ledgerTransportService: {} }));
+jest.mock('@/services/ledger/transport', () => ({
+  ledgerTransportService: {},
+}));
 jest.mock('@/services/ledger/algorand', () => ({ ledgerAlgorandService: {} }));
 jest.mock('@/services/network', () => ({ NetworkService: {} }));
 jest.mock('../../secure/AccountSecureStorage', () => ({
@@ -107,6 +109,16 @@ describe('hasWalletWithAccountsStrict — absence vs failure (TASK-213)', () => 
     await expect(
       MultiAccountWalletService.hasWalletWithAccountsStrict()
     ).rejects.toBeInstanceOf(SyntaxError);
+  });
+
+  it('THROWS (fails closed) on valid JSON with a NON-array accounts field — corruption, not absence', async () => {
+    // Regression for Codex P2: {"accounts":{}} is valid JSON but structurally
+    // corrupt. It must NOT resolve false (absence ⇒ unlocked setup); it must
+    // throw so the auth-init path fails closed into recovery.
+    mockStore[WALLET_KEY] = JSON.stringify({ accounts: {} });
+    await expect(
+      MultiAccountWalletService.hasWalletWithAccountsStrict()
+    ).rejects.toThrow(/not an array/);
   });
 
   it('is a PURE read — never writes (no migration/cache side effect)', async () => {

--- a/src/services/wallet/__tests__/hasWalletWithAccountsStrict.test.ts
+++ b/src/services/wallet/__tests__/hasWalletWithAccountsStrict.test.ts
@@ -127,3 +127,61 @@ describe('hasWalletWithAccountsStrict — absence vs failure (TASK-213)', () => 
     expect(mockStorageSet).not.toHaveBeenCalled();
   });
 });
+
+// TASK-213 Codex round-4: hasKeyBearingAccountStrict is the durable, keystore-
+// independent corroborating signal that closes the residual Android swallow-to-
+// null fail-open. It answers "does a persisted wallet hold ≥1 locally-key-bearing
+// (STANDARD) account?" — a state that is IMPOSSIBLE without a configured PIN.
+describe('hasKeyBearingAccountStrict — STANDARD-account signal (TASK-213)', () => {
+  it('resolves FALSE for genuine absence (no wallet blob)', async () => {
+    await expect(
+      MultiAccountWalletService.hasKeyBearingAccountStrict()
+    ).resolves.toBe(false);
+  });
+
+  it('resolves TRUE when a STANDARD (locally-key-bearing) account is present', async () => {
+    mockStore[WALLET_KEY] = JSON.stringify({
+      accounts: [{ id: 'a', type: 'standard' }],
+    });
+    await expect(
+      MultiAccountWalletService.hasKeyBearingAccountStrict()
+    ).resolves.toBe(true);
+  });
+
+  it('resolves FALSE for a watch-only / ledger / remote-signer wallet (no local key ⇒ PIN-less is legit)', async () => {
+    mockStore[WALLET_KEY] = JSON.stringify({
+      accounts: [
+        { id: 'w', type: 'watch' },
+        { id: 'l', type: 'ledger' },
+        { id: 'r', type: 'remote_signer' },
+      ],
+    });
+    await expect(
+      MultiAccountWalletService.hasKeyBearingAccountStrict()
+    ).resolves.toBe(false);
+  });
+
+  it('THROWS (fails closed) when the storage read FAILS — a read failure, not absence', async () => {
+    mockStorageGet.mockImplementationOnce(async () => {
+      throw new Error('AsyncStorage unavailable');
+    });
+    await expect(
+      MultiAccountWalletService.hasKeyBearingAccountStrict()
+    ).rejects.toThrow('AsyncStorage unavailable');
+  });
+
+  it('resolves FALSE (never a false positive) on an unparseable blob — corruption is owned by hasWalletWithAccountsStrict', async () => {
+    mockStore[WALLET_KEY] = '{not-valid-json';
+    await expect(
+      MultiAccountWalletService.hasKeyBearingAccountStrict()
+    ).resolves.toBe(false);
+  });
+
+  it('is a PURE read — never writes', async () => {
+    mockStore[WALLET_KEY] = JSON.stringify({
+      accounts: [{ id: 'a', type: 'standard' }],
+    });
+    await MultiAccountWalletService.hasKeyBearingAccountStrict();
+    expect(mockStorageSet).not.toHaveBeenCalled();
+  });
+});

--- a/src/services/wallet/index.ts
+++ b/src/services/wallet/index.ts
@@ -1639,6 +1639,45 @@ export class MultiAccountWalletService {
   }
 
   /**
+   * STRICT, boot-only probe: does a persisted wallet hold ≥1 locally-KEY-BEARING
+   * (STANDARD) account? (TASK-213 Codex round-4). A STANDARD account stores its
+   * private key encrypted under the user secret, and setupPin ALWAYS precedes the
+   * key import (SecuritySetupScreen), so a STANDARD account can NEVER exist
+   * without a PIN having been configured. WATCH / LEDGER / REMOTE_SIGNER accounts
+   * hold no local PIN-wrapped key, so a PIN-less wallet of only those is legit.
+   *
+   * The auth-init path uses this as a corroborating durable signal (wallet
+   * metadata lives in plaintext AsyncStorage, UNAFFECTED by an Android keystore
+   * desync) to close the residual Android fail-OPEN the per-key presence sentinel
+   * cannot cover: a PRE-sentinel install whose keystore breaks on its very first
+   * boot after upgrade has no sentinel yet, so a swallowed-to-null PIN read looks
+   * like genuine absence — but if a STANDARD account exists, that "absence" is
+   * impossible and must be a read FAILURE ⇒ fail CLOSED.
+   *
+   * PROPAGATES a storage READ failure (fail closed, same as the sibling strict
+   * reads); resolves `false` for genuine absence or a structurally-unusable blob
+   * (whose corruption is already surfaced by hasWalletWithAccountsStrict). It only
+   * ever answers a POSITIVE "a key-bearing account exists", never weakens a verdict.
+   */
+  static async hasKeyBearingAccountStrict(): Promise<boolean> {
+    const walletData = await this.getStoredValueStrict(this.WALLET_KEY);
+    if (!walletData) {
+      return false;
+    }
+    try {
+      const parsed = JSON.parse(walletData) as Wallet;
+      if (!Array.isArray(parsed.accounts)) {
+        return false;
+      }
+      return parsed.accounts.some((acc) => acc?.type === AccountType.STANDARD);
+    } catch {
+      // A corrupt blob is handled (thrown) by hasWalletWithAccountsStrict; here we
+      // must not emit a false POSITIVE, so treat an unparseable blob as "unknown".
+      return false;
+    }
+  }
+
+  /**
    * Strict sibling of getStoredValue (TASK-213): reads the primary then the
    * legacy secure-store location but PROPAGATES storage read errors instead of
    * collapsing them to null. Resolves `null` ONLY for genuine absence (both

--- a/src/services/wallet/index.ts
+++ b/src/services/wallet/index.ts
@@ -1595,6 +1595,57 @@ export class MultiAccountWalletService {
     }
   }
 
+  /**
+   * STRICT, boot-only wallet-presence probe (TASK-213). Unlike getCurrentWallet()
+   * — which swallows storage read errors and resolves `null`, making a genuine
+   * read FAILURE indistinguishable from "no wallet" (the auth-init fail-OPEN) —
+   * this variant THROWS on a genuine storage read failure (or a present-but-
+   * corrupt/unparseable blob) and resolves `false` ONLY for genuine ABSENCE (no
+   * wallet stored, or a stored wallet with zero accounts).
+   *
+   * It does NOT decrypt or return key material, does NOT heal-on-read, and does
+   * NOT touch the module wallet cache — it only answers "does a usable wallet
+   * exist?" so the auth-init path can distinguish absence from failure.
+   *
+   * Used EXCLUSIVELY by AuthContext.checkInitialAuthState so lock computation can
+   * fail CLOSED (the "secure storage unavailable" recovery state) on a storage
+   * read failure. Every OTHER caller must keep using getCurrentWallet(), whose
+   * error-swallowing contract (resolve null on failure) is relied on across its
+   * many call sites, including signing.
+   */
+  static async hasWalletWithAccountsStrict(): Promise<boolean> {
+    // Strict raw read: a throw (keychain / AsyncStorage unavailable) propagates
+    // to the caller instead of collapsing to null.
+    const walletData = await this.getStoredValueStrict(this.WALLET_KEY);
+    if (!walletData) {
+      // Genuine ABSENCE — no wallet blob in either the primary or legacy location.
+      return false;
+    }
+    // A present-but-corrupt blob is a read FAILURE, not absence: let JSON.parse
+    // throw so the caller fails CLOSED rather than treating corruption as "no
+    // wallet" (which would drop into the unlocked setup state).
+    const parsed = JSON.parse(walletData) as Wallet;
+    return Array.isArray(parsed.accounts) && parsed.accounts.length > 0;
+  }
+
+  /**
+   * Strict sibling of getStoredValue (TASK-213): reads the primary then the
+   * legacy secure-store location but PROPAGATES storage read errors instead of
+   * collapsing them to null. Resolves `null` ONLY for genuine absence (both
+   * locations empty). No JSON parse, no migration WRITE, no cache side effect.
+   */
+  private static async getStoredValueStrict(
+    key: string
+  ): Promise<string | null> {
+    // A throw here is a genuine read failure and propagates; `null` = absent.
+    const value = await storage.getItem(key);
+    if (value) {
+      return value;
+    }
+    const legacy = await secureStorage.getItem(key);
+    return legacy ?? null;
+  }
+
   private static async storeValue(key: string, value: string): Promise<void> {
     try {
       await storage.setItem(key, value);

--- a/src/services/wallet/index.ts
+++ b/src/services/wallet/index.ts
@@ -1625,7 +1625,17 @@ export class MultiAccountWalletService {
     // throw so the caller fails CLOSED rather than treating corruption as "no
     // wallet" (which would drop into the unlocked setup state).
     const parsed = JSON.parse(walletData) as Wallet;
-    return Array.isArray(parsed.accounts) && parsed.accounts.length > 0;
+    if (!Array.isArray(parsed.accounts)) {
+      // Valid JSON but a structurally-corrupt wallet (missing / non-array
+      // `accounts`, e.g. {"accounts":{}}). That is corruption, NOT absence —
+      // fail CLOSED by throwing so the auth-init path enters recovery rather
+      // than the unlocked setup state. Only a genuine EMPTY array below is the
+      // intended absence-like "no accounts yet" ⇒ setup case.
+      throw new Error(
+        'Corrupt wallet blob: `accounts` is present but not an array'
+      );
+    }
+    return parsed.accounts.length > 0;
   }
 
   /**


### PR DESCRIPTION
## The bug (fail-OPEN at boot)

`AuthContext.checkInitialAuthState()` computed the lock state from
`getCurrentWallet()` + `hasPin()`. Both production implementations **swallow their
own storage errors and resolve falsy** (`null` / `false`), so a genuine
secure-storage **read failure** (transient keychain/keystore unavailability,
corruption, OS error) was **indistinguishable from genuine absence** ("no wallet /
no PIN") and dropped into the **unlocked setup state** — wallet accessible without
auth. Discovered by Codex during TASK-177; auth-semantics change, so it was filed
for human sign-off rather than fixed in the perf PR.

## Approved design (Dave sign-off, Option A — fail-closed recovery state)

1. **Distinguish failure from absence.** New STRICT, boot-only probes used ONLY by
   the auth-init path:
   - `AccountSecureStorage.hasPinStrict()`
   - `MultiAccountWalletService.hasWalletWithAccountsStrict()`

   They **throw** on a genuine secure-storage read/decrypt failure and resolve
   falsy **only** for genuine absence. The error-swallowing contract of the
   existing `hasPin()` / `getCurrentWallet()` is **unchanged** for their many other
   callers (incl. signing) — those still resolve falsy on error.
2. **Bounded retry/backoff.** `checkInitialAuthState` retries the strict reads up
   to 3 times with a short linear backoff (200/400 ms) to tolerate transient
   cold-boot keychain/keystore unavailability. Retry happens **only on failure**,
   never on genuine absence.
3. **Fail-closed recovery state.** New `authState.securityUnavailable` is set true
   when the strict reads still fail after retry. `AuthGuard` (and the navigator)
   then render a new **"Secure storage unavailable"** screen with a **Retry**
   button (re-runs the check) and a restart hint. It grants **zero wallet access**
   — neither the unlocked setup state nor the normal PIN lock.
4. **Never stuck.** Retry re-runs the check and recovers if storage becomes
   readable; a transient failure that succeeds on retry proceeds normally and never
   shows the recovery screen. The bounded backoff cannot hang; the existing 10 s
   splash watchdog is a last-resort net.

### Unchanged behavior
- Genuine absence (no wallet / no PIN) → unlocked setup.
- Genuine wallet + PIN → locked.

## Cross-cutting fixes surfaced by adversarial (Codex) review

- **Single source of truth for the initial route.** `AppStack` no longer runs a
  second, error-swallowing `getCurrentWallet()` route check (which could route to
  the **un-guarded** Onboarding flow on a storage failure, bypassing recovery —
  `AuthGuard` only wraps `Main`). The route now derives from the authoritative auth
  verdict (`authState.hasWallet`, set atomically with the lock decision from the
  same strict read), gated on `authState.authChecked`, so route can never diverge
  from the fail-closed state — including after a recovery Retry or a transient blip.
- **Corrupt wallet blob fails closed.** `hasWalletWithAccountsStrict` throws on
  valid JSON with a non-array `accounts` field (e.g. `{"accounts":{}}`) instead of
  treating it as absence; only a genuine empty array stays the "no accounts yet"
  setup case.
- **Extension platform fail-open closed.** The Chrome-extension adapters swallowed
  read/decrypt failures to `null` (a decrypt error or `chrome.runtime.lastError`
  read error looked like absence). They now **throw** on genuine failure and
  resolve `null` only on absence — matching the mobile/expo contract and keeping
  the strict-read approach sound cross-platform. Safe for the error-swallowing
  callers (they catch); also prevents a pre-existing encryption-key regeneration on
  a transient read.

## Tests

Added, all passing:
- `AuthContext.test.tsx` — (a) failing PIN read → recovery; (b) failing wallet read
  → recovery; (c) genuine absence → unlocked setup; (d) wallet+PIN → locked;
  (e) transient failure that recovers on retry → normal, no recovery; (f) recovery
  Retry re-runs and recovers (with a `hasWallet`-after-recovery guard); plus parity
  and non-critical-read isolation cases.
- `hasPinStrict.test.ts` / `hasWalletWithAccountsStrict.test.ts` — source-level
  proof the strict probes throw on failure, resolve false on absence, are pure
  reads (no migration write / cache mutation), and that `hasPin()` still swallows.
- `storageFailClosed.test.ts` / `secureStorageFailClosed.test.ts` — extension
  adapters throw on chrome read error / decrypt failure, null on absence.

## Gate results

- `npm run typecheck` — **0 errors from this diff.** (The only `tsc` output is two
  pre-existing `Cannot find module 'expo-splash-screen'` errors in
  `index.ts` / `splashController.ts` — files this PR does not touch — because that
  declared dependency is not installed in the local checkout; identical on
  `origin/main`.)
- `npm run lint` — **clean (0 errors)**; only the repo's pre-existing warnings.
- `npm test -- --ci` — **1076 passing.** The only failing suite is the pre-existing
  `splashController.test.ts` (16 tests, all `Cannot find module
  'expo-splash-screen'`), unrelated to and untouched by this diff; it fails
  identically on `origin/main`.

## Codex self-review

Ran `codex exec` (read-only) against the full diff across 4 rounds; each round's
findings were fixed and re-reviewed. Final verdict: **CLEAN.**

Rounds fixed: recovery-bypass via un-guarded onboarding → single-source route;
structured-corrupt wallet → fail closed; extension adapter fail-open → throw on
failure. Accepted (not a fail-OPEN): background wallet-store metadata hydration +
notification account subscription run pre-auth on every boot by existing F-03
design — recovery is at least as restrictive as the normal locked state (no PIN
entry, no vault unlock, no signing, sanitized metadata only, no key material).

## Pre-release verification

Device-visual checks — **the "Secure storage unavailable" recovery screen appears
on a persistent secure-storage read failure, and Retry recovers once storage is
readable** — are folded into the **HT-218** pre-release batch. No per-PR device
gate is created for this change.
