### PR TITLE
fix(ledger): detach listener + close orphaned transport on involuntary disconnect (TASK-216)

### DIFF
--- a/src/services/ledger/__tests__/transport.test.ts
+++ b/src/services/ledger/__tests__/transport.test.ts
@@ -281,3 +281,351 @@ describe('checkConnectionHealth race-timer cleanup (F-24)', () => {
     expect(jest.getTimerCount()).toBe(0);
   });
 });
+
+// ===========================================================================
+// (d) Involuntary teardown: detach the disconnect listener AND close the
+//     orphaned transport (TASK-216 — follow-up to F-24).
+//
+// The three INVOLUNTARY null-out paths (BLE 'remove', USB 'remove', health-
+// check auto-disconnect) used to clear currentTransport + stop monitoring but
+// left currentDisconnectHandler attached to, and never close()d, the now-dead
+// transport — a dangling-listener + unclosed-transport leak. All three now
+// route through releaseTransport(), mirroring the explicit disconnect() path.
+// ===========================================================================
+
+describe('involuntary transport teardown (TASK-216)', () => {
+  /**
+   * Put the service into a "connected" state around `fakeTransport` without
+   * driving a full connect(): set the private current* fields + a disconnect
+   * handler and start monitoring, exactly as a live connection would. Returns
+   * the handler so a test can assert it gets detached.
+   */
+  function primeConnected(
+    fakeTransport: ReturnType<typeof makeFakeTransport>,
+    deviceId: string
+  ): () => void {
+    const handler = jest.fn();
+    const s = service as unknown as {
+      currentTransport: unknown;
+      currentDeviceId: string;
+      currentDisconnectHandler: (() => void) | null;
+    };
+    s.currentTransport = fakeTransport;
+    s.currentDeviceId = deviceId;
+    s.currentDisconnectHandler = handler;
+    // Emitted teardown errors would otherwise go unobserved.
+    service.on('error', () => {});
+    service.startConnectionHealthMonitoring();
+    expect(service.isHealthMonitoringActive()).toBe(true);
+    return handler;
+  }
+
+  function assertTornDown(
+    fakeTransport: ReturnType<typeof makeFakeTransport>,
+    handler: () => void
+  ) {
+    // Listener detached from the dead transport…
+    expect(fakeTransport.off).toHaveBeenCalledWith('disconnect', handler);
+    // …transport closed…
+    expect(fakeTransport.close).toHaveBeenCalledTimes(1);
+    // …monitoring stopped and references dropped.
+    expect(service.isHealthMonitoringActive()).toBe(false);
+    const s = service as unknown as {
+      currentTransport: unknown;
+      currentDisconnectHandler: unknown;
+    };
+    expect(s.currentTransport).toBeNull();
+    expect(s.currentDisconnectHandler).toBeNull();
+  }
+
+  it('health-check auto-disconnect detaches the listener AND closes the transport', async () => {
+    const fakeTransport = makeFakeTransport();
+    // A "serious" error string routes checkConnectionHealth into the
+    // auto-disconnect branch (matched on 'disconnected').
+    fakeTransport.send = jest
+      .fn()
+      .mockRejectedValue(new Error('device disconnected'));
+    const handler = primeConnected(fakeTransport, 'dev');
+
+    await (
+      service as unknown as { checkConnectionHealth: () => Promise<void> }
+    ).checkConnectionHealth();
+    // close() is dispatched on a microtask (fire-and-forget); flush it.
+    await Promise.resolve();
+
+    assertTornDown(fakeTransport, handler);
+  });
+
+  it('USB discovery "remove" of the connected device detaches the listener AND closes the transport', async () => {
+    let usbObserver: { next: (e: unknown) => void } | undefined;
+    mockHidTransport.listen.mockImplementation((obs: any) => {
+      usbObserver = obs;
+      return { unsubscribe: jest.fn() };
+    });
+
+    await service.startDiscovery({ ble: false, usb: true });
+    expect(usbObserver).toBeDefined();
+
+    const fakeTransport = makeFakeTransport();
+    const handler = primeConnected(fakeTransport, USB_DEVICE_ID);
+    const disconnected: (string | undefined)[] = [];
+    service.on('disconnected', (info) =>
+      disconnected.push('id' in info ? info.id : undefined)
+    );
+
+    // The connected USB device is unplugged mid-discovery.
+    usbObserver!.next({
+      type: 'remove',
+      descriptor: { vendorId: 1, productId: 2 },
+    });
+    // close() is invoked synchronously; flush the fire-and-forget promise.
+    await Promise.resolve();
+
+    assertTornDown(fakeTransport, handler);
+    // Removing the connected device signals a disconnect, not just removal.
+    expect(disconnected).toContain(USB_DEVICE_ID);
+  });
+
+  it('BLE discovery "remove" of the connected device detaches the listener AND closes the transport', async () => {
+    // BLE discovery gates on runtime permissions; grant them for the test.
+    jest
+      .spyOn(
+        service as unknown as {
+          ensureBlePermissions: () => Promise<boolean>;
+        },
+        'ensureBlePermissions'
+      )
+      .mockResolvedValue(true);
+    let bleObserver: { next: (e: unknown) => void } | undefined;
+    mockBleTransport.listen.mockImplementation((obs: any) => {
+      bleObserver = obs;
+      return { unsubscribe: jest.fn() };
+    });
+
+    await service.startDiscovery({ ble: true, usb: false });
+    expect(bleObserver).toBeDefined();
+
+    const BLE_ID = 'ble-device-1';
+    const fakeTransport = makeFakeTransport();
+    const handler = primeConnected(fakeTransport, BLE_ID);
+    const disconnected: (string | undefined)[] = [];
+    service.on('disconnected', (info) =>
+      disconnected.push('id' in info ? info.id : undefined)
+    );
+
+    // The connected BLE device drops out of range mid-discovery.
+    bleObserver!.next({ type: 'remove', descriptor: { id: BLE_ID } });
+    await Promise.resolve();
+
+    assertTornDown(fakeTransport, handler);
+    // Removing the connected device signals a disconnect, not just removal.
+    expect(disconnected).toContain(BLE_ID);
+  });
+
+  it('teardown is idempotent — a second involuntary path racing the same transport does not double-close', async () => {
+    const fakeTransport = makeFakeTransport();
+    const handler = primeConnected(fakeTransport, USB_DEVICE_ID);
+
+    // Two teardown paths land on the SAME transport before the first close()
+    // settles (e.g. a health-check auto-disconnect while a USB 'remove' fires).
+    // The first claims it; the second must see it already claimed and no-op.
+    const releaseTransport = (t: unknown) =>
+      (
+        service as unknown as {
+          releaseTransport: (t: unknown) => Promise<void>;
+        }
+      ).releaseTransport(t);
+    await Promise.all([
+      releaseTransport(fakeTransport),
+      releaseTransport(fakeTransport),
+    ]);
+
+    // Exactly one close() + one detach despite two teardown calls.
+    expect(fakeTransport.close).toHaveBeenCalledTimes(1);
+    expect(fakeTransport.off).toHaveBeenCalledTimes(1);
+    expect(fakeTransport.off).toHaveBeenCalledWith('disconnect', handler);
+  });
+
+  it('a stale health-check failure does not tear down a successor transport', async () => {
+    const oldTransport = makeFakeTransport();
+    oldTransport.send = jest
+      .fn()
+      .mockRejectedValue(new Error('device disconnected'));
+    primeConnected(oldTransport, 'old-dev');
+    const disconnected: (string | undefined)[] = [];
+    service.on('disconnected', (info) =>
+      disconnected.push('id' in info ? info.id : undefined)
+    );
+
+    // Probe starts against oldTransport, then suspends at the APDU await.
+    const check = (
+      service as unknown as { checkConnectionHealth: () => Promise<void> }
+    ).checkConnectionHealth();
+
+    // A successor connects and takes over currentTransport while the (already
+    // doomed) probe of oldTransport is still in flight.
+    const newTransport = makeFakeTransport();
+    const s = service as unknown as {
+      currentTransport: unknown;
+      currentDeviceId: string;
+      currentDisconnectHandler: (() => void) | null;
+    };
+    s.currentTransport = newTransport;
+    s.currentDeviceId = 'new-dev';
+    s.currentDisconnectHandler = jest.fn();
+
+    await check;
+    await Promise.resolve();
+
+    // The stale failure tears down oldTransport (it's no longer current, so
+    // releaseTransport no-ops) — the successor must be left fully intact.
+    expect(newTransport.close).not.toHaveBeenCalled();
+    expect(newTransport.off).not.toHaveBeenCalled();
+    expect(s.currentTransport).toBe(newTransport);
+    expect(s.currentDeviceId).toBe('new-dev');
+    // The stale health-check loser stays silent — it did not claim the
+    // transport, so it re-marks nothing (in real code the successor takeover
+    // via connect()->disconnect() is what marks the old device). The live
+    // successor is never marked.
+    expect(disconnected).not.toContain('new-dev');
+  });
+
+  it('a discovery remove during an in-flight health check emits disconnected exactly once', async () => {
+    let usbObserver: { next: (e: unknown) => void } | undefined;
+    mockHidTransport.listen.mockImplementation((obs: any) => {
+      usbObserver = obs;
+      return { unsubscribe: jest.fn() };
+    });
+    await service.startDiscovery({ ble: false, usb: true });
+
+    const fakeTransport = makeFakeTransport();
+    fakeTransport.send = jest
+      .fn()
+      .mockRejectedValue(new Error('device disconnected'));
+    primeConnected(fakeTransport, USB_DEVICE_ID);
+    const disconnected: (string | undefined)[] = [];
+    service.on('disconnected', (info) =>
+      disconnected.push('id' in info ? info.id : undefined)
+    );
+
+    // Health check starts probing the device, then suspends at the APDU await.
+    const check = (
+      service as unknown as { checkConnectionHealth: () => Promise<void> }
+    ).checkConnectionHealth();
+
+    // The device is unplugged mid-probe: the discovery 'remove' claims + marks
+    // it. The subsequent stale health-check failure must NOT re-mark it.
+    usbObserver!.next({
+      type: 'remove',
+      descriptor: { vendorId: 1, productId: 2 },
+    });
+    await check;
+    await Promise.resolve();
+
+    expect(disconnected.filter((id) => id === USB_DEVICE_ID)).toHaveLength(1);
+  });
+
+  it('disconnect() does not mark a device disconnected if a successor reconnects it during close()', async () => {
+    const oldTransport = makeFakeTransport();
+    let resolveClose: (() => void) | undefined;
+    oldTransport.close = jest.fn(
+      () => new Promise<void>((r) => (resolveClose = r))
+    );
+    primeConnected(oldTransport, USB_DEVICE_ID);
+    const markSpy = jest.spyOn(
+      service as unknown as {
+        markDeviceDisconnected: (id: string) => void;
+      },
+      'markDeviceDisconnected'
+    );
+
+    // releaseTransport clears state synchronously, then disconnect() awaits the
+    // (hanging) close(). Flush the microtask that actually invokes close().
+    const disconnecting = service.disconnect();
+    await Promise.resolve();
+    expect(resolveClose).toBeDefined();
+
+    // A successor reconnects the SAME device while close() is still pending.
+    const s = service as unknown as {
+      currentTransport: unknown;
+      currentDeviceId: string;
+    };
+    s.currentTransport = makeFakeTransport();
+    s.currentDeviceId = USB_DEVICE_ID;
+
+    resolveClose!();
+    await disconnecting;
+
+    // The stale teardown must NOT flag the reconnected device disconnected.
+    expect(markSpy).not.toHaveBeenCalled();
+    expect(s.currentDeviceId).toBe(USB_DEVICE_ID);
+  });
+
+  it('a stale transport-initiated disconnect does not clobber a same-device successor', async () => {
+    const svc = service as unknown as {
+      attachDisconnectListener: (t: unknown, id: string) => void;
+      currentTransport: unknown;
+      currentDeviceId: string;
+      currentDisconnectHandler: (() => void) | null;
+      markDeviceDisconnected: (id: string) => void;
+    };
+
+    // Live connection on USB_DEVICE_ID with its disconnect handler registered.
+    const oldTransport = makeFakeTransport();
+    svc.attachDisconnectListener(oldTransport, USB_DEVICE_ID);
+    const oldHandler = getDisconnectHandler(oldTransport);
+    svc.currentTransport = oldTransport;
+    svc.currentDeviceId = USB_DEVICE_ID;
+    service.startConnectionHealthMonitoring();
+
+    // The SAME device reconnects: a successor takes over + registers its own
+    // disconnect handler (attachDisconnectListener updates currentDisconnectHandler).
+    const newTransport = makeFakeTransport();
+    svc.attachDisconnectListener(newTransport, USB_DEVICE_ID);
+    const newHandler = getDisconnectHandler(newTransport);
+    svc.currentTransport = newTransport;
+    svc.currentDeviceId = USB_DEVICE_ID;
+
+    const markSpy = jest.spyOn(svc, 'markDeviceDisconnected');
+
+    // The OLD transport now fires its (stale) disconnect event.
+    oldHandler();
+
+    // Successor untouched: still current, its handler intact, still monitored,
+    // and no spurious 'disconnected' emitted for the live device.
+    expect(svc.currentTransport).toBe(newTransport);
+    expect(svc.currentDeviceId).toBe(USB_DEVICE_ID);
+    expect(svc.currentDisconnectHandler).toBe(newHandler);
+    expect(service.isHealthMonitoringActive()).toBe(true);
+    expect(markSpy).not.toHaveBeenCalled();
+  });
+
+  it('a transport-initiated disconnect on the live transport detaches the listener AND closes it', async () => {
+    const svc = service as unknown as {
+      attachDisconnectListener: (t: unknown, id: string) => void;
+      currentTransport: unknown;
+      currentDeviceId: string;
+      currentDisconnectHandler: (() => void) | null;
+    };
+    const fakeTransport = makeFakeTransport();
+    svc.attachDisconnectListener(fakeTransport, USB_DEVICE_ID);
+    const handler = getDisconnectHandler(fakeTransport);
+    svc.currentTransport = fakeTransport;
+    svc.currentDeviceId = USB_DEVICE_ID;
+    service.on('error', () => {});
+    service.startConnectionHealthMonitoring();
+
+    // The connected transport fires its own 'disconnect' (device dropped).
+    handler();
+    // close() is dispatched on a microtask (fire-and-forget); flush it.
+    await Promise.resolve();
+
+    // Now routed through releaseTransport: listener detached + transport closed,
+    // not just state cleared.
+    expect(fakeTransport.off).toHaveBeenCalledWith('disconnect', handler);
+    expect(fakeTransport.close).toHaveBeenCalledTimes(1);
+    expect(service.isHealthMonitoringActive()).toBe(false);
+    expect(svc.currentTransport).toBeNull();
+    expect(svc.currentDisconnectHandler).toBeNull();
+  });
+});

