### PR TITLE
perf(lists): virtualize transaction/asset/message/friend/claimable lists (TASK-39)

### DIFF
--- a/src/components/common/ListEmptyState.tsx
+++ b/src/components/common/ListEmptyState.tsx
@@ -1,0 +1,84 @@
+/**
+ * ListEmptyState - shared icon + title + subtitle empty state for lists.
+ *
+ * Consolidates the near-identical empty states that were re-declared per
+ * screen. Designed to be passed by reference as `ListEmptyComponent` so the
+ * list only evaluates it when the data set is actually empty.
+ */
+
+import React from 'react';
+import { StyleProp, StyleSheet, Text, View, ViewStyle } from 'react-native';
+import { Ionicons } from '@expo/vector-icons';
+import { useTheme } from '@/contexts/ThemeContext';
+import { useThemedStyles } from '@/hooks/useThemedStyles';
+import { Theme } from '@/constants/themes';
+
+interface ListEmptyStateProps {
+  /** Ionicons glyph rendered above the title. */
+  icon?: React.ComponentProps<typeof Ionicons>['name'];
+  iconSize?: number;
+  /** Icon color (defaults to the theme muted text color). */
+  iconColor?: string;
+  title: string;
+  subtitle?: string;
+  /** Optional call-to-action rendered below the subtitle. */
+  action?: React.ReactNode;
+  style?: StyleProp<ViewStyle>;
+  testID?: string;
+}
+
+export const ListEmptyState: React.FC<ListEmptyStateProps> = ({
+  icon,
+  iconSize = 64,
+  iconColor,
+  title,
+  subtitle,
+  action,
+  style,
+  testID,
+}) => {
+  const styles = useThemedStyles(createStyles);
+  const { theme } = useTheme();
+
+  return (
+    <View style={[styles.container, style]} testID={testID}>
+      {!!icon && (
+        <Ionicons
+          name={icon}
+          size={iconSize}
+          color={iconColor ?? theme.colors.textMuted}
+        />
+      )}
+      <Text style={styles.title}>{title}</Text>
+      {!!subtitle && <Text style={styles.subtitle}>{subtitle}</Text>}
+      {action}
+    </View>
+  );
+};
+
+const createStyles = (theme: Theme) =>
+  StyleSheet.create({
+    container: {
+      alignItems: 'center',
+      justifyContent: 'center',
+      paddingVertical: theme.spacing.xl,
+      paddingHorizontal: theme.spacing.xl,
+    },
+    title: {
+      fontSize: 20,
+      fontWeight: '600',
+      color: theme.colors.text,
+      marginTop: theme.spacing.md,
+      marginBottom: theme.spacing.xs,
+      textAlign: 'center',
+    },
+    subtitle: {
+      fontSize: 16,
+      color: theme.colors.textMuted,
+      textAlign: 'center',
+      lineHeight: 22,
+      paddingHorizontal: theme.spacing.md,
+    },
+  });
+
+export default ListEmptyState;

--- a/src/components/common/ListFooterSpinner.tsx
+++ b/src/components/common/ListFooterSpinner.tsx
@@ -1,0 +1,71 @@
+/**
+ * ListFooterSpinner - shared "loading more" footer for virtualized lists.
+ *
+ * Replaces the near-identical inline footer that was duplicated across every
+ * paginated list in the app. Pass `visible` so callers can keep using
+ * `ListFooterComponent={<ListFooterSpinner visible={isLoadingMore} />}`
+ * without re-implementing the null case.
+ */
+
+import React from 'react';
+import {
+  ActivityIndicator,
+  StyleProp,
+  StyleSheet,
+  Text,
+  View,
+  ViewStyle,
+} from 'react-native';
+import { useTheme } from '@/contexts/ThemeContext';
+import { useThemedStyles } from '@/hooks/useThemedStyles';
+import { Theme } from '@/constants/themes';
+
+interface ListFooterSpinnerProps {
+  /** Render nothing when false (default true). */
+  visible?: boolean;
+  /** Optional label rendered under the spinner. */
+  text?: string;
+  size?: 'small' | 'large';
+  /** Spinner color (defaults to the theme primary). */
+  color?: string;
+  style?: StyleProp<ViewStyle>;
+  testID?: string;
+}
+
+export const ListFooterSpinner: React.FC<ListFooterSpinnerProps> = ({
+  visible = true,
+  text,
+  size = 'small',
+  color,
+  style,
+  testID,
+}) => {
+  const styles = useThemedStyles(createStyles);
+  const { theme } = useTheme();
+
+  if (!visible) {
+    return null;
+  }
+
+  return (
+    <View style={[styles.container, style]} testID={testID}>
+      <ActivityIndicator size={size} color={color ?? theme.colors.primary} />
+      {!!text && <Text style={styles.text}>{text}</Text>}
+    </View>
+  );
+};
+
+const createStyles = (theme: Theme) =>
+  StyleSheet.create({
+    container: {
+      paddingVertical: theme.spacing.md,
+      alignItems: 'center',
+    },
+    text: {
+      fontSize: 14,
+      color: theme.colors.textSecondary,
+      marginTop: theme.spacing.xs,
+    },
+  });
+
+export default ListFooterSpinner;

--- a/src/components/nft/CollectionBrowser.tsx
+++ b/src/components/nft/CollectionBrowser.tsx
@@ -13,6 +13,7 @@ import { ARC72Collection } from '@/types/nft';
 import { NFTService } from '@/services/nft';
 import { Theme } from '@/constants/themes';
 import CollectionListItem from '@/components/common/CollectionListItem';
