### PR TITLE
fix(secure): boot reconcile to repair cross-store secret/metadata half-state (TASK-222)

### DIFF
--- a/src/contexts/AuthContext.tsx
+++ b/src/contexts/AuthContext.tsx
@@ -7,6 +7,7 @@ import React, {
 } from 'react';
 import { AppState, Platform, AppStateStatus } from 'react-native';
 import { MultiAccountWalletService } from '@/services/wallet';
+import { reconcileCrossStoreHalfState } from '@/services/wallet/crossStoreReconcile';
 import { AccountSecureStorage } from '@/services/secure';
 import {
   isPinSetupPending,
@@ -371,6 +372,28 @@ export function AuthProvider({ children }: { children: React.ReactNode }) {
       }
 
       const { hasWallet, hasPin, hasKeyBearingAccount } = lockState;
+
+      // BOOT RECONCILE (TASK-222, Component 3 of DOC-221): repair cross-store
+      // secret/metadata half-state left by a crash mid-storeAccount or a
+      // partially-completed reset — an orphaned secret (no wallet-blob account)
+      // or a phantom account (blob STANDARD entry whose secret is gone). Runs
+      // AFTER the strict lock reads succeed so it never fires on an unreadable
+      // store, and it is FAIL-CLOSED end to end: it aborts (deletes nothing) on
+      // any strict read/probe failure. Bounded by withTimeout and best-effort
+      // (result swallowed) so a wedged read or a repair error degrades to "no
+      // repair this boot" and never stalls the splash. It intentionally does NOT
+      // recompute the lock verdict from `lockState`: the only path that could
+      // change wallet existence is pruning a phantom whose secret is already gone
+      // (an unusable account); leaving this boot's fail-safe LOCKED verdict stand
+      // is correct, and the store is consistent for the next boot / any signing.
+      await withTimeout(
+        reconcileCrossStoreHalfState(),
+        STRICT_READ_TIMEOUT_MS,
+        'cross-store boot reconcile'
+      ).catch((error) => {
+        // ids/status only upstream; here we log the failure class, not contents.
+        console.warn('Cross-store boot reconcile skipped:', error);
+      });
 
       // SELF-HEAL (TASK-213, anti-fail-open): a readable PIN proves setup
       // completed, so any lingering pin_setup_pending breadcrumb is stale. Clear

--- a/src/contexts/AuthContext.tsx
+++ b/src/contexts/AuthContext.tsx
@@ -198,6 +198,17 @@ export function AuthProvider({ children }: { children: React.ReactNode }) {
   const authStateRef = useRef(authState);
   authStateRef.current = authState;
 
+  // TASK-222: one-shot latch for the cross-store boot reconcile. checkInitialAuthState
+  // is ALSO invoked by recheckAuthState() (ChangePinScreen, LockScreen, recovery),
+  // i.e. on a LIVE, possibly-unlocked wallet — not only at boot. The reconcile's
+  // destructive primitives are ownership-UNCHECKED (they infer delete from absence),
+  // which is only safe when no account-creation can be in-flight — true at the first
+  // boot check, NOT on a mid-session recheck. This latch guarantees the reconcile
+  // runs at most ONCE per app launch (the first successful auth check), so a recheck
+  // can never arm it against a concurrent creation. It resets on remount (next launch),
+  // so a boot where the reconcile could not run (strict reads failed) retries next boot.
+  const bootReconcileDoneRef = useRef(false);
+
   useEffect(() => {
     checkInitialAuthState();
     // Capture the subscription remover so the effect cleanup can tear the
@@ -380,49 +391,65 @@ export function AuthProvider({ children }: { children: React.ReactNode }) {
       // any strict read/probe failure. Bounded by withTimeout and best-effort
       // (a failure is swallowed) so a wedged read or a repair error degrades to
       // "no repair this boot" and never stalls the splash.
-      const reconcileOutcome = await withTimeout(
-        reconcileCrossStoreHalfState(),
-        STRICT_READ_TIMEOUT_MS,
-        'cross-store boot reconcile'
-      ).catch((error) => {
-        // ids/status only upstream; here we log the failure class, not contents.
-        console.warn('Cross-store boot reconcile skipped:', error);
-        return null;
-      });
+      //
+      // LATCHED to run at most ONCE per app launch (bootReconcileDoneRef): this
+      // function is reused by recheckAuthState() on a live/unlocked wallet, where
+      // the reconcile's ownership-unchecked deletes would be unsafe against a
+      // concurrent creation. The latch is set only once we reach here (after the
+      // strict reads succeeded), so a failed-strict-reads boot retries next launch.
+      //
+      // Residual (accepted): the outer withTimeout can, on a wedged store, abandon
+      // Phase 2 mid-flight and skip the refresh below, routing on the stale verdict
+      // while the abandoned prune later empties the wallet. This is fail-SAFE (still
+      // locked, never falls open) and self-heals next boot; Phase 1 now probes
+      // concurrently and the prune runs first, so the window is small.
+      if (!bootReconcileDoneRef.current) {
+        bootReconcileDoneRef.current = true;
 
-      // If the reconcile PRUNED a phantom account it may have emptied the wallet
-      // (pruneStandardAccounts → clearAllWallets), which invalidates the
-      // pre-reconcile lock signals — routing on the stale `hasWallet=true` would
-      // land the user in Main with no wallet after PIN entry instead of
-      // onboarding (Codex P2). Refresh the three strict signals ONCE so the
-      // verdict reflects the repair. Best-effort + bounded: on any failure keep
-      // the pre-reconcile FAIL-SAFE (locked) verdict — never fall open. Orphan
-      // deletion never affects these blob-derived signals, so this only runs on
-      // the rare phantom-prune path.
-      if (
-        reconcileOutcome &&
-        reconcileOutcome.phantomAccountsPruned.length > 0
-      ) {
-        try {
-          const [freshWallet, freshPin, freshKeyBearing] = await withTimeout(
-            Promise.all([
-              MultiAccountWalletService.hasWalletWithAccountsStrict(),
-              AccountSecureStorage.hasPinStrict(),
-              MultiAccountWalletService.hasKeyBearingAccountStrict(),
-            ]),
-            STRICT_READ_TIMEOUT_MS,
-            'post-reconcile lock-read refresh'
-          );
-          lockState = {
-            hasWallet: freshWallet,
-            hasPin: freshPin,
-            hasKeyBearingAccount: freshKeyBearing,
-          };
-        } catch (error) {
-          console.warn(
-            'Post-reconcile lock refresh failed; keeping prior verdict:',
-            error
-          );
+        const reconcileOutcome = await withTimeout(
+          reconcileCrossStoreHalfState(),
+          STRICT_READ_TIMEOUT_MS,
+          'cross-store boot reconcile'
+        ).catch((error) => {
+          // ids/status only upstream; here we log the failure class, not contents.
+          console.warn('Cross-store boot reconcile skipped:', error);
+          return null;
+        });
+
+        // If the reconcile PRUNED a phantom account it may have emptied the wallet
+        // (pruneStandardAccounts → clearAllWallets), which invalidates the
+        // pre-reconcile lock signals — routing on the stale `hasWallet=true` would
+        // land the user in Main with no wallet after PIN entry instead of
+        // onboarding (Codex P2). Refresh the three strict signals ONCE so the
+        // verdict reflects the repair. Best-effort + bounded: on any failure keep
+        // the pre-reconcile FAIL-SAFE (locked) verdict — never fall open. Orphan
+        // deletion never affects these blob-derived signals, so this only runs on
+        // the rare phantom-prune path.
+        if (
+          reconcileOutcome &&
+          reconcileOutcome.phantomAccountsPruned.length > 0
+        ) {
+          try {
+            const [freshWallet, freshPin, freshKeyBearing] = await withTimeout(
+              Promise.all([
+                MultiAccountWalletService.hasWalletWithAccountsStrict(),
+                AccountSecureStorage.hasPinStrict(),
+                MultiAccountWalletService.hasKeyBearingAccountStrict(),
+              ]),
+              STRICT_READ_TIMEOUT_MS,
+              'post-reconcile lock-read refresh'
+            );
+            lockState = {
+              hasWallet: freshWallet,
+              hasPin: freshPin,
+              hasKeyBearingAccount: freshKeyBearing,
+            };
+          } catch (error) {
+            console.warn(
+              'Post-reconcile lock refresh failed; keeping prior verdict:',
+              error
+            );
+          }
         }
       }
 

--- a/src/contexts/AuthContext.tsx
+++ b/src/contexts/AuthContext.tsx
@@ -371,29 +371,62 @@ export function AuthProvider({ children }: { children: React.ReactNode }) {
         return;
       }
 
-      const { hasWallet, hasPin, hasKeyBearingAccount } = lockState;
-
       // BOOT RECONCILE (TASK-222, Component 3 of DOC-221): repair cross-store
       // secret/metadata half-state left by a crash mid-storeAccount or a
       // partially-completed reset — an orphaned secret (no wallet-blob account)
       // or a phantom account (blob STANDARD entry whose secret is gone). Runs
       // AFTER the strict lock reads succeed so it never fires on an unreadable
-      // store, and it is FAIL-CLOSED end to end: it aborts (deletes nothing) on
+      // store, and it is FAIL-CLOSED end to end: it aborts (repairs nothing) on
       // any strict read/probe failure. Bounded by withTimeout and best-effort
-      // (result swallowed) so a wedged read or a repair error degrades to "no
-      // repair this boot" and never stalls the splash. It intentionally does NOT
-      // recompute the lock verdict from `lockState`: the only path that could
-      // change wallet existence is pruning a phantom whose secret is already gone
-      // (an unusable account); leaving this boot's fail-safe LOCKED verdict stand
-      // is correct, and the store is consistent for the next boot / any signing.
-      await withTimeout(
+      // (a failure is swallowed) so a wedged read or a repair error degrades to
+      // "no repair this boot" and never stalls the splash.
+      const reconcileOutcome = await withTimeout(
         reconcileCrossStoreHalfState(),
         STRICT_READ_TIMEOUT_MS,
         'cross-store boot reconcile'
       ).catch((error) => {
         // ids/status only upstream; here we log the failure class, not contents.
         console.warn('Cross-store boot reconcile skipped:', error);
+        return null;
       });
+
+      // If the reconcile PRUNED a phantom account it may have emptied the wallet
+      // (pruneStandardAccounts → clearAllWallets), which invalidates the
+      // pre-reconcile lock signals — routing on the stale `hasWallet=true` would
+      // land the user in Main with no wallet after PIN entry instead of
+      // onboarding (Codex P2). Refresh the three strict signals ONCE so the
+      // verdict reflects the repair. Best-effort + bounded: on any failure keep
+      // the pre-reconcile FAIL-SAFE (locked) verdict — never fall open. Orphan
+      // deletion never affects these blob-derived signals, so this only runs on
+      // the rare phantom-prune path.
+      if (
+        reconcileOutcome &&
+        reconcileOutcome.phantomAccountsPruned.length > 0
+      ) {
+        try {
+          const [freshWallet, freshPin, freshKeyBearing] = await withTimeout(
+            Promise.all([
+              MultiAccountWalletService.hasWalletWithAccountsStrict(),
+              AccountSecureStorage.hasPinStrict(),
+              MultiAccountWalletService.hasKeyBearingAccountStrict(),
+            ]),
+            STRICT_READ_TIMEOUT_MS,
+            'post-reconcile lock-read refresh'
+          );
+          lockState = {
+            hasWallet: freshWallet,
+            hasPin: freshPin,
+            hasKeyBearingAccount: freshKeyBearing,
+          };
+        } catch (error) {
+          console.warn(
+            'Post-reconcile lock refresh failed; keeping prior verdict:',
+            error
+          );
+        }
+      }
+
+      const { hasWallet, hasPin, hasKeyBearingAccount } = lockState;
 
       // SELF-HEAL (TASK-213, anti-fail-open): a readable PIN proves setup
       // completed, so any lingering pin_setup_pending breadcrumb is stale. Clear

--- a/src/contexts/__tests__/AuthContext.test.tsx
+++ b/src/contexts/__tests__/AuthContext.test.tsx
@@ -22,6 +22,7 @@ import { act, renderHook } from '@testing-library/react-native';
 import { AuthProvider, useAuth } from '../AuthContext';
 
 import { MultiAccountWalletService } from '@/services/wallet';
+import { reconcileCrossStoreHalfState } from '@/services/wallet/crossStoreReconcile';
 import { AccountSecureStorage } from '@/services/secure';
 import { SessionKeyVault } from '@/services/secure/SessionKeyVault';
 import { unlockVaultWithBiometrics } from '@/services/secure/biometricUnlock';
@@ -44,6 +45,14 @@ jest.mock('@/services/wallet', () => ({
     // (STANDARD) account? Used to close the Android swallow-to-null fail-open.
     hasKeyBearingAccountStrict: jest.fn(),
   },
+}));
+
+// TASK-222: the cross-store boot reconcile. Mocked so the hook's integration
+// behavior (never-blocks-boot, post-phantom-prune verdict refresh, one-shot
+// latch) is driven deterministically without exercising the real reconcile
+// (unit-tested separately). Default (no-op success) is set in beforeEach.
+jest.mock('@/services/wallet/crossStoreReconcile', () => ({
+  reconcileCrossStoreHalfState: jest.fn(),
 }));
 
 jest.mock('@/services/secure', () => ({
@@ -129,6 +138,15 @@ const mockEnterLocked = enterLockedState as jest.Mock;
 const mockIsPinSetupPending = isPinSetupPending as jest.Mock;
 const mockClearPinSetupPending = clearPinSetupPending as jest.Mock;
 const mockSetUnlocked = AppLockSignal.setUnlocked as jest.Mock;
+const mockReconcile = reconcileCrossStoreHalfState as jest.Mock;
+
+// A clean, no-op reconcile result (nothing to repair).
+const RECONCILE_NOOP = {
+  ran: true,
+  orphanSecretsDeleted: [],
+  phantomAccountsPruned: [],
+  staleJournalDropped: [],
+};
 
 // A non-empty account list so checkInitialAuthState treats the wallet as
 // "requires auth". Address is a throwaway label, never key material.
@@ -213,6 +231,9 @@ beforeEach(() => {
   // mocked for any incidental callers but no longer gate the initial lock state.
   mockHasWalletStrict.mockResolvedValue(true);
   mockHasPinStrict.mockResolvedValue(true);
+  // TASK-222: default the boot reconcile to a clean no-op so it never perturbs
+  // the lock verdict in tests that don't opt into a repair scenario.
+  mockReconcile.mockResolvedValue(RECONCILE_NOOP);
   // Default to NO key-bearing account so the Codex round-4 guard
   // (hasKeyBearingAccount && !hasPin ⇒ recovery) never fires unless a test opts
   // in — the guard only matters for the wallet+no-PIN cases, which the existing
@@ -812,6 +833,88 @@ describe('AuthContext — TASK-213 fail-closed recovery on storage read failure'
       expect(result.current.authState.securityUnavailable).toBe(false);
     }
   );
+});
+
+// TASK-222 Component 3 — the boot-reconcile hook's INTEGRATION into
+// checkInitialAuthState (the reconcile itself is unit-tested in
+// crossStoreReconcile.test.ts). These cover the acceptance criteria a unit test
+// of the pure function cannot: never blocks boot, the post-phantom-prune verdict
+// refresh, fail-safe on refresh failure, and the one-shot boot latch.
+describe('AuthContext — TASK-222 boot reconcile hook', () => {
+  it('never blocks boot: a reconcile REJECTION is swallowed and boot still reaches a terminal verdict', async () => {
+    mockHasWalletStrict.mockResolvedValue(true);
+    mockHasPinStrict.mockResolvedValue(true);
+    mockReconcile.mockRejectedValue(new Error('reconcile boom'));
+    const warnSpy = jest.spyOn(console, 'warn').mockImplementation(() => {});
+
+    const { result } = await mountAuth();
+
+    // Verdict comes from the strict reads; the reconcile failure is ignored.
+    expect(result.current.authState.authChecked).toBe(true);
+    expect(result.current.authState.isLocked).toBe(true);
+    expect(result.current.authState.securityUnavailable).toBe(false);
+    expect(result.current.authState.hasWallet).toBe(true);
+
+    warnSpy.mockRestore();
+  });
+
+  it('phantom prune that empties the wallet REFRESHES the verdict to onboarding', async () => {
+    // Boot verdict reads wallet+PIN present (⇒ would be LOCKED); the reconcile
+    // reports it pruned a phantom, so the refresh re-reads the now-empty store.
+    mockHasWalletStrict.mockResolvedValueOnce(true).mockResolvedValue(false);
+    mockHasPinStrict.mockResolvedValueOnce(true).mockResolvedValue(false);
+    mockReconcile.mockResolvedValue({
+      ...RECONCILE_NOOP,
+      phantomAccountsPruned: ['acct-1'],
+    });
+
+    const { result } = await mountAuth();
+
+    // Refreshed signals: no wallet ⇒ unlocked onboarding, not a locked ghost.
+    expect(result.current.authState.hasWallet).toBe(false);
+    expect(result.current.authState.isLocked).toBe(false);
+    expect(result.current.authState.securityUnavailable).toBe(false);
+    expect(result.current.authState.authChecked).toBe(true);
+  });
+
+  it('a REFRESH failure after a phantom prune keeps the prior LOCKED verdict (never falls open)', async () => {
+    mockHasWalletStrict
+      .mockResolvedValueOnce(true) // boot verdict: wallet present
+      .mockRejectedValue(new Error('refresh read boom')); // refresh fails
+    mockHasPinStrict.mockResolvedValue(true);
+    mockReconcile.mockResolvedValue({
+      ...RECONCILE_NOOP,
+      phantomAccountsPruned: ['acct-1'],
+    });
+    const warnSpy = jest.spyOn(console, 'warn').mockImplementation(() => {});
+
+    const { result } = await mountAuth();
+
+    // Refresh threw ⇒ keep the pre-reconcile fail-safe verdict (LOCKED).
+    expect(result.current.authState.isLocked).toBe(true);
+    expect(result.current.authState.hasWallet).toBe(true);
+    expect(result.current.authState.securityUnavailable).toBe(false);
+    expect(result.current.authState.authChecked).toBe(true);
+
+    warnSpy.mockRestore();
+  });
+
+  it('runs the reconcile at boot exactly ONCE and NOT again on recheckAuthState (one-shot latch)', async () => {
+    mockHasWalletStrict.mockResolvedValue(true);
+    mockHasPinStrict.mockResolvedValue(true);
+
+    const { result } = await mountAuth();
+    expect(mockReconcile).toHaveBeenCalledTimes(1);
+
+    // A mid-session recheck (as ChangePinScreen / LockScreen trigger) must NOT
+    // re-arm the ownership-unchecked reconcile against a possible live creation.
+    await act(async () => {
+      await result.current.recheckAuthState();
+    });
+    await flush();
+
+    expect(mockReconcile).toHaveBeenCalledTimes(1);
+  });
 });
 
 describe('AuthContext — PIN unlock', () => {

--- a/src/services/secure/AccountSecureStorage.ts
+++ b/src/services/secure/AccountSecureStorage.ts
@@ -1280,7 +1280,9 @@ export class AccountSecureStorage {
       timeoutMs,
       'secret presence probe'
     );
-    if (primary != null) {
+    // Truthiness (not `!= null`) to match the reader's `if (stored)` semantics —
+    // an empty-string value reads as absent there too (Codex P2).
+    if (primary) {
       return true;
     }
     // Primary absent: mirror migrateLegacyAccountDataLocked. A set wipe tombstone
@@ -1300,7 +1302,8 @@ export class AccountSecureStorage {
       timeoutMs,
       'legacy secret presence probe'
     );
-    return legacy != null;
+    // Truthiness to match migrateLegacyAccountDataLocked's `if (!legacyData)`.
+    return !!legacy;
   }
 
   /**
@@ -1993,6 +1996,29 @@ export class AccountSecureStorage {
         `Failed to retrieve account list: ${(error as Error).message}`
       );
     }
+  }
+
+  /**
+   * READ-ONLY strict read of the account-id list for the boot reconcile
+   * (TASK-222). getAllAccountIds MIGRATES a legacy secure-store list — it WRITES
+   * the primary and DELETES the legacy copy — which would be a mutation during
+   * the reconcile's abort-safe phase-one reads (a later probe/journal failure
+   * must leave the store untouched; Codex P2). This sibling reads the primary,
+   * then the legacy location, WITHOUT migrating, and PROPAGATES a read failure or
+   * a corrupt (unparseable) list so the reconcile fails closed. Resolves `[]`
+   * only for genuine absence.
+   */
+  static async readAccountListStrict(): Promise<string[]> {
+    const primary = await storage.getItem(this.METADATA_LIST_KEY);
+    if (primary) {
+      // A corrupt list throws here → propagates → reconcile aborts (fail closed).
+      return JSON.parse(primary) as string[];
+    }
+    const legacy = await secureStorage.getItem(this.METADATA_LIST_KEY);
+    if (legacy) {
+      return JSON.parse(legacy) as string[];
+    }
+    return [];
   }
 
   private static async encryptPrivateKey(

--- a/src/services/secure/AccountSecureStorage.ts
+++ b/src/services/secure/AccountSecureStorage.ts
@@ -2020,13 +2020,17 @@ export class AccountSecureStorage {
    * only for genuine absence.
    */
   static async readAccountListStrict(): Promise<string[]> {
+    // `!= null` (not truthiness): a present-but-EMPTY value ('') is CORRUPTION,
+    // not absence — a genuinely absent list is null. Routing '' to the parser
+    // makes JSON.parse('') throw → reconcile aborts (fail closed). Collapsing ''
+    // to [] would silently drop the list as a candidate source (Codex).
     const primary = await storage.getItem(this.METADATA_LIST_KEY);
-    if (primary) {
+    if (primary != null) {
       // A corrupt list throws here → propagates → reconcile aborts (fail closed).
       return this.parseAccountListStrict(primary);
     }
     const legacy = await secureStorage.getItem(this.METADATA_LIST_KEY);
-    if (legacy) {
+    if (legacy != null) {
       return this.parseAccountListStrict(legacy);
     }
     return [];

--- a/src/services/secure/AccountSecureStorage.ts
+++ b/src/services/secure/AccountSecureStorage.ts
@@ -2012,13 +2012,31 @@ export class AccountSecureStorage {
     const primary = await storage.getItem(this.METADATA_LIST_KEY);
     if (primary) {
       // A corrupt list throws here → propagates → reconcile aborts (fail closed).
-      return JSON.parse(primary) as string[];
+      return this.parseAccountListStrict(primary);
     }
     const legacy = await secureStorage.getItem(this.METADATA_LIST_KEY);
     if (legacy) {
-      return JSON.parse(legacy) as string[];
+      return this.parseAccountListStrict(legacy);
     }
     return [];
+  }
+
+  /**
+   * Parse + STRUCTURALLY VALIDATE an account-id list for the strict read. A list
+   * that is valid JSON but not a string[] (e.g. `"id"`, `{}`, or `[1,2]`) is
+   * CORRUPTION, not data — returning it unchecked would spread non-ids (a bare
+   * string spreads into per-character candidate ids) into the reconcile's
+   * destructive classification (Codex P2). Throw so the reconcile fails closed.
+   */
+  private static parseAccountListStrict(raw: string): string[] {
+    const parsed = JSON.parse(raw) as unknown;
+    if (
+      !Array.isArray(parsed) ||
+      !parsed.every((id) => typeof id === 'string')
+    ) {
+      throw new Error('Corrupt account list: not an array of strings');
+    }
+    return parsed as string[];
   }
 
   private static async encryptPrivateKey(

--- a/src/services/secure/AccountSecureStorage.ts
+++ b/src/services/secure/AccountSecureStorage.ts
@@ -1327,7 +1327,9 @@ export class AccountSecureStorage {
     if (raw == null) {
       return {};
     }
-    // Throw (not swallow) on corruption so the reconcile fails closed.
+    // Throw (not swallow) on corruption so the reconcile fails closed. Validate
+    // the full declared shape: a non-null, non-array object whose values are all
+    // strings (the per-attempt tokens). Keys are always strings from JSON.
     const parsed = JSON.parse(raw) as unknown;
     if (
       parsed === null ||
@@ -1335,6 +1337,15 @@ export class AccountSecureStorage {
       Array.isArray(parsed)
     ) {
       throw new Error('Corrupt pending-creation journal: not an object');
+    }
+    if (
+      !Object.values(parsed as Record<string, unknown>).every(
+        (token) => typeof token === 'string'
+      )
+    ) {
+      throw new Error(
+        'Corrupt pending-creation journal: non-string token value'
+      );
     }
     return parsed as Record<string, string>;
   }

--- a/src/services/secure/AccountSecureStorage.ts
+++ b/src/services/secure/AccountSecureStorage.ts
@@ -1239,6 +1239,113 @@ export class AccountSecureStorage {
     });
   }
 
+  // ───────────────────────────────────────────────────────────────────────────
+  // TASK-222 — boot-reconcile strict probes. These back the fail-closed
+  // cross-store half-state repair (crossStoreReconcile.ts, hooked at boot in
+  // AuthContext). Every probe here must either return a DEFINITE answer or THROW
+  // — never swallow a read failure to a falsy "absent", because the reconcile
+  // interprets "absent" destructively (an absent secret makes its blob account a
+  // phantom to prune). A swallowed keychain hiccup reported as "absent" would
+  // mass-prune live accounts, so these siblings of the internal readers fail
+  // CLOSED (propagate) instead. See the strict-read family in the wallet service
+  // (getStoredValueStrict, TASK-213) for the same discipline on the blob side.
+  // ───────────────────────────────────────────────────────────────────────────
+
+  /**
+   * STRICT presence probe for a single account's secret (TASK-222). Reads the
+   * PRIMARY secret key ONLY — no legacy fallback and no migration WRITE (unlike
+   * readSecretLocked, which folds/rewrites legacy blobs), so a boot probe never
+   * mutates the store it is inspecting. Resolves `true` if the primary secret is
+   * present, `false` for genuine absence, and PROPAGATES a read failure/timeout
+   * (the caller aborts the whole destructive pass on any throw). Needs no unlock
+   * — it inspects presence, never decrypts. Bounded so a wedged keychain read
+   * cannot stall boot: a hang becomes a rejection the reconcile treats as "read
+   * failed → abort", NOT as "absent".
+   */
+  static async probeSecretPresenceStrict(
+    accountId: string,
+    timeoutMs: number = 1500
+  ): Promise<boolean> {
+    const raw = await this.withTimeout(
+      secureStorage.getItem(this.secretKey(accountId)),
+      timeoutMs,
+      'secret presence probe'
+    );
+    return raw != null;
+  }
+
+  /**
+   * STRICT read of the durable pending-creation journal (TASK-222). Public
+   * sibling of readPendingCreateJournal for the boot reconcile. A `storage`
+   * read failure PROPAGATES (fail closed); only a structurally-malformed value
+   * degrades to `{}` (the private reader already tolerates bad JSON, and a
+   * corrupt journal is not a reason to abort a repair). Bounded so a wedged read
+   * cannot stall boot.
+   */
+  static async readPendingCreatesStrict(
+    timeoutMs: number = 1500
+  ): Promise<Record<string, string>> {
+    return this.withTimeout(
+      this.readPendingCreateJournal(),
+      timeoutMs,
+      'pending-creation journal read'
+    );
+  }
+
+  /**
+   * Unconditionally drop the given ids from the pending-creation journal
+   * (TASK-222 reconcile cleanup) under the key-mutation mutex. Unlike
+   * deleteAccountIfAttemptMatches this is NOT ownership-checked — the reconcile
+   * runs once at boot before any creation flow starts, and it drops only entries
+   * it has already classified as orphaned-secret (deleted here) or stale (no
+   * secret, no blob account). Touches ONLY the journal; deleting the secret is
+   * the caller's separate deleteAccount step. A no-op for ids not present.
+   */
+  static async dropPendingCreateEntries(ids: string[]): Promise<void> {
+    if (ids.length === 0) return;
+    return this.runKeyMutationExclusive(async () => {
+      const journal = await this.readPendingCreateJournal();
+      let changed = false;
+      for (const id of ids) {
+        if (journal[id] !== undefined) {
+          delete journal[id];
+          changed = true;
+        }
+      }
+      if (changed) {
+        await this.writePendingCreateJournal(journal);
+      }
+    });
+  }
+
+  /**
+   * Reject `promise` if it has not settled within `ms`. On timeout the abandoned
+   * read's eventual settlement is ignored and a labelled Error is thrown so the
+   * boot reconcile fails CLOSED (treats it as a read failure, not "absent").
+   * Mirrors the AuthContext withTimeout used for the strict lock reads.
+   */
+  private static withTimeout<T>(
+    promise: Promise<T>,
+    ms: number,
+    label: string
+  ): Promise<T> {
+    return new Promise<T>((resolve, reject) => {
+      const timer = setTimeout(() => {
+        reject(new Error(`${label} timed out after ${ms}ms`));
+      }, ms);
+      promise.then(
+        (value) => {
+          clearTimeout(timer);
+          resolve(value);
+        },
+        (error) => {
+          clearTimeout(timer);
+          reject(error);
+        }
+      );
+    });
+  }
+
   /** The body of storeAccount, assuming the key-mutation mutex is HELD. Shared by
    *  storeAccount (public wrapper) and storeAccountForCreation. */
   private static async storeAccountLocked(

--- a/src/services/secure/AccountSecureStorage.ts
+++ b/src/services/secure/AccountSecureStorage.ts
@@ -1252,44 +1252,88 @@ export class AccountSecureStorage {
   // ───────────────────────────────────────────────────────────────────────────
 
   /**
-   * STRICT presence probe for a single account's secret (TASK-222). Reads the
-   * PRIMARY secret key ONLY — no legacy fallback and no migration WRITE (unlike
-   * readSecretLocked, which folds/rewrites legacy blobs), so a boot probe never
-   * mutates the store it is inspecting. Resolves `true` if the primary secret is
-   * present, `false` for genuine absence, and PROPAGATES a read failure/timeout
-   * (the caller aborts the whole destructive pass on any throw). Needs no unlock
-   * — it inspects presence, never decrypts. Bounded so a wedged keychain read
-   * cannot stall boot: a hang becomes a rejection the reconcile treats as "read
-   * failed → abort", NOT as "absent".
+   * STRICT presence probe for a single account's secret (TASK-222). Answers "is
+   * this account's key RETRIEVABLE?" with the SAME semantics as the real reader
+   * (readSecretLocked → migrateLegacyAccountDataLocked), but READ-ONLY — it never
+   * performs the migration write, so a boot probe never mutates the store it is
+   * inspecting. Mirroring the reader is load-bearing: the reader treats a missing
+   * PRIMARY secret as a reason to migrate a still-present LEGACY `voi_account_<id>`
+   * blob, so a live, not-yet-migrated account has NO primary secret yet. Probing
+   * the primary key alone would misclassify such an account as a phantom and
+   * prune it — losing funds (Codex P1). Presence is therefore:
+   *   primary present                          → true
+   *   primary absent, wipe tombstone SET       → false  (migration bails; the
+   *                                                       secret is intentionally
+   *                                                       dead — mirrors :1030)
+   *   primary absent, no tombstone, legacy blob → true   (live + migratable)
+   *   otherwise                                → false  (genuine absence)
+   * PROPAGATES a read failure/timeout so the caller aborts the whole destructive
+   * pass on any throw. Needs no unlock — it inspects presence, never decrypts.
+   * Bounded so a wedged keychain read cannot stall boot.
    */
   static async probeSecretPresenceStrict(
     accountId: string,
     timeoutMs: number = 1500
   ): Promise<boolean> {
-    const raw = await this.withTimeout(
+    const primary = await this.withTimeout(
       secureStorage.getItem(this.secretKey(accountId)),
       timeoutMs,
       'secret presence probe'
     );
-    return raw != null;
+    if (primary != null) {
+      return true;
+    }
+    // Primary absent: mirror migrateLegacyAccountDataLocked. A set wipe tombstone
+    // means a legacy blob is intentionally dead (never resurrected) → absent.
+    const wiped = await this.withTimeout(
+      storage.getItem(this.SECURE_WIPE_TOMBSTONE_KEY),
+      timeoutMs,
+      'wipe tombstone probe'
+    );
+    if (wiped != null) {
+      return false;
+    }
+    // No tombstone: a surviving legacy `voi_account_<id>` blob is a LIVE key the
+    // reader would migrate on next access — count it as present (do NOT migrate).
+    const legacy = await this.withTimeout(
+      secureStorage.getItem(`${this.LEGACY_STORAGE_KEY_PREFIX}${accountId}`),
+      timeoutMs,
+      'legacy secret presence probe'
+    );
+    return legacy != null;
   }
 
   /**
-   * STRICT read of the durable pending-creation journal (TASK-222). Public
-   * sibling of readPendingCreateJournal for the boot reconcile. A `storage`
-   * read failure PROPAGATES (fail closed); only a structurally-malformed value
-   * degrades to `{}` (the private reader already tolerates bad JSON, and a
-   * corrupt journal is not a reason to abort a repair). Bounded so a wedged read
+   * STRICT read of the durable pending-creation journal (TASK-222). Unlike the
+   * tolerant private readPendingCreateJournal (which degrades bad JSON to `{}` —
+   * a safe default on the WRITE paths), this FAILS CLOSED for the reconcile: a
+   * storage read failure OR structurally-malformed content (unparseable, or a
+   * non-object) PROPAGATES, so a corrupt journal aborts the destructive pass
+   * rather than silently hiding a journal-only half-created secret from repair
+   * (Codex P2). Resolves `{}` only for genuine absence. Bounded so a wedged read
    * cannot stall boot.
    */
   static async readPendingCreatesStrict(
     timeoutMs: number = 1500
   ): Promise<Record<string, string>> {
-    return this.withTimeout(
-      this.readPendingCreateJournal(),
+    const raw = await this.withTimeout(
+      storage.getItem(this.PENDING_CREATES_KEY),
       timeoutMs,
       'pending-creation journal read'
     );
+    if (raw == null) {
+      return {};
+    }
+    // Throw (not swallow) on corruption so the reconcile fails closed.
+    const parsed = JSON.parse(raw) as unknown;
+    if (
+      parsed === null ||
+      typeof parsed !== 'object' ||
+      Array.isArray(parsed)
+    ) {
+      throw new Error('Corrupt pending-creation journal: not an object');
+    }
+    return parsed as Record<string, string>;
   }
 
   /**

--- a/src/services/secure/AccountSecureStorage.ts
+++ b/src/services/secure/AccountSecureStorage.ts
@@ -1338,13 +1338,14 @@ export class AccountSecureStorage {
     ) {
       throw new Error('Corrupt pending-creation journal: not an object');
     }
+    const entries = parsed as Record<string, unknown>;
+    // Reject an empty key (a garbage candidate id) or a non-string token value.
     if (
-      !Object.values(parsed as Record<string, unknown>).every(
-        (token) => typeof token === 'string'
-      )
+      Object.keys(entries).some((id) => id === '') ||
+      !Object.values(entries).every((token) => typeof token === 'string')
     ) {
       throw new Error(
-        'Corrupt pending-creation journal: non-string token value'
+        'Corrupt pending-creation journal: empty key or non-string token'
       );
     }
     return parsed as Record<string, string>;
@@ -2047,9 +2048,13 @@ export class AccountSecureStorage {
     const parsed = JSON.parse(raw) as unknown;
     if (
       !Array.isArray(parsed) ||
-      !parsed.every((id) => typeof id === 'string')
+      !parsed.every((id) => typeof id === 'string' && id !== '')
     ) {
-      throw new Error('Corrupt account list: not an array of strings');
+      // Reject non-string OR empty-string entries: an empty/garbage id must not
+      // become a reconcile candidate (Codex).
+      throw new Error(
+        'Corrupt account list: not an array of non-empty strings'
+      );
     }
     return parsed as string[];
   }

--- a/src/services/secure/__tests__/reconcilePrimitives.test.ts
+++ b/src/services/secure/__tests__/reconcilePrimitives.test.ts
@@ -84,6 +84,16 @@ describe('probeSecretPresenceStrict', () => {
     ).resolves.toBe(false);
   });
 
+  // Codex P2: match the reader's `if (stored)` truthiness — an empty-string
+  // primary value is ABSENT to the reader, so the probe must fall through (here,
+  // to legacy/tombstone, both empty → false), not report the empty as present.
+  it('treats an empty-string primary value as absent (truthiness, not != null)', async () => {
+    mockSecure.set(`${SECRET_PREFIX}acc1`, '');
+    await expect(
+      AccountSecureStorage.probeSecretPresenceStrict('acc1')
+    ).resolves.toBe(false);
+  });
+
   // Codex P1: a live account whose key is still in LEGACY format (not yet
   // migrated) has NO primary secret. The reader would migrate it on next access,
   // so the probe MUST count it as present — else the reconcile prunes a real,
@@ -177,6 +187,52 @@ describe('readPendingCreatesStrict', () => {
     await expect(
       AccountSecureStorage.readPendingCreatesStrict()
     ).rejects.toThrow('not an object');
+  });
+});
+
+describe('readAccountListStrict', () => {
+  const METADATA_LIST_KEY = 'voi_account_list';
+
+  it('returns the primary list', async () => {
+    mockKv.set(METADATA_LIST_KEY, JSON.stringify(['a', 'b']));
+    await expect(AccountSecureStorage.readAccountListStrict()).resolves.toEqual(
+      ['a', 'b']
+    );
+  });
+
+  it('returns [] for genuine absence', async () => {
+    await expect(AccountSecureStorage.readAccountListStrict()).resolves.toEqual(
+      []
+    );
+  });
+
+  it('reads the legacy list WITHOUT migrating (no write, no delete)', async () => {
+    // Primary absent, legacy present: getAllAccountIds would migrate here; the
+    // strict read-only sibling must NOT write the primary or delete the legacy.
+    mockSecure.set(METADATA_LIST_KEY, JSON.stringify(['c']));
+    await expect(AccountSecureStorage.readAccountListStrict()).resolves.toEqual(
+      ['c']
+    );
+    expect(storage.setItem).not.toHaveBeenCalled();
+    expect(secureStorage.deleteItem).not.toHaveBeenCalled();
+    // Legacy copy still there (untouched).
+    expect(mockSecure.get(METADATA_LIST_KEY)).toBe(JSON.stringify(['c']));
+  });
+
+  it('PROPAGATES a storage read failure (fail closed)', async () => {
+    (storage.getItem as jest.Mock).mockRejectedValueOnce(
+      new Error('list read failed')
+    );
+    await expect(AccountSecureStorage.readAccountListStrict()).rejects.toThrow(
+      'list read failed'
+    );
+  });
+
+  it('THROWS on a corrupt (unparseable) primary list', async () => {
+    mockKv.set(METADATA_LIST_KEY, '{not json');
+    await expect(
+      AccountSecureStorage.readAccountListStrict()
+    ).rejects.toThrow();
   });
 });
 

--- a/src/services/secure/__tests__/reconcilePrimitives.test.ts
+++ b/src/services/secure/__tests__/reconcilePrimitives.test.ts
@@ -59,6 +59,8 @@ import { secureStorage, storage } from '@/platform';
 import { AccountSecureStorage } from '../AccountSecureStorage';
 
 const SECRET_PREFIX = 'voi_account_secret_';
+const LEGACY_PREFIX = 'voi_account_';
+const WIPE_TOMBSTONE_KEY = 'voi_secure_wiped';
 const PENDING_CREATES_KEY = 'voi_pending_account_creates';
 const mockSecureGet = secureStorage.getItem as jest.Mock;
 
@@ -76,10 +78,49 @@ describe('probeSecretPresenceStrict', () => {
     ).resolves.toBe(true);
   });
 
-  it('resolves false for a genuinely absent secret', async () => {
+  it('resolves false for a genuinely absent secret (no primary, no legacy)', async () => {
     await expect(
       AccountSecureStorage.probeSecretPresenceStrict('missing')
     ).resolves.toBe(false);
+  });
+
+  // Codex P1: a live account whose key is still in LEGACY format (not yet
+  // migrated) has NO primary secret. The reader would migrate it on next access,
+  // so the probe MUST count it as present — else the reconcile prunes a real,
+  // fund-bearing account as a phantom.
+  it('resolves true when only a LEGACY secret exists (migratable, no tombstone)', async () => {
+    mockSecure.set(`${LEGACY_PREFIX}acc1`, JSON.stringify({ any: 'legacy' }));
+    await expect(
+      AccountSecureStorage.probeSecretPresenceStrict('acc1')
+    ).resolves.toBe(true);
+  });
+
+  // Mirrors migrateLegacyAccountDataLocked: a set wipe tombstone means a
+  // surviving legacy blob is intentionally dead and must NOT be resurrected.
+  it('resolves false for a legacy-only secret when the wipe tombstone is set', async () => {
+    mockSecure.set(`${LEGACY_PREFIX}acc1`, JSON.stringify({ any: 'legacy' }));
+    mockKv.set(WIPE_TOMBSTONE_KEY, '1');
+    await expect(
+      AccountSecureStorage.probeSecretPresenceStrict('acc1')
+    ).resolves.toBe(false);
+  });
+
+  it('short-circuits on a present primary — no legacy/tombstone read, no write', async () => {
+    mockSecure.set(`${SECRET_PREFIX}acc1`, JSON.stringify({ any: 'payload' }));
+    await AccountSecureStorage.probeSecretPresenceStrict('acc1');
+    // Exactly one secure getItem (the primary); tombstone/legacy never consulted.
+    expect(mockSecureGet).toHaveBeenCalledTimes(1);
+    expect(mockSecureGet).toHaveBeenCalledWith(`${SECRET_PREFIX}acc1`);
+    expect(storage.getItem).not.toHaveBeenCalled();
+    expect(secureStorage.setItem).not.toHaveBeenCalled();
+  });
+
+  it('never migrates/writes even when it falls through to the legacy blob', async () => {
+    mockSecure.set(`${LEGACY_PREFIX}acc1`, JSON.stringify({ any: 'legacy' }));
+    await AccountSecureStorage.probeSecretPresenceStrict('acc1');
+    // Read-only probe: no secret write, no legacy delete (no migration).
+    expect(secureStorage.setItem).not.toHaveBeenCalled();
+    expect(secureStorage.deleteItem).not.toHaveBeenCalled();
   });
 
   it('PROPAGATES a read failure (fail closed, not false)', async () => {
@@ -95,14 +136,6 @@ describe('probeSecretPresenceStrict', () => {
     await expect(
       AccountSecureStorage.probeSecretPresenceStrict('acc1', 20)
     ).rejects.toThrow('timed out');
-  });
-
-  it('reads ONLY the primary key — no legacy fallback / migration write', async () => {
-    await AccountSecureStorage.probeSecretPresenceStrict('acc1');
-    // Exactly one getItem, for the primary secret key; no write anywhere.
-    expect(mockSecureGet).toHaveBeenCalledTimes(1);
-    expect(mockSecureGet).toHaveBeenCalledWith(`${SECRET_PREFIX}acc1`);
-    expect(secureStorage.setItem).not.toHaveBeenCalled();
   });
 });
 
@@ -127,6 +160,23 @@ describe('readPendingCreatesStrict', () => {
     await expect(
       AccountSecureStorage.readPendingCreatesStrict()
     ).rejects.toThrow('kv read failed');
+  });
+
+  // Codex P2: unlike the tolerant private reader, the STRICT read must fail
+  // closed on corrupt content rather than degrade to {} (which would hide a
+  // journal-only half-created secret from the reconcile).
+  it('THROWS on unparseable journal content (fail closed, not {})', async () => {
+    mockKv.set(PENDING_CREATES_KEY, '{not json');
+    await expect(
+      AccountSecureStorage.readPendingCreatesStrict()
+    ).rejects.toThrow();
+  });
+
+  it('THROWS on structurally-invalid journal (non-object)', async () => {
+    mockKv.set(PENDING_CREATES_KEY, JSON.stringify(['a', 'b']));
+    await expect(
+      AccountSecureStorage.readPendingCreatesStrict()
+    ).rejects.toThrow('not an object');
   });
 });
 

--- a/src/services/secure/__tests__/reconcilePrimitives.test.ts
+++ b/src/services/secure/__tests__/reconcilePrimitives.test.ts
@@ -235,6 +235,15 @@ describe('readAccountListStrict', () => {
     );
   });
 
+  // Codex: a present-but-empty value is corruption, not absence — must not
+  // collapse to [] (which silently drops the list as a candidate source).
+  it('THROWS on a present-but-empty ("") stored list', async () => {
+    mockKv.set(METADATA_LIST_KEY, '');
+    await expect(
+      AccountSecureStorage.readAccountListStrict()
+    ).rejects.toThrow();
+  });
+
   it('THROWS on a corrupt (unparseable) primary list', async () => {
     mockKv.set(METADATA_LIST_KEY, '{not json');
     await expect(

--- a/src/services/secure/__tests__/reconcilePrimitives.test.ts
+++ b/src/services/secure/__tests__/reconcilePrimitives.test.ts
@@ -186,7 +186,14 @@ describe('readPendingCreatesStrict', () => {
     mockKv.set(PENDING_CREATES_KEY, JSON.stringify({ a: 't1', b: 5 }));
     await expect(
       AccountSecureStorage.readPendingCreatesStrict()
-    ).rejects.toThrow('non-string token value');
+    ).rejects.toThrow('non-string token');
+  });
+
+  it('THROWS on a journal with an empty-string key (garbage candidate id)', async () => {
+    mockKv.set(PENDING_CREATES_KEY, JSON.stringify({ '': 't1' }));
+    await expect(
+      AccountSecureStorage.readPendingCreatesStrict()
+    ).rejects.toThrow('empty key');
   });
 
   it('THROWS on structurally-invalid journal (non-object)', async () => {
@@ -257,14 +264,21 @@ describe('readAccountListStrict', () => {
   it('THROWS on valid JSON that is not an array (e.g. a bare string)', async () => {
     mockKv.set(METADATA_LIST_KEY, JSON.stringify('abc'));
     await expect(AccountSecureStorage.readAccountListStrict()).rejects.toThrow(
-      'not an array of strings'
+      'non-empty strings'
     );
   });
 
   it('THROWS on an array containing non-string entries', async () => {
     mockKv.set(METADATA_LIST_KEY, JSON.stringify(['a', 2, 'c']));
     await expect(AccountSecureStorage.readAccountListStrict()).rejects.toThrow(
-      'not an array of strings'
+      'non-empty strings'
+    );
+  });
+
+  it('THROWS on an array containing an empty-string entry (garbage id)', async () => {
+    mockKv.set(METADATA_LIST_KEY, JSON.stringify(['a', '', 'c']));
+    await expect(AccountSecureStorage.readAccountListStrict()).rejects.toThrow(
+      'non-empty strings'
     );
   });
 });

--- a/src/services/secure/__tests__/reconcilePrimitives.test.ts
+++ b/src/services/secure/__tests__/reconcilePrimitives.test.ts
@@ -234,6 +234,23 @@ describe('readAccountListStrict', () => {
       AccountSecureStorage.readAccountListStrict()
     ).rejects.toThrow();
   });
+
+  // Codex P2: valid JSON that is not a string[] is corruption — returning it
+  // would spread non-ids (a bare string spreads per-character) into the
+  // reconcile's destructive classification. Must throw (fail closed).
+  it('THROWS on valid JSON that is not an array (e.g. a bare string)', async () => {
+    mockKv.set(METADATA_LIST_KEY, JSON.stringify('abc'));
+    await expect(AccountSecureStorage.readAccountListStrict()).rejects.toThrow(
+      'not an array of strings'
+    );
+  });
+
+  it('THROWS on an array containing non-string entries', async () => {
+    mockKv.set(METADATA_LIST_KEY, JSON.stringify(['a', 2, 'c']));
+    await expect(AccountSecureStorage.readAccountListStrict()).rejects.toThrow(
+      'not an array of strings'
+    );
+  });
 });
 
 describe('dropPendingCreateEntries', () => {

--- a/src/services/secure/__tests__/reconcilePrimitives.test.ts
+++ b/src/services/secure/__tests__/reconcilePrimitives.test.ts
@@ -182,6 +182,13 @@ describe('readPendingCreatesStrict', () => {
     ).rejects.toThrow();
   });
 
+  it('THROWS on a journal with a non-string token value', async () => {
+    mockKv.set(PENDING_CREATES_KEY, JSON.stringify({ a: 't1', b: 5 }));
+    await expect(
+      AccountSecureStorage.readPendingCreatesStrict()
+    ).rejects.toThrow('non-string token value');
+  });
+
   it('THROWS on structurally-invalid journal (non-object)', async () => {
     mockKv.set(PENDING_CREATES_KEY, JSON.stringify(['a', 'b']));
     await expect(

--- a/src/services/secure/__tests__/reconcilePrimitives.test.ts
+++ b/src/services/secure/__tests__/reconcilePrimitives.test.ts
@@ -1,0 +1,167 @@
+// TASK-222: the secure-store strict primitives the boot reconcile leans on —
+// probeSecretPresenceStrict (fail-closed per-secret presence probe, no legacy
+// migration WRITE), readPendingCreatesStrict (public strict journal read), and
+// dropPendingCreateEntries (unconditional mutex-guarded journal prune). The
+// presence probe is the load-bearing fail-closed primitive: it must PROPAGATE a
+// read failure/timeout rather than reporting a hiccup as "absent", or the
+// reconcile would mass-prune live accounts.
+//
+// SECURITY NOTE: secureStorage / AsyncStorage are in-memory Map sinks; no key
+// material is used.
+
+const mockSecure = new Map<string, string>();
+const mockKv = new Map<string, string>();
+
+jest.mock('@/platform', () => {
+  const nodeCrypto = require('crypto');
+  return {
+    crypto: {
+      getRandomBytes: async (n: number): Promise<Uint8Array> =>
+        Uint8Array.from(nodeCrypto.randomBytes(n)),
+      sha256: async (input: string): Promise<string> =>
+        nodeCrypto.createHash('sha256').update(input).digest('hex'),
+      randomUUID: () => nodeCrypto.randomUUID(),
+    },
+    secureStorage: {
+      getItem: jest.fn(async (k: string) =>
+        mockSecure.has(k) ? mockSecure.get(k)! : null
+      ),
+      setItem: jest.fn(async (k: string, v: string) => {
+        mockSecure.set(k, v);
+      }),
+      deleteItem: jest.fn(async (k: string) => {
+        mockSecure.delete(k);
+      }),
+    },
+    storage: {
+      getItem: jest.fn(async (k: string) =>
+        mockKv.has(k) ? mockKv.get(k)! : null
+      ),
+      setItem: jest.fn(async (k: string, v: string) => {
+        mockKv.set(k, v);
+      }),
+      removeItem: jest.fn(async (k: string) => {
+        mockKv.delete(k);
+      }),
+      multiRemove: jest.fn(async (keys: string[]) => {
+        keys.forEach((k) => mockKv.delete(k));
+      }),
+    },
+    biometrics: {
+      isAvailable: async () => false,
+      isEnrolled: async () => false,
+    },
+    deviceId: { getDeviceId: async () => 'task222-test-device' },
+  };
+});
+
+import { secureStorage, storage } from '@/platform';
+import { AccountSecureStorage } from '../AccountSecureStorage';
+
+const SECRET_PREFIX = 'voi_account_secret_';
+const PENDING_CREATES_KEY = 'voi_pending_account_creates';
+const mockSecureGet = secureStorage.getItem as jest.Mock;
+
+beforeEach(() => {
+  mockSecure.clear();
+  mockKv.clear();
+  jest.clearAllMocks();
+});
+
+describe('probeSecretPresenceStrict', () => {
+  it('resolves true when the primary secret is present', async () => {
+    mockSecure.set(`${SECRET_PREFIX}acc1`, JSON.stringify({ any: 'payload' }));
+    await expect(
+      AccountSecureStorage.probeSecretPresenceStrict('acc1')
+    ).resolves.toBe(true);
+  });
+
+  it('resolves false for a genuinely absent secret', async () => {
+    await expect(
+      AccountSecureStorage.probeSecretPresenceStrict('missing')
+    ).resolves.toBe(false);
+  });
+
+  it('PROPAGATES a read failure (fail closed, not false)', async () => {
+    mockSecureGet.mockRejectedValueOnce(new Error('keystore wedged'));
+    await expect(
+      AccountSecureStorage.probeSecretPresenceStrict('acc1')
+    ).rejects.toThrow('keystore wedged');
+  });
+
+  it('rejects on timeout when the read hangs (bounded)', async () => {
+    // A getItem that never settles must become a rejection, not hang boot.
+    mockSecureGet.mockImplementationOnce(() => new Promise(() => {}));
+    await expect(
+      AccountSecureStorage.probeSecretPresenceStrict('acc1', 20)
+    ).rejects.toThrow('timed out');
+  });
+
+  it('reads ONLY the primary key — no legacy fallback / migration write', async () => {
+    await AccountSecureStorage.probeSecretPresenceStrict('acc1');
+    // Exactly one getItem, for the primary secret key; no write anywhere.
+    expect(mockSecureGet).toHaveBeenCalledTimes(1);
+    expect(mockSecureGet).toHaveBeenCalledWith(`${SECRET_PREFIX}acc1`);
+    expect(secureStorage.setItem).not.toHaveBeenCalled();
+  });
+});
+
+describe('readPendingCreatesStrict', () => {
+  it('returns the journal contents', async () => {
+    mockKv.set(PENDING_CREATES_KEY, JSON.stringify({ a: 't1', b: 't2' }));
+    await expect(
+      AccountSecureStorage.readPendingCreatesStrict()
+    ).resolves.toEqual({ a: 't1', b: 't2' });
+  });
+
+  it('returns {} when the journal is absent', async () => {
+    await expect(
+      AccountSecureStorage.readPendingCreatesStrict()
+    ).resolves.toEqual({});
+  });
+
+  it('PROPAGATES a storage read failure', async () => {
+    (storage.getItem as jest.Mock).mockRejectedValueOnce(
+      new Error('kv read failed')
+    );
+    await expect(
+      AccountSecureStorage.readPendingCreatesStrict()
+    ).rejects.toThrow('kv read failed');
+  });
+});
+
+describe('dropPendingCreateEntries', () => {
+  it('removes only the listed ids and leaves the rest', async () => {
+    mockKv.set(
+      PENDING_CREATES_KEY,
+      JSON.stringify({ a: 't1', b: 't2', c: 't3' })
+    );
+    await AccountSecureStorage.dropPendingCreateEntries(['a', 'c']);
+    await expect(
+      AccountSecureStorage.readPendingCreatesStrict()
+    ).resolves.toEqual({ b: 't2' });
+  });
+
+  it('clears the journal key entirely when the last entry is dropped', async () => {
+    mockKv.set(PENDING_CREATES_KEY, JSON.stringify({ only: 't1' }));
+    await AccountSecureStorage.dropPendingCreateEntries(['only']);
+    expect(mockKv.has(PENDING_CREATES_KEY)).toBe(false);
+  });
+
+  it('is a no-op for an empty id list (no write)', async () => {
+    mockKv.set(PENDING_CREATES_KEY, JSON.stringify({ a: 't1' }));
+    await AccountSecureStorage.dropPendingCreateEntries([]);
+    expect(storage.setItem).not.toHaveBeenCalled();
+    expect(storage.removeItem).not.toHaveBeenCalled();
+  });
+
+  it('is a no-op when no id matches (no write)', async () => {
+    mockKv.set(PENDING_CREATES_KEY, JSON.stringify({ a: 't1' }));
+    await AccountSecureStorage.dropPendingCreateEntries(['x', 'y']);
+    expect(storage.setItem).not.toHaveBeenCalled();
+    expect(storage.removeItem).not.toHaveBeenCalled();
+    await expect(
+      AccountSecureStorage.readPendingCreatesStrict()
+    ).resolves.toEqual({ a: 't1' });
+  });
+});

--- a/src/services/wallet/__tests__/crossStoreReconcile.test.ts
+++ b/src/services/wallet/__tests__/crossStoreReconcile.test.ts
@@ -241,3 +241,45 @@ describe('reconcileCrossStoreHalfState — repairs (clean read picture)', () => 
     });
   });
 });
+
+describe('reconcileCrossStoreHalfState — Phase 2 is best-effort (partial failure)', () => {
+  // Codex P2: prune runs first; if a later orphan delete throws, the outcome must
+  // still report the completed prune so the caller can refresh the (now stale)
+  // lock verdict — the reconcile must NOT throw away the result.
+  it('preserves a completed phantom prune when a later orphan delete throws', async () => {
+    setup({
+      blob: ['phantom'],
+      list: ['orphan'],
+      journal: {},
+      secrets: ['orphan'], // orphan has a secret, no blob → orphan-delete
+    });
+    secure.deleteAccount.mockRejectedValueOnce(
+      new Error('keychain delete failed')
+    );
+
+    // Does NOT reject — Phase 2 is best-effort.
+    const result = await reconcileCrossStoreHalfState();
+
+    expect(wallet.pruneStandardAccounts).toHaveBeenCalledWith(['phantom']);
+    expect(result.ran).toBe(true);
+    // The prune completed and is reported so the caller refreshes the verdict...
+    expect(result.phantomAccountsPruned).toEqual(['phantom']);
+    // ...but the failed orphan delete is NOT reported as done.
+    expect(result.orphanSecretsDeleted).toEqual([]);
+    // Journal drop for the failed orphan did not run (retried next boot).
+    expect(secure.dropPendingCreateEntries).not.toHaveBeenCalled();
+  });
+
+  it('reports no completed work when the phantom prune itself throws', async () => {
+    setup({ blob: ['phantom'], list: [], journal: {}, secrets: [] });
+    wallet.pruneStandardAccounts.mockRejectedValueOnce(
+      new Error('storeWallet failed')
+    );
+
+    const result = await reconcileCrossStoreHalfState();
+
+    expect(result.ran).toBe(true);
+    // Prune threw → not recorded → caller does NOT refresh (wallet likely intact).
+    expect(result.phantomAccountsPruned).toEqual([]);
+  });
+});

--- a/src/services/wallet/__tests__/crossStoreReconcile.test.ts
+++ b/src/services/wallet/__tests__/crossStoreReconcile.test.ts
@@ -11,7 +11,7 @@
 
 jest.mock('@/services/secure', () => ({
   AccountSecureStorage: {
-    getAllAccountIds: jest.fn(),
+    readAccountListStrict: jest.fn(),
     readPendingCreatesStrict: jest.fn(),
     probeSecretPresenceStrict: jest.fn(),
     deleteAccount: jest.fn(async () => {}),
@@ -31,7 +31,7 @@ import { MultiAccountWalletService } from '../index';
 import { reconcileCrossStoreHalfState } from '../crossStoreReconcile';
 
 const secure = AccountSecureStorage as unknown as {
-  getAllAccountIds: jest.Mock;
+  readAccountListStrict: jest.Mock;
   readPendingCreatesStrict: jest.Mock;
   probeSecretPresenceStrict: jest.Mock;
   deleteAccount: jest.Mock;
@@ -56,7 +56,7 @@ function setup(opts: {
   secrets?: string[];
 }) {
   const secrets = new Set(opts.secrets ?? []);
-  secure.getAllAccountIds.mockResolvedValue(opts.list ?? []);
+  secure.readAccountListStrict.mockResolvedValue(opts.list ?? []);
   secure.readPendingCreatesStrict.mockResolvedValue(opts.journal ?? {});
   wallet.getStandardAccountIdsStrict.mockResolvedValue(opts.blob ?? []);
   secure.probeSecretPresenceStrict.mockImplementation(async (id: string) =>
@@ -89,7 +89,9 @@ describe('reconcileCrossStoreHalfState — fail-closed abort (delete nothing)', 
 
   it('aborts and mutates nothing when the account-list read throws', async () => {
     setup({ blob: ['a'], secrets: ['a'] });
-    secure.getAllAccountIds.mockRejectedValue(new Error('list read failed'));
+    secure.readAccountListStrict.mockRejectedValue(
+      new Error('list read failed')
+    );
 
     await expect(reconcileCrossStoreHalfState()).rejects.toThrow(
       'list read failed'

--- a/src/services/wallet/__tests__/crossStoreReconcile.test.ts
+++ b/src/services/wallet/__tests__/crossStoreReconcile.test.ts
@@ -1,0 +1,241 @@
+// TASK-222 — boot reconcile (Component 3 of the cross-store reset-hardening
+// design, DOC-221). These prove the FAIL-CLOSED orchestration: the pass gathers
+// every strict read + secret probe first and, on ANY read/probe failure, aborts
+// having mutated NOTHING. Only on a fully-known picture does it repair the three
+// half-state classes — orphan secret, phantom account, stale journal entry.
+//
+// The coordinator's own logic is the safety surface, so we mock the two services
+// it drives and assert exactly which mutations run (and, crucially, which do NOT).
+//
+// SECURITY NOTE: no key material anywhere — ids are opaque strings.
+
+jest.mock('@/services/secure', () => ({
+  AccountSecureStorage: {
+    getAllAccountIds: jest.fn(),
+    readPendingCreatesStrict: jest.fn(),
+    probeSecretPresenceStrict: jest.fn(),
+    deleteAccount: jest.fn(async () => {}),
+    dropPendingCreateEntries: jest.fn(async () => {}),
+  },
+}));
+
+jest.mock('../index', () => ({
+  MultiAccountWalletService: {
+    getStandardAccountIdsStrict: jest.fn(),
+    pruneStandardAccounts: jest.fn(async () => {}),
+  },
+}));
+
+import { AccountSecureStorage } from '@/services/secure';
+import { MultiAccountWalletService } from '../index';
+import { reconcileCrossStoreHalfState } from '../crossStoreReconcile';
+
+const secure = AccountSecureStorage as unknown as {
+  getAllAccountIds: jest.Mock;
+  readPendingCreatesStrict: jest.Mock;
+  probeSecretPresenceStrict: jest.Mock;
+  deleteAccount: jest.Mock;
+  dropPendingCreateEntries: jest.Mock;
+};
+const wallet = MultiAccountWalletService as unknown as {
+  getStandardAccountIdsStrict: jest.Mock;
+  pruneStandardAccounts: jest.Mock;
+};
+
+/**
+ * Configure the mocked stores.
+ * @param blob   STANDARD account ids in the wallet blob.
+ * @param list   ids in the secure account list (voi_account_list).
+ * @param journal pending-creation journal { id: token }.
+ * @param secrets set of ids whose secret is PRESENT.
+ */
+function setup(opts: {
+  blob?: string[];
+  list?: string[];
+  journal?: Record<string, string>;
+  secrets?: string[];
+}) {
+  const secrets = new Set(opts.secrets ?? []);
+  secure.getAllAccountIds.mockResolvedValue(opts.list ?? []);
+  secure.readPendingCreatesStrict.mockResolvedValue(opts.journal ?? {});
+  wallet.getStandardAccountIdsStrict.mockResolvedValue(opts.blob ?? []);
+  secure.probeSecretPresenceStrict.mockImplementation(async (id: string) =>
+    secrets.has(id)
+  );
+}
+
+function assertNoMutation() {
+  expect(secure.deleteAccount).not.toHaveBeenCalled();
+  expect(secure.dropPendingCreateEntries).not.toHaveBeenCalled();
+  expect(wallet.pruneStandardAccounts).not.toHaveBeenCalled();
+}
+
+beforeEach(() => {
+  jest.clearAllMocks();
+});
+
+describe('reconcileCrossStoreHalfState — fail-closed abort (delete nothing)', () => {
+  it('aborts and mutates nothing when the wallet-blob strict read throws', async () => {
+    setup({ list: ['a'], secrets: ['a'] });
+    wallet.getStandardAccountIdsStrict.mockRejectedValue(
+      new Error('blob read failed')
+    );
+
+    await expect(reconcileCrossStoreHalfState()).rejects.toThrow(
+      'blob read failed'
+    );
+    assertNoMutation();
+  });
+
+  it('aborts and mutates nothing when the account-list read throws', async () => {
+    setup({ blob: ['a'], secrets: ['a'] });
+    secure.getAllAccountIds.mockRejectedValue(new Error('list read failed'));
+
+    await expect(reconcileCrossStoreHalfState()).rejects.toThrow(
+      'list read failed'
+    );
+    assertNoMutation();
+  });
+
+  it('aborts and mutates nothing when the journal read throws', async () => {
+    setup({ blob: ['a'], secrets: ['a'] });
+    secure.readPendingCreatesStrict.mockRejectedValue(
+      new Error('journal read failed')
+    );
+
+    await expect(reconcileCrossStoreHalfState()).rejects.toThrow(
+      'journal read failed'
+    );
+    assertNoMutation();
+  });
+
+  // THE regression: a single probe failure must NOT be read as "secret absent"
+  // and mass-delete/prune. It must abort the entire destructive pass.
+  it('aborts and mass-deletes NOTHING when any secret probe throws', async () => {
+    // Three blob STANDARD accounts; probing the second one fails. If the pass
+    // treated the failure (or the other absences) as truth it would prune all.
+    setup({ blob: ['a', 'b', 'c'], list: ['a', 'b', 'c'] });
+    secure.probeSecretPresenceStrict.mockImplementation(async (id: string) => {
+      if (id === 'b') throw new Error('keychain wedged');
+      return false; // a, c would look phantom — must NOT be pruned
+    });
+
+    await expect(reconcileCrossStoreHalfState()).rejects.toThrow(
+      'keychain wedged'
+    );
+    assertNoMutation();
+  });
+
+  it('aborts when a probe times out (bounded, treated as read failure)', async () => {
+    setup({ blob: ['a'], list: ['a'] });
+    secure.probeSecretPresenceStrict.mockRejectedValue(
+      new Error('secret presence probe timed out after 1500ms')
+    );
+
+    await expect(reconcileCrossStoreHalfState()).rejects.toThrow('timed out');
+    assertNoMutation();
+  });
+});
+
+describe('reconcileCrossStoreHalfState — repairs (clean read picture)', () => {
+  it('deletes an orphan secret (present, no blob account) and drops its journal entry', async () => {
+    // 'orphan' has a secret + a journal entry but no wallet-blob account.
+    setup({
+      blob: [],
+      list: ['orphan'],
+      journal: { orphan: 't1' },
+      secrets: ['orphan'],
+    });
+
+    const result = await reconcileCrossStoreHalfState();
+
+    expect(secure.deleteAccount).toHaveBeenCalledTimes(1);
+    expect(secure.deleteAccount).toHaveBeenCalledWith('orphan');
+    expect(secure.dropPendingCreateEntries).toHaveBeenCalledWith(['orphan']);
+    expect(wallet.pruneStandardAccounts).not.toHaveBeenCalled();
+    expect(result).toMatchObject({
+      ran: true,
+      orphanSecretsDeleted: ['orphan'],
+      phantomAccountsPruned: [],
+      staleJournalDropped: [],
+    });
+  });
+
+  it('prunes a phantom account (blob STANDARD, secret strictly absent)', async () => {
+    setup({ blob: ['phantom'], list: ['phantom'], secrets: [] });
+
+    const result = await reconcileCrossStoreHalfState();
+
+    expect(wallet.pruneStandardAccounts).toHaveBeenCalledTimes(1);
+    expect(wallet.pruneStandardAccounts).toHaveBeenCalledWith(['phantom']);
+    expect(secure.deleteAccount).not.toHaveBeenCalled();
+    expect(result).toMatchObject({
+      ran: true,
+      phantomAccountsPruned: ['phantom'],
+      orphanSecretsDeleted: [],
+    });
+  });
+
+  it('drops a stale journal entry (no secret, no blob account)', async () => {
+    setup({ blob: [], list: [], journal: { stale: 't9' }, secrets: [] });
+
+    const result = await reconcileCrossStoreHalfState();
+
+    expect(secure.dropPendingCreateEntries).toHaveBeenCalledWith(['stale']);
+    expect(secure.deleteAccount).not.toHaveBeenCalled();
+    expect(wallet.pruneStandardAccounts).not.toHaveBeenCalled();
+    expect(result).toMatchObject({ ran: true, staleJournalDropped: ['stale'] });
+  });
+
+  it('is a no-op on a fully-consistent picture (blob ⟺ secret)', async () => {
+    setup({ blob: ['a', 'b'], list: ['a', 'b'], secrets: ['a', 'b'] });
+
+    const result = await reconcileCrossStoreHalfState();
+
+    assertNoMutation();
+    expect(result).toEqual({
+      ran: true,
+      orphanSecretsDeleted: [],
+      phantomAccountsPruned: [],
+      staleJournalDropped: [],
+    });
+  });
+
+  it('does NOT touch an account-list-only ghost (no secret, no blob, no journal)', async () => {
+    // An id in the account list with neither secret nor blob account nor journal
+    // entry is out of this design's three repair classes — left as-is.
+    setup({ blob: [], list: ['ghost'], secrets: [] });
+
+    const result = await reconcileCrossStoreHalfState();
+
+    assertNoMutation();
+    expect(result.ran).toBe(true);
+  });
+
+  it('handles a mixed picture: orphan + phantom + stale together', async () => {
+    setup({
+      blob: ['phantom', 'ok'],
+      list: ['orphan', 'ok'],
+      journal: { orphan: 't1', stale: 't2' },
+      secrets: ['orphan', 'ok'],
+    });
+
+    const result = await reconcileCrossStoreHalfState();
+
+    // orphan: secret present, not in blob → delete + journal drop
+    expect(secure.deleteAccount).toHaveBeenCalledWith('orphan');
+    // phantom: blob STANDARD, secret absent → prune
+    expect(wallet.pruneStandardAccounts).toHaveBeenCalledWith(['phantom']);
+    // stale + orphan journal ids dropped; 'ok' untouched
+    const dropped = secure.dropPendingCreateEntries.mock
+      .calls[0][0] as string[];
+    expect(dropped.sort()).toEqual(['orphan', 'stale']);
+    expect(secure.deleteAccount).toHaveBeenCalledTimes(1); // NOT 'ok'
+    expect(result).toMatchObject({
+      ran: true,
+      orphanSecretsDeleted: ['orphan'],
+      phantomAccountsPruned: ['phantom'],
+      staleJournalDropped: ['stale'],
+    });
+  });
+});

--- a/src/services/wallet/__tests__/getStandardAccountIdsStrict.test.ts
+++ b/src/services/wallet/__tests__/getStandardAccountIdsStrict.test.ts
@@ -114,6 +114,30 @@ it('THROWS on a structurally-corrupt blob (accounts not an array)', async () => 
   ).rejects.toThrow('not an array');
 });
 
+it('THROWS on a STANDARD account with a non-string id (corruption, not data)', async () => {
+  // Raw strict read — no heal pass — so a non-string id is corruption that must
+  // not become a reconcile candidate. Fail closed.
+  mockStore[WALLET_KEY] = JSON.stringify({
+    id: 'w1',
+    version: '1',
+    createdAt: '',
+    accounts: [
+      {
+        id: 42,
+        address: 'ADDR',
+        publicKey: 'PUB',
+        type: 'standard',
+        isHidden: false,
+      },
+    ],
+    activeAccountId: '',
+    settings: {},
+  });
+  await expect(
+    MultiAccountWalletService.getStandardAccountIdsStrict()
+  ).rejects.toThrow('non-string id');
+});
+
 it('does not write or migrate (pure read)', async () => {
   mockStore[WALLET_KEY] = blob([{ id: 's1', type: 'standard' }]);
   await MultiAccountWalletService.getStandardAccountIdsStrict();

--- a/src/services/wallet/__tests__/getStandardAccountIdsStrict.test.ts
+++ b/src/services/wallet/__tests__/getStandardAccountIdsStrict.test.ts
@@ -114,28 +114,59 @@ it('THROWS on a structurally-corrupt blob (accounts not an array)', async () => 
   ).rejects.toThrow('not an array');
 });
 
-it('THROWS on a STANDARD account with a non-string id (corruption, not data)', async () => {
-  // Raw strict read — no heal pass — so a non-string id is corruption that must
-  // not become a reconcile candidate. Fail closed.
-  mockStore[WALLET_KEY] = JSON.stringify({
+function blobWithAccount(acc: Record<string, unknown>): string {
+  return JSON.stringify({
     id: 'w1',
     version: '1',
     createdAt: '',
-    accounts: [
-      {
-        id: 42,
-        address: 'ADDR',
-        publicKey: 'PUB',
-        type: 'standard',
-        isHidden: false,
-      },
-    ],
+    accounts: [acc],
     activeAccountId: '',
     settings: {},
   });
+}
+
+it('THROWS on a STANDARD account with a non-string id (corruption, not data)', async () => {
+  // Raw strict read — no heal pass — so a non-string id is corruption that must
+  // not become a reconcile candidate. Fail closed.
+  mockStore[WALLET_KEY] = blobWithAccount({
+    id: 42,
+    address: 'ADDR',
+    publicKey: 'PUB',
+    type: 'standard',
+    isHidden: false,
+  });
   await expect(
     MultiAccountWalletService.getStandardAccountIdsStrict()
-  ).rejects.toThrow('non-string id');
+  ).rejects.toThrow('malformed account entry');
+});
+
+it('THROWS on an empty-string account id', async () => {
+  mockStore[WALLET_KEY] = blobWithAccount({
+    id: '',
+    address: 'ADDR',
+    publicKey: 'PUB',
+    type: 'standard',
+    isHidden: false,
+  });
+  await expect(
+    MultiAccountWalletService.getStandardAccountIdsStrict()
+  ).rejects.toThrow('malformed account entry');
+});
+
+// The critical case: a STANDARD account whose `type` is corrupted to an
+// unrecognized value would silently drop out of the standard-id set and, if that
+// id appears in the list/journal with a present secret, be deleted as an orphan.
+it('THROWS on an account with an unrecognized type (corrupt enum)', async () => {
+  mockStore[WALLET_KEY] = blobWithAccount({
+    id: 'a',
+    address: 'ADDR',
+    publicKey: 'PUB',
+    type: 42,
+    isHidden: false,
+  });
+  await expect(
+    MultiAccountWalletService.getStandardAccountIdsStrict()
+  ).rejects.toThrow('malformed account entry');
 });
 
 it('THROWS on a present-but-empty primary blob (corruption, not absence)', async () => {

--- a/src/services/wallet/__tests__/getStandardAccountIdsStrict.test.ts
+++ b/src/services/wallet/__tests__/getStandardAccountIdsStrict.test.ts
@@ -1,0 +1,123 @@
+// TASK-222: MultiAccountWalletService.getStandardAccountIdsStrict() — the
+// STRICT, boot-only read of STANDARD (key-bearing) account ids that the
+// cross-store reconcile matches against secure-store secrets. It MUST fail
+// CLOSED: a storage read FAILURE or a CORRUPT blob propagates (so the reconcile
+// aborts rather than orphan-deleting every real secret), while a genuine ABSENCE
+// resolves []. Pure read — no migration write, no cache mutation.
+//
+// SECURITY NOTE: no key material; blobs are minimal throwaway JSON.
+
+let mockStore: Record<string, string> = {};
+
+jest.mock('@/platform', () => ({
+  storage: {
+    getItem: jest.fn(async (k: string) =>
+      Object.prototype.hasOwnProperty.call(mockStore, k) ? mockStore[k] : null
+    ),
+    setItem: jest.fn(async (k: string, v: string) => {
+      mockStore[k] = v;
+    }),
+    removeItem: jest.fn(async (k: string) => {
+      delete mockStore[k];
+    }),
+  },
+  secureStorage: {
+    getItem: jest.fn(async () => null),
+    setItem: jest.fn(async () => {}),
+    deleteItem: jest.fn(async () => {}),
+  },
+}));
+
+jest.mock('@/services/ledger/transport', () => ({
+  ledgerTransportService: {},
+}));
+jest.mock('@/services/ledger/algorand', () => ({ ledgerAlgorandService: {} }));
+jest.mock('@/services/network', () => ({ NetworkService: {} }));
+jest.mock('../../secure/AccountSecureStorage', () => ({
+  AccountSecureStorage: {},
+}));
+
+import { storage, secureStorage } from '@/platform';
+import { MultiAccountWalletService } from '../index';
+
+const WALLET_KEY = 'voi_wallet_metadata';
+const mockStorageGet = storage.getItem as jest.Mock;
+const mockSecureGet = secureStorage.getItem as jest.Mock;
+
+function blob(accounts: { id: string; type: string }[]): string {
+  return JSON.stringify({
+    id: 'w1',
+    version: '1',
+    createdAt: '',
+    accounts: accounts.map((a) => ({
+      id: a.id,
+      address: 'ADDR',
+      publicKey: 'PUB',
+      type: a.type,
+      isHidden: false,
+    })),
+    activeAccountId: accounts[0]?.id ?? '',
+    settings: {},
+  });
+}
+
+beforeEach(() => {
+  mockStore = {};
+  jest.clearAllMocks();
+});
+
+it('returns [] for genuine absence (no blob)', async () => {
+  await expect(
+    MultiAccountWalletService.getStandardAccountIdsStrict()
+  ).resolves.toEqual([]);
+});
+
+it('returns only STANDARD account ids, excluding other types', async () => {
+  mockStore[WALLET_KEY] = blob([
+    { id: 's1', type: 'standard' },
+    { id: 'w1', type: 'watch' },
+    { id: 'l1', type: 'ledger' },
+    { id: 's2', type: 'standard' },
+    { id: 'r1', type: 'remote_signer' },
+  ]);
+
+  await expect(
+    MultiAccountWalletService.getStandardAccountIdsStrict()
+  ).resolves.toEqual(['s1', 's2']);
+});
+
+it('returns [] for a present blob with zero accounts', async () => {
+  mockStore[WALLET_KEY] = blob([]);
+  await expect(
+    MultiAccountWalletService.getStandardAccountIdsStrict()
+  ).resolves.toEqual([]);
+});
+
+it('PROPAGATES a storage read failure (fail closed, not [])', async () => {
+  mockStorageGet.mockRejectedValueOnce(new Error('keychain unavailable'));
+  await expect(
+    MultiAccountWalletService.getStandardAccountIdsStrict()
+  ).rejects.toThrow('keychain unavailable');
+});
+
+it('THROWS on an unparseable blob (corruption is not absence)', async () => {
+  mockStore[WALLET_KEY] = '{not valid json';
+  await expect(
+    MultiAccountWalletService.getStandardAccountIdsStrict()
+  ).rejects.toThrow();
+});
+
+it('THROWS on a structurally-corrupt blob (accounts not an array)', async () => {
+  mockStore[WALLET_KEY] = JSON.stringify({ accounts: {} });
+  await expect(
+    MultiAccountWalletService.getStandardAccountIdsStrict()
+  ).rejects.toThrow('not an array');
+});
+
+it('does not write or migrate (pure read)', async () => {
+  mockStore[WALLET_KEY] = blob([{ id: 's1', type: 'standard' }]);
+  await MultiAccountWalletService.getStandardAccountIdsStrict();
+  expect(storage.setItem).not.toHaveBeenCalled();
+  // Present primary means the legacy secure-store fallback is never consulted.
+  expect(mockSecureGet).not.toHaveBeenCalled();
+});

--- a/src/services/wallet/__tests__/getStandardAccountIdsStrict.test.ts
+++ b/src/services/wallet/__tests__/getStandardAccountIdsStrict.test.ts
@@ -138,6 +138,15 @@ it('THROWS on a STANDARD account with a non-string id (corruption, not data)', a
   ).rejects.toThrow('non-string id');
 });
 
+it('THROWS on a present-but-empty primary blob (corruption, not absence)', async () => {
+  // '' would collapse to [] via getStoredValueStrict and make every present
+  // secret look like an orphan → mass-deleted. Must fail closed.
+  mockStore[WALLET_KEY] = '';
+  await expect(
+    MultiAccountWalletService.getStandardAccountIdsStrict()
+  ).rejects.toThrow('present but empty');
+});
+
 it('does not write or migrate (pure read)', async () => {
   mockStore[WALLET_KEY] = blob([{ id: 's1', type: 'standard' }]);
   await MultiAccountWalletService.getStandardAccountIdsStrict();

--- a/src/services/wallet/crossStoreReconcile.ts
+++ b/src/services/wallet/crossStoreReconcile.ts
@@ -48,9 +48,16 @@ const EMPTY_RESULT: ReconcileResult = {
 
 /**
  * Repair cross-store secret/metadata half-state, fail-closed. Safe to call once
- * at boot after the strict lock-determining reads succeed. Returns a summary; on
- * any strict read/probe failure it returns `{ ran: false }` having mutated
- * nothing. Presence-based — needs no unlock.
+ * at boot after the strict lock-determining reads succeed. Presence-based — needs
+ * no unlock.
+ *
+ * Two phases with different failure semantics:
+ *  - Phase 1 (reads/probes) is STRICT and all-or-nothing: any failure THROWS
+ *    (rejects) before any mutation, so the pass deletes nothing on a bad read.
+ *  - Phase 2 (mutations) is BEST-EFFORT: it never throws; the resolved summary
+ *    reports the repairs that ACTUALLY completed, so a later-step failure cannot
+ *    discard a verdict-affecting prune the caller must react to. Remaining repairs
+ *    are retried next boot.
  */
 export async function reconcileCrossStoreHalfState(): Promise<ReconcileResult> {
   // ── Phase 1: STRICT reads. Any throw here aborts the whole pass (delete
@@ -120,44 +127,64 @@ export async function reconcileCrossStoreHalfState(): Promise<ReconcileResult> {
     // (an account-list-only ghost) not a repair target of this design; left as-is.
   }
 
-  // Prune phantoms from the wallet blob FIRST (empty ⇒ canonical clearAllWallets).
-  // This is the only mutation that can change the boot lock verdict (emptying the
-  // wallet), so run it earliest — if the caller's outer boot timeout races Phase 2,
-  // the verdict-affecting change is most likely already committed before the
-  // caller reads back the refreshed signals.
-  if (phantomIds.length > 0) {
-    await MultiAccountWalletService.pruneStandardAccounts(phantomIds);
-  }
-  // Deletes: each acquires the key-mutation mutex, serialized against any secret
-  // write. deleteAccount removes secret + secure metadata + account-list entry.
-  for (const id of orphanSecretIds) {
-    await AccountSecureStorage.deleteAccount(id);
-  }
-  // Drop journal entries for the orphans we just deleted AND the stale entries.
-  const journalIdsToDrop = [...orphanSecretIds, ...staleJournalIds];
-  if (journalIdsToDrop.length > 0) {
-    await AccountSecureStorage.dropPendingCreateEntries(journalIdsToDrop);
+  // Phase 2 is BEST-EFFORT and reports what it ACTUALLY completed. Fail-closed is
+  // a Phase-1 property (never delete on a bad read); once Phase 1 passed cleanly,
+  // a Phase-2 mutation FAILURE is a storage error, not a safety issue. Crucially,
+  // a later-step failure must NOT discard the outcome: if a phantom prune already
+  // emptied the wallet and then an orphan delete throws, the caller still needs to
+  // see phantomAccountsPruned so it can refresh the (now stale) lock verdict (Codex
+  // P2). So track completed work and return it even if a step throws.
+  const phantomsPruned: string[] = [];
+  const orphansDeleted: string[] = [];
+  const journalDropped: string[] = [];
+  try {
+    // Prune phantoms FIRST — the only mutation that can change the boot lock
+    // verdict (emptying the wallet ⇒ canonical clearAllWallets) — so the
+    // verdict-affecting change is committed as early as possible.
+    if (phantomIds.length > 0) {
+      await MultiAccountWalletService.pruneStandardAccounts(phantomIds);
+      phantomsPruned.push(...phantomIds);
+    }
+    // Deletes: each acquires the key-mutation mutex, serialized against any secret
+    // write. deleteAccount removes secret + secure metadata + account-list entry.
+    for (const id of orphanSecretIds) {
+      await AccountSecureStorage.deleteAccount(id);
+      orphansDeleted.push(id);
+    }
+    // Drop journal entries for the orphans we just deleted AND the stale entries.
+    const journalIdsToDrop = [...orphansDeleted, ...staleJournalIds];
+    if (journalIdsToDrop.length > 0) {
+      await AccountSecureStorage.dropPendingCreateEntries(journalIdsToDrop);
+      journalDropped.push(...journalIdsToDrop);
+    }
+  } catch (error) {
+    // A Phase-2 repair failed after Phase 1 passed cleanly. Keep the partial
+    // outcome (below) so the caller can still refresh the verdict; the remaining
+    // repairs are retried on the next boot. ids/status only — no secret material.
+    console.warn('[bootReconcile] Phase 2 repair partially failed:', error);
   }
 
   if (
-    orphanSecretIds.length > 0 ||
-    phantomIds.length > 0 ||
-    staleJournalIds.length > 0
+    orphansDeleted.length > 0 ||
+    phantomsPruned.length > 0 ||
+    journalDropped.length > 0
   ) {
     // ids/status only — no key/mnemonic/secret material.
     console.log(
       `[bootReconcile] repaired cross-store half-state: ` +
-        `${orphanSecretIds.length} orphan secret(s), ` +
-        `${phantomIds.length} phantom account(s), ` +
-        `${staleJournalIds.length} stale journal entr(ies)`
+        `${orphansDeleted.length} orphan secret(s), ` +
+        `${phantomsPruned.length} phantom account(s), ` +
+        `${journalDropped.length} journal entr(ies) dropped`
     );
   }
 
   return {
     ran: true,
-    orphanSecretsDeleted: orphanSecretIds,
-    phantomAccountsPruned: phantomIds,
-    staleJournalDropped: staleJournalIds,
+    orphanSecretsDeleted: orphansDeleted,
+    phantomAccountsPruned: phantomsPruned,
+    staleJournalDropped: staleJournalIds.filter((id) =>
+      journalDropped.includes(id)
+    ),
   };
 }
 

--- a/src/services/wallet/crossStoreReconcile.ts
+++ b/src/services/wallet/crossStoreReconcile.ts
@@ -76,15 +76,21 @@ export async function reconcileCrossStoreHalfState(): Promise<ReconcileResult> {
     ...journalIds,
   ]);
 
-  // Probe EVERY candidate's secret presence before touching anything. A single
-  // probe throw/timeout aborts — we never delete on a partially-read picture.
-  const secretPresent = new Map<string, boolean>();
-  for (const id of candidates) {
-    secretPresent.set(
-      id,
-      await AccountSecureStorage.probeSecretPresenceStrict(id)
-    );
-  }
+  // Probe EVERY candidate's secret presence before touching anything. Run the
+  // probes CONCURRENTLY (Promise.all) so Phase 1 wall-clock is one probe deep, not
+  // the sum over N candidates — otherwise a multi-account device can be starved by
+  // the caller's boot timeout and never actually repair. Fail-closed is preserved:
+  // Promise.all rejects on the FIRST probe throw/timeout, so the whole pass aborts
+  // before any mutation — we never delete on a partially-read picture.
+  const candidateList = [...candidates];
+  const presence = await Promise.all(
+    candidateList.map((id) =>
+      AccountSecureStorage.probeSecretPresenceStrict(id)
+    )
+  );
+  const secretPresent = new Map<string, boolean>(
+    candidateList.map((id, i) => [id, presence[i]])
+  );
 
   // ── Phase 2: classify + act. Reached ONLY when every read/probe above
   // succeeded, so an "absent" below is a true absence, never a swallowed error.
@@ -114,6 +120,14 @@ export async function reconcileCrossStoreHalfState(): Promise<ReconcileResult> {
     // (an account-list-only ghost) not a repair target of this design; left as-is.
   }
 
+  // Prune phantoms from the wallet blob FIRST (empty ⇒ canonical clearAllWallets).
+  // This is the only mutation that can change the boot lock verdict (emptying the
+  // wallet), so run it earliest — if the caller's outer boot timeout races Phase 2,
+  // the verdict-affecting change is most likely already committed before the
+  // caller reads back the refreshed signals.
+  if (phantomIds.length > 0) {
+    await MultiAccountWalletService.pruneStandardAccounts(phantomIds);
+  }
   // Deletes: each acquires the key-mutation mutex, serialized against any secret
   // write. deleteAccount removes secret + secure metadata + account-list entry.
   for (const id of orphanSecretIds) {
@@ -123,10 +137,6 @@ export async function reconcileCrossStoreHalfState(): Promise<ReconcileResult> {
   const journalIdsToDrop = [...orphanSecretIds, ...staleJournalIds];
   if (journalIdsToDrop.length > 0) {
     await AccountSecureStorage.dropPendingCreateEntries(journalIdsToDrop);
-  }
-  // Prune phantoms from the wallet blob (empty ⇒ canonical clearAllWallets).
-  if (phantomIds.length > 0) {
-    await MultiAccountWalletService.pruneStandardAccounts(phantomIds);
   }
 
   if (

--- a/src/services/wallet/crossStoreReconcile.ts
+++ b/src/services/wallet/crossStoreReconcile.ts
@@ -1,0 +1,152 @@
+// TASK-222 — boot reconcile: repair cross-store secret/metadata half-state.
+//
+// Component 3 of the cross-store reset-hardening design (DOC-221; follows the
+// TASK-220 primitives — durable pending-creation journal, in-memory reset
+// generation, wipe tombstone — and the TASK-213 strict-read family). A crash
+// mid-`storeAccount` (secret written, wallet-metadata not yet) or a reset that
+// tears down one store but dies before the other can leave a durable half-state
+// the live guards cannot catch on their own: an orphaned secret (present in the
+// secure store, no matching wallet-blob account) or a phantom account (a blob
+// STANDARD account whose secret is gone). This runs ONCE at boot and repairs it.
+//
+// FAIL-CLOSED is the whole safety story. The repair is DESTRUCTIVE (it deletes
+// secrets and prunes accounts), and it infers "delete" from ABSENCE — so a
+// swallowed read failure reported as "absent" would mass-delete live accounts.
+// Every read/probe here is STRICT (propagates on failure/timeout). The pass is
+// two-phase: gather EVERY read + probe first; if ANY of them throws, ABORT the
+// whole thing having deleted NOTHING. Only when the entire picture is known
+// without error does the destructive phase run.
+//
+// Invariant repaired (DOC-221): for every STANDARD account, `wallet-blob entry
+// ⟺ secure secret exists`. Only STANDARD accounts hold a secret; WATCH / LEDGER
+// / REKEYED / REMOTE_SIGNER accounts hold none and are never touched here.
+//
+// Bounded + never blocks boot: each probe is time-bounded, and the AuthContext
+// caller additionally wraps the whole call in a timeout + best-effort catch, so
+// a reconcile failure degrades to "no repair this boot", never a stuck splash.
+//
+// Logging is ids/status ONLY — never a key, mnemonic, or secret payload.
+
+import { AccountSecureStorage } from '@/services/secure';
+
+import { MultiAccountWalletService } from './index';
+
+export interface ReconcileResult {
+  /** false when Phase 1 hit a read/probe failure and the pass was aborted. */
+  ran: boolean;
+  orphanSecretsDeleted: string[];
+  phantomAccountsPruned: string[];
+  staleJournalDropped: string[];
+}
+
+const EMPTY_RESULT: ReconcileResult = {
+  ran: false,
+  orphanSecretsDeleted: [],
+  phantomAccountsPruned: [],
+  staleJournalDropped: [],
+};
+
+/**
+ * Repair cross-store secret/metadata half-state, fail-closed. Safe to call once
+ * at boot after the strict lock-determining reads succeed. Returns a summary; on
+ * any strict read/probe failure it returns `{ ran: false }` having mutated
+ * nothing. Presence-based — needs no unlock.
+ */
+export async function reconcileCrossStoreHalfState(): Promise<ReconcileResult> {
+  // ── Phase 1: STRICT reads. Any throw here aborts the whole pass (delete
+  // nothing). getStandardAccountIdsStrict / getAllAccountIds / the journal read
+  // all propagate a storage failure; a corrupt wallet blob propagates too.
+  const blobStandardIds =
+    await MultiAccountWalletService.getStandardAccountIdsStrict();
+  const accountListIds = await AccountSecureStorage.getAllAccountIds();
+  const journal = await AccountSecureStorage.readPendingCreatesStrict();
+  const journalIds = Object.keys(journal);
+
+  const blobStandardSet = new Set(blobStandardIds);
+
+  // Candidate universe: every id that could be half-committed in EITHER store.
+  // The journal closes the unindexed-secret gap — a secret written just before a
+  // crash is journaled even before it reaches the account list.
+  const candidates = new Set<string>([
+    ...blobStandardIds,
+    ...accountListIds,
+    ...journalIds,
+  ]);
+
+  // Probe EVERY candidate's secret presence before touching anything. A single
+  // probe throw/timeout aborts — we never delete on a partially-read picture.
+  const secretPresent = new Map<string, boolean>();
+  for (const id of candidates) {
+    secretPresent.set(
+      id,
+      await AccountSecureStorage.probeSecretPresenceStrict(id)
+    );
+  }
+
+  // ── Phase 2: classify + act. Reached ONLY when every read/probe above
+  // succeeded, so an "absent" below is a true absence, never a swallowed error.
+  const orphanSecretIds: string[] = [];
+  const phantomIds: string[] = [];
+  const staleJournalIds: string[] = [];
+
+  for (const id of candidates) {
+    const hasSecret = secretPresent.get(id) === true;
+    const inBlob = blobStandardSet.has(id);
+    const inJournal = journal[id] !== undefined;
+
+    if (hasSecret && !inBlob) {
+      // Orphan secret: a live secret with no wallet-blob account. Delete the
+      // secret (+ its secure metadata/list entry) and drop any journal entry.
+      orphanSecretIds.push(id);
+    } else if (!hasSecret && inBlob) {
+      // Phantom account: a blob STANDARD account whose secret is gone. Prune it
+      // from the blob (the account is unusable — no key to sign with).
+      phantomIds.push(id);
+    } else if (!hasSecret && !inBlob && inJournal) {
+      // Stale journal entry: a never-completed / already-cleaned creation left a
+      // journal id with no secret and no account. Drop the bookkeeping.
+      staleJournalIds.push(id);
+    }
+    // hasSecret && inBlob → consistent; !hasSecret && !inBlob && !inJournal →
+    // (an account-list-only ghost) not a repair target of this design; left as-is.
+  }
+
+  // Deletes: each acquires the key-mutation mutex, serialized against any secret
+  // write. deleteAccount removes secret + secure metadata + account-list entry.
+  for (const id of orphanSecretIds) {
+    await AccountSecureStorage.deleteAccount(id);
+  }
+  // Drop journal entries for the orphans we just deleted AND the stale entries.
+  const journalIdsToDrop = [...orphanSecretIds, ...staleJournalIds];
+  if (journalIdsToDrop.length > 0) {
+    await AccountSecureStorage.dropPendingCreateEntries(journalIdsToDrop);
+  }
+  // Prune phantoms from the wallet blob (empty ⇒ canonical clearAllWallets).
+  if (phantomIds.length > 0) {
+    await MultiAccountWalletService.pruneStandardAccounts(phantomIds);
+  }
+
+  if (
+    orphanSecretIds.length > 0 ||
+    phantomIds.length > 0 ||
+    staleJournalIds.length > 0
+  ) {
+    // ids/status only — no key/mnemonic/secret material.
+    console.log(
+      `[bootReconcile] repaired cross-store half-state: ` +
+        `${orphanSecretIds.length} orphan secret(s), ` +
+        `${phantomIds.length} phantom account(s), ` +
+        `${staleJournalIds.length} stale journal entr(ies)`
+    );
+  }
+
+  return {
+    ran: true,
+    orphanSecretsDeleted: orphanSecretIds,
+    phantomAccountsPruned: phantomIds,
+    staleJournalDropped: staleJournalIds,
+  };
+}
+
+/** The aborted-pass result, exported for the caller's logging/telemetry. */
+export const RECONCILE_ABORTED = EMPTY_RESULT;

--- a/src/services/wallet/crossStoreReconcile.ts
+++ b/src/services/wallet/crossStoreReconcile.ts
@@ -54,11 +54,14 @@ const EMPTY_RESULT: ReconcileResult = {
  */
 export async function reconcileCrossStoreHalfState(): Promise<ReconcileResult> {
   // ── Phase 1: STRICT reads. Any throw here aborts the whole pass (delete
-  // nothing). getStandardAccountIdsStrict / getAllAccountIds / the journal read
-  // all propagate a storage failure; a corrupt wallet blob propagates too.
+  // nothing). getStandardAccountIdsStrict / readAccountListStrict / the journal
+  // read all propagate a storage failure; a corrupt wallet blob propagates too.
+  // readAccountListStrict (not getAllAccountIds) is READ-ONLY — getAllAccountIds
+  // migrates a legacy list (write + delete), which would mutate the store during
+  // this abort-safe read phase (Codex P2).
   const blobStandardIds =
     await MultiAccountWalletService.getStandardAccountIdsStrict();
-  const accountListIds = await AccountSecureStorage.getAllAccountIds();
+  const accountListIds = await AccountSecureStorage.readAccountListStrict();
   const journal = await AccountSecureStorage.readPendingCreatesStrict();
   const journalIds = Object.keys(journal);
 

--- a/src/services/wallet/index.ts
+++ b/src/services/wallet/index.ts
@@ -2038,9 +2038,19 @@ export class MultiAccountWalletService {
         'Corrupt wallet blob: `accounts` is present but not an array'
       );
     }
-    return parsed.accounts
+    const standardIds = parsed.accounts
       .filter((acc) => acc?.type === AccountType.STANDARD)
       .map((acc) => acc.id);
+    // This is a RAW strict read (no heal/validate pass like getCurrentWallet), so
+    // a STANDARD account with a non-string id is CORRUPTION — feeding it to the
+    // reconcile as a candidate id would drive destructive classification on bad
+    // data. Throw so the reconcile fails closed (Codex).
+    if (!standardIds.every((id) => typeof id === 'string')) {
+      throw new Error(
+        'Corrupt wallet blob: STANDARD account with a non-string id'
+      );
+    }
+    return standardIds;
   }
 
   /**

--- a/src/services/wallet/index.ts
+++ b/src/services/wallet/index.ts
@@ -2026,8 +2026,22 @@ export class MultiAccountWalletService {
    * decrypt, no heal-on-read, no cache side effect.
    */
   static async getStandardAccountIdsStrict(): Promise<string[]> {
+    // A present-but-EMPTY primary blob ('') is CORRUPTION, not absence (a
+    // genuinely absent wallet is null). getStoredValueStrict collapses '' to null
+    // (its `if (value)` skip), which here would return [] and make EVERY present
+    // secret look like an orphan → mass-deleted by the reconcile. Detect the raw
+    // empty string up front and fail CLOSED (Codex). This is the sole destructive
+    // amplification of the pre-existing ''-as-absent ambiguity, so it is guarded
+    // here rather than in the shared getStoredValueStrict (whose lock-verdict
+    // callers keep their existing absence semantics).
+    const rawPrimary = await storage.getItem(this.WALLET_KEY);
+    if (rawPrimary === '') {
+      throw new Error('Corrupt wallet blob: present but empty');
+    }
     const walletData = await this.getStoredValueStrict(this.WALLET_KEY);
-    if (!walletData) {
+    // `== null` (not truthiness): a '' surfaced from the legacy location is also
+    // corruption and must reach JSON.parse (which throws) rather than collapse.
+    if (walletData == null) {
       // Genuine absence — mirrors hasWalletWithAccountsStrict's absence case.
       return [];
     }

--- a/src/services/wallet/index.ts
+++ b/src/services/wallet/index.ts
@@ -2052,19 +2052,30 @@ export class MultiAccountWalletService {
         'Corrupt wallet blob: `accounts` is present but not an array'
       );
     }
-    const standardIds = parsed.accounts
-      .filter((acc) => acc?.type === AccountType.STANDARD)
-      .map((acc) => acc.id);
     // This is a RAW strict read (no heal/validate pass like getCurrentWallet), so
-    // a STANDARD account with a non-string id is CORRUPTION — feeding it to the
-    // reconcile as a candidate id would drive destructive classification on bad
-    // data. Throw so the reconcile fails closed (Codex).
-    if (!standardIds.every((id) => typeof id === 'string')) {
-      throw new Error(
-        'Corrupt wallet blob: STANDARD account with a non-string id'
-      );
+    // validate EVERY account entry fully rather than silently filtering. A
+    // malformed entry — a non-string/empty id, or an UNRECOGNIZED `type` — is
+    // CORRUPTION, not data: a STANDARD account whose `type` field is corrupted to
+    // a non-standard value would silently drop out of the blob-standard set here,
+    // and if that id is then supplied by the account list or journal with a
+    // present secret, the reconcile would misclassify it as an orphan and DELETE
+    // its secret. Throw so the reconcile fails closed on any malformed entry
+    // (Codex). A genuinely non-STANDARD account (watch/ledger/rekeyed/remote) has
+    // a recognized type and is simply not a STANDARD id — that is valid data.
+    const validTypes = new Set<string>(Object.values(AccountType));
+    for (const acc of parsed.accounts) {
+      if (
+        acc == null ||
+        typeof acc.id !== 'string' ||
+        acc.id === '' ||
+        !validTypes.has(acc.type)
+      ) {
+        throw new Error('Corrupt wallet blob: malformed account entry');
+      }
     }
-    return standardIds;
+    return parsed.accounts
+      .filter((acc) => acc.type === AccountType.STANDARD)
+      .map((acc) => acc.id);
   }
 
   /**

--- a/src/services/wallet/index.ts
+++ b/src/services/wallet/index.ts
@@ -2015,6 +2015,72 @@ export class MultiAccountWalletService {
   }
 
   /**
+   * STRICT, boot-only read of the STANDARD (key-bearing) account ids from the
+   * persisted wallet blob (TASK-222). Sibling of hasKeyBearingAccountStrict, but
+   * returns the ids so the cross-store reconcile can match blob accounts against
+   * secure-store secrets. FAILS CLOSED: a storage read failure or a corrupt blob
+   * (unparseable, or `accounts` present-but-not-an-array) PROPAGATES so the
+   * reconcile aborts its destructive pass rather than treating corruption as
+   * "no STANDARD accounts" (which would orphan-delete every real secret). A
+   * genuine ABSENCE (no blob, or an empty/tombstoned blob) resolves `[]`. No
+   * decrypt, no heal-on-read, no cache side effect.
+   */
+  static async getStandardAccountIdsStrict(): Promise<string[]> {
+    const walletData = await this.getStoredValueStrict(this.WALLET_KEY);
+    if (!walletData) {
+      // Genuine absence — mirrors hasWalletWithAccountsStrict's absence case.
+      return [];
+    }
+    // Let JSON.parse throw on a corrupt blob so the caller fails CLOSED.
+    const parsed = JSON.parse(walletData) as Wallet;
+    if (!Array.isArray(parsed.accounts)) {
+      throw new Error(
+        'Corrupt wallet blob: `accounts` is present but not an array'
+      );
+    }
+    return parsed.accounts
+      .filter((acc) => acc?.type === AccountType.STANDARD)
+      .map((acc) => acc.id);
+  }
+
+  /**
+   * Remove the given STANDARD account ids from the wallet blob only (TASK-222
+   * reconcile: phantom-metadata repair — a blob STANDARD account whose secret is
+   * strictly absent). Touches ONLY the wallet metadata blob; the secure store is
+   * the caller's separate concern (a phantom has no secret to delete). If the
+   * prune empties the wallet, routes through clearAllWallets so the canonical
+   * wipe path (tombstone + memo bust + epoch bump) runs instead of persisting an
+   * empty accounts array. Epoch-guarded like every other blob mutation so a reset
+   * racing boot is not undone. A no-op when nothing matches.
+   */
+  static async pruneStandardAccounts(ids: string[]): Promise<void> {
+    if (ids.length === 0) return;
+    const readEpoch = walletResetEpoch;
+    const wallet = await this.getCurrentWallet();
+    if (!wallet) {
+      // No wallet to prune (absent or a reset already wiped it) — nothing to do.
+      return;
+    }
+    const toPrune = new Set(ids);
+    const remaining = wallet.accounts.filter((acc) => !toPrune.has(acc.id));
+    if (remaining.length === wallet.accounts.length) {
+      // None of the ids were present — no write.
+      return;
+    }
+    if (remaining.length === 0) {
+      // Pruning empties the wallet — use the canonical metadata wipe.
+      await this.clearAllWallets();
+      return;
+    }
+    wallet.accounts = remaining;
+    // Keep activeAccountId pointing at a surviving account.
+    if (toPrune.has(wallet.activeAccountId)) {
+      wallet.activeAccountId = remaining[0].id;
+    }
+    await this.storeWallet(wallet, readEpoch);
+  }
+
+  /**
    * Strict sibling of getStoredValue (TASK-213): reads the primary then the
    * legacy secure-store location but PROPAGATES storage read errors instead of
    * collapsing them to null. Resolves `null` ONLY for genuine absence (both


### PR DESCRIPTION
## What

Component 3 of the cross-store reset-hardening design (**DOC-221**, follow-up to the merged **TASK-220** #143). Adds a **fail-closed, run-once-at-boot reconcile** that repairs the durable cross-store half-state a crash mid-`storeAccount` (secret written, wallet-metadata not yet) or a partially-completed reset can leave:

- **orphan secret** — a secure-store secret with no wallet-blob account → deleted
- **phantom account** — a blob STANDARD account whose secret is gone → pruned (empty ⇒ `clearAllWallets`)
- **stale journal entry** — a never-completed creation's journal id → dropped

Repairs the invariant *(for every STANDARD account: wallet-blob entry ⟺ secure secret exists)*.

## How

- **New secure-side strict primitives** (`AccountSecureStorage`): `probeSecretPresenceStrict` (bounded, read-only, mirrors the reader's primary→tombstone→legacy presence semantics — no migration write), `readAccountListStrict` (read-only, no legacy migration), `readPendingCreatesStrict`, `dropPendingCreateEntries`.
- **New wallet-side strict primitives** (`MultiAccountWalletService`): `getStandardAccountIdsStrict`, `pruneStandardAccounts`.
- **Coordinator** (`crossStoreReconcile.ts`): two-phase. **Phase 1** = all strict reads + concurrent secret probes; **any** read/probe failure/timeout → abort having mutated nothing. **Phase 2** = best-effort repairs that report what actually completed (a later-step failure never discards a verdict-affecting prune).
- **Boot hook** (`AuthContext`): runs after the strict lock reads succeed, **one-shot latched** (never re-fires on `recheckAuthState` — its ownership-unchecked deletes must not race a live creation), bounded + best-effort (never stalls boot), and refreshes the lock verdict if a phantom prune emptied the wallet (routes to onboarding, never falls open).

## Safety

Every candidate-id source is fully shape-validated (missing/empty-string/unparseable/wrong-type/corrupt-enum all fail closed). Touches only `voi_account_secret_*` / journal / the wallet blob per id — never `DEVICE_ID_KEY`/PIN/salt/biometric. ids/status-only logging (no key/mnemonic). **JS-only → OTA-eligible, no runtime-version bump.** Extension/web unaffected.

## Verification

- `npm run typecheck` ✅ (0)  ·  `npm run lint` ✅ (0 errors)  ·  `npm test` ✅ **1228 tests**
- New tests: coordinator fail-closed orchestration incl. the **no-mass-delete-on-probe-error regression** + Phase-2 partial-failure; strict-primitive fail-closed behavior; AuthContext hook integration (never-blocks-boot, phantom-prune verdict refresh, refresh-failure keeps locked verdict, one-shot latch).
- **Codex** crypto review: CLEAN (multiple rounds — found & fixed a real legacy-secret data-loss vector, strict-read gaps, a stale-verdict routing bug, an in-Phase-1 migration write, exhaustive candidate validation, and a Phase-2 partial-failure regression).
- **Adversarial `code-review-analyzer`** pass: confirmed the STANDARD⟺secret invariant holds and the refresh cannot fall open; its MEDIUM/LOW findings (recheck re-entrancy, probe starvation, untested hook) are all addressed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)