### PR TITLE
feat(errors): add central error-mapping utility (TASK-41)

### DIFF
--- a/src/screens/transaction/AppCallConfirmScreen.tsx
+++ b/src/screens/transaction/AppCallConfirmScreen.tsx
@@ -24,6 +24,7 @@ import { NetworkId } from '@/types/network';
 import { WalletAccount } from '@/types/wallet';
 import { getNetworkConfig } from '@/services/network/config';
 import { decodeBase64Url } from '@/utils/arc0090Uri';
+import { getUserFacingMessage, toErrorAlert } from '@/utils/errorMapping';
 import { RootStackParamList } from '@/navigation/AppNavigator';
 
 // Algorand zero address (used as template placeholder)
@@ -173,11 +174,17 @@ export default function AppCallConfirmScreen() {
           ]
         );
       } else if (!success && result?.error) {
-        setError(result.error.message || 'Transaction failed');
-        Alert.alert(
-          'Transaction Failed',
-          result.error.message || 'Failed to submit transaction'
+        // TASK-41: app calls fail with `logic eval error: assert failed pc=…`,
+        // which means nothing to a user. Map it to a plain-language reason.
+        setError(
+          getUserFacingMessage(result.error, {
+            fallbackMessage: "We couldn't submit this transaction.",
+          })
         );
+        const { message } = toErrorAlert(result.error, {
+          fallbackMessage: "We couldn't submit this transaction.",
+        });
+        Alert.alert('Transaction Failed', message);
       }
     },
     [navigation]

--- a/src/screens/transaction/KeyregConfirmScreen.tsx
+++ b/src/screens/transaction/KeyregConfirmScreen.tsx
@@ -28,6 +28,7 @@ import { NetworkId } from '@/types/network';
 import { WalletAccount } from '@/types/wallet';
 import { getNetworkConfig } from '@/services/network/config';
 import { decodeBase64Url } from '@/utils/arc0090Uri';
+import { getUserFacingMessage, toErrorAlert } from '@/utils/errorMapping';
 import { RootStackParamList } from '@/navigation/AppNavigator';
 
 type KeyregConfirmScreenRouteProp = RouteProp<
@@ -144,11 +145,17 @@ export default function KeyregConfirmScreen() {
           ]
         );
       } else if (!success && result?.error) {
-        setError(result.error.message || 'Transaction failed');
-        Alert.alert(
-          'Transaction Failed',
-          result.error.message || 'Failed to submit transaction'
+        // TASK-41: `result.error` is whatever the signer/algod threw. Map it
+        // instead of piping the raw message into the banner and the alert.
+        setError(
+          getUserFacingMessage(result.error, {
+            fallbackMessage: "We couldn't submit this transaction.",
+          })
         );
+        const { message } = toErrorAlert(result.error, {
+          fallbackMessage: "We couldn't submit this transaction.",
+        });
+        Alert.alert('Transaction Failed', message);
       }
     },
     [params.isOnline, navigation]

--- a/src/screens/wallet/AccountInfoScreen.tsx
+++ b/src/screens/wallet/AccountInfoScreen.tsx
@@ -27,6 +27,7 @@ import {
   useWalletStore,
 } from '@/store/walletStore';
 import { formatCurrency } from '@/utils/formatting';
+import { isAccountNotFoundError } from '@/utils/errorMapping';
 import EnvoiProfileCard from '@/components/envoi/EnvoiProfileCard';
 import { NetworkService } from '@/services/network';
 import { MimirApiService } from '@/services/mimir';
@@ -211,11 +212,11 @@ export default function AccountInfoScreen() {
         setVoiAccountInfo(info);
       } catch (error) {
         console.error('Failed to load Voi account info:', error);
-        if (
-          error instanceof Error &&
-          error.message &&
-          error.message.includes('account does not exist')
-        ) {
+        // TASK-41: this used to be `error.message.includes('account does not
+        // exist')` — control flow bound to one exact algod string. Any
+        // rewording (or a typed AccountNotFoundError) silently fell through
+        // and left the card blank forever. Classify instead of string-match.
+        if (isAccountNotFoundError(error)) {
           setVoiAccountInfo({
             address: displayAddress,
             amount: 0,
@@ -235,11 +236,8 @@ export default function AccountInfoScreen() {
         setAlgoAccountInfo(info);
       } catch (error) {
         console.error('Failed to load Algorand account info:', error);
-        if (
-          error instanceof Error &&
-          error.message &&
-          error.message.includes('account does not exist')
-        ) {
+        // TASK-41: see loadVoi — classified, not string-matched.
+        if (isAccountNotFoundError(error)) {
           setAlgoAccountInfo({
             address: displayAddress,
             amount: 0,

--- a/src/screens/wallet/AssetDetailScreen.tsx
+++ b/src/screens/wallet/AssetDetailScreen.tsx
@@ -30,6 +30,7 @@ import {
 import { formatNativeBalance, formatAssetBalance } from '@/utils/bigint';
 import { formatCurrency } from '@/utils/formatting';
 import { dedupeTransactions } from '@/utils/transactions';
+import { toErrorAlert } from '@/utils/errorMapping';
 import TransactionAddressDisplay from '@/components/transaction/TransactionAddressDisplay';
 import { useCurrentNetworkConfig } from '@/store/networkStore';
 import { getNetworkConfig } from '@/services/network/config';
@@ -782,7 +783,13 @@ export default function AssetDetailScreen() {
         [{ text: 'OK', onPress: () => navigation.goBack() }]
       );
     } catch (error: any) {
-      Alert.alert('Error', `Failed to opt out: ${error.message}`);
+      // TASK-41: this was the literal `Failed to opt out: ${error.message}`
+      // called out by the audit — an opt-out that trips the minimum balance
+      // showed raw algod text.
+      const { message } = toErrorAlert(error, {
+        fallbackMessage: "We couldn't remove this asset from your wallet.",
+      });
+      Alert.alert('Opt-Out Failed', message);
     } finally {
       setOptingOut(false);
     }

--- a/src/screens/wallet/ClaimAllConfirmationScreen.tsx
+++ b/src/screens/wallet/ClaimAllConfirmationScreen.tsx
@@ -48,6 +48,7 @@ import {
 import VoiNetworkService, { NetworkService } from '@/services/network';
 import EnvoiService, { EnvoiSearchResult } from '@/services/envoi';
 import { normalizeAssetImageUrl } from '@/utils/assetImages';
+import { toErrorAlert } from '@/utils/errorMapping';
 import {
   resolveAddressOrName,
   isLikelyEnvoiName,
@@ -417,10 +418,10 @@ export default function ClaimAllConfirmationScreen() {
         callbackId,
       });
     } catch (error) {
-      const message =
-        error instanceof Error
-          ? error.message
-          : 'Failed to build claim transactions';
+      // TASK-41: claim building fails with raw contract/algod strings.
+      const { message } = toErrorAlert(error, {
+        fallbackMessage: "We couldn't build these claim transactions.",
+      });
       Alert.alert('Claim Failed', message);
     } finally {
       setIsClaiming(false);

--- a/src/screens/wallet/MultiNetworkAssetScreen.tsx
+++ b/src/screens/wallet/MultiNetworkAssetScreen.tsx
@@ -23,6 +23,7 @@ import {
 } from '@/store/walletStore';
 import { formatNativeBalance, formatAssetBalance } from '@/utils/bigint';
 import { formatCurrency } from '@/utils/formatting';
+import { toErrorAlert } from '@/utils/errorMapping';
 import { getNetworkConfig } from '@/services/network/config';
 import { NetworkId } from '@/types/network';
 import { SwapService } from '@/services/swap';
@@ -357,7 +358,12 @@ export default function MultiNetworkAssetScreen() {
           `Successfully opted into ${optInPending.symbol} on ${getNetworkConfig(optInPending.networkId).name}`
         );
       } catch (error: any) {
-        Alert.alert('Error', `Failed to opt in: ${error.message}`);
+        // TASK-41: opt-in failures are almost always a minimum-balance
+        // shortfall; the raw algod string never said so.
+        const { message } = toErrorAlert(error, {
+          fallbackMessage: "We couldn't opt in to this asset.",
+        });
+        Alert.alert('Opt-In Failed', message);
         setShowAuthModal(false);
       } finally {
         setIsOptingIn(false);

--- a/src/screens/wallet/SendScreen.tsx
+++ b/src/screens/wallet/SendScreen.tsx
@@ -60,6 +60,7 @@ import {
   formatAddress,
 } from '@/utils/address';
 import { isAlgorandPaymentUri, parseAlgorandUri } from '@/utils/algorandUri';
+import { toErrorAlert } from '@/utils/errorMapping';
 import EnvoiService, { EnvoiSearchResult } from '@/services/envoi';
 import AccountSelector from '@/components/account/AccountSelector';
 import AccountListModal from '@/components/account/AccountListModal';
@@ -1507,10 +1508,13 @@ export default function SendScreen() {
       });
     } catch (error) {
       console.error('Error preparing transaction:', error);
-      Alert.alert(
-        'Error',
-        error instanceof Error ? error.message : 'Failed to prepare transaction'
-      );
+      // TASK-41: never surface the raw SDK/algod message here — it produces
+      // strings like "TransactionPool.Remember: ... overspend ..." at the most
+      // stressful moment in the app.
+      const { title, message } = toErrorAlert(error, {
+        fallbackMessage: "We couldn't prepare this transaction.",
+      });
+      Alert.alert(title, message);
     } finally {
       setIsSending(false);
     }

--- a/src/screens/wallet/SwapScreen.tsx
+++ b/src/screens/wallet/SwapScreen.tsx
@@ -49,6 +49,7 @@ import tokenMappingService from '@/services/token-mapping';
 import { NetworkService } from '@/services/network';
 import algosdk from 'algosdk';
 import { getTokenImageSource } from '@/utils/tokenImages';
+import { getUserFacingMessage, toErrorAlert } from '@/utils/errorMapping';
 import {
   parseAmountToBaseUnits,
   sanitizeAmountInput,
@@ -349,10 +350,11 @@ export default function SwapScreen() {
     } catch (error) {
       if (requestId !== quoteRequestIdRef.current) return;
       console.error('Error fetching quote:', error);
+      // TASK-41: aggregator/HTTP errors are unreadable ("Deflex: 502 <html>…").
       setQuoteError(
-        error instanceof Error
-          ? error.message
-          : 'Failed to get quote. Please try again.'
+        getUserFacingMessage(error, {
+          fallbackMessage: "We couldn't get a quote for this swap.",
+        })
       );
       setQuote(null);
     } finally {
@@ -810,12 +812,12 @@ export default function SwapScreen() {
       });
     } catch (error) {
       console.error('Error executing swap:', error);
-      Alert.alert(
-        'Swap Failed',
-        error instanceof Error
-          ? error.message
-          : 'Failed to execute swap. Please try again.'
-      );
+      // TASK-41: keep the "Swap Failed" framing but map the body — a raw
+      // algod/aggregator string here is the least actionable message in the app.
+      const { message } = toErrorAlert(error, {
+        fallbackMessage: "We couldn't complete this swap.",
+      });
+      Alert.alert('Swap Failed', message);
     } finally {
       setIsSwapping(false);
       setIsWaitingForConfirmation(false);

--- a/src/screens/wallet/TransactionConfirmationScreen.tsx
+++ b/src/screens/wallet/TransactionConfirmationScreen.tsx
@@ -31,6 +31,7 @@ import { NetworkId } from '@/types/network';
 import { getNetworkConfig } from '@/services/network/config';
 import { useCurrentNetwork } from '@/store/networkStore';
 import { parseAmountToBaseUnits } from '@/utils/bigint';
+import { toErrorAlert } from '@/utils/errorMapping';
 // Removed TransactionConfirmationCard in favor of unified TransactionVerification
 import EnvoiProfileCard from '@/components/envoi/EnvoiProfileCard';
 import { useThemedStyles } from '@/hooks/useThemedStyles';
@@ -243,10 +244,12 @@ export default function TransactionConfirmationScreen() {
           ? 0
           : parseAmountToBaseUnits(params.amount, decimals);
     } catch (error) {
-      Alert.alert(
-        'Invalid amount',
-        error instanceof Error ? error.message : 'Please re-enter the amount.'
-      );
+      // TASK-41: `parseAmountToBaseUnits` throws developer-facing text
+      // ("Amount exceeds safe integer range for 6 decimals"); map it.
+      const { message } = toErrorAlert(error, {
+        fallbackMessage: "That amount couldn't be read.",
+      });
+      Alert.alert('Invalid Amount', message);
       return;
     }
 

--- a/src/services/algorand-price/index.ts
+++ b/src/services/algorand-price/index.ts
@@ -19,10 +19,15 @@ export class AlgorandPriceError extends Error {
   constructor(
     message: string,
     public status?: number,
-    public code?: string
+    public code?: string,
+    /** TASK-41: originating error, preserved across retry-loop rebuilds. */
+    cause?: unknown
   ) {
     super(message);
     this.name = 'AlgorandPriceError';
+    if (cause !== undefined) {
+      this.cause = cause;
+    }
   }
 }
 
@@ -165,7 +170,10 @@ export class AlgorandPriceService {
       }
 
       throw new AlgorandPriceError(
-        `Network error: ${error instanceof Error ? error.message : 'Unknown error'}`
+        `Network error: ${error instanceof Error ? error.message : 'Unknown error'}`,
+        undefined,
+        'NETWORK_ERROR',
+        error
       );
     }
   }
@@ -205,8 +213,14 @@ export class AlgorandPriceService {
       }
     }
 
+    // TASK-41 (DR-6): only transport failures reach here (a non-OK response is
+    // returned, not thrown), so there is no status — but the code and the
+    // originating error must survive for the error-mapper.
     throw new AlgorandPriceError(
-      `All ${this.config.retryAttempts} attempts failed. Last error: ${lastError!.message}`
+      `All ${this.config.retryAttempts} attempts failed. Last error: ${lastError!.message}`,
+      undefined,
+      'NETWORK_ERROR',
+      lastError!
     );
   }
 

--- a/src/services/ledger/algorand.ts
+++ b/src/services/ledger/algorand.ts
@@ -26,6 +26,7 @@ import {
   isLedgerSigningInProgress,
   setLedgerSigningInProgress,
 } from './signingState';
+import { isLedgerTransportError } from '@/utils/errorMapping';
 
 export interface LedgerAccountDerivation {
   address: string;
@@ -313,11 +314,13 @@ class LedgerAlgorandService {
       } catch (error) {
         lastError = error instanceof Error ? error : new Error(String(error));
 
-        // Don't retry on certain errors
+        // Don't retry on certain errors.
+        // TASK-41: the transport check was two case-sensitive substring tests
+        // on `message`, which missed `DisconnectedDevice` and any lowercase
+        // variant and then burned the full retry budget on a dead transport.
         if (
           error instanceof LedgerAppNotOpenError ||
-          lastError.message.includes('COMMUNICATION_ERROR') ||
-          lastError.message.includes('Transport')
+          isLedgerTransportError(error)
         ) {
           break;
         }

--- a/src/services/ledger/transport.ts
+++ b/src/services/ledger/transport.ts
@@ -11,6 +11,7 @@ import {
 } from '@/types/wallet';
 import { ledgerDeviceStorage, LedgerDeviceStorage } from './storage';
 import { isLedgerSigningInProgress } from '@/services/ledger/signingState';
+import { isPermissionDeniedError } from '@/utils/errorMapping';
 
 // F-24: Lazy transport-module loaders. The BLE transport pulls in
 // react-native-ble-plx + rxjs and the HID transport its own native deps; both
@@ -421,11 +422,11 @@ export class LedgerTransportService {
             lastError.message
           );
 
-          // Don't retry on permission errors
-          if (
-            lastError.message.includes('Permission') ||
-            lastError.message.includes('Unauthorized')
-          ) {
+          // Don't retry on permission errors.
+          // TASK-41: was two case-sensitive substring tests on `message`, so a
+          // lowercase "permission denied" from the BLE stack was retried
+          // pointlessly instead of surfacing the Settings prompt.
+          if (isPermissionDeniedError(error)) {
             break;
           }
 

--- a/src/services/mimir/index.ts
+++ b/src/services/mimir/index.ts
@@ -97,10 +97,19 @@ export class MimirApiError extends Error {
   constructor(
     message: string,
     public status?: number,
-    public code?: string
+    public code?: string,
+    /**
+     * TASK-41: originating error, preserved when the retry loop or the outer
+     * catch rebuilds the failure. The error-mapper reads it to distinguish an
+     * abort/timeout from a DNS failure.
+     */
+    cause?: unknown
   ) {
     super(message);
     this.name = 'MimirApiError';
+    if (cause !== undefined) {
+      this.cause = cause;
+    }
   }
 }
 
@@ -159,7 +168,10 @@ export class MimirApiService {
 
       console.error('Mimir API request failed:', error);
       throw new MimirApiError(
-        `Network error: ${error instanceof Error ? error.message : 'Unknown error'}`
+        `Network error: ${error instanceof Error ? error.message : 'Unknown error'}`,
+        undefined,
+        'NETWORK_ERROR',
+        error
       );
     }
   }
@@ -248,7 +260,10 @@ export class MimirApiService {
 
       console.error('Mimir API ARC-200 transfers request failed:', error);
       throw new MimirApiError(
-        `Network error: ${error instanceof Error ? error.message : 'Unknown error'}`
+        `Network error: ${error instanceof Error ? error.message : 'Unknown error'}`,
+        undefined,
+        'NETWORK_ERROR',
+        error
       );
     }
   }
@@ -345,7 +360,10 @@ export class MimirApiService {
 
       console.error('Mimir API tokens request failed:', error);
       throw new MimirApiError(
-        `Network error: ${error instanceof Error ? error.message : 'Unknown error'}`
+        `Network error: ${error instanceof Error ? error.message : 'Unknown error'}`,
+        undefined,
+        'NETWORK_ERROR',
+        error
       );
     }
   }
@@ -385,8 +403,15 @@ export class MimirApiService {
       }
     }
 
+    // TASK-41 (DR-6): the retry loop only ever sees transport failures (a
+    // non-OK response is returned, not thrown), so there is no status to
+    // carry — but the code and the originating error must survive, otherwise
+    // the mapper cannot tell an offline device from an aborted request.
     throw new MimirApiError(
-      `All ${this.config.retryAttempts} attempts failed. Last error: ${lastError!.message}`
+      `All ${this.config.retryAttempts} attempts failed. Last error: ${lastError!.message}`,
+      undefined,
+      'NETWORK_ERROR',
+      lastError!
     );
   }
 
@@ -425,7 +450,10 @@ export class MimirApiService {
 
       console.error('Mimir API account info request failed:', error);
       throw new MimirApiError(
-        `Network error: ${error instanceof Error ? error.message : 'Unknown error'}`
+        `Network error: ${error instanceof Error ? error.message : 'Unknown error'}`,
+        undefined,
+        'NETWORK_ERROR',
+        error
       );
     }
   }
@@ -473,7 +501,10 @@ export class MimirApiService {
 
       console.error('Mimir API approvals request failed:', error);
       throw new MimirApiError(
-        `Network error: ${error instanceof Error ? error.message : 'Unknown error'}`
+        `Network error: ${error instanceof Error ? error.message : 'Unknown error'}`,
+        undefined,
+        'NETWORK_ERROR',
+        error
       );
     }
   }
@@ -521,7 +552,10 @@ export class MimirApiService {
 
       console.error('Mimir API balance request failed:', error);
       throw new MimirApiError(
-        `Network error: ${error instanceof Error ? error.message : 'Unknown error'}`
+        `Network error: ${error instanceof Error ? error.message : 'Unknown error'}`,
+        undefined,
+        'NETWORK_ERROR',
+        error
       );
     }
   }

--- a/src/services/price/index.ts
+++ b/src/services/price/index.ts
@@ -47,10 +47,15 @@ export class VoiPriceError extends Error {
   constructor(
     message: string,
     public status?: number,
-    public code?: string
+    public code?: string,
+    /** TASK-41: originating error, preserved across retry-loop rebuilds. */
+    cause?: unknown
   ) {
     super(message);
     this.name = 'VoiPriceError';
+    if (cause !== undefined) {
+      this.cause = cause;
+    }
   }
 }
 
@@ -149,7 +154,10 @@ export class VoiPriceService {
       }
 
       throw new VoiPriceError(
-        `Network error: ${error instanceof Error ? error.message : 'Unknown error'}`
+        `Network error: ${error instanceof Error ? error.message : 'Unknown error'}`,
+        undefined,
+        'NETWORK_ERROR',
+        error
       );
     }
   }