+import { ListFooterSpinner } from '@/components/common/ListFooterSpinner';
 
 interface CollectionBrowserProps {
   theme: Theme;
@@ -193,13 +194,7 @@ export default function CollectionBrowser({
         onEndReached={handleLoadMore}
         onEndReachedThreshold={0.5}
         ListEmptyComponent={renderEmptyState}
-        ListFooterComponent={
-          loadingMore ? (
-            <View style={styles.loadingMoreContainer}>
-              <ActivityIndicator size="small" color={theme.colors.primary} />
-            </View>
-          ) : null
-        }
+        ListFooterComponent={<ListFooterSpinner visible={loadingMore} />}
         showsVerticalScrollIndicator={false}
       />
     </>
@@ -255,9 +250,5 @@ const styles = StyleSheet.create({
   loadingText: {
     fontSize: 16,
     marginTop: 16,
-  },
-  loadingMoreContainer: {
-    paddingVertical: 16,
-    alignItems: 'center',
   },
 });

--- a/src/components/nft/NFTGridView.tsx
+++ b/src/components/nft/NFTGridView.tsx
@@ -26,7 +26,11 @@ interface NFTGridViewProps {
   refreshing?: boolean;
   onRefresh?: () => void;
   onEndReached?: () => void;
-  ListEmptyComponent?: React.ReactElement;
+  /**
+   * Prefer passing a component reference (not `render()` output) so the list
+   * only evaluates the empty state when there is actually nothing to show.
+   */
+  ListEmptyComponent?: React.ComponentType<unknown> | React.ReactElement | null;
   ListFooterComponent?: React.ReactElement;
   processingNFTKey?: string | null;
   imageErrors?: Set<string>;

--- a/src/components/social/FriendListItem.tsx
+++ b/src/components/social/FriendListItem.tsx
@@ -51,6 +51,10 @@ export default function FriendListItem({
     <BlurredContainer
       style={styles.container}
       borderRadius={theme.borderRadius.lg}
+      // Row of a virtualized list: BlurView must not be mounted inside a
+      // FlatList/SectionList (Android view recycling crashes — see
+      // SafeBlurView). Falls back to the solid glass background.
+      disableBlur
     >
       <TouchableOpacity
         style={styles.touchable}

--- a/src/components/transaction/TransactionListItem.tsx
+++ b/src/components/transaction/TransactionListItem.tsx
@@ -270,6 +270,10 @@ const TransactionListItem = React.memo(
         style={containerStyle}
         borderRadius={theme.borderRadius.lg}
         opacity={0.7}
+        // Row of a virtualized list: BlurView must not be mounted inside a
+        // FlatList/VirtualizedList (Android view recycling crashes — see
+        // SafeBlurView). Falls back to the solid glass background.
+        disableBlur
       >
         <TouchableOpacity
           onPress={() => onPress(transaction)}

--- a/src/screens/social/ChatScreen.tsx
+++ b/src/screens/social/ChatScreen.tsx
@@ -32,6 +32,7 @@ import MessagingService, {
   isMessagingKeyRegistered,
 } from '@/services/messaging';
 import type { FriendsStackParamList } from '@/navigation/AppNavigator';
+import { ListFooterSpinner } from '@/components/common/ListFooterSpinner';
 import UniversalHeader from '@/components/common/UniversalHeader';
 import { useTheme } from '@/contexts/ThemeContext';
 import { formatAddress } from '@/utils/address';
@@ -423,13 +424,7 @@ export default function ChatScreen() {
           keyboardShouldPersistTaps="handled"
           onEndReached={handleLoadMore}
           onEndReachedThreshold={0.3}
-          ListFooterComponent={
-            isLoadingMore ? (
-              <View style={styles.loadingMore}>
-                <ActivityIndicator size="small" color={theme.colors.primary} />
-              </View>
-            ) : null
-          }
+          ListFooterComponent={<ListFooterSpinner visible={isLoadingMore} />}
           ListEmptyComponent={
             <View style={styles.emptyState}>
               <View style={styles.emptyStateInner}>
@@ -542,10 +537,6 @@ const createStyles = (theme: Theme) =>
     },
     messagesContent: {
       paddingVertical: theme.spacing.md,
-    },
-    loadingMore: {
-      paddingVertical: theme.spacing.md,
-      alignItems: 'center',
     },
     emptyListContent: {
       flexGrow: 1,

--- a/src/screens/social/FriendsScreen.tsx
+++ b/src/screens/social/FriendsScreen.tsx
@@ -1,9 +1,9 @@
-import React, { useState, useEffect, useCallback } from 'react';
+import React, { useState, useEffect, useCallback, useMemo } from 'react';
 import {
   View,
   Text,
   StyleSheet,
-  ScrollView,
+  SectionList,
   TextInput,
   TouchableOpacity,
   RefreshControl,
@@ -20,6 +20,7 @@ import FriendListItem from '@/components/social/FriendListItem';
 import type { FriendsStackParamList } from '@/navigation/AppNavigator';
 import { NFTBackground } from '@/components/common/NFTBackground';
 import { BlurredContainer } from '@/components/common/BlurredContainer';
+import { ListEmptyState } from '@/components/common/ListEmptyState';
 import UniversalHeader from '@/components/common/UniversalHeader';
 import { useTheme } from '@/contexts/ThemeContext';
 import { GlassButton } from '@/components/common/GlassButton';
@@ -55,9 +56,24 @@ export default function FriendsScreen() {
     ? searchFriends(searchQuery)
     : sortedFriends;
 
-  // Group friends
-  const favorites = filteredFriends.filter((f) => f.isFavorite);
-  const regular = filteredFriends.filter((f) => !f.isFavorite);
+  // Group friends into SectionList sections (empty groups are omitted so no
+  // header renders for them, matching the previous conditional rendering).
+  const sections = useMemo(() => {
+    const favorites = filteredFriends.filter((f) => f.isFavorite);
+    const regular = filteredFriends.filter((f) => !f.isFavorite);
+
+    const result: { title: string; data: Friend[] }[] = [];
+    if (favorites.length > 0) {
+      result.push({ title: 'Favorites', data: favorites });
+    }
+    if (regular.length > 0) {
+      result.push({
+        title: searchQuery.trim() ? 'Results' : 'All Friends',
+        data: regular,
+      });
+    }
+    return result;
+  }, [filteredFriends, searchQuery]);
 
   // Handle friend press
   const handleFriendPress = useCallback(
@@ -85,47 +101,71 @@ export default function FriendsScreen() {
   }, [navigation]);
 
   // Render empty state
-  const renderEmptyState = () => {
+  const renderEmptyState = useCallback(() => {
     if (isLoading) {
       return null;
     }
 
     if (searchQuery.trim()) {
       return (
-        <View style={styles.emptyState}>
-          <Ionicons
-            name="search-outline"
-            size={64}
-            color={theme.colors.textMuted}
-          />
-          <Text style={styles.emptyTitle}>No friends found</Text>
-          <Text style={styles.emptyText}>Try a different search term</Text>
-        </View>
+        <ListEmptyState
+          icon="search-outline"
+          title="No friends found"
+          subtitle="Try a different search term"
+          style={styles.emptyState}
+        />
       );
     }
 
     return (
-      <View style={styles.emptyState}>
-        <Ionicons
-          name="people-outline"
-          size={64}
-          color={theme.colors.textMuted}
-        />
-        <Text style={styles.emptyTitle}>No friends yet</Text>
-        <Text style={styles.emptyText}>
-          Add friends by searching for their Envoi name
-        </Text>
-        <GlassButton
-          variant="primary"
-          size="md"
-          label="Add Friend"
-          icon="person-add"
-          onPress={handleAddFriend}
-          style={{ marginTop: theme.spacing.lg }}
-        />
-      </View>
+      <ListEmptyState
+        icon="people-outline"
+        title="No friends yet"
+        subtitle="Add friends by searching for their Envoi name"
+        style={styles.emptyState}
+        action={
+          <GlassButton
+            variant="primary"
+            size="md"
+            label="Add Friend"
+            icon="person-add"
+            onPress={handleAddFriend}
+            style={{ marginTop: theme.spacing.lg }}
+          />
+        }
+      />
     );
-  };
+  }, [
+    isLoading,
+    searchQuery,
+    styles.emptyState,
+    handleAddFriend,
+    theme.spacing.lg,
+  ]);
+
+  const renderFriendItem = useCallback(
+    ({ item }: { item: Friend }) => (
+      <FriendListItem
+        friend={item}
+        onPress={handleFriendPress}
+        showLastInteraction={false}
+        showAddress
+      />
+    ),
+    [handleFriendPress]
+  );
+
+  const renderSectionHeader = useCallback(
+    ({ section }: { section: { title: string; data: Friend[] } }) => (
+      <View style={styles.sectionHeader}>
+        <Text style={styles.sectionTitle}>{section.title}</Text>
+        <Text style={styles.sectionCount}>{section.data.length}</Text>
+      </View>
+    ),
+    [styles.sectionHeader, styles.sectionTitle, styles.sectionCount]
+  );
+
+  const keyExtractor = useCallback((item: Friend) => item.id, []);
 
   return (
     <NFTBackground>
@@ -193,11 +233,13 @@ export default function FriendsScreen() {
         </BlurredContainer>
 
         {/* Friends List */}
-        <ScrollView
+        <SectionList
+          sections={sections}
+          renderItem={renderFriendItem}
+          renderSectionHeader={renderSectionHeader}
+          keyExtractor={keyExtractor}
           contentContainerStyle={
-            filteredFriends.length === 0
-              ? styles.emptyListContent
-              : styles.listContent
+            sections.length === 0 ? styles.emptyListContent : styles.listContent
           }
           refreshControl={
             <RefreshControl
@@ -206,51 +248,18 @@ export default function FriendsScreen() {
               tintColor={theme.colors.primary}
             />
           }
-        >
-          {filteredFriends.length === 0 ? (
-            renderEmptyState()
-          ) : (
-            <>
-              {favorites.length > 0 && (
-                <View style={styles.section}>
-                  <View style={styles.sectionHeader}>
-                    <Text style={styles.sectionTitle}>Favorites</Text>
-                    <Text style={styles.sectionCount}>{favorites.length}</Text>
-                  </View>
-                  {favorites.map((friend) => (
-                    <FriendListItem
-                      key={friend.id}
-                      friend={friend}
-                      onPress={handleFriendPress}
-                      showLastInteraction={false}
-                      showAddress={true}
-                    />
-                  ))}
-                </View>
-              )}
-
-              {regular.length > 0 && (
-                <View style={styles.section}>
-                  <View style={styles.sectionHeader}>
-                    <Text style={styles.sectionTitle}>
-                      {searchQuery.trim() ? 'Results' : 'All Friends'}
-                    </Text>
-                    <Text style={styles.sectionCount}>{regular.length}</Text>
-                  </View>
-                  {regular.map((friend) => (
-                    <FriendListItem
-                      key={friend.id}
-                      friend={friend}
-                      onPress={handleFriendPress}
-                      showLastInteraction={false}
-                      showAddress={true}
-                    />
-                  ))}
-                </View>
-              )}
-            </>
-          )}
-        </ScrollView>
+          ListEmptyComponent={renderEmptyState}
+          stickySectionHeadersEnabled={false}
+          // Rows are variable height (name/address wrapping), so no
+          // getItemLayout here — a wrong fixed height breaks scrolling.
+          initialNumToRender={12}
+          maxToRenderPerBatch={12}
+          windowSize={11}
+          // Safe: rows pass `disableBlur`, so no BlurView is mounted inside
+          // this VirtualizedList (see SafeBlurView's Android warning).
+          removeClippedSubviews
+          showsVerticalScrollIndicator={false}
+        />
 
         {/* Floating Add Button */}
         <TouchableOpacity
@@ -312,9 +321,6 @@ const createStyles = (theme: Theme) =>
       justifyContent: 'center',
       padding: theme.spacing.sm,
     },
-    section: {
-      marginBottom: theme.spacing.sm,
-    },
     sectionHeader: {
       flexDirection: 'row',
       alignItems: 'center',
@@ -340,20 +346,6 @@ const createStyles = (theme: Theme) =>
       alignItems: 'center',
       paddingHorizontal: theme.spacing.xl,
       paddingVertical: theme.spacing.xxl,
-    },
-    emptyTitle: {
-      fontSize: 20,
-      fontWeight: '600',
-      color: theme.colors.text,
-      marginTop: theme.spacing.lg,
-      marginBottom: theme.spacing.sm,
-      textAlign: 'center',
-    },
-    emptyText: {
-      fontSize: 14,
-      color: theme.colors.textMuted,
-      textAlign: 'center',
-      lineHeight: 20,
     },
     fab: {
       position: 'absolute',

--- a/src/screens/social/MessagesInboxScreen.tsx
+++ b/src/screens/social/MessagesInboxScreen.tsx
@@ -3,7 +3,7 @@ import {
   View,
   Text,
   StyleSheet,
-  ScrollView,
+  FlatList,
   TextInput,
   TouchableOpacity,
   RefreshControl,
@@ -34,6 +34,7 @@ import { MessageThread, MESSAGE_FEE_DISPLAY } from '@/services/messaging/types';
 import type { FriendsStackParamList } from '@/navigation/AppNavigator';
 import { NFTBackground } from '@/components/common/NFTBackground';
 import { BlurredContainer } from '@/components/common/BlurredContainer';
+import { ListEmptyState } from '@/components/common/ListEmptyState';
 import UniversalHeader from '@/components/common/UniversalHeader';
 import { useTheme } from '@/contexts/ThemeContext';
 import { GlassButton } from '@/components/common/GlassButton';
@@ -375,14 +376,13 @@ export default function MessagesInboxScreen() {
   );
 
   // Render thread item
-  const renderThreadItem = (thread: MessageThread) => {
+  const renderThreadItem = ({ item: thread }: { item: MessageThread }) => {
     const friendInfo = getFriendInfo(thread);
     const hasUnread = thread.unreadCount > 0;
     const isHidden = hiddenThreads.has(thread.friendAddress);
 
     return (
       <Swipeable
-        key={thread.friendAddress}
         renderRightActions={() => renderRightActions(thread.friendAddress)}
         overshootRight={false}
       >
@@ -392,6 +392,10 @@ export default function MessagesInboxScreen() {
             isHidden && showHiddenThreads && styles.threadItemHidden,
           ]}
           borderRadius={theme.borderRadius.lg}
+          // Row of a virtualized list: BlurView must not be mounted inside a
+          // FlatList/VirtualizedList (Android view recycling crashes — see
+          // SafeBlurView). Falls back to the solid glass background.
+          disableBlur
         >
           <TouchableOpacity
             style={styles.threadTouchable}
@@ -498,7 +502,7 @@ export default function MessagesInboxScreen() {
   })();
 
   // Render unsupported message for Ledger accounts
-  const renderLedgerUnsupported = () => {
+  const renderLedgerUnsupported = useCallback(() => {
     return (
       <View style={styles.emptyState}>
         <Ionicons
@@ -514,10 +518,10 @@ export default function MessagesInboxScreen() {
         </Text>
       </View>
     );
-  };
+  }, [styles, theme.colors.textMuted]);
 
   // Render key registration prompt
-  const renderKeyRegistrationPrompt = () => {
+  const renderKeyRegistrationPrompt = useCallback(() => {
     return (
       <View style={styles.emptyState}>
         <Ionicons name="key-outline" size={64} color={theme.colors.primary} />
@@ -547,10 +551,12 @@ export default function MessagesInboxScreen() {
         )}
       </View>
     );
-  };
+  }, [styles, theme, isRegistering, handleRegisterKey]);
 
-  // Render empty state
-  const renderEmptyState = () => {
+  // Render empty state. Memoized: an unstable component identity makes
+  // VirtualizedList remount the empty subtree (and its GlassButton animations)
+  // on every render.
+  const renderEmptyState = useCallback(() => {
     // Show unsupported message for Ledger accounts
     if (isLedgerBacked) {
       return renderLedgerUnsupported();
@@ -573,40 +579,55 @@ export default function MessagesInboxScreen() {
 
     if (searchQuery.trim()) {
       return (
-        <View style={styles.emptyState}>
-          <Ionicons
-            name="search-outline"
-            size={64}
-            color={theme.colors.textMuted}
-          />
-          <Text style={styles.emptyTitle}>No conversations found</Text>
-          <Text style={styles.emptyText}>Try a different search term</Text>
-        </View>
+        <ListEmptyState
+          icon="search-outline"
+          title="No conversations found"
+          subtitle="Try a different search term"
+          style={styles.emptyState}
+        />
       );
     }
 
     return (
-      <View style={styles.emptyState}>
-        <Ionicons
-          name="chatbubbles-outline"
-          size={64}
-          color={theme.colors.textMuted}
-        />
-        <Text style={styles.emptyTitle}>No messages yet</Text>
-        <Text style={styles.emptyText}>
-          Start a conversation with someone on the Voi Network
-        </Text>
-        <GlassButton
-          variant="primary"
-          size="md"
-          label="New Message"
-          icon="create-outline"
-          onPress={handleNewMessage}
-          style={{ marginTop: theme.spacing.lg }}
-        />
-      </View>
+      <ListEmptyState
+        icon="chatbubbles-outline"
+        title="No messages yet"
+        subtitle="Start a conversation with someone on the Voi Network"
+        style={styles.emptyState}
+        action={
+          <GlassButton
+            variant="primary"
+            size="md"
+            label="New Message"
+            icon="create-outline"
+            onPress={handleNewMessage}
+            style={{ marginTop: theme.spacing.lg }}
+          />
+        }
+      />
     );
-  };
+  }, [
+    isLedgerBacked,
+    isCheckingRegistration,
+    isKeyRegistered,
+    searchQuery,
+    styles,
+    theme,
+    handleNewMessage,
+    renderLedgerUnsupported,
+    renderKeyRegistrationPrompt,
+  ]);
+
+  // Threads are only listable once messaging is usable for this account;
+  // otherwise the list stays empty and ListEmptyComponent explains why.
+  const canShowThreads =
+    !isLedgerBacked && !isCheckingRegistration && isKeyRegistered;
+  const threadListData = canShowThreads ? filteredThreads : [];
+
+  const keyExtractor = useCallback(
+    (item: MessageThread) => item.friendAddress,
+    []
+  );
 
   return (
     <NFTBackground>
@@ -696,17 +717,17 @@ export default function MessagesInboxScreen() {
         )}
 
         {/* Messages List */}
-        <ScrollView
+        <FlatList
+          data={threadListData}
+          renderItem={renderThreadItem}
+          keyExtractor={keyExtractor}
           contentContainerStyle={
-            isLedgerBacked ||
-            isCheckingRegistration ||
-            filteredThreads.length === 0 ||
-            !isKeyRegistered
+            threadListData.length === 0
               ? styles.emptyListContent
               : styles.listContent
           }
           refreshControl={
-            !isLedgerBacked && isKeyRegistered && !isCheckingRegistration ? (
+            canShowThreads ? (
               <RefreshControl
                 refreshing={isRefreshing}
                 onRefresh={handleRefresh}
@@ -714,14 +735,17 @@ export default function MessagesInboxScreen() {
               />
             ) : undefined
           }
-        >
-          {isLedgerBacked ||
-          isCheckingRegistration ||
-          !isKeyRegistered ||
-          filteredThreads.length === 0
-            ? renderEmptyState()
-            : filteredThreads.map(renderThreadItem)}
-        </ScrollView>
+          ListEmptyComponent={renderEmptyState}
+          // Rows are variable height (name/preview wrapping), so no
+          // getItemLayout here — a wrong fixed height breaks scrolling.
+          initialNumToRender={12}
+          maxToRenderPerBatch={12}
+          windowSize={11}
+          // Safe: rows pass `disableBlur`, so no BlurView is mounted inside
+          // this VirtualizedList (see SafeBlurView's Android warning).
+          removeClippedSubviews
+          showsVerticalScrollIndicator={false}
+        />
 
         {/* Account List Modal */}
         <AccountListModal

--- a/src/screens/wallet/AssetDetailScreen.tsx
+++ b/src/screens/wallet/AssetDetailScreen.tsx
@@ -4,7 +4,7 @@ import {
   Text,
   StyleSheet,
   RefreshControl,
-  ScrollView,
+  FlatList,
   TouchableOpacity,
   Alert,
   ActivityIndicator,
@@ -44,6 +44,8 @@ import { NetworkService } from '@/services/network';
 import UnifiedAuthModal from '@/components/UnifiedAuthModal';
 import { BlurredContainer } from '@/components/common/BlurredContainer';
 import { GlassCard } from '@/components/common/GlassCard';
+import { ListEmptyState } from '@/components/common/ListEmptyState';
+import { ListFooterSpinner } from '@/components/common/ListFooterSpinner';
 import { NFTBackground } from '@/components/common/NFTBackground';
 import { useTheme } from '@/contexts/ThemeContext';
 import { SwapService } from '@/services/swap';
@@ -69,7 +71,7 @@ export default function AssetDetailScreen() {
   const [optingOut, setOptingOut] = useState(false);
   const [isSwappable, setIsSwappable] = useState(false);
   const [checkingSwappable, setCheckingSwappable] = useState(true);
-  const loadMoreCalledRef = React.useRef(false);
+  const loadMoreInFlightRef = React.useRef(false);
   const route = useRoute();
   const navigation = useNavigation<StackNavigationProp<any>>();
   const isSwapEnabled = useIsSwapEnabled();
@@ -827,32 +829,29 @@ export default function AssetDetailScreen() {
   const pagination = accountState.assetTransactionsPagination?.[assetKey];
 
   const handleLoadMore = React.useCallback(() => {
-    // Prevent duplicate calls
-    if (loadMoreCalledRef.current) {
+    // The store only flips `isLoadingMore` after an await, so guard on an
+    // in-flight ref as well — otherwise two `onEndReached` events fired in the
+    // same tick would both pass the store-side check and double-fetch a page.
+    if (loadMoreInFlightRef.current) {
       return;
     }
-
-    console.log('[handleLoadMore] Called - assetId:', assetId);
-    console.log(
-      '[handleLoadMore] Asset pagination state:',
-      JSON.stringify(pagination)
-    );
 
     if (!pagination || !pagination.hasMore || pagination.isLoadingMore) {
-      console.log(
-        '[handleLoadMore] Skipping - no more data or already loading'
-      );
       return;
     }
 
-    console.log('[handleLoadMore] Triggering loadMoreAssetTransactions');
-    loadMoreCalledRef.current = true;
-    loadMoreAssetTransactions(accountId, assetId, isArc200);
-
-    setTimeout(() => {
-      loadMoreCalledRef.current = false;
-    }, 1000);
+    loadMoreInFlightRef.current = true;
+    void loadMoreAssetTransactions(accountId, assetId, isArc200).finally(() => {
+      loadMoreInFlightRef.current = false;
+    });
   }, [assetId, accountId, pagination, isArc200, loadMoreAssetTransactions]);
+
+  // Index-suffixed for the same reason as TransactionHistoryScreen: indexer
+  // payloads can repeat an id, and duplicate keys drop rows from a FlatList.
+  const keyExtractor = React.useCallback(
+    (item: TransactionInfo, index: number) => `${item.id}-${index}`,
+    []
+  );
 
   const renderTransactionItem = ({ item: tx }: { item: TransactionInfo }) => {
     const isOutgoing = tx.from === currentAccount?.address;
@@ -865,6 +864,10 @@ export default function AssetDetailScreen() {
         ]}
         borderRadius={theme.borderRadius.lg}
         opacity={0.7}
+        // Row of a virtualized list: BlurView must not be mounted inside a
+        // FlatList/VirtualizedList (Android view recycling crashes — see
+        // SafeBlurView). Falls back to the solid glass background.
+        disableBlur
       >
         <TouchableOpacity
           style={{ flex: 1 }}
@@ -1194,31 +1197,28 @@ export default function AssetDetailScreen() {
     </>
   );
 
-  const renderListFooter = () => {
-    // All assets now use assetTransactionsPagination (including native VOI)
-    if (!pagination?.hasMore) return null;
-
-    return (
-      <View style={{ paddingVertical: 20, alignItems: 'center' }}>
-        {pagination?.isLoadingMore && (
-          <ActivityIndicator size="small" color={themeColors.primary} />
-        )}
-      </View>
-    );
-  };
-
-  const renderListEmpty = () => (
-    <View style={styles.emptyTransactions}>
-      <Ionicons
-        name="receipt-outline"
-        size={64}
-        color={themeColors.textMuted}
+  // All assets now use assetTransactionsPagination (including native VOI).
+  // Memoized: an unstable component identity makes VirtualizedList remount the
+  // footer/empty subtree on every render.
+  const renderListFooter = React.useCallback(
+    () => (
+      <ListFooterSpinner
+        visible={!!pagination?.hasMore && !!pagination?.isLoadingMore}
       />
-      <Text style={styles.emptyTitle}>No transactions yet</Text>
-      <Text style={styles.emptySubtitle}>
-        Transactions for this asset will appear here when they occur.
-      </Text>
-    </View>
+    ),
+    [pagination?.hasMore, pagination?.isLoadingMore]
+  );
+
+  const renderListEmpty = React.useCallback(
+    () => (
+      <ListEmptyState
+        icon="receipt-outline"
+        title="No transactions yet"
+        subtitle="Transactions for this asset will appear here when they occur."
+        style={styles.emptyTransactions}
+      />
+    ),
+    [styles.emptyTransactions]
   );
 
   return (
@@ -1233,20 +1233,33 @@ export default function AssetDetailScreen() {
           onAccountSelectorPress={() => {}}
         />
 
-        <ScrollView
+        <FlatList
+          data={filteredTransactions}
+          renderItem={renderTransactionItem}
+          keyExtractor={keyExtractor}
           contentContainerStyle={styles.content}
           refreshControl={
             <RefreshControl refreshing={refreshing} onRefresh={onRefresh} />
           }
-        >
-          {renderListHeader()}
-          {filteredTransactions.length === 0
-            ? renderListEmpty()
-            : filteredTransactions.map((tx) => (
-                <View key={tx.id}>{renderTransactionItem({ item: tx })}</View>
-              ))}
-          {renderListFooter()}
-        </ScrollView>
+          // Passed as an element, not a component reference: the header is
+          // large and interactive, and an unstable component identity would
+          // make VirtualizedList remount the whole subtree on every render.
+          ListHeaderComponent={renderListHeader()}
+          ListEmptyComponent={renderListEmpty}
+          ListFooterComponent={renderListFooter}
+          onEndReached={handleLoadMore}
+          onEndReachedThreshold={0.5}
+          // Rows are variable height (address/label wrapping), so no
+          // getItemLayout here — a wrong fixed height breaks scrolling.
+          initialNumToRender={10}
+          maxToRenderPerBatch={10}
+          windowSize={11}
+          // Intentionally left off: the list header still renders GlassCard /
+          // BlurredContainer glass, and clipping detaches/reattaches those
+          // native views on Android (see SafeBlurView). Rows themselves pass
+          // `disableBlur`, so nothing is recycled with a live BlurView.
+          removeClippedSubviews={false}
+        />
 
         {/* PIN Entry Modal */}
         <UnifiedAuthModal
@@ -1429,21 +1442,6 @@ const createStyles = (theme: Theme) =>
     },
     emptyTransactions: {
       paddingVertical: theme.spacing.xl,
-      alignItems: 'center',
-    },
-    emptyTitle: {
-      fontSize: 20,
-      fontWeight: '600',
-      color: theme.colors.text,
-      marginTop: theme.spacing.md,
-      marginBottom: theme.spacing.xs,
-    },
-    emptySubtitle: {
-      fontSize: 16,
-      color: theme.colors.textMuted,
-      textAlign: 'center',
-      lineHeight: 22,
-      paddingHorizontal: theme.spacing.md,
     },
     transactionItem: {
       padding: theme.spacing.lg,

--- a/src/screens/wallet/ClaimableTokensScreen.tsx
+++ b/src/screens/wallet/ClaimableTokensScreen.tsx
@@ -10,7 +10,7 @@ import {
   View,
   Text,
   StyleSheet,
-  ScrollView,
+  FlatList,
   RefreshControl,
   TouchableOpacity,
   ActivityIndicator,
@@ -266,30 +266,112 @@ export default function ClaimableTokensScreen() {
     );
   };
 
-  // Render empty state
-  const renderEmptyState = () => (
-    <View style={styles.emptyContainer}>
-      <View style={styles.emptyIconContainer}>
-        <Ionicons
-          name="gift-outline"
-          size={64}
-          color={styles.emptyIcon.color}
-        />
+  // Render empty state. This screen keeps its own empty state rather than the
+  // shared ListEmptyState: it has a distinct circular icon badge.
+  const renderEmptyState = useCallback(
+    () => (
+      <View style={styles.emptyContainer}>
+        <View style={styles.emptyIconContainer}>
+          <Ionicons
+            name="gift-outline"
+            size={64}
+            color={styles.emptyIcon.color}
+          />
+        </View>
+        <Text style={styles.emptyTitle}>No Claimable Tokens</Text>
+        <Text style={styles.emptySubtitle}>
+          When someone approves tokens for you to claim, they will appear here.
+        </Text>
       </View>
-      <Text style={styles.emptyTitle}>No Claimable Tokens</Text>
-      <Text style={styles.emptySubtitle}>
-        When someone approves tokens for you to claim, they will appear here.
-      </Text>
-    </View>
+    ),
+    [styles]
   );
 
   // Render loading state
-  const renderLoadingState = () => (
-    <View style={styles.loadingContainer}>
-      <ActivityIndicator size="large" color={theme.colors.primary} />
-      <Text style={styles.loadingText}>Loading claimable tokens...</Text>
-    </View>
+  const renderLoadingState = useCallback(
+    () => (
+      <View style={styles.loadingContainer}>
+        <ActivityIndicator size="large" color={theme.colors.primary} />
+        <Text style={styles.loadingText}>Loading claimable tokens...</Text>
+      </View>
+    ),
+    [styles, theme.colors.primary]
   );
+
+  // Empty slot doubles as the initial-load placeholder so pull-to-refresh
+  // stays available in both states. Memoized: an unstable component identity
+  // makes VirtualizedList remount the empty subtree on every render.
+  const showLoadingState = isLoading && !isRefreshing;
+  const renderListEmpty = useCallback(
+    () => (showLoadingState ? renderLoadingState() : renderEmptyState()),
+    [showLoadingState, renderLoadingState, renderEmptyState]
+  );
+
+  // Summary + pending-refresh banner scroll with the list, as before.
+  const renderListHeader = () => {
+    if (displayedItems.length === 0) return null;
+
+    return (
+      <>
+        {/* Pending refresh indicator */}
+        {isPendingRefresh && (
+          <Animated.View
+            style={[styles.pendingRefreshBanner, pulseAnimatedStyle]}
+          >
+            <ActivityIndicator size="small" color={theme.colors.primary} />
+            <Text style={styles.pendingRefreshText}>
+              Updating claim status...
+            </Text>
+          </Animated.View>
+        )}
+
+        {/* Summary card */}
+        <GlassCard variant="light" padding="md" style={styles.summaryCard}>
+          <View style={styles.summaryRow}>
+            <View style={styles.summaryItem}>
+              <Text style={styles.summaryValue}>{visibleCount}</Text>
+              <Text style={styles.summaryLabel}>Available</Text>
+            </View>
+            <View style={styles.summaryDivider} />
+            <View style={styles.summaryItem}>
+              <Text style={styles.summaryValue}>{claimableCount}</Text>
+              <Text style={styles.summaryLabel}>Claimable</Text>
+            </View>
+            {hiddenCount > 0 && (
+              <>
+                <View style={styles.summaryDivider} />
+                <View style={styles.summaryItem}>
+                  <Text style={styles.summaryValue}>{hiddenCount}</Text>
+                  <Text style={styles.summaryLabel}>Hidden</Text>
+                </View>
+              </>
+            )}
+          </View>
+        </GlassCard>
+      </>
+    );
+  };
+
+  // Each row keeps its own Swipeable. FlatList keys cells by `keyExtractor`
+  // and mounts/unmounts them (it does not reuse instances across items), so a
+  // row's open/closed swipe state stays bound to its own item.
+  const renderItem = useCallback(
+    ({ item }: { item: ClaimableItem }) => (
+      <Swipeable
+        renderRightActions={() => renderRightActions(item)}
+        overshootRight={false}
+      >
+        <ClaimableTokenItem
+          item={item}
+          onPress={() => handleItemPress(item)}
+          isHidden={hiddenApprovals.has(item.id)}
+        />
+      </Swipeable>
+    ),
+    [hiddenApprovals, renderRightActions, handleItemPress]
+  );
+
+  const keyExtractor = useCallback((item: ClaimableItem) => item.id, []);
 
   return (
     <NFTBackground>
@@ -327,9 +409,16 @@ export default function ClaimableTokensScreen() {
           </TouchableOpacity>
         )}
 
-        <ScrollView
+        <FlatList
           style={styles.scrollView}
-          contentContainerStyle={styles.scrollContent}
+          data={displayedItems}
+          renderItem={renderItem}
+          keyExtractor={keyExtractor}
+          contentContainerStyle={
+            displayedItems.length === 0
+              ? styles.emptyListContent
+              : styles.scrollContent
+          }
           refreshControl={
             <RefreshControl
               refreshing={isRefreshing}
@@ -337,78 +426,22 @@ export default function ClaimableTokensScreen() {
               tintColor={theme.colors.primary}
             />
           }
-        >
-          {isLoading && !isRefreshing && displayedItems.length === 0 ? (
-            renderLoadingState()
-          ) : displayedItems.length === 0 ? (
-            renderEmptyState()
-          ) : (
-            <>
-              {/* Pending refresh indicator */}
-              {isPendingRefresh && (
-                <Animated.View
-                  style={[styles.pendingRefreshBanner, pulseAnimatedStyle]}
-                >
-                  <ActivityIndicator
-                    size="small"
-                    color={theme.colors.primary}
-                  />
-                  <Text style={styles.pendingRefreshText}>
-                    Updating claim status...
-                  </Text>
-                </Animated.View>
-              )}
-
-              {/* Summary card */}
-              <GlassCard
-                variant="light"
-                padding="md"
-                style={styles.summaryCard}
-              >
-                <View style={styles.summaryRow}>
-                  <View style={styles.summaryItem}>
-                    <Text style={styles.summaryValue}>{visibleCount}</Text>
-                    <Text style={styles.summaryLabel}>Available</Text>
-                  </View>
-                  <View style={styles.summaryDivider} />
-                  <View style={styles.summaryItem}>
-                    <Text style={styles.summaryValue}>{claimableCount}</Text>
-                    <Text style={styles.summaryLabel}>Claimable</Text>
-                  </View>
-                  {hiddenCount > 0 && (
-                    <>
-                      <View style={styles.summaryDivider} />
-                      <View style={styles.summaryItem}>
-                        <Text style={styles.summaryValue}>{hiddenCount}</Text>
-                        <Text style={styles.summaryLabel}>Hidden</Text>
-                      </View>
-                    </>
-                  )}
-                </View>
-              </GlassCard>
-
-              {/* Token list */}
-              <View style={styles.listContainer}>
-                {displayedItems.map((item) => {
-                  const isHidden = hiddenApprovals.has(item.id);
-                  return (
-                    <Swipeable
-                      key={item.id}
-                      renderRightActions={() => renderRightActions(item)}
-                      overshootRight={false}
-                    >
-                      <ClaimableTokenItem
-                        item={item}
-                        onPress={() => handleItemPress(item)}
-                        isHidden={isHidden}
-                      />
-                    </Swipeable>
-                  );
-                })}
-              </View>
-            </>
-          )}
-        </ScrollView>
+          // Passed as an element, not a component reference: the header holds
+          // a running Reanimated banner, and an unstable component identity
+          // would make VirtualizedList remount it on every render.
+          ListHeaderComponent={renderListHeader()}
+          ListEmptyComponent={renderListEmpty}
+          // Rows are variable height (token name/amount wrapping), so no
+          // getItemLayout here — a wrong fixed height breaks scrolling.
+          initialNumToRender={10}
+          maxToRenderPerBatch={10}
+          windowSize={11}
+          // Intentionally left off: the list header renders a GlassCard, whose
+          // glass uses BlurView, and clipping detaches/reattaches those native
+          // views on Android (see SafeBlurView). Rows themselves use plain
+          // Views, so nothing is recycled with a live BlurView.
+          removeClippedSubviews={false}
+        />
       </SafeAreaView>
     </NFTBackground>
   );
@@ -425,6 +458,11 @@ const createStyles = (theme: Theme) =>
     scrollContent: {
       padding: 16,
       paddingBottom: 32,
+    },
+    emptyListContent: {
+      flexGrow: 1,
+      justifyContent: 'center',
+      padding: 16,
     },
     hiddenToggle: {
       flexDirection: 'row',
@@ -480,9 +518,6 @@ const createStyles = (theme: Theme) =>
       width: 1,
       height: 32,
       backgroundColor: theme.colors.border,
-    },
-    listContainer: {
-      gap: 0,
     },
     swipeAction: {
       justifyContent: 'center',

--- a/src/screens/wallet/CollectionDetailScreen.tsx
+++ b/src/screens/wallet/CollectionDetailScreen.tsx
@@ -18,6 +18,7 @@ import type { StackNavigationProp } from '@react-navigation/stack';
 import { useActiveAccount } from '@/store/walletStore';
 import { NFTService } from '@/services/nft';
 import { NFTToken, ARC72Collection } from '@/types/nft';
+import { ListFooterSpinner } from '@/components/common/ListFooterSpinner';
 import UniversalHeader from '@/components/common/UniversalHeader';
 import { useTheme } from '@/contexts/ThemeContext';
 
@@ -379,13 +380,7 @@ export default function CollectionDetailScreen() {
           onEndReached={handleLoadMore}
           onEndReachedThreshold={0.5}
           ListEmptyComponent={renderEmptyState}
-          ListFooterComponent={
-            loadingMore ? (
-              <View style={styles.loadingMoreContainer}>
-                <ActivityIndicator size="small" color={theme.colors.primary} />
-              </View>
-            ) : null
-          }
+          ListFooterComponent={<ListFooterSpinner visible={loadingMore} />}
           showsVerticalScrollIndicator={false}
         />
       )}
@@ -514,9 +509,5 @@ const styles = StyleSheet.create({
   loadingText: {
     fontSize: 16,
     marginTop: 16,
-  },
-  loadingMoreContainer: {
-    paddingVertical: 16,
-    alignItems: 'center',
   },
 });

--- a/src/screens/wallet/NFTScreen.tsx
+++ b/src/screens/wallet/NFTScreen.tsx
@@ -375,31 +375,39 @@ export default function NFTScreen() {
     );
   };
 
-  const renderEmptyState = () => (
-    <View style={styles.emptyContainer}>
-      <GlassCard variant="light" style={styles.emptyCard}>
-        <View
-          style={[
-            styles.emptyIconContainer,
-            { backgroundColor: `${theme.colors.primary}15` },
-          ]}
-        >
-          <Ionicons
-            name="images-outline"
-            size={48}
-            color={theme.colors.primary}
-          />
-        </View>
-        <Text style={[styles.emptyTitle, { color: theme.colors.text }]}>
-          No NFTs Found
-        </Text>
-        <Text
-          style={[styles.emptySubtitle, { color: theme.colors.textSecondary }]}
-        >
-          Your NFT collection will appear here when you have ARC-72 tokens
-        </Text>
-      </GlassCard>
-    </View>
+  // Memoized: an unstable component identity makes VirtualizedList remount the
+  // empty subtree on every render.
+  const renderEmptyState = useCallback(
+    () => (
+      <View style={styles.emptyContainer}>
+        <GlassCard variant="light" style={styles.emptyCard}>
+          <View
+            style={[
+              styles.emptyIconContainer,
+              { backgroundColor: `${theme.colors.primary}15` },
+            ]}
+          >
+            <Ionicons
+              name="images-outline"
+              size={48}
+              color={theme.colors.primary}
+            />
+          </View>
+          <Text style={[styles.emptyTitle, { color: theme.colors.text }]}>
+            No NFTs Found
+          </Text>
+          <Text
+            style={[
+              styles.emptySubtitle,
+              { color: theme.colors.textSecondary },
+            ]}
+          >
+            Your NFT collection will appear here when you have ARC-72 tokens
+          </Text>
+        </GlassCard>
+      </View>
+    ),
+    [styles, theme]
   );
 
   const renderContent = () => {
@@ -428,7 +436,7 @@ export default function NFTScreen() {
           theme={theme}
           refreshing={refreshing}
           onRefresh={onRefresh}
-          ListEmptyComponent={renderEmptyState()}
+          ListEmptyComponent={renderEmptyState}
           processingNFTKey={settingThemeNFT}
           imageErrors={imageErrors}
           onImageError={handleImageError}

--- a/src/screens/wallet/TransactionHistoryScreen.tsx
+++ b/src/screens/wallet/TransactionHistoryScreen.tsx
@@ -1,10 +1,10 @@
-import React, { useState, useEffect, useCallback } from 'react';
+import React, { useState, useEffect, useCallback, useRef } from 'react';
 import {
   View,
   Text,
   StyleSheet,
   RefreshControl,
-  ScrollView,
+  FlatList,
   TouchableOpacity,
   ActivityIndicator,
   ListRenderItem,
@@ -25,12 +25,15 @@ import { useThemedStyles } from '@/hooks/useThemedStyles';
 import { Theme } from '@/constants/themes';
 import { serializeTransactionForNavigation } from '@/utils/navigationParams';
 import { BlurredContainer } from '@/components/common/BlurredContainer';
+import { ListEmptyState } from '@/components/common/ListEmptyState';
+import { ListFooterSpinner } from '@/components/common/ListFooterSpinner';
 import { NFTBackground } from '@/components/common/NFTBackground';
 import { useTheme } from '@/contexts/ThemeContext';
 import { useCurrentNetwork } from '@/store/networkStore';
 
 export default function TransactionHistoryScreen() {
   const [refreshing, setRefreshing] = useState(false);
+  const loadMoreInFlightRef = useRef(false);
   const navigation = useNavigation<StackNavigationProp<any>>();
   const styles = useThemedStyles(createStyles);
   const { theme } = useTheme();
@@ -109,7 +112,11 @@ export default function TransactionHistoryScreen() {
   };
 
   const handleLoadMore = useCallback(async () => {
+    // The store only flips `isLoadingMore` after an await, so guard on an
+    // in-flight ref as well — otherwise two `onEndReached` events fired in the
+    // same tick would both pass the store-side check and double-fetch a page.
     if (
+      loadMoreInFlightRef.current ||
       !activeAccount ||
       !accountState.transactionsPagination?.hasMore ||
       accountState.transactionsPagination?.isLoadingMore
@@ -117,10 +124,13 @@ export default function TransactionHistoryScreen() {
       return;
     }
 
+    loadMoreInFlightRef.current = true;
     try {
       await loadMoreTransactions(activeAccount.id);
     } catch (error) {
       console.error('Failed to load more transactions:', error);
+    } finally {
+      loadMoreInFlightRef.current = false;
     }
   }, [
     activeAccount,
@@ -224,23 +234,28 @@ export default function TransactionHistoryScreen() {
     ]
   );
 
-  const renderFooter = () => {
-    if (!accountState.transactionsPagination?.isLoadingMore) {
-      return null;
-    }
+  const renderFooter = useCallback(
+    () => (
+      <ListFooterSpinner
+        visible={!!accountState.transactionsPagination?.isLoadingMore}
+        text="Loading more transactions..."
+      />
+    ),
+    [accountState.transactionsPagination?.isLoadingMore]
+  );
 
-    return (
-      <View style={styles.loadingFooter}>
-        <ActivityIndicator
-          size="small"
-          color={styles.activityIndicator.color}
-        />
-        <Text style={styles.loadingFooterText}>
-          Loading more transactions...
-        </Text>
-      </View>
-    );
-  };
+  const renderEmptyState = useCallback(
+    () => (
+      <ListEmptyState
+        icon="receipt-outline"
+        iconColor={styles.emptyIcon.color}
+        title="No Transactions"
+        subtitle="Your transaction history will appear here when you start using your wallet."
+        style={styles.emptyContainer}
+      />
+    ),
+    [styles.emptyContainer, styles.emptyIcon.color]
+  );
 
   const keyExtractor = useCallback(
     (item: TransactionInfo, index: number) => `${item.id}-${index}`,
@@ -288,35 +303,34 @@ export default function TransactionHistoryScreen() {
             />
             <Text style={styles.loadingText}>Loading transactions...</Text>
           </View>
-        ) : allTransactions.length === 0 ? (
-          <View style={styles.emptyContainer}>
-            <Ionicons
-              name="receipt-outline"
-              size={64}
-              color={styles.emptyIcon.color}
-            />
-            <Text style={styles.emptyTitle}>No Transactions</Text>
-            <Text style={styles.emptySubtitle}>
-              Your transaction history will appear here when you start using
-              your wallet.
-            </Text>
-          </View>
         ) : (
-          <ScrollView
-            contentContainerStyle={styles.listContainer}
+          <FlatList
+            data={allTransactions}
+            renderItem={renderTransaction}
+            keyExtractor={keyExtractor}
+            contentContainerStyle={
+              allTransactions.length === 0
+                ? styles.emptyListContainer
+                : styles.listContainer
+            }
             refreshControl={
               <RefreshControl refreshing={refreshing} onRefresh={onRefresh} />
             }
             onScrollBeginDrag={() => updateActivity()}
             showsVerticalScrollIndicator={false}
-          >
-            {allTransactions.map((item, index) => (
-              <View key={`${item.id}-${index}`}>
-                {renderTransaction({ item, index, separators: {} as any })}
-              </View>
-            ))}
-            {renderFooter()}
-          </ScrollView>
+            onEndReached={handleLoadMore}
+            onEndReachedThreshold={0.5}
+            ListEmptyComponent={renderEmptyState}
+            ListFooterComponent={renderFooter}
+            // Rows are variable height (address/label wrapping), so no
+            // getItemLayout here — a wrong fixed height breaks scrolling.
+            initialNumToRender={12}
+            maxToRenderPerBatch={12}
+            windowSize={11}
+            // Safe: rows pass `disableBlur`, so no BlurView is mounted inside
+            // this VirtualizedList (see SafeBlurView's Android warning).
+            removeClippedSubviews
+          />
         )}
       </SafeAreaView>
     </NFTBackground>
@@ -366,33 +380,15 @@ const createStyles = (theme: Theme) =>
       paddingVertical: 80,
       paddingHorizontal: theme.spacing.xl,
     },
-    emptyTitle: {
-      fontSize: 24,
-      fontWeight: '600',
-      color: theme.colors.text,
-      marginTop: theme.spacing.md,
-      marginBottom: theme.spacing.sm,
-    },
-    emptySubtitle: {
-      fontSize: 16,
-      color: theme.colors.textMuted,
-      textAlign: 'center',
-      lineHeight: 24,
-      paddingHorizontal: theme.spacing.md,
-    },
     listContainer: {
       paddingHorizontal: theme.spacing.md,
       paddingVertical: theme.spacing.sm,
       paddingBottom: theme.spacing.xxl,
     },
-    loadingFooter: {
-      paddingVertical: theme.spacing.lg,
-      alignItems: 'center',
-    },
-    loadingFooterText: {
-      fontSize: 14,
-      color: theme.colors.textSecondary,
-      marginTop: theme.spacing.xs,
+    emptyListContainer: {
+      flexGrow: 1,
+      justifyContent: 'center',
+      paddingHorizontal: theme.spacing.md,
     },
     backIcon: {
       color: theme.colors.primary,


### PR DESCRIPTION
Implements **TASK-39** (PLAN-12 Phase 1, Wave 1).

All five audited screens rendered every row at once inside a `ScrollView` + `.map()`, and the pagination that already exists in `walletStore` was never attached to anything.

## What changed

| Screen | Conversion |
|---|---|
| `TransactionHistoryScreen` | `ScrollView` → `FlatList`; `onEndReached` wired to the previously-dead `handleLoadMore`; dropped the `separators: {} as any` cast |
| `AssetDetailScreen` | `ScrollView` → `FlatList`; the ~238-line interactive asset header moved into `ListHeaderComponent`; `onEndReached` wired to the previously-dead `handleLoadMore` |
| `FriendsScreen` | `ScrollView` 2× `.map()` → `SectionList` (grouping already existed) |
| `MessagesInboxScreen` | `ScrollView` → `FlatList`; `renderThreadItem` now takes `({ item })`; all empty / Ledger / registration states moved to `ListEmptyComponent` |
| `ClaimableTokensScreen` | `ScrollView` → `FlatList`; `Swipeable` rows preserved; summary card + pending-refresh banner moved to `ListHeaderComponent` |

Pull-to-refresh is preserved on all five.

## Hard prerequisite — `disableBlur` (DR-4)

`SafeBlurView` warns that `BlurView` must not be mounted inside a `FlatList`/`VirtualizedList` on Android (view-recycling crashes). `BlurredContainer` has a purpose-built `disableBlur` prop that was **declared and never passed at a single call site** — almost certainly why these lists were `ScrollView`s.

`disableBlur` is now threaded through every virtualized row component:
`TransactionListItem`, `FriendListItem`, `AssetDetailScreen`'s transaction row, `MessagesInboxScreen`'s thread row.

Real blur only rendered when `!disableBlur && !!theme.backgroundImageUrl`, so **non-NFT-theme users see zero visual change**; NFT-theme users lose per-row blur (falling back to `theme.colors.glassBackground`) but keep the background image.

**Scoping note:** blur is left intact in the two `ListHeaderComponent`s that use `GlassCard`/`BlurredContainer` (AssetDetail balance card, Claimables summary card) — headers are not recycled cells and removing their blur would be a visual regression DR-4 did not sanction. Those two lists set `removeClippedSubviews={false}` so Android never detaches/reattaches those native views. App-wide NFT-glass `BlurView` remains TASK-194's scope.

## Fold-ins

- **Shared `ListFooterSpinner` / `ListEmptyState`** extracted into `src/components/common/`. The footer spinner was duplicated near-identically 5+ times and the TransactionHistory/AssetDetail empty states were nearly character-identical. Adopted in TransactionHistory, AssetDetail, Friends, MessagesInbox, plus `ChatScreen`, `CollectionDetailScreen` and `CollectionBrowser`.
- **`NFTScreen.tsx`** passed `ListEmptyComponent={renderEmptyState()}` (eager); now passed by reference. `NFTGridView`'s prop type widened to accept a component reference.
- **Load-more race:** both stores flip `isLoadingMore` only *after* an `await`, so two `onEndReached` events in the same tick would both pass the store-side guard and double-fetch a page. Both screens now hold a promise-scoped in-flight ref. On AssetDetail this replaces a hand-rolled `setTimeout(…, 1000)` guard (and three `console.log`s) that could unblock before the request finished.
- **Memoized list slots:** `VirtualizedList` renders `ListEmptyComponent`/`ListFooterComponent` as `<Component />`, so an unstable function identity remounts the subtree on every render (including `GlassButton`'s Reanimated loops). The empty/footer renderers are now `useCallback`-memoized; the two large interactive headers are passed as elements instead.

## Perf props

`getItemLayout` is **deliberately not applied** — every converted row is variable height and a wrong fixed height causes scroll/virtualization bugs. `initialNumToRender` / `maxToRenderPerBatch` / `windowSize` are tuned per-list; `removeClippedSubviews` is enabled only where neither rows nor header mount a `BlurView`.

## Constraints

- **FlatList, not FlashList** (DR-5) — no new native dependency.
- **JS-only / OTA-shippable** (DR-8) — no `app.config.js`, native config, or version changes.

## Gates

- `npm run typecheck` — 0 errors
- `npm run lint` — 0 errors (680 pre-existing warnings, baseline 681)
- `npm test -- --ci` — 1228 passed, 75 suites (baseline preserved)
- Codex review — CLEAN

Android dev-client scroll/recycling verification is deferred to the batched pre-release check, per the task's acceptance criteria.
