### PR TITLE
fix(wallet): harden account creation/import/restore against a concurrent full reset (TASK-220)

### DIFF
--- a/src/services/backup/__tests__/restorePinSetupPending.test.ts
+++ b/src/services/backup/__tests__/restorePinSetupPending.test.ts
@@ -20,6 +20,17 @@ jest.mock('@/services/secure/AccountSecureStorage', () => ({
     clearAll: jest.fn(async () => {
       order.push('clearAll');
     }),
+    // TASK-220: STANDARD restore now writes the key via the guarded atomic
+    // storeAccountForCreation (returns an ownership token); non-secret types
+    // still use storeAccount. The breadcrumb-ordering invariant (mark BEFORE any
+    // key-bearing write) is unchanged.
+    getResetGeneration: jest.fn(() => 0),
+    storeAccountForCreation: jest.fn(async () => {
+      order.push('storeAccount');
+      return 'token-1';
+    }),
+    commitPendingCreate: jest.fn(async () => {}),
+    deleteAccountIfAttemptMatches: jest.fn(async () => {}),
     storeAccount: jest.fn(async () => {
       order.push('storeAccount');
     }),

--- a/src/services/backup/restorers.ts
+++ b/src/services/backup/restorers.ts
@@ -19,6 +19,7 @@ import {
   RekeyedAccountMetadata,
   LedgerAccountMetadata,
   RemoteSignerAccountMetadata,
+  ResetRacedError,
   Wallet,
   withDefaultAuthLevel,
 } from '@/types/wallet';
@@ -168,6 +169,16 @@ export async function restoreAccounts(accounts: BackupAccountData[]): Promise<{
     return counts;
   }
 
+  // TASK-220: this runs AFTER performFullRestore's clearAllData() (restore's own
+  // reset). Capture the secure reset generation now so the whole restore —
+  // per-account secret writes AND the final wallet-metadata commit — is atomic
+  // against ANOTHER full reset racing the restore: on such a race every write
+  // aborts (ResetRacedError) and the STANDARD secrets already written are rolled
+  // back (ownership-checked), so the racing reset wins with no orphaned key or
+  // resurrected wallet (DR-2).
+  const creationGen = AccountSecureStorage.getResetGeneration();
+  const pendingCreates: { id: string; token: string }[] = [];
+
   try {
     const restoredAccounts: (
       | StandardAccountMetadata
@@ -215,14 +226,20 @@ export async function restoreAccounts(accounts: BackupAccountData[]): Promise<{
             hasBackup: backupAccount.hasBackup || true, // Restored = backed up
           };
 
-          // Store account securely (this encrypts the private key)
-          await AccountSecureStorage.storeAccount(
-            standardAccount,
-            algoAccount.sk
-          );
-
-          // Clear secret key from memory
-          algoAccount.sk.fill(0);
+          // Store account securely (this encrypts the private key). TASK-220:
+          // the guarded atomic write journals ownership + aborts if a reset
+          // raced; the token lets us roll back precisely this secret.
+          try {
+            const token = await AccountSecureStorage.storeAccountForCreation(
+              standardAccount,
+              algoAccount.sk,
+              creationGen
+            );
+            pendingCreates.push({ id: standardAccount.id, token });
+          } finally {
+            // Clear secret key from memory regardless of outcome.
+            algoAccount.sk.fill(0);
+          }
 
           restoredAccounts.push(standardAccount);
           counts.standard++;
@@ -382,11 +399,35 @@ export async function restoreAccounts(accounts: BackupAccountData[]): Promise<{
       // TASK-111: route through the sanitizing wrapper instead of a raw
       // storage.setItem so any per-account mnemonic is stripped before
       // persistence and legacy secure-store copies are cleared.
-      await MultiAccountWalletService.persistRestoredWallet(wallet);
+      // TASK-220: generation-guarded so a reset racing the restore aborts this
+      // commit (ResetRacedError) instead of resurrecting the wallet.
+      await MultiAccountWalletService.persistRestoredWallet(
+        wallet,
+        creationGen
+      );
+    }
+
+    // TASK-220: metadata committed — finalize each STANDARD secret (drop its
+    // journal entry) and clear the secure wipe tombstone (generation-conditional).
+    for (const p of pendingCreates) {
+      await AccountSecureStorage.commitPendingCreate(
+        p.id,
+        p.token,
+        creationGen
+      );
     }
 
     return counts;
   } catch (error) {
+    // TASK-220 DR-2: a reset raced the restore → roll back precisely the STANDARD
+    // secrets this attempt wrote (ownership-checked; a no-op for ones the reset
+    // already deleted), then surface the race so restore reports cleanly.
+    if (error instanceof ResetRacedError) {
+      for (const p of pendingCreates) {
+        await AccountSecureStorage.deleteAccountIfAttemptMatches(p.id, p.token);
+      }
+      throw error;
+    }
     throw new BackupError(
       `Failed to restore accounts: ${error instanceof Error ? error.message : 'Unknown error'}`,
       'RESTORE_FAILED'

--- a/src/services/backup/restorers.ts
+++ b/src/services/backup/restorers.ts
@@ -263,7 +263,10 @@ export async function restoreAccounts(accounts: BackupAccountData[]): Promise<{
             notes: backupAccount.notes,
           };
 
-          await AccountSecureStorage.storeAccount(watchAccount);
+          await AccountSecureStorage.storeAccountMetadataForCreation(
+            watchAccount,
+            creationGen
+          );
           restoredAccounts.push(watchAccount);
           counts.watch++;
           counts.total++;
@@ -289,7 +292,10 @@ export async function restoreAccounts(accounts: BackupAccountData[]): Promise<{
             rekeyedFrom: backupAccount.rekeyedFrom,
           };
 
-          await AccountSecureStorage.storeAccount(rekeyedAccount);
+          await AccountSecureStorage.storeAccountMetadataForCreation(
+            rekeyedAccount,
+            creationGen
+          );
           restoredAccounts.push(rekeyedAccount);
           counts.rekeyed++;
           counts.total++;
@@ -316,7 +322,10 @@ export async function restoreAccounts(accounts: BackupAccountData[]): Promise<{
             deviceName: backupAccount.deviceName,
           };
 
-          await AccountSecureStorage.storeAccount(ledgerAccount);
+          await AccountSecureStorage.storeAccountMetadataForCreation(
+            ledgerAccount,
+            creationGen
+          );
           restoredAccounts.push(ledgerAccount);
           counts.ledger++;
           counts.total++;
@@ -360,7 +369,10 @@ export async function restoreAccounts(accounts: BackupAccountData[]): Promise<{
             authLevel: withDefaultAuthLevel(backupAccount.authLevel),
           };
 
-          await AccountSecureStorage.storeAccount(remoteSignerAccount);
+          await AccountSecureStorage.storeAccountMetadataForCreation(
+            remoteSignerAccount,
+            creationGen
+          );
           restoredAccounts.push(remoteSignerAccount);
           counts.remoteSigner++;
           counts.total++;
@@ -408,13 +420,9 @@ export async function restoreAccounts(accounts: BackupAccountData[]): Promise<{
     }
 
     // TASK-220: metadata committed — finalize each STANDARD secret (drop its
-    // journal entry) and clear the secure wipe tombstone (generation-conditional).
+    // pending-creation journal entry). The secure wipe tombstone stays sticky.
     for (const p of pendingCreates) {
-      await AccountSecureStorage.commitPendingCreate(
-        p.id,
-        p.token,
-        creationGen
-      );
+      await AccountSecureStorage.commitPendingCreate(p.id, p.token);
     }
 
     return counts;

--- a/src/services/secure/AccountSecureStorage.ts
+++ b/src/services/secure/AccountSecureStorage.ts
@@ -32,6 +32,8 @@ import {
   AccountRetrievalError,
   AccountNotFoundError,
   AuthenticationRequiredError,
+  ResetRacedError,
+  DuplicatePendingCreateError,
 } from '../../types/wallet';
 import {
   KeyEnvelopeV2,
@@ -199,6 +201,46 @@ export class AccountSecureStorage {
   private static readonly DEVICE_ID_KEY = 'voi_device_installation_id';
   private static readonly PIN_TIMEOUT_KEY = 'voi_pin_timeout_setting';
   private static readonly PIN_THROTTLE_KEY = 'voi_pin_throttle';
+
+  // ───────────────────────────────────────────────────────────────────────────
+  // TASK-220: cross-store (secret ↔ wallet-metadata) reset hardening. READ THE
+  // DECISION RECORD (DOC-221) BEFORE CHANGING. Mirrors the wallet-metadata
+  // store's TASK-212 mechanism on the secure-key side, which had NO durable
+  // guard of its own (only the in-memory keyMutationChain mutex).
+  //
+  //   - secureResetGeneration: in-memory monotonic counter bumped SYNCHRONOUSLY
+  //     at clearAll() entry (before the mutex), so it is synchronous with the
+  //     reset REQUEST. A creation captures it before its secret write; the write
+  //     (storeAccountForCreation) and the later wallet-metadata write are both
+  //     skipped/aborted if it advanced — the discriminator that fires in the
+  //     clearAll()→clearAllWallets() window (the wallet epoch bumps only in
+  //     clearAllWallets, too late for the secure side).
+  //   - SECURE_WIPE_TOMBSTONE_KEY: durable "secrets were intentionally wiped"
+  //     marker. Set by clearAll before its destructive removals; makes
+  //     migrateLegacyAccountDataLocked REFUSE to resurrect a wiped secret from a
+  //     surviving legacy blob (incl. across a restart, when the in-memory
+  //     generation is gone). Cleared ONLY by commitPendingCreate AFTER a
+  //     successful wallet-metadata commit — NEVER on a bare secret write (that
+  //     would reopen a crash-resurrection window).
+  //   - PENDING_CREATES_KEY: durable intent journal { [accountId]: token }
+  //     written BEFORE the secret so an in-flight/crashed creation's secret is
+  //     enumerable even before it reaches any index (the account list is written
+  //     AFTER the secret). Drained by clearAll (a reset deletes journaled
+  //     in-flight secrets too) and consulted by boot reconcile (TASK-222). The
+  //     token records per-attempt OWNERSHIP so a raced attempt's rollback only
+  //     deletes the secret IT wrote, never a later same-id attempt's.
+  //
+  // Concurrency: storeAccountForCreation / commitPendingCreate /
+  // deleteAccountIfAttemptMatches acquire the key-mutation mutex around the
+  // whole compose (journal + secret/tombstone); clearAll already holds it. The
+  // journal/tombstone helpers below are PLAIN AsyncStorage ops (no mutex) so
+  // they compose safely inside either — never call a mutex-acquiring method from
+  // inside clearAll (non-reentrant chain → deadlock).
+  // ───────────────────────────────────────────────────────────────────────────
+  private static readonly SECURE_WIPE_TOMBSTONE_KEY = 'voi_secure_wiped';
+  private static readonly PENDING_CREATES_KEY = 'voi_pending_account_creates';
+  private static secureResetGeneration = 0;
+  private static pendingCreateTokenCounter = 0;
 
   // In-memory promise-chain mutex serializing the throttle read-modify-write so
   // concurrent verifyPin calls (e.g. batch signing) can never lose an
@@ -975,6 +1017,19 @@ export class AccountSecureStorage {
     accountId: string
   ): Promise<PersistedAccountMetadata | null> {
     try {
+      // TASK-220: refuse to resurrect a secret from a surviving legacy blob while
+      // the durable wipe tombstone is set. A full reset deletes account secrets
+      // then leaves this marker; without the bail, the next readMetadata/
+      // getPrivateKey miss would re-migrate a legacy `voi_account_<id>` copy and
+      // undo the wipe (incl. across a restart, when secureResetGeneration is 0
+      // again). Cleared by the first committed creation/restore. Migration only
+      // fires when the PRIMARY secret is absent, so this never blocks a freshly
+      // written real secret.
+      const wiped = await storage.getItem(this.SECURE_WIPE_TOMBSTONE_KEY);
+      if (wiped != null) {
+        return null;
+      }
+
       const legacyKey = `${this.LEGACY_STORAGE_KEY_PREFIX}${accountId}`;
       const legacyData = await secureStorage.getItem(legacyKey);
       if (!legacyData) {
@@ -1023,61 +1078,200 @@ export class AccountSecureStorage {
     // secret payload AND the account-list mutation — so a store can never
     // interleave with a setupPin/changePin rewrap enumeration+commit. See the
     // keyMutationChain comment above.
+    return this.runKeyMutationExclusive(() =>
+      this.storeAccountLocked(account, privateKey)
+    );
+  }
+
+  // ───────────────────────────────────────────────────────────────────────────
+  // TASK-220 cross-store creation protocol. READ DOC-221 BEFORE CHANGING.
+  // ───────────────────────────────────────────────────────────────────────────
+
+  /** Current in-memory secure reset generation (bumped by clearAll). A creation
+   *  captures this before its secret write and guards both stores on it. */
+  static getResetGeneration(): number {
+    return this.secureResetGeneration;
+  }
+
+  /** Mint a per-attempt ownership token. In-memory monotonic counter — ownership
+   *  only needs to be unique among LIVE attempts in one process; a crashed
+   *  attempt's journal entry is reconciled by id at boot (TASK-222). */
+  private static nextPendingCreateToken(): string {
+    this.pendingCreateTokenCounter += 1;
+    return `t${this.pendingCreateTokenCounter}`;
+  }
+
+  /** Read the durable pending-creation journal. PLAIN storage op (no mutex) —
+   *  callers hold the key-mutation mutex around any read-modify-write. */
+  private static async readPendingCreateJournal(): Promise<
+    Record<string, string>
+  > {
+    const raw = await storage.getItem(this.PENDING_CREATES_KEY);
+    if (!raw) return {};
+    try {
+      const parsed = JSON.parse(raw) as unknown;
+      return parsed && typeof parsed === 'object'
+        ? (parsed as Record<string, string>)
+        : {};
+    } catch {
+      return {};
+    }
+  }
+
+  /** Write (or clear) the durable pending-creation journal. PLAIN storage op. */
+  private static async writePendingCreateJournal(
+    journal: Record<string, string>
+  ): Promise<void> {
+    if (Object.keys(journal).length === 0) {
+      await storage.removeItem(this.PENDING_CREATES_KEY);
+      return;
+    }
+    await storage.setItem(this.PENDING_CREATES_KEY, JSON.stringify(journal));
+  }
+
+  /**
+   * Atomic guarded secret write for a NEW STANDARD account (TASK-220). In ONE
+   * key-mutation-mutex task: (1) abort if a reset advanced the generation since
+   * the creation began (reset wins); (2) reject a duplicate pending id (another
+   * attempt owns it — prevents an earlier attempt's rollback deleting a later
+   * attempt's secret); (3) record the ownership token in the durable journal
+   * BEFORE writing the secret; (4) write the secret + secure metadata. Because
+   * the generation check and the secret write share one mutex task, no clearAll
+   * can interleave between them — either this sees the reset (writes nothing) or
+   * clearAll sees the journal entry and deletes the secret.
+   *
+   * Returns the ownership token to pass to commitPendingCreate (on success) or
+   * deleteAccountIfAttemptMatches (on rollback). Throws ResetRacedError or
+   * DuplicatePendingCreateError WITHOUT persisting anything.
+   */
+  static async storeAccountForCreation(
+    account: AccountMetadata,
+    privateKey: Uint8Array,
+    creationGen: number
+  ): Promise<string> {
     return this.runKeyMutationExclusive(async () => {
-      try {
-        const hasPin = await this.hasPin();
-        const lastAccessed = new Date().toISOString();
+      if (this.secureResetGeneration !== creationGen) {
+        throw new ResetRacedError();
+      }
+      const journal = await this.readPendingCreateJournal();
+      if (journal[account.id] !== undefined) {
+        throw new DuplicatePendingCreateError();
+      }
+      const token = this.nextPendingCreateToken();
+      journal[account.id] = token;
+      await this.writePendingCreateJournal(journal);
+      await this.storeAccountLocked(account, privateKey);
+      return token;
+    });
+  }
 
-        const metadata: PersistedAccountMetadata = {
-          accountId: account.id,
-          address: account.address,
-          type: account.type,
-          publicData: {
-            publicKey: account.publicKey,
-            label: account.label || '',
-            color: account.color || '#000000',
-            createdAt: account.createdAt,
-            importedAt: account.importedAt,
-            avatarUrl: account.avatarUrl,
-            avatarUpdatedAt: account.avatarUpdatedAt,
-          },
-          authMethod: hasPin ? 'pin' : 'biometric',
-          lastAccessed,
-        };
-
-        // Encrypt and store private key for Standard accounts.
-        //
-        // ALWAYS write the legacy device-key (Format A) envelope — NEVER v2 here
-        // (Codex P1-2). A device-key blob is PIN-independent and can be read back
-        // regardless of the PIN/vault state, so a newly-stored account can never
-        // be stranded under an obsolete/mismatched vault secret (the entire
-        // "wrapped under a secret the credential can't reproduce" class). New
-        // accounts are upgraded to the user-secret v2 envelope by setupPin /
-        // changePin (which enumerate + re-wrap them) or by the PR5 migration
-        // engine. The global key-mutation mutex (held here) still serializes this
-        // write against any concurrent rewrap, so a store during a changePin is
-        // ordered either fully before the enumeration (→ re-wrapped) or fully
-        // after the commit (→ stays device-readable, upgraded on the next
-        // enumerate). Either way the key is readable — never lost (P1-B).
-        if (account.type === AccountType.STANDARD && privateKey) {
-          const encryptedPrivateKey = await this.encryptPrivateKey(privateKey);
-          await this.saveSecret(account.id, {
-            accountId: account.id,
-            encryptedPrivateKey,
-            authMethod: metadata.authMethod,
-          });
-        } else {
-          await this.saveSecret(account.id, null);
-        }
-
-        // Store metadata for quick access
-        await this.storeAccountMetadata(metadata);
-      } catch (error) {
-        throw new AccountStorageError(
-          `Failed to store account: ${error instanceof Error ? error.message : 'Unknown error'}`
-        );
+  /**
+   * Commit a pending creation AFTER its wallet-metadata write succeeded: drop the
+   * journal entry (iff still ours) and clear the secure wipe tombstone — but ONLY
+   * if the generation is still the one this creation captured, so a LATER reset's
+   * tombstone is never clobbered (Codex R2).
+   */
+  static async commitPendingCreate(
+    accountId: string,
+    token: string,
+    creationGen: number
+  ): Promise<void> {
+    return this.runKeyMutationExclusive(async () => {
+      const journal = await this.readPendingCreateJournal();
+      if (journal[accountId] === token) {
+        delete journal[accountId];
+        await this.writePendingCreateJournal(journal);
+      }
+      // Generation-conditional: only the creation that is still "current" (no
+      // reset since it began) may declare the wiped state over. A creation that
+      // was raced never reaches here (its metadata write throws ResetRacedError).
+      if (this.secureResetGeneration === creationGen) {
+        await storage.removeItem(this.SECURE_WIPE_TOMBSTONE_KEY);
       }
     });
+  }
+
+  /**
+   * Ownership-safe rollback of a raced creation's secret (TASK-220 / DR-2): delete
+   * the secret + metadata ONLY if the journal still records THIS attempt's token
+   * for the id. A no-op if a reset already drained the journal (secret already
+   * gone) or a later attempt now owns the id — so an earlier raced attempt can
+   * never delete a legitimately-recreated same-id account.
+   */
+  static async deleteAccountIfAttemptMatches(
+    accountId: string,
+    token: string
+  ): Promise<void> {
+    return this.runKeyMutationExclusive(async () => {
+      const journal = await this.readPendingCreateJournal();
+      if (journal[accountId] !== token) {
+        return;
+      }
+      await this.deleteAccountLocked(accountId);
+      delete journal[accountId];
+      await this.writePendingCreateJournal(journal);
+    });
+  }
+
+  /** The body of storeAccount, assuming the key-mutation mutex is HELD. Shared by
+   *  storeAccount (public wrapper) and storeAccountForCreation. */
+  private static async storeAccountLocked(
+    account: AccountMetadata,
+    privateKey?: Uint8Array
+  ): Promise<void> {
+    try {
+      const hasPin = await this.hasPin();
+      const lastAccessed = new Date().toISOString();
+
+      const metadata: PersistedAccountMetadata = {
+        accountId: account.id,
+        address: account.address,
+        type: account.type,
+        publicData: {
+          publicKey: account.publicKey,
+          label: account.label || '',
+          color: account.color || '#000000',
+          createdAt: account.createdAt,
+          importedAt: account.importedAt,
+          avatarUrl: account.avatarUrl,
+          avatarUpdatedAt: account.avatarUpdatedAt,
+        },
+        authMethod: hasPin ? 'pin' : 'biometric',
+        lastAccessed,
+      };
+
+      // Encrypt and store private key for Standard accounts.
+      //
+      // ALWAYS write the legacy device-key (Format A) envelope — NEVER v2 here
+      // (Codex P1-2). A device-key blob is PIN-independent and can be read back
+      // regardless of the PIN/vault state, so a newly-stored account can never
+      // be stranded under an obsolete/mismatched vault secret (the entire
+      // "wrapped under a secret the credential can't reproduce" class). New
+      // accounts are upgraded to the user-secret v2 envelope by setupPin /
+      // changePin (which enumerate + re-wrap them) or by the PR5 migration
+      // engine. The global key-mutation mutex (held here) still serializes this
+      // write against any concurrent rewrap, so a store during a changePin is
+      // ordered either fully before the enumeration (→ re-wrapped) or fully
+      // after the commit (→ stays device-readable, upgraded on the next
+      // enumerate). Either way the key is readable — never lost (P1-B).
+      if (account.type === AccountType.STANDARD && privateKey) {
+        const encryptedPrivateKey = await this.encryptPrivateKey(privateKey);
+        await this.saveSecret(account.id, {
+          accountId: account.id,
+          encryptedPrivateKey,
+          authMethod: metadata.authMethod,
+        });
+      } else {
+        await this.saveSecret(account.id, null);
+      }
+
+      // Store metadata for quick access
+      await this.storeAccountMetadata(metadata);
+    } catch (error) {
+      throw new AccountStorageError(
+        `Failed to store account: ${error instanceof Error ? error.message : 'Unknown error'}`
+      );
+    }
   }
 
   static async retrieveAccount(accountId: string): Promise<AccountMetadata> {
@@ -3228,18 +3422,41 @@ export class AccountSecureStorage {
   }
 
   static async clearAll(): Promise<void> {
+    // TASK-220: bump the secure reset generation SYNCHRONOUSLY here, BEFORE
+    // acquiring the mutex, so it is synchronous with the reset REQUEST (a
+    // concurrent creation that has already captured the old generation is then
+    // reliably aborted, even if the mutex is momentarily busy). Mirrors
+    // clearAllWallets bumping walletResetEpoch at its entry (TASK-212).
+    this.secureResetGeneration += 1;
     // Full wipe deletes account key material → hold the GLOBAL key-mutation
     // mutex across the whole thing (P1-1a) so it can't interleave with a rewrap
     // or a store. Uses deleteAccountLocked (already inside the mutex — never
     // re-acquire, which would deadlock the promise-chain lock).
     return this.runKeyMutationExclusive(async () => {
       try {
-        const accountIds = await this.getAllAccountIds();
+        // TASK-220: set the durable wipe tombstone FIRST, before any destructive
+        // removal — if the app dies mid-wipe we are left tombstone-set (legacy
+        // resurrection blocked) rather than secrets-gone-without-a-marker. A
+        // committed creation/restore clears it later.
+        await storage.setItem(this.SECURE_WIPE_TOMBSTONE_KEY, '1');
 
-        // Delete all accounts
-        for (const accountId of accountIds) {
+        // TASK-220: drain the pending-creation journal — an in-flight creation
+        // may have written a secret that is not yet in the account list (the
+        // list is written AFTER the secret), so deleting only listed ids would
+        // leave that secret orphaned. Union the journaled ids with the account
+        // list and delete every one, then clear the journal.
+        const journal = await this.readPendingCreateJournal();
+        const listedIds = await this.getAllAccountIds();
+        const idsToDelete = new Set<string>([
+          ...listedIds,
+          ...Object.keys(journal),
+        ]);
+
+        // Delete all accounts (listed + in-flight-journaled)
+        for (const accountId of idsToDelete) {
           await this.deleteAccountLocked(accountId);
         }
+        await this.writePendingCreateJournal({});
 
         // Clear PIN and settings from general storage
         // NOTE: DEVICE_ID_KEY is intentionally NOT cleared - it's used for key derivation

--- a/src/services/secure/AccountSecureStorage.ts
+++ b/src/services/secure/AccountSecureStorage.ts
@@ -1601,15 +1601,22 @@ export class AccountSecureStorage {
           throw new VaultLockedError();
         }
 
-        // Cache the key for subsequent calls (60-second TTL). TASK-220: skip if a
-        // full reset advanced the generation since this read began — do not
-        // repopulate a cache the reset just zeroed with a just-wiped secret.
-        if (this.secureResetGeneration === readGen) {
-          this.privateKeyCache.set(cacheKey, {
-            key: new Uint8Array(privateKey), // Store a copy
-            timestamp: Date.now(),
-          });
+        // TASK-220: a full reset (clearAll) during any await of this read wiped the
+        // persisted secret this key derives from and zeroed the in-memory cache.
+        // Abort (zero + throw) — mirroring the vault-lock abort above — so an
+        // in-flight pre-reset signing read never RETURNS or re-caches a key a
+        // "delete everything" just removed. In normal operation the generation
+        // never advances mid-read, so signing is unaffected.
+        if (this.secureResetGeneration !== readGen) {
+          privateKey.fill(0);
+          throw new ResetRacedError();
         }
+
+        // Cache the key for subsequent calls (60-second TTL).
+        this.privateKeyCache.set(cacheKey, {
+          key: new Uint8Array(privateKey), // Store a copy
+          timestamp: Date.now(),
+        });
 
         // LAZY MIGRATION TRIGGER (DOC-137 §4.5.1, PR5): a legacy-tier (Format
         // A/C) decrypt just succeeded and a verified secret is available (an
@@ -1649,7 +1656,10 @@ export class AccountSecureStorage {
           error instanceof AccountRetrievalError ||
           // Vault locked mid-derivation (Codex P1-D): surface as-is so the caller
           // re-auths rather than treating it as a generic retrieval failure.
-          error instanceof VaultLockedError
+          error instanceof VaultLockedError ||
+          // TASK-220: reset raced this read — surface as-is so signing aborts
+          // cleanly rather than reporting a generic retrieval failure.
+          error instanceof ResetRacedError
         ) {
           throw error;
         }

--- a/src/services/secure/AccountSecureStorage.ts
+++ b/src/services/secure/AccountSecureStorage.ts
@@ -219,9 +219,10 @@ export class AccountSecureStorage {
   //     marker. Set by clearAll before its destructive removals; makes
   //     migrateLegacyAccountDataLocked REFUSE to resurrect a wiped secret from a
   //     surviving legacy blob (incl. across a restart, when the in-memory
-  //     generation is gone). Cleared ONLY by commitPendingCreate AFTER a
-  //     successful wallet-metadata commit — NEVER on a bare secret write (that
-  //     would reopen a crash-resurrection window).
+  //     generation is gone). STICKY: once set by a reset it is never cleared, so
+  //     a surviving legacy blob for ANY old id can never be resurrected. A new
+  //     account writes its primary secret directly (never migrates), so a
+  //     permanent tombstone blocks nothing legitimate.
   //   - PENDING_CREATES_KEY: durable intent journal { [accountId]: token }
   //     written BEFORE the secret so an in-flight/crashed creation's secret is
   //     enumerable even before it reaches any index (the account list is written
@@ -1166,27 +1167,51 @@ export class AccountSecureStorage {
   }
 
   /**
+   * Generation-guarded write for a NON-SECRET account record (watch / rekeyed /
+   * ledger / remote-signer) created during restore (TASK-220, Codex diff-review
+   * P2). No secret exists to orphan or journal, but the write must still ABORT
+   * (ResetRacedError) if a reset raced the restore so it does not leave a secure
+   * account-metadata/list record behind after the wipe. The generation check and
+   * the write share one mutex task, so no clearAll can interleave.
+   */
+  static async storeAccountMetadataForCreation(
+    account: AccountMetadata,
+    creationGen: number
+  ): Promise<void> {
+    return this.runKeyMutationExclusive(async () => {
+      if (this.secureResetGeneration !== creationGen) {
+        throw new ResetRacedError();
+      }
+      await this.storeAccountLocked(account);
+    });
+  }
+
+  /**
    * Commit a pending creation AFTER its wallet-metadata write succeeded: drop the
-   * journal entry (iff still ours) and clear the secure wipe tombstone — but ONLY
-   * if the generation is still the one this creation captured, so a LATER reset's
-   * tombstone is never clobbered (Codex R2).
+   * journal entry (iff still ours).
+   *
+   * The secure wipe tombstone is intentionally NOT cleared here — it is STICKY
+   * after an explicit reset (Codex diff-review P1). Clearing it on a new creation
+   * would re-enable migrateLegacyAccountDataLocked and let a SURVIVING legacy
+   * `voi_account_<otherId>` blob — one whose best-effort legacy delete failed at
+   * wipe time, for a DIFFERENT old id — resurrect its secret. Unlike the single
+   * wallet-metadata blob (whose tombstone TASK-212 clears on the one primary
+   * write), the secure store holds many per-account secrets, so one new account's
+   * write proves nothing about other ids. A freshly created/restored account
+   * writes its PRIMARY secret directly and never needs migration, so a permanent
+   * tombstone blocks nothing legitimate; nothing writes legacy-format secrets
+   * anymore (they are read-only for one-time migration). Net: once a device has
+   * been wiped, pre-wipe secrets can never be resurrected.
    */
   static async commitPendingCreate(
     accountId: string,
-    token: string,
-    creationGen: number
+    token: string
   ): Promise<void> {
     return this.runKeyMutationExclusive(async () => {
       const journal = await this.readPendingCreateJournal();
       if (journal[accountId] === token) {
         delete journal[accountId];
         await this.writePendingCreateJournal(journal);
-      }
-      // Generation-conditional: only the creation that is still "current" (no
-      // reset since it began) may declare the wiped state over. A creation that
-      // was raced never reaches here (its metadata write throws ResetRacedError).
-      if (this.secureResetGeneration === creationGen) {
-        await storage.removeItem(this.SECURE_WIPE_TOMBSTONE_KEY);
       }
     });
   }

--- a/src/services/secure/AccountSecureStorage.ts
+++ b/src/services/secure/AccountSecureStorage.ts
@@ -1023,9 +1023,10 @@ export class AccountSecureStorage {
       // then leaves this marker; without the bail, the next readMetadata/
       // getPrivateKey miss would re-migrate a legacy `voi_account_<id>` copy and
       // undo the wipe (incl. across a restart, when secureResetGeneration is 0
-      // again). Cleared by the first committed creation/restore. Migration only
-      // fires when the PRIMARY secret is absent, so this never blocks a freshly
-      // written real secret.
+      // again). The marker is STICKY — never cleared in production (see
+      // commitPendingCreate) — so a surviving legacy blob for ANY old id stays
+      // dead after a wipe. Migration only fires when the PRIMARY secret is absent,
+      // so this never blocks a freshly written real secret.
       const wiped = await storage.getItem(this.SECURE_WIPE_TOMBSTONE_KEY);
       if (wiped != null) {
         return null;

--- a/src/services/secure/AccountSecureStorage.ts
+++ b/src/services/secure/AccountSecureStorage.ts
@@ -1370,6 +1370,12 @@ export class AccountSecureStorage {
     pin?: string
   ): Promise<Uint8Array> {
     const cacheKey = `${accountId}-${pin || 'biometric'}`;
+    // TASK-220: the reset generation at read start. A full reset (clearAll) bumps
+    // it synchronously and zeroes the in-memory key cache; if it advances while
+    // this read is in flight, we must NOT repopulate the cache with a key derived
+    // from a now-wiped secret (that would revive a key a "delete everything" just
+    // removed, for up to the 60 s TTL).
+    const readGen = this.secureResetGeneration;
 
     // Periodically clean up expired entries
     if (Math.random() < 0.1) {
@@ -1595,11 +1601,15 @@ export class AccountSecureStorage {
           throw new VaultLockedError();
         }
 
-        // Cache the key for subsequent calls (60-second TTL)
-        this.privateKeyCache.set(cacheKey, {
-          key: new Uint8Array(privateKey), // Store a copy
-          timestamp: Date.now(),
-        });
+        // Cache the key for subsequent calls (60-second TTL). TASK-220: skip if a
+        // full reset advanced the generation since this read began — do not
+        // repopulate a cache the reset just zeroed with a just-wiped secret.
+        if (this.secureResetGeneration === readGen) {
+          this.privateKeyCache.set(cacheKey, {
+            key: new Uint8Array(privateKey), // Store a copy
+            timestamp: Date.now(),
+          });
+        }
 
         // LAZY MIGRATION TRIGGER (DOC-137 §4.5.1, PR5): a legacy-tier (Format
         // A/C) decrypt just succeeded and a verified secret is available (an
@@ -3453,6 +3463,11 @@ export class AccountSecureStorage {
     // reliably aborted, even if the mutex is momentarily busy). Mirrors
     // clearAllWallets bumping walletResetEpoch at its entry (TASK-212).
     this.secureResetGeneration += 1;
+    // TASK-220: zero the in-memory private-key cache NOW (synchronously) so a full
+    // wipe can't leave a decrypted key readable from cache after the persisted
+    // secret is gone. Paired with the generation guard on the cache write in
+    // getPrivateKey, an in-flight pre-reset read can't repopulate it either.
+    this.clearPrivateKeyCache();
     // Full wipe deletes account key material → hold the GLOBAL key-mutation
     // mutex across the whole thing (P1-1a) so it can't interleave with a rewrap
     // or a store. Uses deleteAccountLocked (already inside the mutex — never

--- a/src/services/secure/__tests__/crossStoreResetHardening.test.ts
+++ b/src/services/secure/__tests__/crossStoreResetHardening.test.ts
@@ -187,6 +187,13 @@ describe('TASK-220 reset drains the journal (reset wins)', () => {
     expect(hasSecret('inflight')).toBe(false);
     expect(Object.keys(journal())).toHaveLength(0);
   });
+
+  it('clearAll zeroes the in-memory private-key cache (Codex diff-review P1)', async () => {
+    const spy = jest.spyOn(AccountSecureStorage, 'clearPrivateKeyCache');
+    await AccountSecureStorage.clearAll();
+    expect(spy).toHaveBeenCalledTimes(1);
+    spy.mockRestore();
+  });
 });
 
 describe('TASK-220 ownership-safe rollback', () => {

--- a/src/services/secure/__tests__/crossStoreResetHardening.test.ts
+++ b/src/services/secure/__tests__/crossStoreResetHardening.test.ts
@@ -1,0 +1,294 @@
+// TASK-220 — cross-store (secret ↔ wallet-metadata) reset hardening. These prove
+// the secure-store half of the "no orphaned key / no phantom account / no
+// resurrection after a delete-everything" invariant (see DOC-221):
+//
+//   * storeAccountForCreation writes the secret AND records an ownership token in
+//     the durable pending-creation journal;
+//   * a full reset racing an in-flight creation ABORTS it (ResetRacedError) and
+//     the reset drains the journal + deletes the just-written secret (reset wins);
+//   * a duplicate pending id is rejected so an earlier raced attempt can never
+//     delete a later same-id attempt's secret;
+//   * ownership-checked rollback deletes ONLY the attempt's own secret;
+//   * the durable wipe tombstone is NOT cleared on a bare secret write, is cleared
+//     generation-conditionally at commit, and blocks legacy-blob resurrection.
+//
+// SECURITY NOTE: key material is throwaway random bytes; nothing real is used or
+// logged. secureStorage / AsyncStorage are in-memory Map sinks.
+
+const mockSecure = new Map<string, string>();
+const mockKv = new Map<string, string>();
+
+jest.mock('@/platform', () => {
+  const nodeCrypto = require('crypto');
+  return {
+    crypto: {
+      getRandomBytes: async (n: number): Promise<Uint8Array> =>
+        Uint8Array.from(nodeCrypto.randomBytes(n)),
+      sha256: async (input: string): Promise<string> =>
+        nodeCrypto.createHash('sha256').update(input).digest('hex'),
+      randomUUID: () => nodeCrypto.randomUUID(),
+    },
+    secureStorage: {
+      getItem: jest.fn(async (k: string) =>
+        mockSecure.has(k) ? mockSecure.get(k)! : null
+      ),
+      setItem: jest.fn(async (k: string, v: string) => {
+        mockSecure.set(k, v);
+      }),
+      deleteItem: jest.fn(async (k: string) => {
+        mockSecure.delete(k);
+      }),
+      getItemWithAuth: jest.fn(async (k: string) =>
+        mockSecure.has(k) ? mockSecure.get(k)! : null
+      ),
+      setItemWithAuth: jest.fn(async (k: string, v: string) => {
+        mockSecure.set(k, v);
+      }),
+    },
+    storage: {
+      getItem: jest.fn(async (k: string) =>
+        mockKv.has(k) ? mockKv.get(k)! : null
+      ),
+      setItem: jest.fn(async (k: string, v: string) => {
+        mockKv.set(k, v);
+      }),
+      removeItem: jest.fn(async (k: string) => {
+        mockKv.delete(k);
+      }),
+      multiRemove: jest.fn(async (keys: string[]) => {
+        keys.forEach((k) => mockKv.delete(k));
+      }),
+    },
+    biometrics: {
+      isAvailable: async () => false,
+      isEnrolled: async () => false,
+    },
+    deviceId: { getDeviceId: async () => 'task220-test-device' },
+  };
+});
+
+import { AccountSecureStorage } from '../AccountSecureStorage';
+import {
+  AccountType,
+  ResetRacedError,
+  DuplicatePendingCreateError,
+  StandardAccountMetadata,
+} from '@/types/wallet';
+
+const SECRET_PREFIX = 'voi_account_secret_';
+const JOURNAL_KEY = 'voi_pending_account_creates';
+const TOMBSTONE_KEY = 'voi_secure_wiped';
+const LEGACY_PREFIX = 'voi_account_';
+const METADATA_PREFIX = 'voi_account_metadata_';
+
+const nodeCrypto = require('crypto');
+
+function standardAccount(id: string): StandardAccountMetadata {
+  return {
+    id,
+    address: `ADDR_${id}`,
+    publicKey: 'aa'.repeat(32),
+    type: AccountType.STANDARD,
+    label: id,
+    color: '#123456',
+    isHidden: false,
+    createdAt: '2026-01-01T00:00:00.000Z',
+    mnemonic: '',
+    hasBackup: true,
+  } as StandardAccountMetadata;
+}
+
+function freshSk(): Uint8Array {
+  return Uint8Array.from(nodeCrypto.randomBytes(64));
+}
+
+const hasSecret = (id: string) => mockSecure.has(`${SECRET_PREFIX}${id}`);
+const journal = (): Record<string, string> => {
+  const raw = mockKv.get(JOURNAL_KEY);
+  return raw ? (JSON.parse(raw) as Record<string, string>) : {};
+};
+const tombstoneSet = () => mockKv.get(TOMBSTONE_KEY) != null;
+
+beforeEach(() => {
+  mockSecure.clear();
+  mockKv.clear();
+  jest.clearAllMocks();
+});
+
+describe('TASK-220 storeAccountForCreation — atomic guarded write', () => {
+  it('writes the secret and journals the ownership token', async () => {
+    const acct = standardAccount('a1');
+    const gen = AccountSecureStorage.getResetGeneration();
+    const token = await AccountSecureStorage.storeAccountForCreation(
+      acct,
+      freshSk(),
+      gen
+    );
+    expect(hasSecret('a1')).toBe(true);
+    expect(journal()['a1']).toBe(token);
+  });
+
+  it('ABORTS (ResetRacedError) and writes NOTHING when a reset advanced the generation', async () => {
+    const acct = standardAccount('a2');
+    const staleGen = AccountSecureStorage.getResetGeneration();
+    // A full reset bumps the secure generation (synchronously, at clearAll entry).
+    await AccountSecureStorage.clearAll();
+    await expect(
+      AccountSecureStorage.storeAccountForCreation(acct, freshSk(), staleGen)
+    ).rejects.toBeInstanceOf(ResetRacedError);
+    expect(hasSecret('a2')).toBe(false);
+    expect(journal()['a2']).toBeUndefined();
+  });
+
+  it('rejects a DUPLICATE pending id (ownership collision) without touching the first attempt', async () => {
+    const gen = AccountSecureStorage.getResetGeneration();
+    const first = await AccountSecureStorage.storeAccountForCreation(
+      standardAccount('dup'),
+      freshSk(),
+      gen
+    );
+    await expect(
+      AccountSecureStorage.storeAccountForCreation(
+        standardAccount('dup'),
+        freshSk(),
+        gen
+      )
+    ).rejects.toBeInstanceOf(DuplicatePendingCreateError);
+    // First attempt's ownership is intact.
+    expect(journal()['dup']).toBe(first);
+    expect(hasSecret('dup')).toBe(true);
+  });
+
+  it('post-reset new wallet STILL persists (P2a not regressed): a creation whose generation matches succeeds even with the tombstone set', async () => {
+    await AccountSecureStorage.clearAll(); // tombstone set, generation bumped
+    const gen = AccountSecureStorage.getResetGeneration();
+    const token = await AccountSecureStorage.storeAccountForCreation(
+      standardAccount('post'),
+      freshSk(),
+      gen
+    );
+    expect(hasSecret('post')).toBe(true);
+    expect(journal()['post']).toBe(token);
+  });
+});
+
+describe('TASK-220 reset drains the journal (reset wins)', () => {
+  it('clearAll deletes an in-flight creation secret and clears the journal', async () => {
+    const gen = AccountSecureStorage.getResetGeneration();
+    await AccountSecureStorage.storeAccountForCreation(
+      standardAccount('inflight'),
+      freshSk(),
+      gen
+    );
+    expect(hasSecret('inflight')).toBe(true);
+
+    await AccountSecureStorage.clearAll();
+
+    expect(hasSecret('inflight')).toBe(false);
+    expect(Object.keys(journal())).toHaveLength(0);
+  });
+});
+
+describe('TASK-220 ownership-safe rollback', () => {
+  it('deleteAccountIfAttemptMatches is a NO-OP for a non-matching token', async () => {
+    const gen = AccountSecureStorage.getResetGeneration();
+    await AccountSecureStorage.storeAccountForCreation(
+      standardAccount('own'),
+      freshSk(),
+      gen
+    );
+    await AccountSecureStorage.deleteAccountIfAttemptMatches('own', 'not-mine');
+    expect(hasSecret('own')).toBe(true); // a later/other owner's secret is safe
+  });
+
+  it('deleteAccountIfAttemptMatches deletes the secret + journal entry for a matching token', async () => {
+    const gen = AccountSecureStorage.getResetGeneration();
+    const token = await AccountSecureStorage.storeAccountForCreation(
+      standardAccount('own2'),
+      freshSk(),
+      gen
+    );
+    await AccountSecureStorage.deleteAccountIfAttemptMatches('own2', token);
+    expect(hasSecret('own2')).toBe(false);
+    expect(journal()['own2']).toBeUndefined();
+  });
+});
+
+describe('TASK-220 wipe tombstone lifecycle', () => {
+  it('is NOT cleared by a bare secret write (crash window stays closed)', async () => {
+    await AccountSecureStorage.clearAll();
+    expect(tombstoneSet()).toBe(true);
+    const gen = AccountSecureStorage.getResetGeneration();
+    await AccountSecureStorage.storeAccountForCreation(
+      standardAccount('t1'),
+      freshSk(),
+      gen
+    );
+    // The secret is committed but the wallet metadata is not yet — the tombstone
+    // must remain until the metadata commit (commitPendingCreate).
+    expect(tombstoneSet()).toBe(true);
+  });
+
+  it('is cleared by commitPendingCreate when the generation still matches', async () => {
+    await AccountSecureStorage.clearAll();
+    const gen = AccountSecureStorage.getResetGeneration();
+    const token = await AccountSecureStorage.storeAccountForCreation(
+      standardAccount('t2'),
+      freshSk(),
+      gen
+    );
+    await AccountSecureStorage.commitPendingCreate('t2', token, gen);
+    expect(tombstoneSet()).toBe(false);
+    expect(journal()['t2']).toBeUndefined();
+  });
+
+  it("does NOT clobber a LATER reset's tombstone (generation-conditional clear)", async () => {
+    await AccountSecureStorage.clearAll();
+    const gen = AccountSecureStorage.getResetGeneration();
+    const token = await AccountSecureStorage.storeAccountForCreation(
+      standardAccount('t3'),
+      freshSk(),
+      gen
+    );
+    // A LATER reset bumps the generation and re-sets the tombstone.
+    await AccountSecureStorage.clearAll();
+    expect(tombstoneSet()).toBe(true);
+    // A late commit for the stale generation must NOT clear the new tombstone.
+    await AccountSecureStorage.commitPendingCreate('t3', token, gen);
+    expect(tombstoneSet()).toBe(true);
+  });
+});
+
+describe('TASK-220 legacy resurrection block', () => {
+  it('migration is BLOCKED while the wipe tombstone is set, and ALLOWED once cleared', async () => {
+    const id = 'legacy1';
+    const legacyBlob = JSON.stringify({
+      accountId: id,
+      address: `ADDR_${id}`,
+      type: 'standard',
+      publicData: {
+        publicKey: 'bb'.repeat(32),
+        label: id,
+        color: '#000000',
+        createdAt: '2026-01-01T00:00:00.000Z',
+      },
+      authMethod: 'biometric',
+      lastAccessed: '2026-01-01T00:00:00.000Z',
+      encryptedPrivateKey: { format: 'test-envelope' },
+    });
+
+    // A wipe happened: tombstone set, but a legacy secure-store copy survives.
+    mockKv.set(TOMBSTONE_KEY, '1');
+    mockSecure.set(`${LEGACY_PREFIX}${id}`, legacyBlob);
+
+    // A read that misses the primary metadata must NOT resurrect the account.
+    await expect(AccountSecureStorage.retrieveAccount(id)).rejects.toThrow();
+    expect(mockKv.has(`${METADATA_PREFIX}${id}`)).toBe(false); // did not migrate
+
+    // Clear the tombstone: migration is re-enabled and the legacy copy resurfaces.
+    mockKv.delete(TOMBSTONE_KEY);
+    const account = await AccountSecureStorage.retrieveAccount(id);
+    expect(account.id).toBe(id);
+    expect(mockKv.has(`${METADATA_PREFIX}${id}`)).toBe(true); // migrated
+  });
+});

--- a/src/services/secure/__tests__/crossStoreResetHardening.test.ts
+++ b/src/services/secure/__tests__/crossStoreResetHardening.test.ts
@@ -9,8 +9,8 @@
 //   * a duplicate pending id is rejected so an earlier raced attempt can never
 //     delete a later same-id attempt's secret;
 //   * ownership-checked rollback deletes ONLY the attempt's own secret;
-//   * the durable wipe tombstone is NOT cleared on a bare secret write, is cleared
-//     generation-conditionally at commit, and blocks legacy-blob resurrection.
+//   * the durable wipe tombstone is STICKY after a reset (never cleared, even by a
+//     later commit) and permanently blocks legacy-blob resurrection.
 //
 // SECURITY NOTE: key material is throwaway random bytes; nothing real is used or
 // logged. secureStorage / AsyncStorage are in-memory Map sinks.
@@ -229,7 +229,7 @@ describe('TASK-220 wipe tombstone lifecycle', () => {
     expect(tombstoneSet()).toBe(true);
   });
 
-  it('is cleared by commitPendingCreate when the generation still matches', async () => {
+  it('is STICKY: commitPendingCreate drops the journal entry but does NOT clear the tombstone (Codex diff-review P1)', async () => {
     await AccountSecureStorage.clearAll();
     const gen = AccountSecureStorage.getResetGeneration();
     const token = await AccountSecureStorage.storeAccountForCreation(
@@ -237,12 +237,15 @@ describe('TASK-220 wipe tombstone lifecycle', () => {
       freshSk(),
       gen
     );
-    await AccountSecureStorage.commitPendingCreate('t2', token, gen);
-    expect(tombstoneSet()).toBe(false);
+    await AccountSecureStorage.commitPendingCreate('t2', token);
+    // The tombstone stays set — a surviving legacy blob for ANY old id must
+    // remain un-resurrectable after a reset.
+    expect(tombstoneSet()).toBe(true);
+    // The journal entry, however, is finalized.
     expect(journal()['t2']).toBeUndefined();
   });
 
-  it("does NOT clobber a LATER reset's tombstone (generation-conditional clear)", async () => {
+  it('stays set across a later reset too (never clobbered / never cleared)', async () => {
     await AccountSecureStorage.clearAll();
     const gen = AccountSecureStorage.getResetGeneration();
     const token = await AccountSecureStorage.storeAccountForCreation(
@@ -250,11 +253,9 @@ describe('TASK-220 wipe tombstone lifecycle', () => {
       freshSk(),
       gen
     );
-    // A LATER reset bumps the generation and re-sets the tombstone.
-    await AccountSecureStorage.clearAll();
+    await AccountSecureStorage.clearAll(); // a LATER reset re-sets it
     expect(tombstoneSet()).toBe(true);
-    // A late commit for the stale generation must NOT clear the new tombstone.
-    await AccountSecureStorage.commitPendingCreate('t3', token, gen);
+    await AccountSecureStorage.commitPendingCreate('t3', token);
     expect(tombstoneSet()).toBe(true);
   });
 });
@@ -290,5 +291,44 @@ describe('TASK-220 legacy resurrection block', () => {
     const account = await AccountSecureStorage.retrieveAccount(id);
     expect(account.id).toBe(id);
     expect(mockKv.has(`${METADATA_PREFIX}${id}`)).toBe(true); // migrated
+  });
+
+  it('sticky tombstone still blocks a surviving legacy blob AFTER a new account is created + committed (Codex diff-review P1)', async () => {
+    const oldId = 'old-legacy';
+    const legacyBlob = JSON.stringify({
+      accountId: oldId,
+      address: `ADDR_${oldId}`,
+      type: 'standard',
+      publicData: {
+        publicKey: 'cc'.repeat(32),
+        label: oldId,
+        color: '#000000',
+        createdAt: '2026-01-01T00:00:00.000Z',
+      },
+      authMethod: 'biometric',
+      lastAccessed: '2026-01-01T00:00:00.000Z',
+      encryptedPrivateKey: { format: 'test-envelope' },
+    });
+
+    // Reset the device (sets the sticky tombstone) but a legacy blob for an OLD
+    // id survives the best-effort legacy delete.
+    await AccountSecureStorage.clearAll();
+    mockSecure.set(`${LEGACY_PREFIX}${oldId}`, legacyBlob);
+
+    // Create + commit a brand-new account after the reset.
+    const gen = AccountSecureStorage.getResetGeneration();
+    const token = await AccountSecureStorage.storeAccountForCreation(
+      standardAccount('brand-new'),
+      freshSk(),
+      gen
+    );
+    await AccountSecureStorage.commitPendingCreate('brand-new', token);
+
+    // The old legacy secret must STILL be un-resurrectable (tombstone sticky).
+    await expect(AccountSecureStorage.retrieveAccount(oldId)).rejects.toThrow();
+    expect(mockKv.has(`${METADATA_PREFIX}${oldId}`)).toBe(false);
+    // ...while the new account is fully usable.
+    const fresh = await AccountSecureStorage.retrieveAccount('brand-new');
+    expect(fresh.id).toBe('brand-new');
   });
 });

--- a/src/services/wallet/index.ts
+++ b/src/services/wallet/index.ts
@@ -159,8 +159,7 @@ export class MultiAccountWalletService {
         await this.addAccountToWallet(accountMetadata, creationGen);
         await AccountSecureStorage.commitPendingCreate(
           accountMetadata.id,
-          token,
-          creationGen
+          token
         );
         return accountMetadata;
       } catch (error) {
@@ -267,8 +266,7 @@ export class MultiAccountWalletService {
         await this.addAccountToWallet(accountMetadata, creationGen);
         await AccountSecureStorage.commitPendingCreate(
           accountMetadata.id,
-          token,
-          creationGen
+          token
         );
         return accountMetadata;
       } catch (error) {

--- a/src/services/wallet/index.ts
+++ b/src/services/wallet/index.ts
@@ -1661,13 +1661,6 @@ export class MultiAccountWalletService {
     }
   }
 
-  private static async storeAccountSecurely(
-    accountMetadata: AccountMetadata,
-    privateKey?: Uint8Array
-  ): Promise<void> {
-    await AccountSecureStorage.storeAccount(accountMetadata, privateKey);
-  }
-
   private static async ensureLedgerAssociation(
     wallet: Wallet,
     account: LedgerAccountMetadata,

--- a/src/services/wallet/index.ts
+++ b/src/services/wallet/index.ts
@@ -27,6 +27,7 @@ import {
   LedgerAccountError,
   LedgerDeviceNotConnectedError,
   RekeyVerificationError,
+  ResetRacedError,
   Wallet,
   WalletSettings,
   withDefaultAuthLevel,
@@ -145,16 +146,45 @@ export class MultiAccountWalletService {
       };
 
       const secretKey = account.sk;
+      // TASK-220: capture the secure reset generation BEFORE the key write so
+      // the cross-store creation is atomic against a concurrent full reset.
+      const creationGen = AccountSecureStorage.getResetGeneration();
+      let token: string | undefined;
       try {
-        await this.storeAccountSecurely(accountMetadata, secretKey);
-        await this.addAccountToWallet(accountMetadata);
+        token = await AccountSecureStorage.storeAccountForCreation(
+          accountMetadata,
+          secretKey,
+          creationGen
+        );
+        await this.addAccountToWallet(accountMetadata, creationGen);
+        await AccountSecureStorage.commitPendingCreate(
+          accountMetadata.id,
+          token,
+          creationGen
+        );
         return accountMetadata;
+      } catch (error) {
+        // DR-2 (reset wins): a reset raced this creation → roll back the just-
+        // written secret (ownership-checked; a no-op if the reset already
+        // deleted it) so neither store keeps a half-created account.
+        if (error instanceof ResetRacedError && token !== undefined) {
+          await AccountSecureStorage.deleteAccountIfAttemptMatches(
+            accountMetadata.id,
+            token
+          );
+        }
+        throw error;
       } finally {
         if (secretKey) {
           secretKey.fill(0);
         }
       }
     } catch (error) {
+      // Preserve ResetRacedError so the UI can show "wallet was reset — creation
+      // cancelled" instead of a generic failure.
+      if (error instanceof ResetRacedError) {
+        throw error;
+      }
       throw new Error(
         `Failed to create account: ${error instanceof Error ? error.message : 'Unknown error'}`
       );
@@ -225,10 +255,30 @@ export class MultiAccountWalletService {
       };
 
       const secretKey = account.sk;
+      // TASK-220: guard the cross-store creation against a concurrent full reset.
+      const creationGen = AccountSecureStorage.getResetGeneration();
+      let token: string | undefined;
       try {
-        await this.storeAccountSecurely(accountMetadata, secretKey);
-        await this.addAccountToWallet(accountMetadata);
+        token = await AccountSecureStorage.storeAccountForCreation(
+          accountMetadata,
+          secretKey,
+          creationGen
+        );
+        await this.addAccountToWallet(accountMetadata, creationGen);
+        await AccountSecureStorage.commitPendingCreate(
+          accountMetadata.id,
+          token,
+          creationGen
+        );
         return accountMetadata;
+      } catch (error) {
+        if (error instanceof ResetRacedError && token !== undefined) {
+          await AccountSecureStorage.deleteAccountIfAttemptMatches(
+            accountMetadata.id,
+            token
+          );
+        }
+        throw error;
       } finally {
         if (secretKey) {
           secretKey.fill(0);
@@ -237,7 +287,8 @@ export class MultiAccountWalletService {
     } catch (error) {
       if (
         error instanceof InvalidMnemonicError ||
-        error instanceof AccountExistsError
+        error instanceof AccountExistsError ||
+        error instanceof ResetRacedError
       ) {
         throw error;
       }
@@ -277,6 +328,10 @@ export class MultiAccountWalletService {
 
     // TASK-212: guard the write against a reset racing this read.
     const readEpoch = walletResetEpoch;
+    // TASK-220: guard the no-wallet CREATION write (below) against a concurrent
+    // full reset. Ledger accounts hold no secret, so there is nothing to roll
+    // back — the guard just stops a reset being defeated by a resurrected wallet.
+    const creationGen = AccountSecureStorage.getResetGeneration();
     const wallet = await this.getCurrentWallet();
 
     try {
@@ -339,9 +394,10 @@ export class MultiAccountWalletService {
           settings: this.getDefaultWalletSettings(),
         };
 
-        // Creation write (no prior wallet existed) — always persist, like
-        // createWallet; it establishes a fresh wallet and has nothing to resurrect.
-        await this.storeWallet(newWallet);
+        // Creation write (no prior wallet existed) — guarded on the creation
+        // generation (TASK-220) so a concurrent reset aborts it instead of
+        // resurrecting a wallet; nothing to resurrect otherwise.
+        await this.storeWallet(newWallet, undefined, creationGen);
       } else {
         wallet.accounts.push(accountMetadata);
         await this.storeWallet(wallet, readEpoch);
@@ -352,7 +408,8 @@ export class MultiAccountWalletService {
       if (
         error instanceof AccountExistsError ||
         error instanceof LedgerAccountError ||
-        error instanceof LedgerDeviceNotConnectedError
+        error instanceof LedgerDeviceNotConnectedError ||
+        error instanceof ResetRacedError
       ) {
         throw error;
       }
@@ -566,12 +623,18 @@ export class MultiAccountWalletService {
         notes: request.notes,
       };
 
-      await this.addAccountToWallet(accountMetadata);
+      // TASK-220: guard the (possibly wallet-creating) metadata write against a
+      // concurrent full reset. Watch accounts hold no secret, so there is nothing
+      // to roll back — the guard just prevents a reset being defeated by a
+      // resurrected/recreated wallet.
+      const creationGen = AccountSecureStorage.getResetGeneration();
+      await this.addAccountToWallet(accountMetadata, creationGen);
       return accountMetadata;
     } catch (error) {
       if (
         error instanceof InvalidAddressError ||
-        error instanceof AccountExistsError
+        error instanceof AccountExistsError ||
+        error instanceof ResetRacedError
       ) {
         throw error;
       }
@@ -630,12 +693,15 @@ export class MultiAccountWalletService {
         rekeyedFrom: request.rekeyedFrom,
       };
 
-      await this.addAccountToWallet(accountMetadata);
+      // TASK-220: guard the metadata write against a concurrent full reset.
+      const creationGen = AccountSecureStorage.getResetGeneration();
+      await this.addAccountToWallet(accountMetadata, creationGen);
       return accountMetadata;
     } catch (error) {
       if (
         error instanceof InvalidAddressError ||
-        error instanceof RekeyVerificationError
+        error instanceof RekeyVerificationError ||
+        error instanceof ResetRacedError
       ) {
         throw error;
       }
@@ -681,12 +747,15 @@ export class MultiAccountWalletService {
         authLevel: withDefaultAuthLevel(request.authLevel),
       };
 
-      await this.addAccountToWallet(accountMetadata);
+      // TASK-220: guard the metadata write against a concurrent full reset.
+      const creationGen = AccountSecureStorage.getResetGeneration();
+      await this.addAccountToWallet(accountMetadata, creationGen);
       return accountMetadata;
     } catch (error) {
       if (
         error instanceof InvalidAddressError ||
-        error instanceof AccountExistsError
+        error instanceof AccountExistsError ||
+        error instanceof ResetRacedError
       ) {
         throw error;
       }
@@ -1013,7 +1082,11 @@ export class MultiAccountWalletService {
   }
 
   static async createWallet(
-    firstAccountMetadata: StandardAccountMetadata
+    firstAccountMetadata: StandardAccountMetadata,
+    // TASK-220: secure reset generation captured before the first account's key
+    // write, so a concurrent full reset aborts this creation (ResetRacedError)
+    // instead of resurrecting a wallet whose secret the reset just deleted.
+    creationGen?: number
   ): Promise<Wallet> {
     const wallet: Wallet = {
       id: this.generateWalletId(),
@@ -1024,7 +1097,7 @@ export class MultiAccountWalletService {
       settings: this.getDefaultWalletSettings(),
     };
 
-    await this.storeWallet(wallet);
+    await this.storeWallet(wallet, undefined, creationGen);
     return wallet;
   }
 
@@ -1414,7 +1487,9 @@ export class MultiAccountWalletService {
           : undefined,
       };
 
-      await this.addAccountToWallet(accountMetadata);
+      // TASK-220: guard the metadata write against a concurrent full reset.
+      const creationGen = AccountSecureStorage.getResetGeneration();
+      await this.addAccountToWallet(accountMetadata, creationGen);
 
       return accountMetadata;
     } catch (error) {
@@ -1648,7 +1723,12 @@ export class MultiAccountWalletService {
   }
 
   private static async addAccountToWallet(
-    accountMetadata: AccountMetadata
+    accountMetadata: AccountMetadata,
+    // TASK-220: the secure reset generation captured by the caller BEFORE it
+    // wrote any secret. Threaded into every metadata creation/add write so a
+    // full reset racing this account-add aborts the write (ResetRacedError)
+    // rather than resurrecting a wiped wallet or orphaning the new key.
+    creationGen: number
   ): Promise<void> {
     // TASK-212: guard the write against a reset racing this read.
     const readEpoch = walletResetEpoch;
@@ -1656,24 +1736,32 @@ export class MultiAccountWalletService {
     if (!wallet) {
       // If no wallet exists, create one with this account
       if (accountMetadata.type === AccountType.STANDARD) {
-        await this.createWallet(accountMetadata as StandardAccountMetadata);
+        await this.createWallet(
+          accountMetadata as StandardAccountMetadata,
+          creationGen
+        );
       } else if (
         accountMetadata.type === AccountType.REMOTE_SIGNER ||
         accountMetadata.type === AccountType.WATCH
       ) {
         // Create wallet with non-standard account (no mnemonic required)
-        await this.createWalletWithAccount(accountMetadata);
+        await this.createWalletWithAccount(accountMetadata, creationGen);
       } else {
         throw new Error('Cannot create wallet with this account type');
       }
     } else {
       wallet.accounts.push(accountMetadata);
-      await this.storeWallet(wallet, readEpoch);
+      // Pass BOTH the read epoch (don't resurrect a concurrently-wiped wallet)
+      // and the creation generation (abort + let the caller roll back a raced
+      // STANDARD key). For a STANDARD add either guard tripping throws
+      // ResetRacedError; for a non-secret add the wallet simply isn't resurrected.
+      await this.storeWallet(wallet, readEpoch, creationGen);
     }
   }
 
   private static async createWalletWithAccount(
-    accountMetadata: AccountMetadata
+    accountMetadata: AccountMetadata,
+    creationGen?: number
   ): Promise<Wallet> {
     const wallet: Wallet = {
       id: this.generateWalletId(),
@@ -1684,7 +1772,7 @@ export class MultiAccountWalletService {
       settings: this.getDefaultWalletSettings(),
     };
 
-    await this.storeWallet(wallet);
+    await this.storeWallet(wallet, undefined, creationGen);
     return wallet;
   }
 
@@ -1717,7 +1805,16 @@ export class MultiAccountWalletService {
    */
   private static async storeWallet(
     wallet: Wallet,
-    readEpoch?: number
+    readEpoch?: number,
+    // TASK-220: pass for a CREATION/ADD write that follows a fresh key/account
+    // creation (createWallet, createWalletWithAccount, ledger/restore creation,
+    // and the STANDARD existing-wallet add). Captured before the secret write;
+    // if the SECURE reset generation advanced since, a full reset raced this
+    // creation, so the write is ABORTED with ResetRacedError (not silently
+    // skipped) — the caller then rolls back the just-written secret and the
+    // reset wins (DR-2). This is the guard that fires in the clearAll()→
+    // clearAllWallets() window, where walletResetEpoch has not yet bumped.
+    creationGen?: number
   ): Promise<void> {
     // Sanitize + serialize a SNAPSHOT now (synchronously), before enqueuing, so a
     // later in-place mutation of `wallet` by the caller can't alter what is
@@ -1726,10 +1823,23 @@ export class MultiAccountWalletService {
       this.sanitizeWalletForPersistence(wallet)
     );
     const wrote = await this.enqueueWalletWrite(async () => {
+      // TASK-220 creation/add guard: abort if a reset advanced the SECURE
+      // generation since this creation captured it. Throwing (not skipping) lets
+      // the caller roll back the secret it already wrote so neither store keeps a
+      // half-created account.
+      if (
+        creationGen !== undefined &&
+        AccountSecureStorage.getResetGeneration() !== creationGen
+      ) {
+        throw new ResetRacedError();
+      }
       if (readEpoch !== undefined) {
         // Guarded write (read-repair OR intentional read-modify-write): skip if a
         // wipe advanced the epoch since the read this write derives from...
         if (readEpoch !== walletResetEpoch) {
+          // A creation/add write must ABORT (so its secret is rolled back), not
+          // silently skip like a pure read-modify-write mutation.
+          if (creationGen !== undefined) throw new ResetRacedError();
           return false;
         }
         // ...OR if a wipe has COMPLETED (tombstone set AND primary now absent)
@@ -1745,6 +1855,7 @@ export class MultiAccountWalletService {
         if (wiped != null) {
           const current = await storage.getItem(this.WALLET_KEY);
           if (current == null) {
+            if (creationGen !== undefined) throw new ResetRacedError();
             return false;
           }
         }
@@ -1776,9 +1887,16 @@ export class MultiAccountWalletService {
    * via sanitizeWalletForPersistence() and clears any legacy secure-store copy.
    * Restore code MUST use this instead of a raw storage.setItem so a restored
    * wallet can never leak a mnemonic into general storage.
+   *
+   * TASK-220: pass the secure reset generation captured at the start of the
+   * restore so this commit is ABORTED (ResetRacedError) if a full reset raced
+   * the restore — the restore then rolls back the secrets it wrote (DR-2).
    */
-  static async persistRestoredWallet(wallet: Wallet): Promise<void> {
-    await this.storeWallet(wallet);
+  static async persistRestoredWallet(
+    wallet: Wallet,
+    creationGen?: number
+  ): Promise<void> {
+    await this.storeWallet(wallet, undefined, creationGen);
   }
 
   private static getDefaultWalletSettings(): WalletSettings {
@@ -1801,7 +1919,17 @@ export class MultiAccountWalletService {
   // Storage methods using platform adapters
   private static async getStoredValue(key: string): Promise<string | null> {
     try {
-      const value = await storage.getItem(key);
+      // TASK-220 (DR-3): serialize ONLY the primary read on the write chain so it
+      // observes a wipe's removeItem that was enqueued before it. Closes the
+      // stale-read window where getCurrentWallet, having captured walletResetEpoch
+      // AFTER a reset already bumped it, still reads the pre-wipe blob because the
+      // wipe's removeItem is queued (so resetRacedRead sees a matching epoch and
+      // returns the stale wallet). Idle chain → ~one microtask; an active wipe →
+      // the read waits for it (the correct read-after-wipe). No reentrancy: the
+      // enqueued task does ONLY getItem; migrateLegacyValue enqueues its OWN task
+      // AFTER this read resolves — sequential, never nested. Parse/heal stay off
+      // the chain (this returns just the raw string).
+      const value = await this.enqueueWalletWrite(() => storage.getItem(key));
       if (value) {
         return value;
       }

--- a/src/store/walletStore.ts
+++ b/src/store/walletStore.ts
@@ -620,13 +620,12 @@ export const useWalletStore = create<WalletState>()(
         const newAccount =
           await MultiAccountWalletService.createStandardAccount(request);
 
-        // If this is the first account, create the wallet
-        let { wallet } = get();
-        if (!wallet) {
-          wallet = await MultiAccountWalletService.createWallet(newAccount);
-        } else {
-          wallet = await MultiAccountWalletService.getCurrentWallet();
-        }
+        // createStandardAccount already persisted the wallet metadata (via
+        // addAccountToWallet, which creates the wallet on the first account).
+        // TASK-220: re-read the authoritative wallet instead of issuing a second,
+        // now generation-guarded, createWallet write — that redundant write both
+        // double-persisted and would need its own creation-generation handling.
+        const wallet = await MultiAccountWalletService.getCurrentWallet();
 
         // Initialize account state
         const { accountStates } = get();

--- a/src/types/wallet.ts
+++ b/src/types/wallet.ts
@@ -371,6 +371,37 @@ export class AccountCreationError extends AccountError {
   }
 }
 
+/**
+ * TASK-220: a full reset/wipe raced an in-flight account creation/import/restore.
+ * The reset wins (DR-2): the creation is aborted and any just-written secret is
+ * rolled back so neither the secure key store nor the wallet metadata is left
+ * holding a half-created account. Surfaced to the UI as "wallet was reset —
+ * creation cancelled, try again."
+ */
+export class ResetRacedError extends AccountError {
+  constructor(
+    message: string = 'A wallet reset occurred while creating this account'
+  ) {
+    super(message, 'RESET_RACED');
+    this.name = 'ResetRacedError';
+  }
+}
+
+/**
+ * TASK-220: a second creation/restore attempt targeted an accountId that already
+ * has an uncommitted pending-creation entry (ownership collision — e.g. two
+ * concurrent restores of the same backup). Rejected at the secret-write boundary
+ * so an earlier attempt's rollback can never delete a later attempt's secret.
+ */
+export class DuplicatePendingCreateError extends AccountError {
+  constructor(
+    message: string = 'Another creation for this account is already in progress'
+  ) {
+    super(message, 'DUPLICATE_PENDING_CREATE');
+    this.name = 'DuplicatePendingCreateError';
+  }
+}
+
 export class AccountImportError extends AccountError {
   constructor(message: string = 'Account import error') {
     super(message, 'ACCOUNT_IMPORT_ERROR');


### PR DESCRIPTION
## What & why (TASK-220)

Account creation/import writes the secure **key** first, then the wallet-**metadata** blob (an `await` between); a full reset wipes secrets (`clearAll`) then metadata (`clearAllWallets`). TASK-212 guarded the metadata store, but the **secure key store had no durable guard**, so a reset racing an in-flight creation could leave the two stores in *opposite* end-states — a **phantom account** whose key was deleted, or a **secret surviving a "delete everything"**. Follow-up to TASK-212. Design + sign-off: **DOC-221** (crypto sign-off from Dave; "full zero-residual").

## Mechanism (crash-repaired + concurrency-safe cross-store consistency)

- **`secureResetGeneration`** — in-memory counter bumped **synchronously at `clearAll` entry**; the discriminator that fires in the `clearAll()`→`clearAllWallets()` window (the wallet epoch bumps too late). A creation captures it before its key write; both the secret write and the metadata write **abort (`ResetRacedError`)** if it advanced. Reset wins (DR-2).
- **`voi_secure_wiped` tombstone** — durable wipe marker; makes legacy migration **refuse to resurrect** a secret from a surviving legacy blob (incl. across a restart). **Sticky** — never cleared in production (a fresh account writes its primary secret directly and never migrates).
- **`voi_pending_account_creates` journal** — durable `{id:token}` written **before** the secret so an in-flight/crashed creation's secret is enumerable before it hits any index. Drained by `clearAll`. Per-attempt **ownership token** → a raced attempt's rollback deletes only the secret *it* wrote; a duplicate pending id is rejected.
- **Creation guard** threaded through every creation/add path (create/import/watch/rekeyed/remote-signer/ledger/auth-import/restore); STANDARD create/import/restore roll back the just-written secret on a raced reset.
- **In-memory key cache** zeroed on reset; `getPrivateKey` captures the generation at read start and **aborts an in-flight read** a reset raced (beside the existing vault-lock epoch check) — no stale key served or re-cached.
- **`getCurrentWallet`** primary read serialized on the write chain (closes the stale-read window, DR-3).
- Removes the redundant second `createWallet` write in `walletStore.createAccount`.

## Verification

- **Gates:** `typecheck` 0 errors · `lint` 0 errors · **1171 unit tests** (13 new cross-store reset-hardening tests). JS-only → OTA-eligible, no native/runtime-version bump. No key/mnemonic reaches logs/AsyncStorage/state; algosdk/Algorand-compatible.
- **Codex review:** CLEAN after 4 diff-review rounds (cross-store race → cache-survives-reset → cache-repopulation → in-flight-return).
- **Adversarial verification:** independent crypto-refutation (reset-wins / lost-update / wrong-deletion / resurrection / deadlock all clean) + happy-path regression skeptic (no regressions).

**Boot reconcile** (the durable crash-repair backstop) is intentionally a **separate PR — TASK-222** (blocked by this).