@@ -189,8 +197,14 @@ export class VoiPriceService {
       }
     }
 
+    // TASK-41 (DR-6): only transport failures reach here (a non-OK response is
+    // returned, not thrown), so there is no status — but the code and the
+    // originating error must survive for the error-mapper.
     throw new VoiPriceError(
-      `All ${this.config.retryAttempts} attempts failed. Last error: ${lastError!.message}`
+      `All ${this.config.retryAttempts} attempts failed. Last error: ${lastError!.message}`,
+      undefined,
+      'NETWORK_ERROR',
+      lastError!
     );
   }
 

--- a/src/services/remoteSigner/__tests__/signingRouter.test.ts
+++ b/src/services/remoteSigner/__tests__/signingRouter.test.ts
@@ -67,7 +67,10 @@ import {
   AccountMetadata,
   AccountType,
   RemoteSignerAccountMetadata,
+  RemoteSignerRequiredError as FromWalletTypes,
 } from '@/types/wallet';
+// TASK-41: imported purely to prove the class identity is shared, not duplicated.
+import { RemoteSignerRequiredError as FromUnifiedSigner } from '@/services/transactions/unifiedSigner';
 
 // ---------------------------------------------------------------------------
 // Fixtures — REAL addresses from deterministic seeds (DR-3)
@@ -513,5 +516,28 @@ describe('validateNotRemoteSigner — fail-closed rejection of remote signers', 
 
   it('does NOT throw for a WATCH account (rejection here is remote-signer specific)', () => {
     expect(() => validateNotRemoteSigner(makeWatch())).not.toThrow();
+  });
+
+  // TASK-41: `RemoteSignerRequiredError` used to be declared TWICE — here and
+  // in `transactions/unifiedSigner.ts` — with incompatible constructors. Two
+  // distinct classes sharing one `name` meant an `instanceof` check against
+  // one silently returned false for an error thrown by the other, and callers
+  // fell through to a generic failure path. It now has a single declaration in
+  // `@/types/wallet`; both modules re-export it.
+  it('is the SAME class across signingRouter, unifiedSigner and @/types/wallet', () => {
+    expect(RemoteSignerRequiredError).toBe(FromWalletTypes);
+    expect(RemoteSignerRequiredError).toBe(FromUnifiedSigner);
+
+    let thrown: unknown;
+    try {
+      validateNotRemoteSigner(makeRemoteSigner('signer-device-xyz'));
+    } catch (err) {
+      thrown = err;
+    }
+
+    // The cross-module check that used to be able to fail.
+    expect(thrown).toBeInstanceOf(FromUnifiedSigner);
+    expect(thrown).toBeInstanceOf(FromWalletTypes);
+    expect((thrown as any).code).toBe('REMOTE_SIGNER_REQUIRED');
   });
 });

--- a/src/services/remoteSigner/signingRouter.ts
+++ b/src/services/remoteSigner/signingRouter.ts
@@ -6,7 +6,11 @@
  */
 
 import algosdk from 'algosdk';
-import { AccountMetadata, AccountType } from '@/types/wallet';
+import {
+  AccountMetadata,
+  AccountType,
+  RemoteSignerRequiredError,
+} from '@/types/wallet';
 import { RemoteSignerService } from './index';
 import { RemoteSignerRequest } from '@/types/remoteSigner';
 import { NetworkService } from '@/services/network';