--- a/src/services/ledger/transport.ts
+++ b/src/services/ledger/transport.ts
@@ -476,41 +476,99 @@ export class LedgerTransportService {
     this.stopDiscovery({ ble: true, usb: true });
   }
 
-  async disconnect(): Promise<void> {
-    if (!this.currentTransport || !this.currentDeviceId) {
-      return;
+  /**
+   * Tear down a transport that is going away: detach its disconnect listener,
+   * drop it as the current transport, stop health monitoring, and close it.
+   * The shared teardown for {@link disconnect} and the involuntary null-out
+   * paths (BLE/USB 'remove', health-check auto-disconnect) — which used to
+   * orphan `currentDisconnectHandler` on a dead transport and leak an unclosed
+   * transport (TASK-216, follow-up to F-24).
+   *
+   * ALL shared state (`currentTransport` / `currentDeviceId` /
+   * `currentDisconnectHandler` + the health-check interval) is cleared
+   * SYNCHRONOUSLY at claim time — before the first await — and ONLY when
+   * `transport` is still `currentTransport`. That gives two guarantees:
+   *   - Idempotent per transport: a second involuntary path (or `disconnect()`)
+   *     racing the same transport while its `close()` is in flight sees it
+   *     already claimed and no-ops instead of double-closing.
+   *   - Successor-safe: a new connection that lands while `close()` is pending
+   *     is a *different* `currentTransport`, so neither this teardown nor its
+   *     caller (which passes the transport it captured before any await) touches
+   *     it. Callers that probe across an await (health-check) must pass the
+   *     transport they probed, not a re-read of `currentTransport`.
+   *
+   * The listener is detached synchronously so the leak is fixed even when the
+   * caller can't await. Returns the (already-caught, never-rejecting) `close()`
+   * promise so a caller that must await teardown can — or `null` when the
+   * transport was already claimed / superseded, so the caller can skip its own
+   * follow-up (e.g. `markDeviceDisconnected`). `close()` failures are emitted as
+   * 'error', never thrown.
+   */
+  private releaseTransport(transport: Transport): Promise<void> | null {
+    // Claim: only the first caller to reach a still-current transport tears it
+    // down. A concurrent path — or a stale probe of a now-superseded transport
+    // — no-ops here, leaving any successor untouched.
+    if (this.currentTransport !== transport) {
+      return null;
     }
+    const handler = this.currentDisconnectHandler;
+    this.currentTransport = null;
+    this.currentDeviceId = null;
+    this.currentDisconnectHandler = null;
+    // F-24: the transport this interval monitored is gone — stop it now.
+    this.stopConnectionHealthMonitoring();
 
-    const deviceId = this.currentDeviceId;
-    const transport = this.currentTransport;
-
+    // Detach disconnect listener synchronously if supported, to avoid leaks.
     try {
-      // Detach disconnect listener if supported to avoid leaks
-      if (this.currentDisconnectHandler) {
+      if (handler) {
         const anyTransport = transport as any;
         if (typeof anyTransport.off === 'function') {
-          anyTransport.off('disconnect', this.currentDisconnectHandler);
+          anyTransport.off('disconnect', handler);
         } else if (typeof anyTransport.removeListener === 'function') {
-          anyTransport.removeListener(
-            'disconnect',
-            this.currentDisconnectHandler
-          );
+          anyTransport.removeListener('disconnect', handler);
+        } else if (typeof anyTransport.removeEventListener === 'function') {
+          // Mirror the addEventListener fallback used when attaching.
+          anyTransport.removeEventListener('disconnect', handler);
         }
-        this.currentDisconnectHandler = null;
       }
-      await transport.close();
     } catch (error) {
       this.emit(
         'error',
         error instanceof Error ? error : new Error(String(error))
       );
-    } finally {
-      this.currentTransport = null;
-      this.currentDeviceId = null;
-      // F-24: no transport is connected anymore — stop the health-check interval
-      // (explicit-disconnect path).
-      this.stopConnectionHealthMonitoring();
-      this.markDeviceDisconnected(deviceId);
+    }
+
+    // close() may reject on an already-gone device (and .then() captures a sync
+    // throw too); emit, never throw, so fire-and-forget callers stay safe.
+    return Promise.resolve()
+      .then(() => transport.close())
+      .catch((error) =>
+        this.emit(
+          'error',
+          error instanceof Error ? error : new Error(String(error))
+        )
+      );
+  }
+
+  async disconnect(): Promise<void> {
+    const transport = this.currentTransport;
+    const deviceId = this.currentDeviceId;
+    if (!transport || !deviceId) {
+      return;
+    }
+
+    // releaseTransport clears state synchronously; await the close so callers
+    // like switchDevice() don't reconnect over a still-closing transport.
+    const closing = this.releaseTransport(transport);
+    if (closing) {
+      await closing;
+      // Only mark the device disconnected if a successor hasn't reconnected the
+      // SAME device while close() was in flight — otherwise this stale teardown
+      // would flag the live device disconnected and emit a spurious
+      // 'disconnected' (TASK-216).
+      if (this.currentDeviceId !== deviceId) {
+        this.markDeviceDisconnected(deviceId);
+      }
     }
   }
 
@@ -642,11 +700,18 @@ export class LedgerTransportService {
         if (type === 'remove' && descriptor) {
           this.devices.delete(descriptor.id);
           if (this.currentDeviceId === descriptor.id) {
-            this.currentDeviceId = null;
-            this.currentTransport = null;
-            // F-24: the connected device went away during discovery — stop the
-            // health-check interval along with the transport it monitored.
-            this.stopConnectionHealthMonitoring();
+            // TASK-216: the connected device went away during discovery. Hand
+            // the transport to releaseTransport, which clears state, stops the
+            // health-check interval, detaches the listener, and closes it.
+            // Fire-and-forget: this discovery callback isn't awaited. Runs
+            // synchronously with no intervening await, so the claim always
+            // succeeds here — signal a disconnect for the connection too (not
+            // only 'deviceRemoved' for the discovery list).
+            const transport = this.currentTransport;
+            if (transport) {
+              void this.releaseTransport(transport);
+              this.markDeviceDisconnected(descriptor.id);
+            }
           }
           this.emit('deviceRemoved', { id: descriptor.id });
         }
@@ -769,11 +834,18 @@ export class LedgerTransportService {
         if (type === 'remove') {
           this.devices.delete(id);
           if (this.currentDeviceId === id) {
-            this.currentDeviceId = null;
-            this.currentTransport = null;
-            // F-24: the connected device went away during discovery — stop the
-            // health-check interval along with the transport it monitored.
-            this.stopConnectionHealthMonitoring();
+            // TASK-216: the connected device went away during discovery. Hand
+            // the transport to releaseTransport, which clears state, stops the
+            // health-check interval, detaches the listener, and closes it.
+            // Fire-and-forget: this discovery callback isn't awaited. Runs
+            // synchronously with no intervening await, so the claim always
+            // succeeds here — signal a disconnect for the connection too (not
+            // only 'deviceRemoved' for the discovery list).
+            const transport = this.currentTransport;
+            if (transport) {
+              void this.releaseTransport(transport);
+              this.markDeviceDisconnected(id);
+            }
           }
           this.emit('deviceRemoved', { id });
         }
@@ -955,14 +1027,20 @@ export class LedgerTransportService {
     deviceId: string
   ): void {
     const handler = () => {
-      if (this.currentDeviceId === deviceId) {
-        this.currentTransport = null;
-        this.currentDeviceId = null;
-        // F-24: transport-initiated disconnect — stop health monitoring so the
-        // interval never outlives the connection it was scoped to.
-        this.stopConnectionHealthMonitoring();
+      // TASK-216: route the live-transport branch through the shared teardown so
+      // a transport-initiated disconnect ALSO detaches this listener and closes
+      // the transport (releasing native BLE/HID resources) — not just clears
+      // state. releaseTransport is successor-safe: it no-ops if a same-device
+      // reconnect already replaced this transport, so a stale/repeated callback
+      // from the dead transport can't clobber the live successor. (F-24 stopped
+      // the health interval here; that now happens inside releaseTransport.)
+      // Mark disconnected only when we claimed the live transport: any successor
+      // takeover routes through releaseTransport/disconnect(), which detaches
+      // this very handler and marks the device, so a superseded callback should
+      // stay silent.
+      if (this.releaseTransport(transport) !== null) {
+        this.markDeviceDisconnected(deviceId);
       }
-      this.markDeviceDisconnected(deviceId);
     };
     this.currentDisconnectHandler = handler;
     const anyTransport = transport as any;
@@ -1209,6 +1287,12 @@ export class LedgerTransportService {
     // APDU wins, the timer would otherwise self-expire ~5s later — a stray,
     // uncollected timer per check (4/min) for the whole connected session.
     let raceTimer: ReturnType<typeof setTimeout> | undefined;
+    // TASK-216: snapshot the transport (and its device) we probe so that, if it
+    // fails, we tear down THIS transport and mark THIS device — not whatever is
+    // current after the await (a successor may have connected while this probe
+    // was in flight). Declared out here so the catch block can reach them.
+    const probedTransport = this.currentTransport;
+    const probedDeviceId = this.currentDeviceId;
     try {
       // APDU: get app and version (same as used by Algorand app service)
       // Use shorter timeout for health checks to avoid blocking
@@ -1219,7 +1303,7 @@ export class LedgerTransportService {
         );
       });
 
-      const healthCheck = this.currentTransport.send(0xb0, 0x01, 0x00, 0x00);
+      const healthCheck = probedTransport.send(0xb0, 0x01, 0x00, 0x00);
 
       await Promise.race([healthCheck, timeout]);
       // console.log('Ledger Health Check: OK'); // Only log failures to reduce noise
@@ -1240,15 +1324,18 @@ export class LedgerTransportService {
           error instanceof Error ? error : new Error(String(error))
         );
 
-        // Consider transport unhealthy; clear state and notify
-        const deviceId = this.currentDeviceId;
-        this.currentTransport = null;
-        this.currentDeviceId = null;
-        // F-24: this check just disconnected the transport it was monitoring —
-        // stop the interval so it does not keep waking on a dead connection.
-        this.stopConnectionHealthMonitoring();
-        if (deviceId) {
-          this.markDeviceDisconnected(deviceId);
+        // Consider the probed transport unhealthy; tear it down and notify.
+        // TASK-216: releaseTransport detaches the listener, clears state, stops
+        // the interval, and closes it — but only if `probedTransport` is still
+        // current. Mark the probed device disconnected ONLY when we actually
+        // claimed the live transport. If a concurrent teardown (disconnect /
+        // discovery 'remove') or a device switch superseded this probe, that
+        // path already marked the device — and connect() always disconnect()s
+        // the old device before switching — so re-marking here would only emit
+        // a duplicate 'disconnected'.
+        const claimed = this.releaseTransport(probedTransport) !== null;
+        if (claimed && probedDeviceId) {
+          this.markDeviceDisconnected(probedDeviceId);
         }
       } else {
         // Log but don't disconnect for temporary issues


### PR DESCRIPTION
## What & why

The three **involuntary** `currentTransport` null-out paths — BLE discovery `'remove'`, USB discovery `'remove'`, and the health-check serious-error auto-disconnect — cleared `currentTransport` and stopped monitoring but left `currentDisconnectHandler` attached to, and never `close()`d, the now-orphaned transport. That leaked a dangling disconnect listener + an unclosed transport (native BLE GATT / HID handle) on every involuntary disconnect. The transport-initiated `'disconnect'` handler had the same gap on the **most common** case — a BLE device dropping out of range.

Fixes **TASK-216** (parent: PLAN-10, Security Hardening).

## Approach

Introduce a shared `releaseTransport(transport)` helper and route **all five** teardown paths through it (explicit `disconnect()`, BLE/USB `'remove'`, health-check auto-disconnect, transport-initiated `'disconnect'`). It:

- **Atomically claims** the teardown — no-ops unless `transport === this.currentTransport`, then clears `currentTransport` / `currentDeviceId` / `currentDisconnectHandler` + stops the health-check interval **synchronously**, before the first `await`.
- **Detaches the listener synchronously** (so the leak is fixed even where the caller can't await) and **closes** the transport (releasing native resources), emitting `close()` failures as `'error'` instead of throwing so fire-and-forget callers are safe.

### Guarantees (each with a regression test)
- **Idempotent** per transport — a second teardown racing the same transport while its `close()` is in flight no-ops instead of double-closing.
- **Successor-safe** — a new connection landing during a pending `close()` is a different `currentTransport`, so teardown no-ops on it. `checkConnectionHealth` snapshots the transport it *probed* and tears down that one; `disconnect()` won't mark a device disconnected if the same device reconnected during its `close()`.
- **Single `'disconnected'` emission** — a physically-removed connected Ledger now resets connection state (previously discovery removal emitted only `'deviceRemoved'`); stale race-losers stay silent (any successor takeover already marks the old device, since `connect()` always `disconnect()`s before switching), so no duplicate or spurious event.

Also adds a `removeEventListener` detach fallback mirroring the existing `addEventListener` attach fallback.

## Scope / risk
- Touches only `src/services/ledger/transport.ts` + its unit test. **No crypto / key / mnemonic / signing material** — this is Ledger hardware-transport lifecycle.
- **OTA-eligible** (JS-only; no native module / config-plugin change).

## Verification
- `npm run typecheck` clean, `npm run lint` clean, **full `npm test` 1146/1146** (16 in the ledger transport suite).
- Reviewed to **CLEAN** by the Codex oracle (multi-round, incl. crypto-adjacent race analysis) + an independent adversarial `code-review-analyzer` pass.
- On-device Ledger flows (connect / sign / unplug-mid-session / switch-device) are covered by the **batched pre-release** hardware verification, not per-PR.

https://claude.ai/code/session_017Q8pVj68gBrfxMrnsyQKpX