### PR TITLE
fix(wallet): serialize metadata writes against external wipe/restore (TASK-212)

### DIFF
--- a/src/services/backup/__tests__/restorePinSetupPending.test.ts
+++ b/src/services/backup/__tests__/restorePinSetupPending.test.ts
@@ -29,6 +29,11 @@ jest.mock('@/services/secure/AccountSecureStorage', () => ({
 
 jest.mock('@/services/wallet', () => ({
   MultiAccountWalletService: {
+    // TASK-212: clearAllData() now funnels the wallet-metadata wipe through the
+    // service instead of removing the key directly.
+    clearAllWallets: jest.fn(async () => {
+      order.push('clearWallet');
+    }),
     persistRestoredWallet: jest.fn(async () => {
       order.push('persistList');
     }),

--- a/src/services/backup/restorers.ts
+++ b/src/services/backup/restorers.ts
@@ -90,8 +90,11 @@ export async function clearAllData(): Promise<void> {
     // Clear all accounts via AccountSecureStorage
     await AccountSecureStorage.clearAll();
 
-    // Clear wallet metadata
-    await storage.removeItem(STORAGE_KEYS.WALLET_KEY);
+    // Clear wallet metadata. TASK-212: funnel the wipe through the wallet
+    // service (instead of removing voi_wallet_metadata directly) so it bumps the
+    // reset epoch + serializes on the write chain — an in-flight getCurrentWallet
+    // read-repair write can no longer resurrect the wallet blob mid-restore.
+    await MultiAccountWalletService.clearAllWallets();
     await storage.removeItem(STORAGE_KEYS.ACCOUNT_LIST);
 
     // Clear settings

--- a/src/services/wallet/__tests__/getCurrentWallet.memo.test.ts
+++ b/src/services/wallet/__tests__/getCurrentWallet.memo.test.ts
@@ -47,11 +47,38 @@ jest.mock('../../secure/AccountSecureStorage', () => ({
 
 import algosdk from 'algosdk';
 import { Buffer } from 'buffer';
-import { storage } from '@/platform';
-import { AccountType, StandardAccountMetadata } from '@/types/wallet';
+import { storage, secureStorage } from '@/platform';
+import { AccountType, StandardAccountMetadata, Wallet } from '@/types/wallet';
 import { MultiAccountWalletService } from '../index';
 
 const WALLET_KEY = 'voi_wallet_metadata';
+const WIPE_TOMBSTONE_KEY = 'voi_wallet_wiped';
+
+/**
+ * Build a persisted-wallet blob whose account has an INVALID address but a valid
+ * hex publicKey, so getCurrentWallet()'s heal-on-read path re-derives the
+ * address and performs a storeWallet() (the read-repair write TASK-212 guards).
+ */
+function makeHealTriggeringBlob(): string {
+  const account = algosdk.generateAccount();
+  return JSON.stringify({
+    id: 'wallet-1',
+    version: '1.0',
+    createdAt: '2026-01-01T00:00:00.000Z',
+    accounts: [
+      {
+        id: 'acc-1',
+        address: 'INVALID_ADDRESS', // fails algosdk.isValidAddress -> heal-on-read
+        publicKey: Buffer.from(account.sk.slice(32)).toString('hex'),
+        type: AccountType.STANDARD,
+        label: 'Account 1',
+        mnemonic: '',
+        createdAt: '2026-01-01T00:00:00.000Z',
+      },
+    ],
+    activeAccountId: 'acc-1',
+  });
+}
 
 /**
  * Build a valid persisted-wallet JSON blob backed by a freshly generated
@@ -316,5 +343,213 @@ describe('getCurrentWallet() memoization (F-22, TASK-179)', () => {
     const w2 = await MultiAccountWalletService.getCurrentWallet();
     if (!w2) throw new Error('expected a wallet');
     expect((storage.setItem as jest.Mock).mock.calls.length).toBeGreaterThan(0);
+  });
+
+  // === TASK-212: write-vs-wipe serialization ===============================
+
+  it('(i) a heal-on-read write does NOT resurrect metadata wiped concurrently by clearAllWallets', async () => {
+    mockStore[WALLET_KEY] = makeHealTriggeringBlob();
+
+    // The read triggers a heal-on-read storeWallet(); it races a wipe funneled
+    // through the service (which bumps the reset epoch synchronously and
+    // serializes the removal on the write chain). The wipe MUST win — the
+    // in-flight repair must not re-persist the stale blob.
+    const readP = MultiAccountWalletService.getCurrentWallet();
+    const wipeP = MultiAccountWalletService.clearAllWallets();
+    await Promise.all([readP, wipeP]);
+    // Drain any trailing queued write.
+    await new Promise((r) => setImmediate(r));
+
+    expect(mockStore[WALLET_KEY]).toBeUndefined();
+    // And the next read confirms no wallet survives.
+    expect(await MultiAccountWalletService.getCurrentWallet()).toBeNull();
+  });
+
+  it('(i2) a heal-on-read write applied with NO concurrent wipe still persists the repair', async () => {
+    mockStore[WALLET_KEY] = makeHealTriggeringBlob();
+
+    const w1 = await MultiAccountWalletService.getCurrentWallet();
+    if (!w1) throw new Error('expected a wallet');
+
+    // No wipe raced this read, so the heal-on-read write is NOT skipped: the
+    // stored blob is rewritten with a valid, re-derived address.
+    expect(mockStore[WALLET_KEY]).toBeDefined();
+    expect(mockStore[WALLET_KEY]).not.toContain('INVALID_ADDRESS');
+    expect(algosdk.isValidAddress(firstStandard(w1).address)).toBe(true);
+  });
+
+  it('(j) sanitizeWalletForPersistence scrubs secrets on ALL account types on the write path (type-agnostic)', async () => {
+    const account = algosdk.generateAccount();
+    const leakedMnemonic = algosdk.secretKeyToMnemonic(account.sk);
+    const leakedPrivateKey = Buffer.from(account.sk).toString('hex');
+    // A WATCH account (which must never carry key material) with a stray mnemonic
+    // AND privateKey. The old type-gated sanitizer (type === STANDARD) would have
+    // persisted both; the type-agnostic one must scrub them on any type.
+    const wallet = {
+      id: 'wallet-1',
+      version: '1.0',
+      createdAt: '2026-01-01T00:00:00.000Z',
+      accounts: [
+        {
+          id: 'acc-1',
+          address: account.addr.toString(),
+          publicKey: Buffer.from(account.sk.slice(32)).toString('hex'),
+          type: AccountType.WATCH,
+          label: 'Watch',
+          mnemonic: leakedMnemonic,
+          privateKey: leakedPrivateKey,
+        },
+      ],
+      activeAccountId: 'acc-1',
+    } as unknown as Wallet;
+
+    // persistRestoredWallet() is the public write wrapper -> storeWallet ->
+    // sanitizeWalletForPersistence.
+    await MultiAccountWalletService.persistRestoredWallet(wallet);
+
+    const persisted = mockStore[WALLET_KEY];
+    expect(persisted).toBeDefined();
+    expect(persisted).not.toContain(leakedMnemonic);
+    expect(persisted).not.toContain(leakedPrivateKey);
+  });
+
+  it('(k) an intentional mutation (setActiveAccount) does NOT resurrect metadata wiped concurrently', async () => {
+    mockStore[WALLET_KEY] = makeWalletBlob().blob; // valid, single account acc-1
+
+    // setActiveAccount reads the wallet, mutates, then storeWallet(). A reset
+    // funneled through the service races between that read and the write. Either
+    // the read fails-closed (getCurrentWallet returns null once the epoch bumps →
+    // "No wallet found" throw) OR the write is skipped (epoch advanced) — both
+    // mean the wipe wins. Tolerate the throw; the point is NO resurrection.
+    const mutateP = MultiAccountWalletService.setActiveAccount('acc-1').catch(
+      () => {}
+    );
+    const wipeP = MultiAccountWalletService.clearAllWallets();
+    await Promise.all([mutateP, wipeP]);
+    await new Promise((r) => setImmediate(r));
+
+    expect(mockStore[WALLET_KEY]).toBeUndefined();
+    expect(await MultiAccountWalletService.getCurrentWallet()).toBeNull();
+  });
+
+  it('(k2) an intentional mutation with NO concurrent wipe still persists', async () => {
+    mockStore[WALLET_KEY] = makeWalletBlob({ label: 'Before' }).blob;
+
+    await MultiAccountWalletService.updateAccountLabel('acc-1', 'After');
+
+    // No wipe raced, so the label update persisted.
+    expect(mockStore[WALLET_KEY]).toBeDefined();
+    const w = await MultiAccountWalletService.getCurrentWallet();
+    if (!w) throw new Error('expected a wallet');
+    expect(firstStandard(w).label).toBe('After');
+  });
+
+  it('(l) after a wipe, a surviving legacy copy is NOT re-migrated to resurrect the wallet (durable tombstone guards it regardless of the in-memory epoch)', async () => {
+    mockStore[WALLET_KEY] = makeWalletBlob().blob;
+    await MultiAccountWalletService.clearAllWallets();
+    // Primary gone; the durable tombstone is persisted in general storage.
+    expect(mockStore[WALLET_KEY]).toBeUndefined();
+    expect(mockStore[WIPE_TOMBSTONE_KEY]).toBe('1');
+
+    // A legacy secure-store copy survives (e.g. its best-effort delete failed).
+    // getStoredValue sees the primary absent and falls back to migrateLegacyValue.
+    const legacyBlob = makeWalletBlob({ label: 'Legacy' }).blob;
+    (secureStorage.getItem as jest.Mock).mockResolvedValueOnce(legacyBlob);
+
+    const result = await MultiAccountWalletService.getCurrentWallet();
+
+    // The tombstone blocks migration — the wiped wallet is NOT resurrected. (The
+    // reset epoch passes here since no wipe raced THIS read; the tombstone is the
+    // effective guard, and it survives an app restart when the epoch resets.)
+    expect(result).toBeNull();
+    expect(mockStore[WALLET_KEY]).toBeUndefined();
+  });
+
+  it('(l2) a create/restore after a wipe clears the tombstone and persists the new wallet', async () => {
+    mockStore[WALLET_KEY] = makeWalletBlob().blob;
+    await MultiAccountWalletService.clearAllWallets();
+    expect(mockStore[WIPE_TOMBSTONE_KEY]).toBe('1');
+
+    // Restore/create writes a fresh primary — the wiped state is over.
+    const fresh = JSON.parse(makeWalletBlob({ label: 'Fresh' }).blob) as Wallet;
+    await MultiAccountWalletService.persistRestoredWallet(fresh);
+
+    expect(mockStore[WALLET_KEY]).toBeDefined();
+    // Tombstone cleared atomically with the write.
+    expect(mockStore[WIPE_TOMBSTONE_KEY]).toBeUndefined();
+    const w = await MultiAccountWalletService.getCurrentWallet();
+    if (!w) throw new Error('expected the restored wallet');
+    expect(firstStandard(w).label).toBe('Fresh');
+  });
+
+  it('(m) migrateLegacyValue fails CLOSED on a corrupt legacy wallet blob (never copies raw secrets to general storage)', async () => {
+    const account = algosdk.generateAccount();
+    const leakedMnemonic = algosdk.secretKeyToMnemonic(account.sk);
+    // A corrupt (non-JSON) legacy secure-store blob that still contains a
+    // mnemonic. Primary storage is empty, so getStoredValue falls back to
+    // migrateLegacyValue.
+    const corruptLegacy = '{not valid json ' + leakedMnemonic;
+    (secureStorage.getItem as jest.Mock).mockResolvedValueOnce(corruptLegacy);
+    (storage.setItem as jest.Mock).mockClear();
+
+    const result = await MultiAccountWalletService.getCurrentWallet();
+
+    // Nothing migrated: no wallet, and the raw secret-bearing payload was NOT
+    // written to general storage.
+    expect(result).toBeNull();
+    expect(mockStore[WALLET_KEY]).toBeUndefined();
+    const wroteSecret = (storage.setItem as jest.Mock).mock.calls.some(
+      (c) => typeof c[1] === 'string' && c[1].includes(leakedMnemonic)
+    );
+    expect(wroteSecret).toBe(false);
+  });
+
+  it('(n) migrateLegacyValue does NOT clobber a primary blob written concurrently (re-checks absence in-chain)', async () => {
+    const freshBlob = makeWalletBlob({ label: 'Fresh' }).blob;
+    const legacyBlob = makeWalletBlob({ label: 'Legacy' }).blob;
+    // getStoredValue sees the primary absent (triggers migration); by the time the
+    // serialized migration task re-checks, a concurrent create/restore has written
+    // a fresh primary blob. The migration must observe that and skip.
+    (storage.getItem as jest.Mock)
+      .mockResolvedValueOnce(null) // getStoredValue: primary absent -> migrate
+      .mockResolvedValueOnce(freshBlob); // migration re-check: primary now present
+    (secureStorage.getItem as jest.Mock).mockResolvedValueOnce(legacyBlob);
+    (storage.setItem as jest.Mock).mockClear();
+
+    await MultiAccountWalletService.getCurrentWallet();
+
+    // Migration must NOT have written the stale legacy blob over the fresh primary.
+    expect(storage.setItem as jest.Mock).not.toHaveBeenCalled();
+  });
+
+  it('(p) getCurrentWallet returns null (fail-closed) when a wipe races the in-flight read', async () => {
+    mockStore[WALLET_KEY] = makeWalletBlob().blob;
+    // Prime the memo so the wallet is fully loaded once.
+    await MultiAccountWalletService.getCurrentWallet();
+
+    // A read starts (captures the reset epoch) and a wipe bumps the epoch before
+    // it returns. getCurrentWallet feeds signing, so it must NOT hand back the
+    // stale pre-wipe wallet — it returns null.
+    const readP = MultiAccountWalletService.getCurrentWallet();
+    const wipeP = MultiAccountWalletService.clearAllWallets();
+    const [read] = await Promise.all([readP, wipeP]);
+
+    expect(read).toBeNull();
+  });
+
+  it('(q) a stuck tombstone beside a PRESENT primary does not disable mutations — the write proceeds and clears it', async () => {
+    mockStore[WALLET_KEY] = makeWalletBlob({ label: 'Before' }).blob;
+    // Simulate a stuck tombstone: set beside a still-present primary (a wipe's
+    // removeItem failed, or a create's tombstone-clear failed, or a crash between
+    // the two). A guarded mutation must NOT silently skip on it.
+    mockStore[WIPE_TOMBSTONE_KEY] = '1';
+
+    await MultiAccountWalletService.updateAccountLabel('acc-1', 'After');
+
+    // The update persisted and the stale tombstone was cleared.
+    expect(mockStore[WIPE_TOMBSTONE_KEY]).toBeUndefined();
+    const w = await MultiAccountWalletService.getCurrentWallet();
+    if (!w) throw new Error('expected wallet');
+    expect(firstStandard(w).label).toBe('After');
   });
 });

--- a/src/services/wallet/__tests__/hasWalletWithAccountsStrict.test.ts
+++ b/src/services/wallet/__tests__/hasWalletWithAccountsStrict.test.ts
@@ -126,6 +126,20 @@ describe('hasWalletWithAccountsStrict — absence vs failure (TASK-213)', () => 
     await MultiAccountWalletService.hasWalletWithAccountsStrict();
     expect(mockStorageSet).not.toHaveBeenCalled();
   });
+
+  it('resolves FALSE when the wipe tombstone is set even if a legacy secure-store copy survives (TASK-212)', async () => {
+    // Wiped: primary absent, durable tombstone set, but a legacy secure-store copy
+    // lingers (its best-effort delete failed). The strict probe must read it as
+    // ABSENT — the tombstone gates the legacy fallback, so a wiped wallet never
+    // boots as "present".
+    mockStore['voi_wallet_wiped'] = '1';
+    mockSecureGet.mockImplementation(async () =>
+      JSON.stringify({ accounts: [{ id: 'a' }] })
+    );
+    await expect(
+      MultiAccountWalletService.hasWalletWithAccountsStrict()
+    ).resolves.toBe(false);
+  });
 });
 
 // TASK-213 Codex round-4: hasKeyBearingAccountStrict is the durable, keystore-

--- a/src/services/wallet/index.ts
+++ b/src/services/wallet/index.ts
@@ -83,9 +83,42 @@ const getCurrentWalletParsesInFlight = new Map<
  */
 const SECRET_ACCOUNT_FIELDS = ['mnemonic', 'privateKey'] as const;
 
+/**
+ * TASK-212 — write-vs-wipe serialization for the wallet-metadata blob.
+ *
+ * getCurrentWallet() performs read-repair WRITES (legacy-mnemonic strip,
+ * heal-on-read address repair) while processing a just-read blob. A concurrent
+ * reset/restore can wipe voi_wallet_metadata BETWEEN that read and the pending
+ * write; the in-flight write would then re-persist (resurrect) the stale
+ * metadata after the wipe. Two coordinated mechanisms close the race:
+ *
+ *   1. A reset EPOCH bumped synchronously by every wipe funneled through the
+ *      service (clearAllWallets — restore now routes through it too). A
+ *      read-repair write captures the epoch at read time and is SKIPPED if a
+ *      wipe bumped it in the meantime. It never applies to intentional writes
+ *      (createWallet / addAccount / persistRestoredWallet), which must persist.
+ *   2. A single write CHAIN that serializes every WALLET_KEY mutation (writes
+ *      AND wipes) so a write and a wipe can never interleave at the storage
+ *      layer — regardless of the storage adapter's ordering guarantees. If a
+ *      read-repair write did slip past the epoch check, the wipe enqueued after
+ *      it still runs last and wins.
+ */
+let walletResetEpoch = 0;
+let walletWriteChain: Promise<unknown> = Promise.resolve();
+
 export class MultiAccountWalletService {
   private static readonly STORAGE_PREFIX = 'voi_account_';
   private static readonly WALLET_KEY = 'voi_wallet_metadata';
+  // TASK-212: durable "wallet was intentionally wiped" tombstone. Persisted in
+  // general storage (survives app restart, unlike the in-memory reset epoch) and
+  // set by clearAllWallets in the same chain task that removes the primary blob.
+  // migrateLegacyValue refuses to resurrect a wallet from a surviving legacy
+  // secure-store copy while this is set (it BAILS when set, so it never itself
+  // clears it); a storeWallet primary write (createWallet / restore / any
+  // intentional write) clears it, marking the wiped state over. Closes the
+  // wipe→migration resurrection gap (incl. across a restart) without keeping the
+  // legacy delete on the write chain.
+  private static readonly WIPE_TOMBSTONE_KEY = 'voi_wallet_wiped';
 
   // Account Management Methods
   static async createStandardAccount(
@@ -242,6 +275,8 @@ export class MultiAccountWalletService {
       );
     }
 
+    // TASK-212: guard the write against a reset racing this read.
+    const readEpoch = walletResetEpoch;
     const wallet = await this.getCurrentWallet();
 
     try {
@@ -304,10 +339,12 @@ export class MultiAccountWalletService {
           settings: this.getDefaultWalletSettings(),
         };
 
+        // Creation write (no prior wallet existed) — always persist, like
+        // createWallet; it establishes a fresh wallet and has nothing to resurrect.
         await this.storeWallet(newWallet);
       } else {
         wallet.accounts.push(accountMetadata);
-        await this.storeWallet(wallet);
+        await this.storeWallet(wallet, readEpoch);
       }
 
       return accountMetadata;
@@ -412,6 +449,8 @@ export class MultiAccountWalletService {
       });
     }
 
+    // TASK-212: guard the ledger-association write against a reset racing this read.
+    const readEpoch = walletResetEpoch;
     const wallet = await this.getCurrentWallet();
     const derivedAccounts = await ledgerAlgorandService.deriveAccounts(
       startIndex,
@@ -437,7 +476,8 @@ export class MultiAccountWalletService {
         await this.ensureLedgerAssociation(
           wallet,
           existingAccount as LedgerAccountMetadata,
-          deviceInfo
+          deviceInfo,
+          readEpoch
         );
       }
 
@@ -466,6 +506,8 @@ export class MultiAccountWalletService {
       );
     }
 
+    // TASK-212: guard the ledger-association write against a reset racing this read.
+    const readEpoch = walletResetEpoch;
     const wallet = await this.getCurrentWallet();
     if (!wallet) {
       throw new Error('No wallet found');
@@ -486,7 +528,8 @@ export class MultiAccountWalletService {
     return this.ensureLedgerAssociation(
       wallet,
       account as LedgerAccountMetadata,
-      deviceInfo
+      deviceInfo,
+      readEpoch
     );
   }
 
@@ -675,6 +718,8 @@ export class MultiAccountWalletService {
     signerDeviceId: string,
     signerDeviceName?: string
   ): Promise<RemoteSignerAccountMetadata> {
+    // TASK-212: guard the write against a reset racing this read.
+    const readEpoch = walletResetEpoch;
     const wallet = await this.getCurrentWallet();
     if (!wallet) {
       throw new Error('No wallet found');
@@ -723,14 +768,31 @@ export class MultiAccountWalletService {
     wallet.accounts[accountIndex] = remoteSignerAccount;
 
     // Store the updated wallet
-    await this.storeWallet(wallet);
+    await this.storeWallet(wallet, readEpoch);
 
     return remoteSignerAccount;
+  }
+
+  /**
+   * TASK-212: true if a wipe/reset advanced the reset epoch since `readEpoch` was
+   * captured. getCurrentWallet() returns null (fail-closed) rather than hand back
+   * a stale pre-wipe wallet — it feeds signing / key retrieval, so a read that a
+   * concurrent reset/restore raced must not be served (the caller re-reads to see
+   * the current state).
+   */
+  private static resetRacedRead(readEpoch: number): boolean {
+    return readEpoch !== walletResetEpoch;
   }
 
   // Wallet Management
   static async getCurrentWallet(): Promise<Wallet | null> {
     try {
+      // TASK-212: capture the reset epoch BEFORE the read. Any read-repair write
+      // this call performs (legacy strip / heal-on-read) is guarded on it and
+      // skipped if a wipe/reset bumps the epoch before the write lands, so a
+      // concurrent restore/reset can't be undone by an in-flight repair.
+      const readEpoch = walletResetEpoch;
+
       // (1) ALWAYS read the current stored raw string. This read is intentionally
       // NOT memoized: external wipes/rewrites that bypass this service (restore
       // clearAllData() removing voi_wallet_metadata directly, migrateLegacyValue
@@ -751,6 +813,7 @@ export class MultiAccountWalletService {
       // hashing + settings merge; hand back a deep clone so the caller can mutate
       // its copy freely.
       if (walletData === cachedWalletRawString && cachedWallet) {
+        if (this.resetRacedRead(readEpoch)) return null;
         return this.deepCloneWallet(cachedWallet);
       }
 
@@ -778,9 +841,11 @@ export class MultiAccountWalletService {
           this.stripAccountSecrets(acc)
         );
 
-        await this.storeWallet(parsed);
+        // Read-repair write: skipped if a wipe/reset raced this read (TASK-212).
+        await this.storeWallet(parsed, readEpoch);
 
-        const sanitized = await this.mergeSettingsAndHeal(parsed);
+        const sanitized = await this.mergeSettingsAndHeal(parsed, readEpoch);
+        if (this.resetRacedRead(readEpoch)) return null;
         return this.deepCloneWallet(sanitized);
       }
 
@@ -791,11 +856,12 @@ export class MultiAccountWalletService {
       const inFlight = getCurrentWalletParsesInFlight.get(walletData);
       if (inFlight) {
         const shared = await inFlight;
+        if (this.resetRacedRead(readEpoch)) return null;
         return shared ? this.deepCloneWallet(shared) : null;
       }
 
       const loadPromise = (async () => {
-        const wallet = await this.mergeSettingsAndHeal(parsed);
+        const wallet = await this.mergeSettingsAndHeal(parsed, readEpoch);
         // Fail-closed: only memoize a wallet whose accounts hold NO secret
         // material, keyed on a secret-free raw string. hasSecretMaterial already
         // guaranteed this above; re-checking the healed result keeps the
@@ -803,7 +869,13 @@ export class MultiAccountWalletService {
         // key material. (If heal-on-read re-stored a repaired address the stored
         // string also changed, so this entry is simply superseded on the next
         // read — never served stale, since every read compares the live string.)
+        //
+        // TASK-212: also require the reset epoch to be unchanged. A wipe/reset
+        // that raced this in-flight load synchronously busts the memo; without
+        // this guard, resuming here would re-populate cachedWallet with the
+        // now-wiped blob (transient stale state until the next read).
         if (
+          readEpoch === walletResetEpoch &&
           !wallet.accounts.some((acc) => this.accountHasSecretMaterial(acc))
         ) {
           cachedWalletRawString = walletData;
@@ -814,6 +886,7 @@ export class MultiAccountWalletService {
       getCurrentWalletParsesInFlight.set(walletData, loadPromise);
       try {
         const wallet = await loadPromise;
+        if (this.resetRacedRead(readEpoch)) return null;
         return this.deepCloneWallet(wallet);
       } finally {
         getCurrentWalletParsesInFlight.delete(walletData);
@@ -832,7 +905,10 @@ export class MultiAccountWalletService {
    * mnemonic-bearing blob (handled inline in getCurrentWallet before it is
    * stripped) can never be routed through the memo.
    */
-  private static async mergeSettingsAndHeal(wallet: Wallet): Promise<Wallet> {
+  private static async mergeSettingsAndHeal(
+    wallet: Wallet,
+    readEpoch: number
+  ): Promise<Wallet> {
     const defaultSettings = this.getDefaultWalletSettings();
     const persistedSettings = wallet.settings ?? {};
     wallet.settings = {
@@ -876,7 +952,8 @@ export class MultiAccountWalletService {
     });
 
     if (modified) {
-      await this.storeWallet(wallet);
+      // Read-repair write: skipped if a wipe/reset raced this read (TASK-212).
+      await this.storeWallet(wallet, readEpoch);
     }
 
     return wallet;
@@ -952,6 +1029,8 @@ export class MultiAccountWalletService {
   }
 
   static async getAccount(accountId: string): Promise<AccountMetadata> {
+    // TASK-212: guard the ledger-association write against a reset racing this read.
+    const readEpoch = walletResetEpoch;
     const wallet = await this.getCurrentWallet();
     if (!wallet) {
       throw new Error('No wallet found');
@@ -971,7 +1050,8 @@ export class MultiAccountWalletService {
         return await this.ensureLedgerAssociation(
           wallet,
           account as LedgerAccountMetadata,
-          connectedDevice
+          connectedDevice,
+          readEpoch
         );
       }
     }
@@ -990,6 +1070,8 @@ export class MultiAccountWalletService {
   static async updateAccountMetadata(
     updatedAccount: AccountMetadata
   ): Promise<void> {
+    // TASK-212: guard the write against a reset racing this read.
+    const readEpoch = walletResetEpoch;
     const wallet = await this.getCurrentWallet();
     if (!wallet) {
       throw new Error('No wallet found');
@@ -1006,16 +1088,21 @@ export class MultiAccountWalletService {
       acc.id === updatedAccount.id ? updatedAccount : acc
     );
 
-    await this.storeWallet({
-      ...wallet,
-      accounts,
-    });
+    await this.storeWallet(
+      {
+        ...wallet,
+        accounts,
+      },
+      readEpoch
+    );
   }
 
   static async updateAccountLabel(
     accountId: string,
     label: string
   ): Promise<AccountMetadata> {
+    // TASK-212: guard the write against a reset racing this read.
+    const readEpoch = walletResetEpoch;
     const wallet = await this.getCurrentWallet();
     if (!wallet) {
       throw new Error('No wallet found');
@@ -1039,15 +1126,20 @@ export class MultiAccountWalletService {
       acc.id === accountId ? updatedAccount : acc
     );
 
-    await this.storeWallet({
-      ...wallet,
-      accounts,
-    });
+    await this.storeWallet(
+      {
+        ...wallet,
+        accounts,
+      },
+      readEpoch
+    );
 
     return updatedAccount;
   }
 
   static async setActiveAccount(accountId: string): Promise<void> {
+    // TASK-212: guard the write against a reset racing this read.
+    const readEpoch = walletResetEpoch;
     const wallet = await this.getCurrentWallet();
     if (!wallet) {
       throw new Error('No wallet found');
@@ -1059,7 +1151,7 @@ export class MultiAccountWalletService {
     }
 
     wallet.activeAccountId = accountId;
-    await this.storeWallet(wallet);
+    await this.storeWallet(wallet, readEpoch);
   }
 
   static async getPrivateKey(accountId: string): Promise<Uint8Array> {
@@ -1067,6 +1159,8 @@ export class MultiAccountWalletService {
   }
 
   static async deleteAccount(accountId: string): Promise<void> {
+    // TASK-212: guard the write against a reset racing this read.
+    const readEpoch = walletResetEpoch;
     const wallet = await this.getCurrentWallet();
     if (!wallet) {
       throw new Error('No wallet found');
@@ -1083,20 +1177,60 @@ export class MultiAccountWalletService {
       wallet.activeAccountId = wallet.accounts[0].id;
     }
 
-    await this.storeWallet(wallet);
+    await this.storeWallet(wallet, readEpoch);
   }
 
   static async clearAllWallets(): Promise<void> {
+    // TASK-212: this is the canonical wallet-metadata wipe — restore
+    // (backup/restorers.ts clearAllData) and LockScreen.performReset() both
+    // funnel through it. Bump the reset epoch and bust the memo SYNCHRONOUSLY,
+    // before any await, so an in-flight read-repair write that captured an older
+    // epoch is skipped and no cached clone survives the reset.
+    walletResetEpoch++;
+    const bumpedEpoch = walletResetEpoch;
+    cachedWalletRawString = null;
+    cachedWallet = null;
     try {
       // Clears wallet METADATA only (the account list / active-account record).
       // Private keys in secure storage are NOT touched here; callers that need a
       // full reset must also call AccountSecureStorage.clearAll() — as
       // LockScreen.performReset() does immediately before invoking this method.
-      await storage.removeItem(this.WALLET_KEY);
-      await this.clearLegacyValue(this.WALLET_KEY);
+      //
+      // Serialize ONLY the primary removeItem + tombstone-set on the chain, so a
+      // hanging legacy secure-store deletion can never block it (or a subsequent
+      // write/wipe). The durable tombstone (survives restart) is what guarantees a
+      // surviving legacy copy can't be re-migrated to resurrect this wallet — so
+      // the legacy delete itself is best-effort below.
+      //
+      // Set the tombstone FIRST, then remove the primary: if the app dies or the
+      // removeItem fails in between, we are left tombstone-set (migration blocked)
+      // + primary-present (still readable) — never primary-gone-without-tombstone,
+      // which would let a surviving legacy copy resurrect on next launch. A stale
+      // tombstone with the primary present is harmless (migration only fires when
+      // the primary is absent) and the next primary write clears it.
+      await this.enqueueWalletWrite(async () => {
+        await storage.setItem(this.WIPE_TOMBSTONE_KEY, '1');
+        await storage.removeItem(this.WALLET_KEY);
+      });
+      // Best-effort legacy secure-store cleanup, OUTSIDE the chain and
+      // fire-and-forget (the tombstone, not this delete, prevents resurrection),
+      // so a stalled/failing keychain op can neither block the chain nor fail the
+      // reset. For migrated installs the legacy key is already absent (no-op).
+      void this.clearLegacyValue(this.WALLET_KEY);
 
       console.log('All wallet metadata cleared');
     } catch (error) {
+      // The primary removal failed — the wallet was NOT wiped. Revert the
+      // optimistic epoch bump (unless another wipe has since advanced it) so
+      // future intentional writes aren't wrongly skipped as if a reset landed.
+      // (Best-effort: the revert can't un-skip a guarded task that already ran in
+      // the failure window, and if setItem(tombstone) succeeded before removeItem
+      // threw, the tombstone lingers beside the still-present primary — both are
+      // self-healing: readers prefer a present primary, and the next successful
+      // primary write clears the stale tombstone. Not a resurrection.)
+      if (walletResetEpoch === bumpedEpoch) {
+        walletResetEpoch = bumpedEpoch - 1;
+      }
       console.error('Failed to clear wallet data:', error);
       throw new Error(
         `Failed to clear wallet data: ${error instanceof Error ? error.message : 'Unknown error'}`
@@ -1464,7 +1598,10 @@ export class MultiAccountWalletService {
   private static async ensureLedgerAssociation(
     wallet: Wallet,
     account: LedgerAccountMetadata,
-    deviceInfo: LedgerDeviceInfo
+    deviceInfo: LedgerDeviceInfo,
+    // TASK-212: epoch captured by the caller before it read `wallet`, so this
+    // metadata-timestamp write is skipped if a reset raced that read.
+    readEpoch: number
   ): Promise<LedgerAccountMetadata> {
     const accountIndex = wallet.accounts.findIndex(
       (acc) => acc.id === account.id
@@ -1499,10 +1636,13 @@ export class MultiAccountWalletService {
     const accounts = [...wallet.accounts];
     accounts[accountIndex] = nextAccount;
 
-    await this.storeWallet({
-      ...wallet,
-      accounts,
-    });
+    await this.storeWallet(
+      {
+        ...wallet,
+        accounts,
+      },
+      readEpoch
+    );
 
     return nextAccount;
   }
@@ -1510,6 +1650,8 @@ export class MultiAccountWalletService {
   private static async addAccountToWallet(
     accountMetadata: AccountMetadata
   ): Promise<void> {
+    // TASK-212: guard the write against a reset racing this read.
+    const readEpoch = walletResetEpoch;
     const wallet = await this.getCurrentWallet();
     if (!wallet) {
       // If no wallet exists, create one with this account
@@ -1526,7 +1668,7 @@ export class MultiAccountWalletService {
       }
     } else {
       wallet.accounts.push(accountMetadata);
-      await this.storeWallet(wallet);
+      await this.storeWallet(wallet, readEpoch);
     }
   }
 
@@ -1546,9 +1688,85 @@ export class MultiAccountWalletService {
     return wallet;
   }
 
-  private static async storeWallet(wallet: Wallet): Promise<void> {
-    const persistencePayload = this.sanitizeWalletForPersistence(wallet);
-    await this.storeValue(this.WALLET_KEY, JSON.stringify(persistencePayload));
+  /**
+   * TASK-212 — serialize a WALLET_KEY mutation on the shared write chain so
+   * writes and wipes never interleave at the storage layer. Each task runs after
+   * the previous settles (success OR failure); a task's rejection is isolated so
+   * it can't poison later writes, but is still surfaced to THIS caller.
+   */
+  private static enqueueWalletWrite<T>(task: () => Promise<T>): Promise<T> {
+    const run = walletWriteChain.then(task, task);
+    walletWriteChain = run.catch(() => {});
+    return run;
+  }
+
+  /**
+   * Persist the wallet metadata, serialized on the write chain.
+   *
+   * TASK-212 — pass `readEpoch` for any write DERIVED FROM A PRIOR getCurrentWallet
+   * READ (the read-repair writes AND every intentional read-modify-write mutation:
+   * addAccount, deleteAccount, setActiveAccount, label/metadata updates, ledger
+   * association, standard→remote-signer conversion, …). The write is then SKIPPED
+   * if a wipe/reset advanced the reset epoch since that read, so a concurrent
+   * restore/reset can't be undone by re-persisting the pre-reset blob (which would
+   * recreate account records whose secure keys were already wiped). The epoch is
+   * re-checked INSIDE the serialized task (after any earlier-enqueued wipe), and
+   * the write chain still guarantees a wipe enqueued afterward wins even if the
+   * check narrowly passes. CREATION writes (createWallet / createWalletWithAccount
+   * / persistRestoredWallet) pass no epoch and always persist.
+   */
+  private static async storeWallet(
+    wallet: Wallet,
+    readEpoch?: number
+  ): Promise<void> {
+    // Sanitize + serialize a SNAPSHOT now (synchronously), before enqueuing, so a
+    // later in-place mutation of `wallet` by the caller can't alter what is
+    // persisted once this task reaches the front of the chain.
+    const serialized = JSON.stringify(
+      this.sanitizeWalletForPersistence(wallet)
+    );
+    const wrote = await this.enqueueWalletWrite(async () => {
+      if (readEpoch !== undefined) {
+        // Guarded write (read-repair OR intentional read-modify-write): skip if a
+        // wipe advanced the epoch since the read this write derives from...
+        if (readEpoch !== walletResetEpoch) {
+          return false;
+        }
+        // ...OR if a wipe has COMPLETED (tombstone set AND primary now absent)
+        // since. A reset started in the epoch-bump→removeItem gap leaves the epoch
+        // matching but the wipe task's tombstone set before this write runs, so
+        // the tombstone is the backstop against a stale mutation resurrecting the
+        // just-wiped wallet. Require the primary to actually be ABSENT: a stuck
+        // tombstone left beside a still-present primary (a failed removeItem/
+        // tombstone-clear, or a crash mid-write) must NOT silently disable
+        // mutations — such a write is not a resurrection and proceeds below,
+        // clearing the stale marker. (Creation writes pass no epoch.)
+        const wiped = await storage.getItem(this.WIPE_TOMBSTONE_KEY);
+        if (wiped != null) {
+          const current = await storage.getItem(this.WALLET_KEY);
+          if (current == null) {
+            return false;
+          }
+        }
+      }
+      // TASK-212: only the PRIMARY (AsyncStorage) write is serialized on the
+      // chain, so a hanging legacy secure-store op can never block a subsequent
+      // write or wipe.
+      await storage.setItem(this.WALLET_KEY, serialized);
+      // A primary blob now exists — the wiped state (if any) is over. Clear the
+      // durable tombstone atomically with the write so migrateLegacyValue is
+      // re-enabled and no stale "wiped" marker lingers past a create/restore.
+      await storage.removeItem(this.WIPE_TOMBSTONE_KEY);
+      return true;
+    });
+    // Best-effort legacy secure-store cleanup, OUTSIDE the chain and
+    // fire-and-forget so a stalled keychain op can't hold up this write (or the
+    // chain). Harmless if it lingers: the primary copy is authoritative and
+    // getStoredValue prefers it (migrateLegacyValue only runs when primary is
+    // absent).
+    if (wrote) {
+      void this.clearLegacyValue(this.WALLET_KEY);
+    }
   }
 
   /**
@@ -1691,60 +1909,118 @@ export class MultiAccountWalletService {
     if (value) {
       return value;
     }
+    // TASK-212: for the wallet blob, honor the durable wipe tombstone BEFORE the
+    // legacy fallback — a wiped wallet whose best-effort legacy delete failed must
+    // read as ABSENT here too, so the strict boot probes never treat a surviving
+    // legacy secure-store copy as a present wallet.
+    if (key === this.WALLET_KEY) {
+      const wiped = await storage.getItem(this.WIPE_TOMBSTONE_KEY);
+      if (wiped != null) {
+        return null;
+      }
+    }
     const legacy = await secureStorage.getItem(key);
     return legacy ?? null;
   }
 
-  private static async storeValue(key: string, value: string): Promise<void> {
-    try {
-      await storage.setItem(key, value);
-      await this.clearLegacyValue(key);
-    } catch (error) {
-      console.error(`Failed to store value for key ${key}:`, error);
-      throw error;
-    }
-  }
-
+  /**
+   * Strip key material from every account before persistence. TASK-212: this is
+   * now type-AGNOSTIC — it removes ALL SECRET_ACCOUNT_FIELDS (mnemonic +
+   * privateKey) from every account regardless of `type`, matching the
+   * type-agnostic read-path detector/scrubber (accountHasSecretMaterial /
+   * stripAccountSecrets, F-22/TASK-179). A corrupt/mistyped account carrying key
+   * material on a non-STANDARD type is now scrubbed on the write path too, not
+   * just the read path. STANDARD accounts keep the persisted-schema shape (an
+   * explicit empty `mnemonic`).
+   */
   private static sanitizeWalletForPersistence(wallet: Wallet): Wallet {
     return {
       ...wallet,
       accounts: wallet.accounts.map((account) => {
-        if (account.type === AccountType.STANDARD) {
-          const { mnemonic: _mnemonic, ...rest } =
-            account as StandardAccountMetadata;
-          return {
-            ...rest,
-            mnemonic: '',
-          } as StandardAccountMetadata;
+        const record: Record<string, unknown> = {
+          ...(account as unknown as Record<string, unknown>),
+        };
+        for (const field of SECRET_ACCOUNT_FIELDS) {
+          delete record[field];
         }
-        return { ...account } as AccountMetadata;
+        if (record.type === AccountType.STANDARD) {
+          record.mnemonic = '';
+        }
+        return record as unknown as AccountMetadata;
       }),
     };
   }
 
   private static async migrateLegacyValue(key: string): Promise<string | null> {
     try {
+      // TASK-212: capture the reset epoch for the WALLET_KEY migration BEFORE
+      // reading the legacy blob, so a concurrent wipe isn't undone by
+      // re-persisting the migrated blob (this is a third read-path write to
+      // WALLET_KEY, alongside heal-on-read and legacy-strip).
+      const migrationEpoch = walletResetEpoch;
+
       // Try to get from secure storage (legacy location)
       const legacyValue = await secureStorage.getItem(key);
       if (!legacyValue) {
         return null;
       }
 
-      let valueToPersist = legacyValue;
       if (key === this.WALLET_KEY) {
+        // Fail CLOSED: sanitize the legacy wallet blob BEFORE it can reach general
+        // storage. A corrupt/unparseable blob may still carry plaintext key
+        // material, so on any parse/sanitize failure we must NOT copy the raw
+        // payload into AsyncStorage — leave the legacy copy and report absence.
+        let sanitized: string;
         try {
           const legacyWallet = JSON.parse(legacyValue) as Wallet;
-          valueToPersist = JSON.stringify(
+          sanitized = JSON.stringify(
             this.sanitizeWalletForPersistence(legacyWallet)
           );
         } catch (error) {
-          console.warn('Failed to sanitize legacy wallet payload', error);
+          console.warn(
+            'Failed to sanitize legacy wallet payload; not migrating',
+            error
+          );
+          return null;
         }
+
+        // Serialize + epoch-guard the WALLET_KEY migration on the write chain.
+        const migrated = await this.enqueueWalletWrite(async () => {
+          if (migrationEpoch !== walletResetEpoch) {
+            // A wipe/reset raced this migration — do NOT resurrect the blob.
+            return false;
+          }
+          // TASK-212: re-check primary ABSENCE inside the serialized task. A
+          // concurrent createWallet/restore may have written a fresh primary blob
+          // while we awaited the legacy value; migrating the stale legacy blob
+          // would clobber it (a reset epoch doesn't change in this race). Because
+          // that write is also serialized on this chain, this read is atomic wrt
+          // it.
+          const current = await storage.getItem(key);
+          if (current != null) {
+            return false;
+          }
+          // TASK-212: honor the durable wipe tombstone. If the wallet was
+          // intentionally wiped and not since re-created, a surviving legacy copy
+          // must NOT resurrect it — this holds even across an app restart (when
+          // the in-memory reset epoch has reset to 0). Any create/restore clears
+          // the tombstone, at which point a primary exists and migration no
+          // longer fires.
+          const wiped = await storage.getItem(this.WIPE_TOMBSTONE_KEY);
+          if (wiped != null) {
+            return false;
+          }
+          await storage.setItem(key, sanitized);
+          return true;
+        });
+        // Drop the legacy copy either way; the wipe path also clears it.
+        await secureStorage.deleteItem(key).catch(() => {});
+        return migrated ? sanitized : null;
       }
 
-      await storage.setItem(key, valueToPersist);
+      await storage.setItem(key, legacyValue);
       await secureStorage.deleteItem(key).catch(() => {});
-      return valueToPersist;
+      return legacyValue;
     } catch (error) {
       console.error(`Failed to migrate legacy value for key ${key}:`, error);
       return null;


### PR DESCRIPTION
## What & why

`getCurrentWallet()`'s read-repair writes — the legacy-mnemonic strip and heal-on-read address repair — call `storeWallet()` while processing a just-read blob. A concurrent reset/restore that wipes `voi_wallet_metadata` **outside** the service (`backup/restorers.ts` `clearAllData` removed the key directly; `LockScreen.performReset`) could land **between** that read and the pending write, so the in-flight write re-persisted (**resurrected**) the stale metadata after the wipe. This is on the highest-risk crypto surface (it feeds signing/key retrieval).

Fixes **TASK-212** (parent: PLAN-10, Security Hardening). Design signed off by @xarmian.

## Approach (funnel wipes through the service + serialize + epoch-guard + durable tombstone)

- **Canonical wipe** — restore and `LockScreen.performReset` both funnel through `clearAllWallets()`, which bumps an in-memory **reset epoch** (reverted if the primary removal fails), busts the memo synchronously, and in one serialized chain task sets a durable **tombstone** then removes the primary.
- **Write chain** — every `WALLET_KEY` mutation (writes AND the wipe's removeItem) is serialized on one promise chain; each chain task does **only** the primary AsyncStorage op, so a hung legacy secure-store op can never block the chain (legacy cleanup is best-effort, off-chain).
- **Epoch-guarded writes** — `storeWallet(wallet, readEpoch?)` skips the write if the epoch advanced since the read it derives from, applied to the read-repair writes **and every intentional read-modify-write mutation** (add/delete/setActive/label/metadata/ledger-association/convert/ledger-import). A guarded write also skips when the tombstone is set **and the primary is absent** (a genuine completed wipe) — closing the epoch-bump→removeItem gap. Creation writes (`createWallet`/`createWalletWithAccount`/`persistRestoredWallet`) always persist and clear the tombstone; a stuck tombstone beside a present primary self-heals.
- **Durable tombstone** (`voi_wallet_wiped`, general storage, survives restart) — `migrateLegacyValue` refuses to resurrect a wiped wallet from a surviving legacy secure-store copy; the strict boot probes gate their legacy fallback on it too. Migration also re-checks primary absence and **fails closed** on a corrupt legacy blob (never copies a raw, possibly secret-bearing payload into general storage).
- **Fail-closed reads** — `getCurrentWallet` re-checks the epoch before every post-await return, returning `null` if a wipe raced (never hands a stale pre-wipe wallet to signing).
- **Defense-in-depth** — `sanitizeWalletForPersistence` is now type-agnostic (scrubs `mnemonic` + `privateKey` on all account types), matching the read-path scrubber.

## Scope / risk
- Touches `src/services/wallet/index.ts` + `src/services/backup/restorers.ts` + tests. **No key/mnemonic reaches logs, general storage, or the memo**; secure-store key storage and Algorand/algosdk compatibility unchanged. **OTA-eligible** (JS-only).
- Two narrow residuals are tracked as follow-up **TASK-220** (for the TASK-53 repository layer): a tiny stale-read microtask gap during an active wipe (keys are wiped too → signing fails at key retrieval), and a creation/import-vs-reset cross-store race.

## Verification
- `npm run typecheck` + `npm run lint` clean; **full `npm test` 1158/1158** (18 in the wallet memo suite, incl. resurrection-race, intentional-mutation, type-agnostic-scrub, fail-closed-migration, durable-tombstone, stuck-tombstone-self-heal, and fail-closed-read regression tests).
- Reviewed to **Codex CLEAN** (11-round crypto review hunting key leakage + Algorand-compat) + an **independent adversarial `code-review-analyzer`** pass that found no defects beyond the two accepted residuals.
- On-device reset/restore/sign flows covered by the **batched pre-release** hardware verification, not per-PR.

https://claude.ai/code/session_017Q8pVj68gBrfxMrnsyQKpX