@@ -193,19 +197,14 @@ export function determineSigningMethod(
 
 /**
  * Error thrown when attempting to sign with a remote signer account
- * but not using the QR flow
+ * but not using the QR flow.
+ *
+ * TASK-41: the canonical declaration now lives in `@/types/wallet` — it was
+ * previously declared here AND in `transactions/unifiedSigner.ts` with
+ * incompatible constructors, so cross-module `instanceof` checks could fail.
+ * Re-exported here so existing import paths keep working.
  */
-export class RemoteSignerRequiredError extends Error {
-  constructor(
-    public readonly accountAddress: string,
-    public readonly signerDeviceId: string
-  ) {
-    super(
-      `Account ${accountAddress} is a remote signer account. Use QR-based signing instead.`
-    );
-    this.name = 'RemoteSignerRequiredError';
-  }
-}
+export { RemoteSignerRequiredError };
 
 /**
  * Validate that an account can be signed directly (not via remote signer)
@@ -214,9 +213,9 @@ export class RemoteSignerRequiredError extends Error {
 export function validateNotRemoteSigner(account: AccountMetadata): void {
   if (account.type === AccountType.REMOTE_SIGNER) {
     const rsAccount = account as any;
-    throw new RemoteSignerRequiredError(
-      account.address,
-      rsAccount.signerDeviceId
-    );
+    throw new RemoteSignerRequiredError({
+      accountAddress: account.address,
+      signerDeviceId: rsAccount.signerDeviceId,
+    });
   }
 }

--- a/src/services/token-mapping/index.ts
+++ b/src/services/token-mapping/index.ts
@@ -453,6 +453,7 @@ export class TokenMappingService {
    */
   private async fetchWithRetry(): Promise<TokenMappingAPIResponse> {
     let lastError: Error | null = null;
+    let lastStatus: number | undefined;
 
     for (let attempt = 1; attempt <= this.config.retryAttempts; attempt++) {
       try {
@@ -483,6 +484,13 @@ export class TokenMappingService {
         return data;
       } catch (error) {
         lastError = error instanceof Error ? error : new Error('Unknown error');
+        // TASK-41 (DR-6): the retry loop used to discard the HTTP status of the
+        // last attempt, so the error-mapper could not tell "rate limited" or
+        // "server down" from a plain fetch failure and every failure degraded
+        // to a generic message. Carry the status forward.
+        if (error instanceof TokenMappingAPIError) {
+          lastStatus = error.status;
+        }
 
         if (attempt < this.config.retryAttempts) {
           console.warn(
@@ -495,7 +503,9 @@ export class TokenMappingService {
     }
 
     throw new TokenMappingAPIError(
-      `Failed after ${this.config.retryAttempts} attempts: ${lastError?.message}`
+      `Failed after ${this.config.retryAttempts} attempts: ${lastError?.message}`,
+      lastStatus,
+      lastError ?? undefined
     );
   }
 

--- a/src/services/token-mapping/types.ts
+++ b/src/services/token-mapping/types.ts
@@ -122,20 +122,31 @@ export class TokenMappingError extends Error {
 export class TokenMappingAPIError extends TokenMappingError {
   constructor(
     message: string,
-    public status?: number
+    public status?: number,
+    /**
+     * TASK-41: the originating error, preserved when a retry loop rebuilds the
+     * failure. Without it the underlying cause (abort, DNS, 503) was lost.
+     */
+    cause?: unknown
   ) {
     super(message, 'API_ERROR', { status });
+    this.name = 'TokenMappingAPIError';
+    if (cause !== undefined) {
+      this.cause = cause;
+    }
   }
 }
 
 export class TokenMappingCacheError extends TokenMappingError {
   constructor(message: string) {
     super(message, 'CACHE_ERROR');
+    this.name = 'TokenMappingCacheError';
   }
 }
 
 export class TokenMappingValidationError extends TokenMappingError {
   constructor(message: string, details?: any) {
     super(message, 'VALIDATION_ERROR', details);
+    this.name = 'TokenMappingValidationError';
   }
 }

--- a/src/services/transactions/unifiedSigner.ts
+++ b/src/services/transactions/unifiedSigner.ts
@@ -17,19 +17,20 @@ import {
   LedgerDeviceNotConnectedError,
   LedgerAppNotOpenError,
   LedgerUserRejectedError,
+  RemoteSignerRequiredError,
 } from '@/types/wallet';
 import { NetworkId } from '@/types/network';
 import { SecureKeyManager } from '@/services/secure/keyManager';
 
 /**
- * Error thrown when attempting to sign with a remote signer account directly
+ * Error thrown when attempting to sign with a remote signer account directly.
+ *
+ * TASK-41: the canonical declaration now lives in `@/types/wallet` — it was
+ * previously declared here AND in `remoteSigner/signingRouter.ts` with
+ * incompatible constructors, so cross-module `instanceof` checks could fail.
+ * Re-exported so existing import paths keep working.
  */
-export class RemoteSignerRequiredError extends Error {
-  constructor(message: string) {
-    super(message);
-    this.name = 'RemoteSignerRequiredError';
-  }
-}
+export { RemoteSignerRequiredError };
 
 /**
  * Unified callback interface for ALL signing operations
@@ -605,10 +606,12 @@ export class UnifiedTransactionSigner {
 
     // Check for REMOTE_SIGNER accounts - these cannot be signed directly
     if (request.account.type === AccountType.REMOTE_SIGNER) {
-      throw new RemoteSignerRequiredError(
-        'This account uses remote signing via QR codes. ' +
-          'Please use the remote signer flow instead of direct signing.'
-      );
+      throw new RemoteSignerRequiredError({
+        accountAddress: request.account.address,
+        message:
+          'This account uses remote signing via QR codes. ' +
+          'Please use the remote signer flow instead of direct signing.',
+      });
     }
 
     // Check for WATCH accounts - these cannot sign at all

--- a/src/types/wallet.ts
+++ b/src/types/wallet.ts
@@ -448,6 +448,45 @@ export class LedgerUserRejectedError extends LedgerAccountError {
   }
 }
 
+export interface RemoteSignerRequiredErrorOptions {
+  /** Address of the account that must be signed remotely. */
+  accountAddress?: string;
+  /** Device id of the paired offline signer, when known. */
+  signerDeviceId?: string;
+  /** Override the generated message. */
+  message?: string;
+}
+
+/**
+ * Thrown when a REMOTE_SIGNER account is asked to sign directly instead of
+ * through the QR flow.
+ *
+ * TASK-41: this class used to be declared TWICE — in
+ * `services/remoteSigner/signingRouter.ts` and `services/transactions/
+ * unifiedSigner.ts` — with incompatible constructors. Two distinct classes
+ * share one `name`, so an `instanceof` check against one of them silently
+ * returned `false` for an error thrown by the other, and callers fell through
+ * to a generic failure path. It now lives here (the one module both signers
+ * already import) and both call sites re-export it for compatibility.
+ */
+export class RemoteSignerRequiredError extends AccountError {
+  readonly accountAddress?: string;
+  readonly signerDeviceId?: string;
+
+  constructor(options: RemoteSignerRequiredErrorOptions = {}) {
+    super(
+      options.message ??
+        (options.accountAddress
+          ? `Account ${options.accountAddress} is a remote signer account. Use QR-based signing instead.`
+          : 'This account uses remote signing via QR codes. Please use the remote signer flow instead of direct signing.'),
+      'REMOTE_SIGNER_REQUIRED'
+    );
+    this.name = 'RemoteSignerRequiredError';
+    this.accountAddress = options.accountAddress;
+    this.signerDeviceId = options.signerDeviceId;
+  }
+}
+
 // Transaction Signing Context
 export interface TransactionSigningContext {
   transaction: any; // algosdk.Transaction type

--- a/src/types/wallet.ts
+++ b/src/types/wallet.ts
@@ -468,6 +468,15 @@ export interface RemoteSignerRequiredErrorOptions {
  * returned `false` for an error thrown by the other, and callers fell through
  * to a generic failure path. It now lives here (the one module both signers
  * already import) and both call sites re-export it for compatibility.
+ *
+ * The constructor takes an OPTIONS OBJECT rather than preserving the two
+ * legacy positional signatures, and that is deliberate: they were mutually
+ * contradictory. `signingRouter` used `(accountAddress, signerDeviceId)` while
+ * `unifiedSigner` used `(message)`, so a single leading string means "an
+ * address" under one and "a user-facing message" under the other. No overload
+ * can disambiguate them, and guessing would either drop the address or print a
+ * bare address where a sentence belongs. Every construction site in the repo
+ * is updated and `tsc` covers all of them, so the change cannot fail silently.
  */
 export class RemoteSignerRequiredError extends AccountError {
   readonly accountAddress?: string;

--- a/src/utils/__tests__/errorMapping.test.ts
+++ b/src/utils/__tests__/errorMapping.test.ts
@@ -1,0 +1,711 @@
+/**
+ * Unit tests for src/utils/errorMapping.ts (TASK-41 / U-05).
+ *
+ * The finding this closes: ~41 call sites across 24 screens piped raw
+ * `error.message` from algosdk/algod/Mimir straight into user-facing alerts,
+ * so a failed send showed `TransactionPool.Remember: transaction ABC:
+ * overspend (account XYZ, data ...)`.
+ *
+ * The tests are grouped by the guarantees the UI now depends on:
+ *
+ *  1. **Secret safety** — the hard one. A mnemonic, private key or seed must
+ *     never survive into a string that can reach an alert, a log or a crash
+ *     report. These use REAL 25-word Algorand mnemonic shapes and real key
+ *     lengths, not toy inputs.
+ *  2. **Real algod/indexer strings** map to actionable plain language. The
+ *     inputs are the literal strings algod emits.
+ *  3. **Typed errors** are honoured ahead of message text, including the
+ *     deduped `RemoteSignerRequiredError`.
+ *  4. **Never blank, never raw** — an unknown failure still produces a
+ *     non-empty message plus sanitized details, and an HTML error body never
+ *     reaches the user.
+ *  5. **Purity / surface-agnosticism** — no RN `Alert` binding; `toErrorAlert`
+ *     returns plain data so the extension target's console-only adapter works.
+ */
+
+import { readFileSync } from 'fs';
+import { join } from 'path';
+
+import {
+  getUserFacingMessage,
+  isAccountNotFoundError,
+  isLedgerTransportError,
+  isPermissionDeniedError,
+  isRetryableError,
+  isUserRejectionError,
+  mapError,
+  redactSecrets,
+  sanitizeDetails,
+  toErrorAlert,
+} from '../errorMapping';
+import {
+  AccountNotFoundError,
+  AuthenticationRequiredError,
+  InvalidAddressError,
+  InvalidMnemonicError,
+  LedgerAppNotOpenError,
+  LedgerDeviceNotConnectedError,
+  LedgerUserRejectedError,
+  RemoteSignerRequiredError,
+} from '@/types/wallet';
+import {
+  NetworkError,
+  NetworkId,
+  NetworkUnavailableError,
+} from '@/types/network';
+
+/** A real-shaped 25-word Algorand mnemonic (never used for a real account). */
+const MNEMONIC_25 =
+  'abandon ability able about above absent absorb abstract absurd abuse access accident account accuse achieve acid acoustic acquire across act action actor actress actual invest';
+
+/** 64 hex chars — the length of a raw Ed25519 seed / private key. */
+const HEX_KEY =
+  'a3f1c09b7d2e4856193a7c5f0b8d6e42fa19c73b850d2e6417ff9a03c5b81d2e';
+
+// ===========================================================================
+// 1. Secret safety — nothing below may leak key material
+// ===========================================================================
+
+describe('redactSecrets — key material never reaches a user-facing string', () => {
+  it('removes a bare 25-word mnemonic run', () => {
+    const out = redactSecrets(
+      `Import failed for phrase ${MNEMONIC_25} at step 3`
+    );
+
+    expect(out).not.toContain('abandon ability able');
+    expect(out).not.toContain('actress actual invest');
+    expect(out).toContain('[redacted]');
+    // Surrounding context survives so the message stays diagnosable. The run
+    // matcher deliberately over-reaches into adjacent lowercase words rather
+    // than risk leaving a mnemonic word behind.
+    expect(out).toContain('Import');
+    expect(out).toContain('at step 3');
+  });
+
+  it('removes a labelled mnemonic even when it is short', () => {
+    const out = redactSecrets('mnemonic: abandon ability able about');
+    expect(out).not.toContain('abandon');
+    expect(out).toContain('[redacted]');
+  });
+
+  it.each([
+    ['private key', `private key: ${HEX_KEY}`],
+    ['secret key', `secretKey=${HEX_KEY}`],
+    ['seed phrase', `seed phrase: ${MNEMONIC_25}`],
+    ['passphrase', 'passphrase: hunter2-correct-horse'],
+    ['password', 'password=s3cr3t!'],
+    ['pin', 'pin: 482913'],
+  ])('removes a labelled %s', (_label, input) => {
+    const out = redactSecrets(input);
+    expect(out).toContain('[redacted]');
+    expect(out).not.toMatch(/hunter2|s3cr3t|482913/);
+    expect(out).not.toContain(HEX_KEY);
+    expect(out).not.toContain('abandon ability');
+  });
+
+  it('removes a bare 64-char hex key with no label at all', () => {
+    const out = redactSecrets(`decrypt failed for ${HEX_KEY}`);
+    expect(out).not.toContain(HEX_KEY);
+    expect(out).toContain('[redacted]');
+  });
+
+  it('removes a bare base64 key blob', () => {
+    // 88 base64 chars — the encoded length of an Ed25519 secret key.
+    const b64 = 'A'.repeat(86) + '==';
+    const out = redactSecrets(`sk=${b64}`);
+    expect(out).not.toContain(b64);
+    expect(out).toContain('[redacted]');
+  });
+
+  it('leaves ordinary error prose and public addresses untouched', () => {
+    const address = 'TESTADDRESSAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA';
+    const input = `overspend (account ${address}, data {})`;
+    expect(redactSecrets(input)).toBe(input);
+  });
+
+  it('is safe on empty input', () => {
+    expect(redactSecrets('')).toBe('');
+  });
+});
+
+describe('mapError — secrets never survive into message, userAction or details', () => {
+  const leaky = [
+    new Error(`Failed to decrypt with mnemonic ${MNEMONIC_25}`),
+    new Error(`SecureStore write failed: privateKey=${HEX_KEY}`),
+    new Error(`unexpected token in {"mnemonic":"${MNEMONIC_25}"}`),
+  ];
+
+  it.each(leaky.map((e, i) => [i, e]))(
+    'case %i leaks nothing into any user-visible field',
+    (_i, error) => {
+      const mapped = mapError(error as Error);
+      const everything = [
+        mapped.message,
+        mapped.userAction,
+        mapped.details ?? '',
+        mapped.code ?? '',
+      ].join(' ');
+
+      expect(everything).not.toContain(HEX_KEY);
+      expect(everything).not.toContain('abandon ability able');
+      expect(everything).not.toContain('actress actual invest');
+    }
+  );
+
+  it('toErrorAlert output is likewise clean', () => {
+    const { title, message } = toErrorAlert(
+      new Error(`boom: ${MNEMONIC_25} / ${HEX_KEY}`)
+    );
+    expect(`${title} ${message}`).not.toContain(HEX_KEY);
+    expect(`${title} ${message}`).not.toContain('abandon ability able');
+  });
+
+  it('does not echo an invalid recovery phrase back to the user', () => {
+    const mapped = mapError(
+      new InvalidMnemonicError(`Invalid mnemonic phrase: ${MNEMONIC_25}`)
+    );
+    expect(mapped.message).not.toContain('abandon');
+    expect(mapped.details).toBeUndefined();
+    expect(mapped.message.toLowerCase()).toContain('recovery phrase');
+  });
+});
+
+// ===========================================================================
+// 2. Real algod / indexer strings → actionable plain language
+// ===========================================================================
+
+describe('mapError — notorious algod strings become plain language', () => {
+  it('maps a TransactionPool overspend to insufficient funds', () => {
+    const mapped = mapError(
+      new Error(
+        'TransactionPool.Remember: transaction JYQ...: overspend (account TESTADDRESSAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA, data {_struct:{} Status:Offline MicroAlgos:{Raw:1000}}, tried to spend {5000000})'
+      )
+    );
+
+    expect(mapped.type).toBe('insufficient_funds');
+    expect(mapped.isGeneric).toBe(false);
+    expect(mapped.retryable).toBe(false);
+    // None of the algod jargon survives.
+    expect(mapped.message).not.toMatch(/TransactionPool|_struct|MicroAlgos/);
+    expect(mapped.message.toLowerCase()).toContain('balance');
+    expect(mapped.userAction).not.toBe('');
+  });
+
+  it('prefers minimum-balance over overspend when algod reports both', () => {
+    // algod emits "overspend" AND "below min" for this case; the min-balance
+    // explanation is the actionable one, so it must win.
+    const mapped = mapError(
+      new Error(
+        'TransactionPool.Remember: transaction ABC: account TESTADDR balance 98000 below min 100000 (0 assets)'
+      )
+    );
+
+    expect(mapped.type).toBe('min_balance');
+    expect(mapped.message.toLowerCase()).toContain('minimum balance');
+  });
+
+  it('maps a missing asset holding to an opt-in explanation', () => {
+    const mapped = mapError(
+      new Error(
+        'TransactionPool.Remember: transaction ABC: asset 12345 missing from TESTADDR'
+      )
+    );
+    expect(mapped.type).toBe('not_opted_in');
+    expect(mapped.message.toLowerCase()).toContain('opted in');
+  });
+
+  it('maps a dead transaction to an expiry explanation', () => {
+    const mapped = mapError(
+      new Error(
+        'TransactionPool.Remember: txn dead: round 5000 outside of 4000--4900'
+      )
+    );
+    expect(mapped.type).toBe('transaction_expired');
+    expect(mapped.retryable).toBe(true);
+  });
+
+  it('maps a duplicate submission', () => {
+    const mapped = mapError(
+      new Error('TransactionPool.Remember: transaction already in ledger: ABC')
+    );
+    expect(mapped.type).toBe('duplicate_transaction');
+    expect(mapped.retryable).toBe(false);
+  });
+
+  it('maps a below-threshold fee', () => {
+    const mapped = mapError(
+      new Error('TransactionPool.Remember: fee 500 below threshold 1000')
+    );
+    expect(mapped.type).toBe('fee_too_low');
+    expect(mapped.retryable).toBe(true);
+  });
+
+  it('maps a logic eval failure to a contract rejection', () => {
+    const mapped = mapError(
+      new Error(
+        'TransactionPool.Remember: transaction ABC: logic eval error: assert failed pc=453. Details: app=12345'
+      )
+    );
+    expect(mapped.type).toBe('app_rejected');
+    expect(mapped.message).not.toContain('pc=453');
+  });
+
+  it('maps a bad authorizer to a rejected transaction', () => {
+    const mapped = mapError(
+      new Error(
+        'transaction ABC: should have been authorized by TESTADDR but was actually authorized by OTHERADDR'
+      )
+    );
+    expect(mapped.type).toBe('transaction_rejected');
+  });
+
+  it('maps "account does not exist" to account_not_found', () => {
+    const mapped = mapError(
+      new Error(
+        'failed to retrieve information from the ledger: account does not exist'
+      )
+    );
+    expect(mapped.type).toBe('account_not_found');
+    expect(mapped.retryable).toBe(false);
+  });
+});
+
+describe('mapError — connectivity and HTTP', () => {
+  it("maps React Native's fetch failure to offline", () => {
+    const mapped = mapError(new TypeError('Network request failed'));
+    expect(mapped.type).toBe('offline');
+    expect(mapped.retryable).toBe(true);
+    expect(mapped.userAction.toLowerCase()).toContain('connection');
+  });
+
+  it('maps an AbortError to a timeout', () => {
+    const abort = new Error('The operation was aborted');
+    abort.name = 'AbortError';
+    expect(mapError(abort).type).toBe('timeout');
+  });
+
+  it.each([
+    [429, 'rate_limited'],
+    [500, 'server_error'],
+    [502, 'server_error'],
+    [503, 'server_error'],
+    [404, 'not_found'],
+    [403, 'permission_denied'],
+    [400, 'validation'],
+  ])('maps HTTP %i to %s', (status, expected) => {
+    // Shaped like MimirApiError / EnvoiApiError: a `status` field.
+    const err = Object.assign(new Error('Request failed'), { status });
+    expect(mapError(err).type).toBe(expected);
+  });
+
+  it('reads statusCode too (SwapServiceError / SnowballApiError shape)', () => {
+    const err = Object.assign(new Error('Deflex quote failed'), {
+      statusCode: 503,
+      name: 'DeflexApiError',
+    });
+    const mapped = mapError(err);
+    expect(mapped.type).toBe('server_error');
+    expect(mapped.status).toBe(503);
+  });
+
+  it('prefers an on-chain reason over the HTTP status that carried it', () => {
+    // algod returns 400 for every rejection; "overspend" is far more useful
+    // than "the service rejected the request".
+    const err = Object.assign(
+      new Error('TransactionPool.Remember: overspend (account TESTADDR)'),
+      { status: 400 }
+    );
+    expect(mapError(err).type).toBe('insufficient_funds');
+  });
+
+  it('reads the algod reason out of response.body.message', () => {
+    const err = Object.assign(new Error('Request failed with status 400'), {
+      status: 400,
+      response: {
+        status: 400,
+        body: { message: 'account does not exist' },
+      },
+    });
+    expect(mapError(err).type).toBe('account_not_found');
+  });
+
+  it('surfaces the code carried by a rebuilt retry error', () => {
+    // The shape mimir/price/algorand-price now throw after retry exhaustion.
+    const err = Object.assign(
+      new Error('All 3 attempts failed. Last error: Network request failed'),
+      { name: 'MimirApiError', code: 'NETWORK_ERROR' }
+    );
+    const mapped = mapError(err);
+    expect(mapped.type).toBe('offline');
+    expect(mapped.code).toBe('NETWORK_ERROR');
+  });
+
+  it('surfaces the status a retry loop preserved (token-mapping fix)', () => {
+    // Before TASK-41 token-mapping dropped this status and every failure
+    // degraded to the generic message.
+    const err = Object.assign(
+      new Error('Failed after 3 attempts: API returned status 503'),
+      { name: 'TokenMappingAPIError', code: 'API_ERROR', status: 503 }
+    );
+    const mapped = mapError(err);
+    expect(mapped.status).toBe(503);
+    expect(mapped.type).toBe('server_error');
+    expect(mapped.isGeneric).toBe(false);
+  });
+});
+
+describe('mapError — WalletConnect and Ledger', () => {
+  it.each([
+    "No matching key. session topic doesn't exist: abc123",
+    'Proposal expired',
+    'Session not found',
+  ])('maps WalletConnect session failure: %s', (msg) => {
+    expect(mapError(new Error(msg)).type).toBe('session_expired');
+  });
+
+  it('maps a user rejection from a dApp request', () => {
+    expect(mapError(new Error('User rejected the request')).type).toBe(
+      'user_rejected'
+    );
+  });
+
+  it('maps Ledger status word 0x6985 to a user rejection', () => {
+    expect(
+      mapError(
+        new Error('Ledger device: Condition of use not satisfied (0x6985)')
+      ).type
+    ).toBe('user_rejected');
+  });
+
+  it('maps a locked Ledger', () => {
+    const mapped = mapError(new Error('Ledger device: Locked device (0x5515)'));
+    expect(mapped.type).toBe('ledger');
+    expect(mapped.userAction.toLowerCase()).toContain('unlock');
+  });
+
+  it('maps a disconnected Ledger transport', () => {
+    const mapped = mapError(
+      new Error('DisconnectedDevice: Ledger device disconnected')
+    );
+    expect(mapped.type).toBe('ledger');
+    expect(mapped.retryable).toBe(true);
+  });
+});
+
+// ===========================================================================
+// 3. Typed errors win over message text
+// ===========================================================================
+
+describe('mapError — typed errors', () => {
+  it('honours AccountNotFoundError regardless of its message', () => {
+    const mapped = mapError(new AccountNotFoundError('nope'));
+    expect(mapped.type).toBe('account_not_found');
+    expect(mapped.code).toBe('ACCOUNT_NOT_FOUND');
+  });
+
+  it('honours AuthenticationRequiredError', () => {
+    const mapped = mapError(new AuthenticationRequiredError());
+    expect(mapped.type).toBe('auth_required');
+    expect(mapped.code).toBe('AUTHENTICATION_REQUIRED');
+  });
+
+  it('honours InvalidAddressError', () => {
+    expect(mapError(new InvalidAddressError()).type).toBe('invalid_address');
+  });
+
+  it.each([
+    [new LedgerUserRejectedError(), 'user_rejected'],
+    [new LedgerAppNotOpenError(), 'ledger'],
+    [new LedgerDeviceNotConnectedError(), 'ledger'],
+  ])('maps Ledger typed error to %s', (error, expected) => {
+    expect(mapError(error).type).toBe(expected);
+  });
+
+  it('distinguishes the two Ledger device states by their user action', () => {
+    expect(mapError(new LedgerAppNotOpenError()).userAction).toMatch(
+      /algorand app/i
+    );
+    expect(mapError(new LedgerDeviceNotConnectedError()).userAction).toMatch(
+      /reconnect/i
+    );
+  });
+
+  it('honours NetworkUnavailableError over the generic NetworkError', () => {
+    expect(
+      mapError(new NetworkUnavailableError(NetworkId.VOI_MAINNET, 'indexer'))
+        .type
+    ).toBe('server_error');
+    expect(mapError(new NetworkError('boom', NetworkId.VOI_MAINNET)).type).toBe(
+      'offline'
+    );
+  });
+
+  it('maps RemoteSignerRequiredError to the QR-signing prompt', () => {
+    const mapped = mapError(
+      new RemoteSignerRequiredError({ accountAddress: 'TESTADDR' })
+    );
+    expect(mapped.type).toBe('remote_signer_required');
+    expect(mapped.code).toBe('REMOTE_SIGNER_REQUIRED');
+    expect(mapped.userAction.toLowerCase()).toContain('qr');
+  });
+});
+
+describe('RemoteSignerRequiredError — single definition', () => {
+  /**
+   * `signingRouter` and `unifiedSigner` each used to declare their own class
+   * with this same `name`, so an `instanceof` check against one silently
+   * returned `false` for an error thrown by the other. Both now re-export this
+   * one declaration; the cross-module identity assertion lives in
+   * `services/remoteSigner/__tests__/signingRouter.test.ts`, which already has
+   * the native-module mocks those service modules need.
+   */
+  it('supports both original construction shapes', () => {
+    const withAddress = new RemoteSignerRequiredError({
+      accountAddress: 'TESTADDR',
+      signerDeviceId: 'device-1',
+    });
+    expect(withAddress.accountAddress).toBe('TESTADDR');
+    expect(withAddress.signerDeviceId).toBe('device-1');
+    expect(withAddress.message).toContain('TESTADDR');
+    expect(withAddress.message.toLowerCase()).toContain('qr');
+
+    const withMessage = new RemoteSignerRequiredError({
+      message: 'This account uses remote signing via QR codes.',
+    });
+    expect(withMessage.message).toMatch(/remote signing via qr/i);
+    expect(withMessage.name).toBe('RemoteSignerRequiredError');
+  });
+});
+
+// ===========================================================================
+// 4. Never blank, never a raw HTTP body
+// ===========================================================================
+
+describe('mapError — degradation of unknown failures', () => {
+  it('never returns an empty message or userAction', () => {
+    const inputs: unknown[] = [
+      undefined,
+      null,
+      '',
+      0,
+      {},
+      [],
+      new Error(''),
+      'plain string failure',
+      { weird: true },
+    ];
+
+    for (const input of inputs) {
+      const mapped = mapError(input);
+      expect(mapped.message.length).toBeGreaterThan(0);
+      expect(mapped.userAction.length).toBeGreaterThan(0);
+      expect(typeof mapped.type).toBe('string');
+    }
+  });
+
+  it('flags an unrecognised failure as generic and attaches details', () => {
+    const mapped = mapError(new Error('EPIPE: broken pipe in widget 7'));
+    expect(mapped.isGeneric).toBe(true);
+    expect(mapped.details).toContain('broken pipe');
+  });
+
+  it('omits details when a rule matched (the message is already actionable)', () => {
+    const mapped = mapError(new Error('TransactionPool.Remember: overspend'));
+    expect(mapped.isGeneric).toBe(false);
+    expect(mapped.details).toBeUndefined();
+  });
+
+  it('can be asked for details even when a rule matched', () => {
+    const mapped = mapError(new Error('TransactionPool.Remember: overspend'), {
+      includeDetailsWhenMapped: true,
+    });
+    expect(mapped.details).toContain('overspend');
+  });
+
+  it('uses a caller-supplied fallback message for unknown failures only', () => {
+    expect(
+      mapError(new Error('weird internal thing'), {
+        fallbackMessage: "We couldn't prepare this transaction.",
+      }).message
+    ).toBe("We couldn't prepare this transaction.");
+
+    // A recognised failure keeps its specific message.
+    expect(
+      mapError(new Error('Network request failed'), {
+        fallbackMessage: "We couldn't prepare this transaction.",
+      }).message
+    ).not.toBe("We couldn't prepare this transaction.");
+  });
+
+  it('never shows a raw HTML error body', () => {
+    const html =
+      '<!DOCTYPE html><html><head><title>502 Bad Gateway</title></head><body><h1>502 Bad Gateway</h1><hr>nginx/1.18.0</body></html>';
+    const mapped = mapError(new Error(html));
+
+    const everything = `${mapped.message} ${mapped.userAction} ${mapped.details ?? ''}`;
+    expect(everything).not.toContain('<html');
+    expect(everything).not.toContain('<h1>');
+    expect(everything).not.toContain('nginx');
+  });
+
+  it('strips stray markup out of details', () => {
+    expect(sanitizeDetails('failed <b>hard</b> at <i>step 2</i>')).toBe(
+      'failed hard at step 2'
+    );
+  });
+
+  it('caps details length so an alert cannot be flooded', () => {
+    const details = sanitizeDetails('x'.repeat(5000));
+    expect(details).toBeDefined();
+    expect(details!.length).toBeLessThanOrEqual(280);
+  });
+
+  it('returns undefined details for values carrying no information', () => {
+    expect(sanitizeDetails(undefined)).toBeUndefined();
+    expect(sanitizeDetails(null)).toBeUndefined();
+    expect(sanitizeDetails('')).toBeUndefined();
+    expect(sanitizeDetails({})).toBeUndefined();
+    expect(sanitizeDetails('   ')).toBeUndefined();
+  });
+
+  it('survives an object with a throwing/ circular shape', () => {
+    const circular: any = { a: 1 };
+    circular.self = circular;
+    expect(() => mapError(circular)).not.toThrow();
+    expect(mapError(circular).message.length).toBeGreaterThan(0);
+  });
+});
+
+// ===========================================================================
+// 5. Presentation helpers — surface-agnostic
+// ===========================================================================
+
+describe('presentation helpers', () => {
+  it('getUserFacingMessage joins the reason and the action', () => {
+    const text = getUserFacingMessage(new Error('Network request failed'));
+    expect(text).toContain("Couldn't reach the network");
+    expect(text.toLowerCase()).toContain('internet connection');
+    expect(text.trim()).toBe(text);
+  });
+
+  it('toErrorAlert returns plain data, not a native call', () => {
+    const alert = toErrorAlert(new TypeError('Network request failed'));
+    expect(alert).toEqual({
+      title: expect.any(String),
+      message: expect.any(String),
+    });
+    expect(alert.title).toBe('No Connection');
+    expect(alert.message.length).toBeGreaterThan(0);
+  });
+
+  it('appends the details expander only for unrecognised failures', () => {
+    expect(toErrorAlert(new Error('quantum flux desync')).message).toContain(
+      'Details:'
+    );
+    expect(
+      toErrorAlert(new Error('TransactionPool.Remember: overspend')).message
+    ).not.toContain('Details:');
+  });
+
+  it('honours an explicit title override', () => {
+    expect(
+      toErrorAlert(new Error('Network request failed'), {
+        title: 'Swap Failed',
+      }).title
+    ).toBe('Swap Failed');
+  });
+
+  it('falls back to a non-empty title for an unmapped type', () => {
+    expect(toErrorAlert(new Error('quantum flux desync')).title).toBe(
+      'Something Went Wrong'
+    );
+  });
+
+  it('does not import react-native (works on the extension target)', () => {
+    // The mapper must stay surface-agnostic: the extension AlertAdapter only
+    // console.logs, so anything bound to RN Alert would be invisible there.
+    const source = readFileSync(
+      join(__dirname, '..', 'errorMapping.ts'),
+      'utf8'
+    );
+    expect(source).not.toMatch(/from ['"]react-native['"]/);
+    expect(source).not.toMatch(/require\(['"]react-native['"]\)/);
+    // No executable call into a native alert surface (comments may mention it).
+    expect(source).not.toMatch(/^\s*Alert\.alert\(/m);
+  });
+});
+
+// ===========================================================================
+// 6. Predicates that replaced string-matching control flow
+// ===========================================================================
+
+describe('predicates', () => {
+  it('isAccountNotFoundError matches the algod string and the typed error', () => {
+    expect(isAccountNotFoundError(new Error('account does not exist'))).toBe(
+      true
+    );
+    expect(isAccountNotFoundError(new AccountNotFoundError())).toBe(true);
+    expect(isAccountNotFoundError(new Error('Network request failed'))).toBe(
+      false
+    );
+    expect(isAccountNotFoundError(undefined)).toBe(false);
+  });
+
+  it('isUserRejectionError matches dApp and Ledger rejections', () => {
+    expect(isUserRejectionError(new Error('User rejected the request'))).toBe(
+      true
+    );
+    expect(isUserRejectionError(new LedgerUserRejectedError())).toBe(true);
+    expect(isUserRejectionError(new Error('overspend'))).toBe(false);
+  });
+
+  it('isLedgerTransportError is case-insensitive and covers DisconnectedDevice', () => {
+    // The old inline checks were case-sensitive `includes('Transport')` /
+    // `includes('COMMUNICATION_ERROR')` and missed both of these.
+    expect(isLedgerTransportError(new Error('DisconnectedDevice'))).toBe(true);
+    expect(isLedgerTransportError(new Error('communication_error'))).toBe(true);
+    expect(isLedgerTransportError(new Error('TransportError: closed'))).toBe(
+      true
+    );
+    expect(isLedgerTransportError(new Error('user cancelled'))).toBe(false);
+  });
+
+  it('isLedgerTransportError does NOT swallow a device status word', () => {
+    // TransportStatusError carries an APDU status (locked device, wrong app),
+    // which IS recoverable by retrying. Classifying it as a dead transport
+    // would abort the retry loop on the first attempt.
+    const statusErr = Object.assign(
+      new Error('Ledger device: Locked device (0x5515)'),
+      { name: 'TransportStatusError', statusCode: 0x5515 }
+    );
+    expect(isLedgerTransportError(statusErr)).toBe(false);
+  });
+
+  it('isPermissionDeniedError covers lowercase and HTTP 401/403', () => {
+    expect(isPermissionDeniedError(new Error('Permission denied'))).toBe(true);
+    expect(isPermissionDeniedError(new Error('permission not granted'))).toBe(
+      true
+    );
+    expect(isPermissionDeniedError(new Error('Unauthorized'))).toBe(true);
+    expect(
+      isPermissionDeniedError(Object.assign(new Error('nope'), { status: 403 }))
+    ).toBe(true);
+    expect(isPermissionDeniedError(new Error('Network request failed'))).toBe(
+      false
+    );
+    // A message that mentions a GRANTED permission is not a denial — treating
+    // it as one would abort a retry loop that could still succeed.
+    expect(
+      isPermissionDeniedError(
+        new Error('Bluetooth permission granted but scan failed')
+      )
+    ).toBe(false);
+  });
+
+  it('isRetryableError mirrors the mapped projection', () => {
+    expect(isRetryableError(new Error('Network request failed'))).toBe(true);
+    expect(
+      isRetryableError(new Error('TransactionPool.Remember: overspend'))
+    ).toBe(false);
+  });
+});

--- a/src/utils/__tests__/errorMapping.test.ts
+++ b/src/utils/__tests__/errorMapping.test.ts
@@ -82,10 +82,63 @@ describe('redactSecrets — key material never reaches a user-facing string', ()
     expect(out).toContain('at step 3');
   });
 
-  it('removes a labelled mnemonic even when it is short', () => {
-    const out = redactSecrets('mnemonic: abandon ability able about');
-    expect(out).not.toContain('abandon');
+  /**
+   * Regression: an earlier version consumed only the FIRST token after the
+   * label, so `mnemonic: <12 words>` leaked 11 of them — practically enough to
+   * recover the phrase. Every word must go, not just the first.
+   */
+  it.each([
+    ['4 words', 'mnemonic: abandon ability able about'],
+    [
+      '12 words',
+      'mnemonic: abandon ability able about above absent absorb abstract absurd abuse access accident',
+    ],
+    ['seed phrase label', 'seed phrase = abandon ability able about'],
+    ['recovery phrase label', 'recovery phrase: abandon ability able about'],
+    [
+      'json shape',
+      'unexpected token in {"mnemonic":"abandon ability able about"}',
+    ],
+    ['is separator', 'the mnemonic is abandon ability able about'],
+  ])('removes EVERY word of a labelled phrase (%s)', (_label, input) => {
+    const out = redactSecrets(input);
+
+    for (const word of [
+      'abandon',
+      'ability',
+      'able',
+      'about',
+      'above',
+      'absent',
+      'absorb',
+      'abstract',
+      'absurd',
+      'abuse',
+      'access',
+      'accident',
+    ]) {
+      expect(out).not.toContain(word);
+    }
     expect(out).toContain('[redacted]');
+  });
+
+  it('catches a bare 8-word phrase fragment with no label', () => {
+    const out = redactSecrets(
+      'restore failed: abandon ability able about above absent absorb abstract'
+    );
+    expect(out).not.toContain('abandon');
+    expect(out).not.toContain('abstract');
+    expect(out).toContain('[redacted]');
+  });
+
+  it('does not mangle a legitimate message that merely names a secret', () => {
+    // No separator after the label, so nothing is consumed.
+    expect(redactSecrets('Invalid mnemonic phrase')).toBe(
+      'Invalid mnemonic phrase'
+    );
+    expect(redactSecrets('PIN required to access private key')).toBe(
+      'PIN required to access private key'
+    );
   });
 
   it.each([

--- a/src/utils/__tests__/errorMapping.test.ts
+++ b/src/utils/__tests__/errorMapping.test.ts
@@ -100,6 +100,13 @@ describe('redactSecrets — key material never reaches a user-facing string', ()
       'unexpected token in {"mnemonic":"abandon ability able about"}',
     ],
     ['is separator', 'the mnemonic is abandon ability able about'],
+    // Terminal punctuation: the LAST word must go too. An enumerated
+    // terminator set left `about.` visible, and a lone trailing word is short
+    // enough that the bare-run matcher could no longer catch it.
+    ['trailing period', 'mnemonic: abandon ability able about.'],
+    ['trailing paren', 'restore failed (mnemonic: abandon ability able about)'],
+    ['trailing semicolon', 'mnemonic="abandon ability able about";'],
+    ['trailing exclamation', 'mnemonic: abandon ability able about!'],
   ])('removes EVERY word of a labelled phrase (%s)', (_label, input) => {
     const out = redactSecrets(input);
 

--- a/src/utils/errorMapping.ts
+++ b/src/utils/errorMapping.ts
@@ -145,13 +145,34 @@ export interface MapErrorOptions {
 
 const REDACTED = '[redacted]';
 
+/** Separator between a secret's label and its value: `:`, `=` or ` is `. */
+const LABEL_SEPARATOR = String.raw`["']?\s*(?::|=|\bis\b)\s*["']?\s*`;
+
 /**
- * `label: value` / `label=value` for anything that names key material.
- * Deliberately greedy on the label side so `secret key`, `private-key`,
- * `seed phrase` etc. all match.
+ * A labelled WORD LIST — `mnemonic: abandon ability able …`.
+ *
+ * This MUST consume the whole run of words, not just the first token. An
+ * earlier version stopped at one `\S+`, which left 11 of a 12-word phrase
+ * intact and practically recoverable from a details expander. The value side
+ * therefore matches one-or-more BIP-39-shaped words (3-8 letters).
  */
-const LABELLED_SECRET_RE =
-  /\b(mnemonic|recovery[\s_-]?phrase|seed[\s_-]?phrase|seed|private[\s_-]?key|privkey|secret[\s_-]?key|secretkey|passphrase|password|passcode|\bpin\b)\b\s*(?:is|:|=)\s*\S+/gi;
+const LABELLED_PHRASE_RE = new RegExp(
+  String.raw`\b(mnemonic(?:[\s_-]?phrase)?|recovery[\s_-]?phrase|seed(?:[\s_-]?phrase)?|backup[\s_-]?phrase)\b` +
+    LABEL_SEPARATOR +
+    String.raw`(?:[a-z]{3,8}(?:[ \t]+|["',]|$))+`,
+  'gi'
+);
+
+/**
+ * A labelled SINGLE-TOKEN secret — `privateKey=…`, `pin: 482913`. Runs after
+ * the phrase rule so a hex/base64-encoded mnemonic or seed is still caught.
+ */
+const LABELLED_SECRET_RE = new RegExp(
+  String.raw`\b(private[\s_-]?key|privkey|secret[\s_-]?key|secretkey|passphrase|password|passcode|pin|mnemonic|seed)\b` +
+    LABEL_SEPARATOR +
+    String.raw`\S+`,
+  'gi'
+);
 
 /** 64+ hex chars — an Ed25519 secret key, a seed, or a raw key blob. */
 const LONG_HEX_RE = /\b[0-9a-fA-F]{64,}\b/g;
@@ -160,12 +181,15 @@ const LONG_HEX_RE = /\b[0-9a-fA-F]{64,}\b/g;
 const LONG_BASE64_RE = /[A-Za-z0-9+/]{60,}={0,2}/g;
 
 /**
- * A run of 12+ consecutive short lowercase words — the shape of a BIP-39 /
- * Algorand mnemonic (all words are 3-8 lowercase letters). Real error prose
- * essentially never produces 12 unbroken words in that alphabet, and erring
- * toward over-redaction is correct here.
+ * A run of 8+ consecutive short lowercase words with no label at all — the
+ * shape of a BIP-39 / Algorand mnemonic (every word is 3-8 lowercase letters).
+ *
+ * 8 rather than 12 so a partially-quoted or truncated phrase is still caught.
+ * Real error prose almost never produces 8 unbroken words in that alphabet,
+ * because ordinary English is full of 1-2 letter words (a, to, is, of, in, it)
+ * that break the run — and over-redaction is the correct direction to err.
  */
-const MNEMONIC_RUN_RE = /\b(?:[a-z]{3,8}[ \t]+){11,}[a-z]{3,8}\b/g;
+const MNEMONIC_RUN_RE = /\b(?:[a-z]{3,8}[ \t]+){7,}[a-z]{3,8}\b/g;
 
 /** Markup, so an HTML error page can never be pasted into an alert body. */
 const HTML_TAG_RE = /<[^>]*>/g;
@@ -175,13 +199,14 @@ const HTML_DOC_RE = /<!doctype html|<html[\s>]/i;
  * Strip anything that could be key material from a string before it reaches a
  * user-facing surface, a log, or a crash report.
  *
- * Order matters: labelled secrets are removed first (so `mnemonic: abandon
- * abandon …` collapses to one token), then raw high-entropy blobs, then bare
- * mnemonic-shaped word runs.
+ * Order matters: labelled word lists first (they consume a whole phrase),
+ * then labelled single tokens, then bare mnemonic-shaped runs, then raw
+ * high-entropy blobs.
  */
 export function redactSecrets(input: string): string {
   if (!input) return '';
   return input
+    .replace(LABELLED_PHRASE_RE, (_m, label: string) => `${label}: ${REDACTED}`)
     .replace(LABELLED_SECRET_RE, (_m, label: string) => `${label}: ${REDACTED}`)
     .replace(MNEMONIC_RUN_RE, REDACTED)
     .replace(LONG_HEX_RE, REDACTED)

--- a/src/utils/errorMapping.ts
+++ b/src/utils/errorMapping.ts
@@ -155,11 +155,17 @@ const LABEL_SEPARATOR = String.raw`["']?\s*(?::|=|\bis\b)\s*["']?\s*`;
  * earlier version stopped at one `\S+`, which left 11 of a 12-word phrase
  * intact and practically recoverable from a details expander. The value side
  * therefore matches one-or-more BIP-39-shaped words (3-8 letters).
+ *
+ * Each word ends at whitespace OR at a lookahead for any non-letter — so a
+ * phrase terminated by punctuation (`… able.`, `… able)`, `… able";`) has its
+ * LAST word consumed too, without swallowing the punctuation itself. An
+ * enumerated terminator set missed those, leaving one word visible that the
+ * bare-run matcher could no longer catch on its own.
  */
 const LABELLED_PHRASE_RE = new RegExp(
   String.raw`\b(mnemonic(?:[\s_-]?phrase)?|recovery[\s_-]?phrase|seed(?:[\s_-]?phrase)?|backup[\s_-]?phrase)\b` +
     LABEL_SEPARATOR +
-    String.raw`(?:[a-z]{3,8}(?:[ \t]+|["',]|$))+`,
+    String.raw`(?:[a-z]{3,8}(?:[ \t]+|(?=[^a-z]|$)))+`,
   'gi'
 );
 

--- a/src/utils/errorMapping.ts
+++ b/src/utils/errorMapping.ts
@@ -1,0 +1,929 @@
+/**
+ * Central error-mapping utility (TASK-41 / U-05).
+ *
+ * The app throws ~40 typed error classes and forwards raw SDK/HTTP failures
+ * straight into user-facing alerts. algod, indexer and Mimir errors are
+ * notoriously cryptic — `TransactionPool.Remember: transaction ...: overspend
+ * (account ...)`, bare HTTP bodies, `logic eval error: assert failed pc=...` —
+ * so users saw unactionable jargon at the most stressful moments (a failed
+ * send, a failed swap, a failed opt-in).
+ *
+ * This module translates any thrown value into a single stable projection:
+ *
+ *     { type, message, retryable, userAction }
+ *
+ * mirroring `simpleLedgerManager.getState()` (`simpleLedgerManager.ts:96-101`),
+ * which was already the closest shape to what the UI needs, plus optional
+ * `code` / `status` / `details` for diagnostics and a details expander.
+ *
+ * Design constraints:
+ *
+ *  - **Pure.** No React, no React Native, no service singletons, no network,
+ *    no platform adapters. It imports only pure type modules. That keeps it
+ *    unit-testable and keeps it working on the extension/web target, whose
+ *    `ExtensionAlertAdapter` merely `console.log`s.
+ *  - **Surface-agnostic.** It never calls `Alert`. `toErrorAlert()` returns
+ *    plain `{ title, message }` data so a caller can route it through RN
+ *    `Alert`, a toast, inline `setError`, or the platform alert adapter.
+ *  - **Never leaks secrets.** Every string that can reach the UI passes
+ *    through `redactSecrets()`, which strips mnemonics, private/secret keys,
+ *    seeds, passphrases and PINs before they can land in an alert body, a log
+ *    line or a crash report.
+ *  - **Never shows a raw HTTP body.** Unknown errors degrade to a generic
+ *    message plus a sanitized, tag-stripped, length-capped `details` string —
+ *    never a blank message and never a raw response body.
+ *
+ * Typed errors are matched by `instanceof` where the defining module is pure
+ * (`@/types/wallet`, `@/types/network`, `@/types/social`) and structurally by
+ * `name` + `status`/`statusCode`/`code` for service-level errors
+ * (`MimirApiError`, `SwapServiceError`, `EnvoiApiError`, `TokenMappingError`,
+ * …) whose modules pull in network config and must not be imported here.
+ */
+
+import {
+  AccountError,
+  AccountNotFoundError,
+  AuthenticationRequiredError,
+  InvalidAddressError,
+  InvalidMnemonicError,
+  LedgerAccountError,
+  LedgerAppNotOpenError,
+  LedgerDeviceNotConnectedError,
+  LedgerUserRejectedError,
+  RemoteSignerRequiredError,
+} from '@/types/wallet';
+import { NetworkError, NetworkUnavailableError } from '@/types/network';
+import { FriendError } from '@/types/social';
+
+// ---------------------------------------------------------------------------
+// Public shape
+// ---------------------------------------------------------------------------
+
+/**
+ * Stable, machine-readable classification of a failure. Screens may branch on
+ * this instead of string-matching `error.message` (which is what
+ * `AccountInfoScreen` and the Ledger retry loops used to do).
+ */
+export type MappedErrorType =
+  // connectivity / transport
+  | 'offline'
+  | 'timeout'
+  | 'rate_limited'
+  | 'server_error'
+  | 'not_found'
+  // funds / on-chain rejections
+  | 'insufficient_funds'
+  | 'min_balance'
+  | 'not_opted_in'
+  | 'transaction_expired'
+  | 'duplicate_transaction'
+  | 'fee_too_low'
+  | 'app_rejected'
+  | 'transaction_rejected'
+  // account state
+  | 'account_not_found'
+  | 'invalid_address'
+  | 'invalid_amount'
+  | 'validation'
+  // signing / auth
+  | 'user_rejected'
+  | 'auth_required'
+  | 'ledger'
+  | 'remote_signer_required'
+  | 'watch_account'
+  | 'permission_denied'
+  // session
+  | 'session_expired'
+  // fallback
+  | 'unknown';
+
+export interface MappedError {
+  /** Stable classification — safe to branch on. */
+  type: MappedErrorType;
+  /** Plain-language, user-facing sentence. Never empty, never raw jargon. */
+  message: string;
+  /** Whether retrying the same operation could plausibly succeed. */
+  retryable: boolean;
+  /** Concrete next step for the user. Never empty. */
+  userAction: string;
+  /** Stable code carried by the underlying typed error, when it had one. */
+  code?: string;
+  /** HTTP-ish status carried by the underlying error, when it had one. */
+  status?: number;
+  /**
+   * Sanitized underlying detail for a "Details" expander: secrets redacted,
+   * HTML stripped, length-capped. `undefined` when nothing useful remains.
+   */
+  details?: string;
+  /**
+   * True when no rule matched and the generic fallback was used. UIs should
+   * surface `details` in this case so the failure is still diagnosable.
+   */
+  isGeneric: boolean;
+}
+
+export interface MapErrorOptions {
+  /**
+   * Replaces the generic fallback message when nothing matches. Use it to give
+   * the unknown case operation-specific wording ("Failed to prepare the
+   * transaction."). Ignored when a rule matches.
+   */
+  fallbackMessage?: string;
+  /** Title for `toErrorAlert` when the mapped type has no better one. */
+  fallbackTitle?: string;
+  /**
+   * Include the sanitized `details` string even when a rule matched. Off by
+   * default: a matched rule already produced an actionable message and the raw
+   * text is usually noise.
+   */
+  includeDetailsWhenMapped?: boolean;
+}
+
+// ---------------------------------------------------------------------------
+// Redaction — nothing below this line may emit unredacted text
+// ---------------------------------------------------------------------------
+
+const REDACTED = '[redacted]';
+
+/**
+ * `label: value` / `label=value` for anything that names key material.
+ * Deliberately greedy on the label side so `secret key`, `private-key`,
+ * `seed phrase` etc. all match.
+ */
+const LABELLED_SECRET_RE =
+  /\b(mnemonic|recovery[\s_-]?phrase|seed[\s_-]?phrase|seed|private[\s_-]?key|privkey|secret[\s_-]?key|secretkey|passphrase|password|passcode|\bpin\b)\b\s*(?:is|:|=)\s*\S+/gi;
+
+/** 64+ hex chars — an Ed25519 secret key, a seed, or a raw key blob. */
+const LONG_HEX_RE = /\b[0-9a-fA-F]{64,}\b/g;
+
+/** 60+ base64 chars — a base64-encoded key/seed (an sk is 88 chars). */
+const LONG_BASE64_RE = /[A-Za-z0-9+/]{60,}={0,2}/g;
+
+/**
+ * A run of 12+ consecutive short lowercase words — the shape of a BIP-39 /
+ * Algorand mnemonic (all words are 3-8 lowercase letters). Real error prose
+ * essentially never produces 12 unbroken words in that alphabet, and erring
+ * toward over-redaction is correct here.
+ */
+const MNEMONIC_RUN_RE = /\b(?:[a-z]{3,8}[ \t]+){11,}[a-z]{3,8}\b/g;
+
+/** Markup, so an HTML error page can never be pasted into an alert body. */
+const HTML_TAG_RE = /<[^>]*>/g;
+const HTML_DOC_RE = /<!doctype html|<html[\s>]/i;
+
+/**
+ * Strip anything that could be key material from a string before it reaches a
+ * user-facing surface, a log, or a crash report.
+ *
+ * Order matters: labelled secrets are removed first (so `mnemonic: abandon
+ * abandon …` collapses to one token), then raw high-entropy blobs, then bare
+ * mnemonic-shaped word runs.
+ */
+export function redactSecrets(input: string): string {
+  if (!input) return '';
+  return input
+    .replace(LABELLED_SECRET_RE, (_m, label: string) => `${label}: ${REDACTED}`)
+    .replace(MNEMONIC_RUN_RE, REDACTED)
+    .replace(LONG_HEX_RE, REDACTED)
+    .replace(LONG_BASE64_RE, REDACTED);
+}
+
+const MAX_DETAILS_LENGTH = 280;
+
+/**
+ * Turn arbitrary error text into something safe to show in a details
+ * expander: secrets redacted, markup stripped, whitespace collapsed, length
+ * capped. Returns `undefined` when nothing meaningful survives.
+ */
+export function sanitizeDetails(input: unknown): string | undefined {
+  if (input === null || input === undefined) return undefined;
+  let text = typeof input === 'string' ? input : safeStringify(input);
+  if (!text) return undefined;
+
+  if (HTML_DOC_RE.test(text)) {
+    // A full HTML error page carries no user value at all.
+    return 'The server returned an unexpected response.';
+  }
+
+  text = redactSecrets(text)
+    .replace(HTML_TAG_RE, ' ')
+    .replace(/\s+/g, ' ')
+    .trim();
+
+  if (!text) return undefined;
+  if (text.length > MAX_DETAILS_LENGTH) {
+    return `${text.slice(0, MAX_DETAILS_LENGTH - 1).trimEnd()}…`;
+  }
+  return text;
+}
+
+function safeStringify(value: unknown): string {
+  if (typeof value === 'string') return value;
+  if (value === null || value === undefined) return '';
+  if (typeof value !== 'object') return String(value);
+  try {
+    const json = JSON.stringify(value);
+    // `{}` carries no information; treat it as nothing.
+    return !json || json === '{}' ? '' : json;
+  } catch {
+    return '';
+  }
+}
+
+// ---------------------------------------------------------------------------
+// Structural extraction
+// ---------------------------------------------------------------------------
+
+interface ErrorFacts {
+  /** Constructor/`name` of the thrown value, when it is an Error. */
+  name: string;
+  /** Raw message text (unredacted — internal use only). */
+  rawMessage: string;
+  /** Every text fragment worth pattern-matching, lowercased. */
+  haystack: string;
+  status?: number;
+  code?: string;
+}
+
+function readNumber(value: unknown): number | undefined {
+  return typeof value === 'number' && Number.isFinite(value)
+    ? value
+    : undefined;
+}
+
+function readString(value: unknown): string | undefined {
+  return typeof value === 'string' && value.length > 0 ? value : undefined;
+}
+
+/**
+ * Collect the metadata the rules need. `status`/`statusCode` and `code` are
+ * read structurally so service errors keep working without importing their
+ * (impure) defining modules: `MimirApiError.status`, `SwapServiceError`/
+ * `SnowballApiError`/`DeflexApiError.statusCode`, `EnvoiApiError.status`,
+ * `TokenMappingError.code`, algosdk's `response.status`.
+ */
+function collectFacts(error: unknown): ErrorFacts {
+  const any = error as any;
+
+  const rawMessage =
+    error instanceof Error
+      ? error.message || ''
+      : typeof error === 'string'
+        ? error
+        : safeStringify(error);
+
+  const name =
+    (error instanceof Error ? error.name : undefined) ||
+    readString(any?.name) ||
+    '';
+
+  const status =
+    readNumber(any?.status) ??
+    readNumber(any?.statusCode) ??
+    readNumber(any?.response?.status);
+
+  const code =
+    readString(any?.code) ??
+    readString(any?.data?.code) ??
+    readString(any?.response?.body?.code);
+
+  // algosdk surfaces the real algod reason under response.body.message; the
+  // outer `message` is often just "Network request failed" or a status line.
+  const fragments = [
+    rawMessage,
+    readString(any?.response?.body?.message),
+    readString(any?.response?.text),
+    readString(any?.data?.message),
+    error instanceof Error && any?.cause instanceof Error
+      ? any.cause.message
+      : undefined,
+    name,
+    code,
+  ].filter(
+    (part): part is string => typeof part === 'string' && part.length > 0
+  );
+
+  return {
+    name,
+    rawMessage,
+    haystack: fragments.join(' | ').toLowerCase(),
+    status,
+    code,
+  };
+}
+
+// ---------------------------------------------------------------------------
+// Rule table
+// ---------------------------------------------------------------------------
+
+type Rule = {
+  type: MappedErrorType;
+  message: string;
+  retryable: boolean;
+  userAction: string;
+};
+
+const GENERIC: Rule = {
+  type: 'unknown',
+  message: 'Something went wrong.',
+  retryable: true,
+  userAction:
+    'Please try again. If it keeps happening, check the details below.',
+};
+
+const OFFLINE: Rule = {
+  type: 'offline',
+  message: "Couldn't reach the network.",
+  retryable: true,
+  userAction: 'Check your internet connection and try again.',
+};
+
+const TIMEOUT: Rule = {
+  type: 'timeout',
+  message: 'The request took too long and was cancelled.',
+  retryable: true,
+  userAction: 'Check your connection and try again.',
+};
+
+const RATE_LIMITED: Rule = {
+  type: 'rate_limited',
+  message: 'Too many requests were sent in a short time.',
+  retryable: true,
+  userAction: 'Wait a moment and try again.',
+};
+
+const SERVER_ERROR: Rule = {
+  type: 'server_error',
+  message: 'The service is temporarily unavailable.',
+  retryable: true,
+  userAction: 'Please try again in a few moments.',
+};
+
+const INSUFFICIENT_FUNDS: Rule = {
+  type: 'insufficient_funds',
+  message: "This account doesn't have enough balance for this transaction.",
+  retryable: false,
+  userAction:
+    'Lower the amount or add funds, remembering to leave enough to cover the network fee.',
+};
+
+const MIN_BALANCE: Rule = {
+  type: 'min_balance',
+  message:
+    'This would drop the account below the minimum balance the network requires.',
+  retryable: false,
+  userAction:
+    'Send a smaller amount, or add funds. Each asset and app you opt into raises the minimum balance.',
+};
+
+const NOT_OPTED_IN: Rule = {
+  type: 'not_opted_in',
+  message: 'The account has not opted in to this asset.',
+  retryable: false,
+  userAction:
+    'Opt in to the asset first — the recipient must opt in before they can receive it.',
+};
+
+const TRANSACTION_EXPIRED: Rule = {
+  type: 'transaction_expired',
+  message: 'The transaction expired before it reached the network.',
+  retryable: true,
+  userAction: 'Please try again to build a fresh transaction.',
+};
+
+const DUPLICATE_TRANSACTION: Rule = {
+  type: 'duplicate_transaction',
+  message: 'This transaction has already been submitted.',
+  retryable: false,
+  userAction: 'Check your transaction history before sending it again.',
+};
+
+const FEE_TOO_LOW: Rule = {
+  type: 'fee_too_low',
+  message: 'The network fee was too low for current conditions.',
+  retryable: true,
+  userAction: 'Please try again — a new fee will be calculated.',
+};
+
+const APP_REJECTED: Rule = {
+  type: 'app_rejected',
+  message: 'The smart contract rejected this transaction.',
+  retryable: false,
+  userAction:
+    'Check the amounts and that the account meets the contract’s requirements, then try again.',
+};
+
+const TRANSACTION_REJECTED: Rule = {
+  type: 'transaction_rejected',
+  message: 'The network rejected this transaction.',
+  retryable: false,
+  userAction: 'Review the transaction details and try again.',
+};
+
+const ACCOUNT_NOT_FOUND: Rule = {
+  type: 'account_not_found',
+  message: 'This account does not exist on the network yet.',
+  retryable: false,
+  userAction: 'Fund the account to activate it on this network.',
+};
+
+const INVALID_ADDRESS: Rule = {
+  type: 'invalid_address',
+  message: "That address isn't valid.",
+  retryable: false,
+  userAction: 'Double-check the recipient address and try again.',
+};
+
+const INVALID_AMOUNT: Rule = {
+  type: 'invalid_amount',
+  message: "That amount isn't valid.",
+  retryable: false,
+  userAction: 'Re-enter the amount and try again.',
+};
+
+const USER_REJECTED: Rule = {
+  type: 'user_rejected',
+  message: 'The request was rejected.',
+  retryable: true,
+  userAction: 'Approve the request to continue, or cancel to abort.',
+};
+
+const AUTH_REQUIRED: Rule = {
+  type: 'auth_required',
+  message: 'Your PIN or biometric confirmation is required to continue.',
+  retryable: true,
+  userAction: 'Authenticate and try again.',
+};
+
+const LEDGER_LOCKED: Rule = {
+  type: 'ledger',
+  message: 'Your Ledger device is locked.',
+  retryable: true,
+  userAction: 'Unlock your Ledger and try again.',
+};
+
+const LEDGER_APP_NOT_OPEN: Rule = {
+  type: 'ledger',
+  message: 'The Algorand app is not open on your Ledger.',
+  retryable: true,
+  userAction: 'Open the Algorand app on your Ledger and try again.',
+};
+
+const LEDGER_DISCONNECTED: Rule = {
+  type: 'ledger',
+  message: 'Your Ledger device is not connected.',
+  retryable: true,
+  userAction:
+    'Reconnect and unlock your Ledger, open the Algorand app, then try again.',
+};
+
+const PERMISSION_DENIED: Rule = {
+  type: 'permission_denied',
+  message: 'The app is missing a permission it needs for this action.',
+  retryable: false,
+  userAction: 'Enable the required permission in your device Settings.',
+};
+
+const REMOTE_SIGNER_REQUIRED: Rule = {
+  type: 'remote_signer_required',
+  message: 'This account signs through a separate device using QR codes.',
+  retryable: false,
+  userAction: 'Use the QR signing flow to approve this transaction.',
+};
+
+const WATCH_ACCOUNT: Rule = {
+  type: 'watch_account',
+  message: 'This is a watch-only account and cannot sign transactions.',
+  retryable: false,
+  userAction: 'Switch to an account you control to continue.',
+};
+
+const SESSION_EXPIRED: Rule = {
+  type: 'session_expired',
+  message: 'The dApp connection is no longer active.',
+  retryable: false,
+  userAction: 'Reconnect to the dApp and try again.',
+};
+
+const NOT_FOUND: Rule = {
+  type: 'not_found',
+  message: "We couldn't find what you were looking for.",
+  retryable: false,
+  userAction: 'Check the details and try again.',
+};
+
+/**
+ * Message-pattern table, evaluated in order against the lowercased haystack.
+ *
+ * The algod/indexer entries cover the strings users actually saw before this
+ * task: `TransactionPool.Remember: ... overspend (account ... )`, `balance
+ * ... below min`, `asset ... missing from`, `txn dead`, `transaction already
+ * in ledger`, `logic eval error`, `should have been authorized by`.
+ *
+ * More specific patterns MUST precede more general ones (e.g. "below min"
+ * before "overspend", since algod reports both together for an account that
+ * would fall under its minimum balance).
+ */
+const MESSAGE_RULES: { pattern: RegExp; rule: Rule }[] = [
+  // --- user cancellation (must beat generic "rejected" wording) ---
+  {
+    pattern: /user (rejected|disapproved|cancell?ed|denied)/,
+    rule: USER_REJECTED,
+  },
+  {
+    pattern: /\b0x6985\b|conditions of use not satisfied/,
+    rule: USER_REJECTED,
+  },
+  {
+    pattern: /request (was )?(rejected|cancell?ed) by (the )?user/,
+    rule: USER_REJECTED,
+  },
+
+  // --- Ledger transport / device state ---
+  { pattern: /\b0x5515\b|locked device|device is locked/, rule: LEDGER_LOCKED },
+  {
+    pattern: /\b0x6d00\b|\b0x6e00\b|app ?not ?open|open the algorand app/,
+    rule: LEDGER_APP_NOT_OPEN,
+  },
+  {
+    pattern:
+      /disconnecteddevice|communication_error|transport(notsupported| error| is not)|no ledger device|ledger device is not connected/,
+    rule: LEDGER_DISCONNECTED,
+  },
+
+  // --- permissions ---
+  {
+    pattern:
+      /permission (denied|not granted)|bluetooth.*(permission|not authorized)|unauthorized access to/,
+    rule: PERMISSION_DENIED,
+  },
+
+  // --- auth ---
+  {
+    pattern:
+      /pin required|invalid pin|incorrect pin|failed to access private key|authentication required|biometric/,
+    rule: AUTH_REQUIRED,
+  },
+
+  // --- account state ---
+  {
+    pattern:
+      /account does not exist|no accounts found|account not found|account unknown/,
+    rule: ACCOUNT_NOT_FOUND,
+  },
+
+  // --- on-chain rejections (order-sensitive) ---
+  {
+    pattern:
+      /below min|minimum balance|min balance|would result in a balance below/,
+    rule: MIN_BALANCE,
+  },
+  {
+    pattern: /overspend|insufficient (funds|balance)|tried to spend/,
+    rule: INSUFFICIENT_FUNDS,
+  },
+  {
+    pattern:
+      /missing from|asset .*not opted in|has not opted in|receiver error|must optin/,
+    rule: NOT_OPTED_IN,
+  },
+  {
+    pattern:
+      /txn dead|transaction .*(expired|dead)|round .*(has passed|is in the past)|lastvalid/,
+    rule: TRANSACTION_EXPIRED,
+  },
+  {
+    pattern:
+      /already in ledger|transactionpool\.remember: txn already|duplicate transaction/,
+    rule: DUPLICATE_TRANSACTION,
+  },
+  {
+    pattern: /fee \d* ?below threshold|fee too (small|low)/,
+    rule: FEE_TOO_LOW,
+  },
+  {
+    pattern: /logic eval error|assert failed|rejected by (logic|approval)/,
+    rule: APP_REJECTED,
+  },
+  {
+    pattern:
+      /should have been authorized by|signature validation failed|invalid signature/,
+    rule: TRANSACTION_REJECTED,
+  },
+  {
+    pattern: /transactionpool\.remember|transaction (was )?rejected/,
+    rule: TRANSACTION_REJECTED,
+  },
+
+  // --- validation ---
+  {
+    pattern: /invalid (algorand )?address|address .*is invalid|checksum/,
+    rule: INVALID_ADDRESS,
+  },
+  {
+    pattern:
+      /invalid amount|amount must be|too many decimal|not a valid number/,
+    rule: INVALID_AMOUNT,
+  },
+
+  // --- account types ---
+  { pattern: /watch(-| )?only|watch accounts cannot/, rule: WATCH_ACCOUNT },
+  { pattern: /remote sign|qr[- ]based signing/, rule: REMOTE_SIGNER_REQUIRED },
+
+  // --- WalletConnect session ---
+  {
+    pattern:
+      /no matching key|session topic doesn'?t exist|(session|proposal|pairing) (has )?expired|session not found/,
+    rule: SESSION_EXPIRED,
+  },
+
+  // --- connectivity (last: these strings are the most generic) ---
+  {
+    pattern:
+      /\btimeout\b|timed out|aborterror|the operation was aborted|\baborted\b/,
+    rule: TIMEOUT,
+  },
+  {
+    pattern:
+      /network request failed|failed to fetch|network error|econnrefused|enotfound|etimedout|dns|offline|no internet|unable to connect/,
+    rule: OFFLINE,
+  },
+];
+
+// ---------------------------------------------------------------------------
+// Mapping
+// ---------------------------------------------------------------------------
+
+function ruleFromStatus(status: number): Rule | undefined {
+  if (status === 401 || status === 403) {
+    return {
+      type: 'permission_denied',
+      message: 'This request was not authorized by the service.',
+      retryable: false,
+      userAction: 'Please try again later, or contact support if it persists.',
+    };
+  }
+  if (status === 404) return NOT_FOUND;
+  if (status === 408) return TIMEOUT;
+  if (status === 429) return RATE_LIMITED;
+  if (status >= 500) return SERVER_ERROR;
+  if (status >= 400) {
+    return {
+      type: 'validation',
+      message: 'The service rejected the request.',
+      retryable: false,
+      userAction: 'Check the details you entered and try again.',
+    };
+  }
+  return undefined;
+}
+
+/** Typed-error matching, first and highest-confidence pass. */
+function ruleFromTypedError(error: unknown): Rule | undefined {
+  if (error instanceof RemoteSignerRequiredError) return REMOTE_SIGNER_REQUIRED;
+  if (error instanceof LedgerUserRejectedError) return USER_REJECTED;
+  if (error instanceof LedgerAppNotOpenError) return LEDGER_APP_NOT_OPEN;
+  if (error instanceof LedgerDeviceNotConnectedError)
+    return LEDGER_DISCONNECTED;
+  if (error instanceof LedgerAccountError) {
+    return {
+      type: 'ledger',
+      message: 'Your Ledger device reported a problem.',
+      retryable: true,
+      userAction:
+        'Make sure your Ledger is unlocked with the Algorand app open, then try again.',
+    };
+  }
+  if (error instanceof AuthenticationRequiredError) return AUTH_REQUIRED;
+  if (error instanceof AccountNotFoundError) return ACCOUNT_NOT_FOUND;
+  if (error instanceof InvalidAddressError) return INVALID_ADDRESS;
+  if (error instanceof InvalidMnemonicError) {
+    return {
+      type: 'validation',
+      // Deliberately says nothing about the phrase itself.
+      message: "That recovery phrase isn't valid.",
+      retryable: false,
+      userAction:
+        'Check the word order and spelling, then enter the phrase again.',
+    };
+  }
+  if (error instanceof NetworkUnavailableError) {
+    return {
+      type: 'server_error',
+      message: 'This network is currently unavailable.',
+      retryable: true,
+      userAction: 'Try again shortly, or switch networks.',
+    };
+  }
+  if (error instanceof NetworkError) return OFFLINE;
+  if (error instanceof FriendError) {
+    return {
+      type: 'validation',
+      message: 'That contact could not be saved.',
+      retryable: false,
+      userAction: 'Check the name or address and try again.',
+    };
+  }
+  return undefined;
+}
+
+/**
+ * Translate any thrown value into a stable, user-safe `{ type, message,
+ * retryable, userAction }` projection.
+ *
+ * Resolution order: typed error → message patterns → HTTP status → generic
+ * fallback. Message patterns run before status because algod returns a 400 for
+ * every on-chain rejection, and "overspend" is far more useful than "the
+ * service rejected the request".
+ */
+export function mapError(
+  error: unknown,
+  options: MapErrorOptions = {}
+): MappedError {
+  const facts = collectFacts(error);
+
+  let rule = ruleFromTypedError(error);
+  let matched = rule !== undefined;
+
+  if (!rule && facts.haystack) {
+    for (const entry of MESSAGE_RULES) {
+      if (entry.pattern.test(facts.haystack)) {
+        rule = entry.rule;
+        matched = true;
+        break;
+      }
+    }
+  }
+
+  if (!rule && facts.status !== undefined) {
+    rule = ruleFromStatus(facts.status);
+    matched = rule !== undefined;
+  }
+
+  if (!rule) {
+    rule = options.fallbackMessage
+      ? { ...GENERIC, message: options.fallbackMessage }
+      : GENERIC;
+  }
+
+  const code =
+    // A typed `code` is more useful than the mapped type, but the mapped type
+    // is what the UI branches on, so keep both.
+    facts.code ??
+    (error instanceof AccountError ? error.code : undefined) ??
+    undefined;
+
+  const details =
+    !matched || options.includeDetailsWhenMapped
+      ? sanitizeDetails(facts.rawMessage)
+      : undefined;
+
+  return {
+    type: rule.type,
+    message: rule.message,
+    retryable: rule.retryable,
+    userAction: rule.userAction,
+    code,
+    status: facts.status,
+    details,
+    isGeneric: !matched,
+  };
+}
+
+// ---------------------------------------------------------------------------
+// Presentation helpers (surface-agnostic — no RN imports)
+// ---------------------------------------------------------------------------
+
+/**
+ * One-line user-facing string: the plain-language message followed by the
+ * suggested action. Use for inline `setError(...)` and toasts.
+ */
+export function getUserFacingMessage(
+  error: unknown,
+  options: MapErrorOptions = {}
+): string {
+  const mapped = mapError(error, options);
+  return `${mapped.message} ${mapped.userAction}`.trim();
+}
+
+export interface ErrorAlertContent {
+  title: string;
+  message: string;
+}
+
+const TITLE_BY_TYPE: Partial<Record<MappedErrorType, string>> = {
+  offline: 'No Connection',
+  timeout: 'Request Timed Out',
+  rate_limited: 'Slow Down',
+  server_error: 'Service Unavailable',
+  insufficient_funds: 'Not Enough Balance',
+  min_balance: 'Minimum Balance',
+  not_opted_in: 'Opt-In Required',
+  transaction_expired: 'Transaction Expired',
+  duplicate_transaction: 'Already Submitted',
+  fee_too_low: 'Fee Too Low',
+  app_rejected: 'Rejected by Contract',
+  transaction_rejected: 'Transaction Rejected',
+  account_not_found: 'Account Not Found',
+  invalid_address: 'Invalid Address',
+  invalid_amount: 'Invalid Amount',
+  user_rejected: 'Request Rejected',
+  auth_required: 'Authentication Required',
+  ledger: 'Ledger Device',
+  remote_signer_required: 'QR Signing Required',
+  watch_account: 'Watch-Only Account',
+  permission_denied: 'Permission Needed',
+  session_expired: 'Connection Expired',
+  validation: 'Check Your Details',
+  not_found: 'Not Found',
+};
+
+/**
+ * Build `{ title, message }` for an alert/dialog. Deliberately returns plain
+ * data rather than calling `Alert.alert`, so callers can route it through RN
+ * `Alert`, a toast, or the platform alert adapter (the extension target's
+ * adapter only `console.log`s).
+ *
+ * When the error was not recognised, the sanitized `details` are appended so a
+ * generic message is still diagnosable — that is the "details expander" in an
+ * alert-shaped surface.
+ */
+export function toErrorAlert(
+  error: unknown,
+  options: MapErrorOptions & { title?: string } = {}
+): ErrorAlertContent {
+  const mapped = mapError(error, options);
+  const parts = [mapped.message, mapped.userAction].filter(Boolean);
+  if (mapped.details) {
+    parts.push(`Details: ${mapped.details}`);
+  }
+  return {
+    title:
+      options.title ??
+      TITLE_BY_TYPE[mapped.type] ??
+      options.fallbackTitle ??
+      'Something Went Wrong',
+    message: parts.join('\n\n'),
+  };
+}
+
+// ---------------------------------------------------------------------------
+// Predicates — replacements for ad-hoc `error.message.includes(...)` branching
+// ---------------------------------------------------------------------------
+
+/**
+ * True when the failure means "this address has no on-chain account yet"
+ * (algod's `account does not exist`). Replaces the raw string match in
+ * `AccountInfoScreen`, which broke whenever algod reworded the error.
+ */
+export function isAccountNotFoundError(error: unknown): boolean {
+  return mapError(error).type === 'account_not_found';
+}
+
+/** True when the user (or their device) explicitly declined the request. */
+export function isUserRejectionError(error: unknown): boolean {
+  return mapError(error).type === 'user_rejected';
+}
+
+/**
+ * True for a Ledger transport/communication failure that will not be fixed by
+ * retrying the same transport. Replaces the `COMMUNICATION_ERROR` / `Transport`
+ * string matches in the Ledger retry loops.
+ */
+export function isLedgerTransportError(error: unknown): boolean {
+  const facts = collectFacts(error);
+  // `TransportStatusError` is an APDU *status word* from the device (locked,
+  // wrong app, user rejected) — not a transport failure. It must NOT be
+  // treated as one, or a retry loop that used to recover from a locked device
+  // would give up on the first attempt.
+  if (/transportstatuserror/.test(facts.haystack)) return false;
+  // No trailing \b: `TransportError` and `TransportRaceCondition` are real
+  // @ledgerhq error names and the old check (`message.includes('Transport')`)
+  // was case-sensitive and missed the `name`.
+  return /disconnecteddevice|communication_error|\btransport/.test(
+    facts.haystack
+  );
+}
+
+/**
+ * True when the platform refused the operation for permission reasons (BLE,
+ * USB, notifications). Replaces the `Permission` / `Unauthorized` string
+ * matches in the Ledger transport retry loop.
+ */
+export function isPermissionDeniedError(error: unknown): boolean {
+  const facts = collectFacts(error);
+  // A message that merely mentions a *granted* permission is not a denial —
+  // treating it as one would abort a retry loop that could still succeed.
+  if (/permissions?\s+(granted|allowed|ok)\b/.test(facts.haystack)) {
+    return false;
+  }
+  if (/\bunauthorized\b|\bpermissions?\b|not authorized/.test(facts.haystack)) {
+    return true;
+  }
+  return facts.status === 401 || facts.status === 403;
+}
+
+/** True when retrying the same operation could plausibly succeed. */
+export function isRetryableError(error: unknown): boolean {
+  return mapError(error).retryable;
+}


### PR DESCRIPTION
Closes **TASK-41** (PLAN-12 Phase 1, Wave 1) — audit finding **U-05**.

## The problem

Raw `error.message` from algosdk/algod/Mimir was piped straight into user-facing alerts at ~41 sites across 24 screens. A failed send showed:

```
TransactionPool.Remember: transaction JYQ...: overspend (account ABC...,
data {_struct:{} Status:Offline MicroAlgos:{Raw:1000}}, tried to spend {5000000})
```

…at the most stressful moment in the app.

## What landed

### `src/utils/errorMapping.ts` — a pure util with Jest coverage

No React, no React Native, no service singletons, no network. It projects any thrown value onto `{ type, message, retryable, userAction }` — the shape `simpleLedgerManager.getState()` already used — plus `code` / `status` / `details`.

Three guarantees, each with tests:

- **Secrets never reach a user-facing string.** `redactSecrets` strips labelled mnemonics (consuming the *whole* phrase), bare 8+ word BIP-39-shaped runs, 64+ char hex keys, 60+ char base64 blobs, and labelled seed/passphrase/PIN/password values. A negative control proves legitimate messages that merely *name* a secret ("Invalid mnemonic phrase") are left untouched.
- **Never blank, never a raw HTTP body.** Unknown failures degrade to a generic message plus sanitized, tag-stripped, 280-char-capped details. A full HTML error page collapses to one sentence.
- **Surface-agnostic.** `toErrorAlert` returns plain `{ title, message }` data and never binds to RN `Alert`, so the extension target's console-only `ExtensionAlertAdapter` keeps working. A test asserts the module never imports `react-native`.

Rules cover the notorious algod/indexer strings (`overspend`, `below min`, `missing from`, `txn dead`, `already in ledger`, `fee below threshold`, `logic eval error`, `should have been authorized by`), WalletConnect session failures, Ledger status words, and HTTP status classes. Message patterns are evaluated **before** status, because algod returns 400 for every on-chain rejection and "overspend" beats "the service rejected the request".

### Error-metadata loss (DR-6, corrected scope)

- `token-mapping/index.ts` — the one genuine offender. Its retry loop discarded the typed HTTP status of the last attempt; it now carries `status` and `cause` into the rebuilt error.
- Mimir / price / algorand-price — the type already survived, but `status`/`code` were never passed. They now thread `code: 'NETWORK_ERROR'` and `cause` through their retry-exhausted and generic-wrap throws.
- `envoi` rethrows unchanged and is left alone, per DR-6.
- **Discovered defect, folded in:** `TokenMappingAPIError` and its siblings never set their own `name` — the base constructor overwrote it with `'TokenMappingError'`.

### Folded in — `RemoteSignerRequiredError` dedupe

It was declared **twice**, in `remoteSigner/signingRouter.ts` and `transactions/unifiedSigner.ts`, with incompatible constructors. Two distinct classes sharing one `name` meant a cross-module `instanceof` could silently return `false` and drop callers into a generic failure path. The canonical declaration moved to `@/types/wallet`; both modules re-export it. A regression test asserts class identity across all three modules.

The constructor takes an options object rather than preserving either positional signature — they were mutually contradictory (a leading string meant "address" in one and "message" in the other), so no overload can disambiguate them. Rationale is recorded in the class doc.

### String-matching control flow replaced

- `AccountInfoScreen` matched the exact algod string `account does not exist`; any rewording left the account card blank forever. Now `isAccountNotFoundError`.
- `ledger/algorand.ts` and `ledger/transport.ts` used **case-sensitive** `message.includes(...)` and missed `DisconnectedDevice` and lowercase permission denials, burning the full retry budget on a dead transport. Now `isLedgerTransportError` / `isPermissionDeniedError` — which deliberately do **not** classify `TransportStatusError` (a recoverable APDU status word like "locked device") as a dead transport, and do not treat a *granted* permission as a denial.

### Screens migrated

Money-critical first: `SendScreen`, `SwapScreen`, `KeyregConfirmScreen`, `AppCallConfirmScreen`, `TransactionConfirmationScreen`, `ClaimAllConfirmationScreen` — plus the two opt-in/opt-out sites the audit cited by name (`AssetDetailScreen`, `MultiNetworkAssetScreen`).

## Gates

| Gate | Baseline | This PR |
| --- | --- | --- |
| `npm run typecheck` | 0 errors | **0 errors** |
| `npm run lint` | 0 errors, 681 warnings | **0 errors, 681 warnings** |
| `npm test` | 1228 tests / 75 suites | **1315 tests / 76 suites** |

JS-only, no native changes — OTA-shippable per DR-8.

## Codex review

Three rounds, converged to **CLEAN**.

- **Round 1 (P2)** — flagged the `RemoteSignerRequiredError` signature change as breaking consumers. Premise disproven by the green typecheck (every construction site is in-repo and updated); the reasoning is now recorded in the class doc instead.
- **Round 2 (P1, real — fixed)** — the labelled-secret rule consumed only the *first* token after `mnemonic:`, leaking 11 words of a 12-word phrase into the details expander, and the bare-run matcher required 12 consecutive words so it no longer saw a full run. Split into a phrase rule that consumes the entire word run (including the JSON `"mnemonic":"…"` and `is` separator forms) plus the single-token rule; bare-run threshold lowered 12 → 8. **The original tests were too weak to catch this** — they asserted only that the first word was gone. They now assert every word is gone across six labelled shapes.
- **Round 3** — CLEAN.

## Deferred

The remaining ~30 raw `error.message` sites in non-money-critical screens (settings, social, remote-signer, walletconnect) are not migrated here — the mapper and its predicates are in place for them, and doing all 24 screens would have materially expanded this diff. Not device-tested; that is batched before release.
