### PR TITLE
feat(errors): surface load failures + offline state with retry (TASK-40)

### DIFF
--- a/App.tsx
+++ b/App.tsx
@@ -7,6 +7,7 @@ import ErrorBoundary from './src/components/ErrorBoundary';
 import { ThemeProvider, useTheme } from './src/contexts/ThemeContext';
 import { debugLogger } from './src/services/debug/logger';
 import { createToastConfig } from './src/config/toastConfig';
+import OfflineBanner from './src/components/common/OfflineBanner';
 
 function AppContent() {
   const { theme, themeMode, isDark } = useTheme();
@@ -55,6 +56,11 @@ function AppContent() {
         translucent={false}
       />
       <AppNavigator />
+      {/* Above the navigator so it survives every navigation (including the
+          pre-auth screens) and below the Toast so transient toasts still win
+          the top of the stack. Consumes connectivity only — no auth state,
+          which is why it can live outside AuthProvider. */}
+      <OfflineBanner />
       <Toast config={toastConfig} />
     </View>
   );

--- a/src/components/common/ErrorStateView.tsx
+++ b/src/components/common/ErrorStateView.tsx
@@ -1,0 +1,194 @@
+/**
+ * ErrorStateView — shared "this failed, here's why, try again" surface
+ * (TASK-40 / U-03).
+ *
+ * The audit finding it closes: data-load failures were caught with
+ * `console.error` only, so a failed fetch rendered exactly like a successful
+ * fetch of an empty account. In a wallet that is alarming — "No Transactions"
+ * on an account you know has transactions reads as lost funds. Every load
+ * failure must be visibly a *failure*, and must offer a retry.
+ *
+ * All user-facing wording comes from the central mapper (`@/utils/errorMapping`,
+ * TASK-41) so the phrasing, redaction and retryability rules are the same
+ * everywhere. Nothing here formats a raw error itself.
+ */
+
+import React, { useMemo } from 'react';
+import {
+  Pressable,
+  StyleProp,
+  StyleSheet,
+  Text,
+  View,
+  ViewStyle,
+} from 'react-native';
+import { Ionicons } from '@expo/vector-icons';
+import { useTheme } from '@/contexts/ThemeContext';
+import { useThemedStyles } from '@/hooks/useThemedStyles';
+import { Theme } from '@/constants/themes';
+import { mapError, type MappedErrorType } from '@/utils/errorMapping';
+
+interface ErrorStateViewProps {
+  /** Raw thrown value or stored error message — mapped internally. */
+  error: unknown;
+  /**
+   * Called when the user taps Retry. Retry is offered whenever this is
+   * provided, including for errors the mapper marks non-retryable: re-running
+   * a read is always safe, and the user having no way forward is the defect
+   * being fixed.
+   */
+  onRetry?: () => void;
+  retryLabel?: string;
+  /** Operation-specific wording for unmapped failures. */
+  fallbackMessage?: string;
+  /**
+   * `block` (default) is the full-height state used in place of a list's empty
+   * state; `inline` is the compact one-line notice used inside cards and as a
+   * list footer.
+   */
+  variant?: 'block' | 'inline';
+  style?: StyleProp<ViewStyle>;
+  testID?: string;
+}
+
+const ICON_BY_TYPE: Partial<
+  Record<MappedErrorType, React.ComponentProps<typeof Ionicons>['name']>
+> = {
+  offline: 'cloud-offline-outline',
+  timeout: 'time-outline',
+  rate_limited: 'hourglass-outline',
+  server_error: 'server-outline',
+  not_found: 'help-circle-outline',
+};
+
+export const ErrorStateView: React.FC<ErrorStateViewProps> = ({
+  error,
+  onRetry,
+  retryLabel = 'Retry',
+  fallbackMessage,
+  variant = 'block',
+  style,
+  testID,
+}) => {
+  const styles = useThemedStyles(createStyles);
+  const { theme } = useTheme();
+
+  const mapped = useMemo(
+    () => mapError(error, { fallbackMessage }),
+    [error, fallbackMessage]
+  );
+
+  const iconName = ICON_BY_TYPE[mapped.type] ?? 'alert-circle-outline';
+  const isInline = variant === 'inline';
+
+  return (
+    <View
+      style={[isInline ? styles.inlineContainer : styles.container, style]}
+      accessibilityRole="alert"
+      testID={testID}
+    >
+      <Ionicons
+        name={iconName}
+        size={isInline ? 18 : 44}
+        color={theme.colors.error}
+      />
+      <View style={isInline ? styles.inlineTextGroup : styles.textGroup}>
+        <Text style={isInline ? styles.inlineMessage : styles.message}>
+          {mapped.message}
+        </Text>
+        {!isInline && !!mapped.userAction && (
+          <Text style={styles.action}>{mapped.userAction}</Text>
+        )}
+      </View>
+      {!!onRetry && (
+        <Pressable
+          onPress={onRetry}
+          style={({ pressed }) => [
+            isInline ? styles.inlineRetryButton : styles.retryButton,
+            pressed && styles.retryButtonPressed,
+          ]}
+          accessibilityRole="button"
+          accessibilityLabel={retryLabel}
+          testID={testID ? `${testID}-retry` : undefined}
+        >
+          <Ionicons name="refresh" size={16} color={theme.colors.primary} />
+          <Text style={styles.retryText}>{retryLabel}</Text>
+        </Pressable>
+      )}
+    </View>
+  );
+};
+
+const createStyles = (theme: Theme) =>
+  StyleSheet.create({
+    container: {
+      alignItems: 'center',
+      justifyContent: 'center',
+      paddingVertical: theme.spacing.xl,
+      paddingHorizontal: theme.spacing.lg,
+      gap: theme.spacing.sm,
+    },
+    inlineContainer: {
+      flexDirection: 'row',
+      alignItems: 'center',
+      paddingVertical: theme.spacing.sm,
+      paddingHorizontal: theme.spacing.sm,
+      borderRadius: theme.borderRadius.md,
+      backgroundColor: theme.colors.errorLight,
+      gap: theme.spacing.sm,
+    },
+    textGroup: {
+      alignItems: 'center',
+      gap: theme.spacing.xs,
+    },
+    inlineTextGroup: {
+      flex: 1,
+    },
+    message: {
+      fontSize: 16,
+      fontWeight: '600',
+      color: theme.colors.text,
+      textAlign: 'center',
+    },
+    inlineMessage: {
+      fontSize: 13,
+      color: theme.colors.text,
+    },
+    action: {
+      fontSize: 14,
+      color: theme.colors.textMuted,
+      textAlign: 'center',
+      lineHeight: 20,
+    },
+    retryButton: {
+      flexDirection: 'row',
+      alignItems: 'center',
+      gap: theme.spacing.xs,
+      marginTop: theme.spacing.xs,
+      paddingVertical: theme.spacing.sm,
+      paddingHorizontal: theme.spacing.lg,
+      borderRadius: theme.borderRadius.md,
+      borderWidth: 1,
+      borderColor: theme.colors.primary,
+    },
+    inlineRetryButton: {
+      flexDirection: 'row',
+      alignItems: 'center',
+      gap: theme.spacing.xs,
+      paddingVertical: theme.spacing.xs,
+      paddingHorizontal: theme.spacing.sm,
+      borderRadius: theme.borderRadius.sm,
+      borderWidth: 1,
+      borderColor: theme.colors.primary,
+    },
+    retryButtonPressed: {
+      opacity: 0.6,
+    },
+    retryText: {
+      fontSize: 14,
+      fontWeight: '600',
+      color: theme.colors.primary,
+    },
+  });
+
+export default ErrorStateView;

--- a/src/components/common/OfflineBanner.tsx
+++ b/src/components/common/OfflineBanner.tsx
@@ -1,0 +1,105 @@
+/**
+ * OfflineBanner — app-wide passive offline indicator (TASK-40 / R-03).
+ *
+ * Before this, `@react-native-community/netinfo` was a declared dependency that
+ * was never imported: when the device dropped connectivity the app showed stale
+ * cached balances with no signal at all, and pull-to-refresh silently did
+ * nothing. This is the single passive surface for that state.
+ *
+ * MOUNT POINT — mounted at the App root (`App.tsx`), above `NavigationContainer`,
+ * so it survives every navigation and covers auth/onboarding screens too.
+ * `AuthProvider` sits BELOW that point (`AppNavigator`), so a root-level banner
+ * cannot read auth state — which is fine and deliberate here: connectivity is
+ * orthogonal to whether the user is unlocked, and the banner consumes no wallet
+ * or auth state whatsoever. (PLAN-12 records this caveat; the alternative —
+ * moving the banner inside `AppNavigator` — would buy access to state this
+ * component does not want and lose coverage of the pre-auth screens.)
+ *
+ * SAFE AREA — there is no `SafeAreaProvider` at the App root (each navigator
+ * creates its own via React Navigation's `SafeAreaProviderCompat`), so
+ * `useSafeAreaInsets()` is unavailable here. Rather than restructure the
+ * provider tree app-wide for one bar, this reads the static
+ * `initialWindowMetrics` captured at launch — the exact fallback
+ * `SafeAreaProviderCompat` itself uses. The app is portrait-locked
+ * (`app.config.js`), so these insets do not change at runtime.
+ */
+
+import React from 'react';
+import { Platform, StatusBar, StyleSheet, Text, View } from 'react-native';
+import { Ionicons } from '@expo/vector-icons';
+import Animated, { FadeInUp, FadeOutUp } from 'react-native-reanimated';
+import { initialWindowMetrics } from 'react-native-safe-area-context';
+import { useConnectivity } from '@/hooks/useConnectivity';
+import { useThemedStyles } from '@/hooks/useThemedStyles';
+import { Theme } from '@/constants/themes';
+
+/**
+ * Static top inset. `initialWindowMetrics` is null on web and in tests; the
+ * Android status bar height is the right fallback there because the app renders
+ * with a non-translucent status bar.
+ */
+const TOP_INSET =
+  initialWindowMetrics?.insets.top ??
+  (Platform.OS === 'android' ? (StatusBar.currentHeight ?? 0) : 0);
+
+export default function OfflineBanner() {
+  const { isOffline } = useConnectivity();
+  const styles = useThemedStyles(createStyles);
+
+  if (!isOffline) {
+    return null;
+  }
+
+  return (
+    <Animated.View
+      entering={FadeInUp.duration(220)}
+      exiting={FadeOutUp.duration(180)}
+      style={[styles.container, { paddingTop: TOP_INSET + 8 }]}
+      pointerEvents="none"
+      accessibilityRole="alert"
+      accessibilityLiveRegion="polite"
+      testID="offline-banner"
+    >
+      <View style={styles.row}>
+        <Ionicons
+          name="cloud-offline-outline"
+          size={16}
+          color={styles.icon.color}
+        />
+        <Text style={styles.text}>
+          You&apos;re offline — balances may be out of date
+        </Text>
+      </View>
+    </Animated.View>
+  );
+}
+
+const createStyles = (theme: Theme) =>
+  StyleSheet.create({
+    container: {
+      position: 'absolute',
+      top: 0,
+      left: 0,
+      right: 0,
+      paddingBottom: theme.spacing.sm,
+      paddingHorizontal: theme.spacing.md,
+      backgroundColor: theme.colors.warning,
+      zIndex: 1000,
+      elevation: 8,
+    },
+    row: {
+      flexDirection: 'row',
+      alignItems: 'center',
+      justifyContent: 'center',
+      gap: theme.spacing.xs,
+    },
+    icon: {
+      color: '#1C1C1E',
+    },
+    text: {
+      fontSize: 13,
+      fontWeight: '600',
+      color: '#1C1C1E',
+      textAlign: 'center',
+    },
+  });

--- a/src/components/common/__tests__/OfflineBanner.test.tsx
+++ b/src/components/common/__tests__/OfflineBanner.test.tsx
@@ -1,0 +1,113 @@
+/**
+ * OfflineBanner tests (TASK-40 / R-03).
+ *
+ * The banner is the app's only passive connectivity signal, so the two things
+ * that matter are: it appears when — and only when — the adapter reports
+ * offline, and it reacts to transitions without a remount.
+ */
+
+import React from 'react';
+import { act, render } from '@testing-library/react-native';
+
+import OfflineBanner from '../OfflineBanner';
+import type { ConnectivityState } from '@/platform';
+
+const ONLINE: ConnectivityState = {
+  isConnected: true,
+  isInternetReachable: true,
+  type: 'wifi',
+};
+const OFFLINE: ConnectivityState = {
+  isConnected: false,
+  isInternetReachable: false,
+  type: 'none',
+};
+
+let mockCurrent: ConnectivityState = ONLINE;
+let mockEmit: ((state: ConnectivityState) => void) | null = null;
+
+jest.mock('@/platform', () => ({
+  connectivity: {
+    getState: () => Promise.resolve(mockCurrent),
+    subscribe: (listener: (state: ConnectivityState) => void) => {
+      mockEmit = listener;
+      listener(mockCurrent);
+      return () => {
+        mockEmit = null;
+      };
+    },
+  },
+  isOffline: (state: ConnectivityState) =>
+    state.isInternetReachable !== null
+      ? !state.isInternetReachable
+      : !state.isConnected,
+}));
+
+jest.mock('@/contexts/ThemeContext', () => ({
+  // eslint-disable-next-line @typescript-eslint/no-require-imports
+  useTheme: () => ({ theme: require('@/constants/themes').lightTheme }),
+}));
+
+jest.mock(
+  '@expo/vector-icons',
+  () => ({
+    Ionicons: () => null,
+  }),
+  { virtual: true }
+);
+
+jest.mock('react-native-safe-area-context', () => ({
+  initialWindowMetrics: {
+    frame: { x: 0, y: 0, width: 390, height: 844 },
+    insets: { top: 47, left: 0, right: 0, bottom: 34 },
+  },
+}));
+
+beforeEach(() => {
+  mockCurrent = ONLINE;
+  mockEmit = null;
+});
+
+// The hook also primes itself with an async `getState()`; settle it so the
+// assertions run against a quiesced tree.
+const settle = () => act(async () => {});
+
+describe('OfflineBanner', () => {
+  it('renders nothing while online', async () => {
+    const { queryByTestId } = render(<OfflineBanner />);
+    await settle();
+    expect(queryByTestId('offline-banner')).toBeNull();
+  });
+
+  it('renders while offline', async () => {
+    mockCurrent = OFFLINE;
+    const { getByTestId } = render(<OfflineBanner />);
+    await settle();
+    expect(getByTestId('offline-banner')).toBeTruthy();
+  });
+
+  it('appears and disappears as connectivity changes', async () => {
+    const { queryByTestId } = render(<OfflineBanner />);
+    await settle();
+    expect(queryByTestId('offline-banner')).toBeNull();
+
+    act(() => {
+      mockEmit?.(OFFLINE);
+    });
+    expect(queryByTestId('offline-banner')).toBeTruthy();
+
+    act(() => {
+      mockEmit?.(ONLINE);
+    });
+    expect(queryByTestId('offline-banner')).toBeNull();
+  });
+
+  it('unsubscribes on unmount', async () => {
+    const { unmount } = render(<OfflineBanner />);
+    await settle();
+    expect(mockEmit).not.toBeNull();
+
+    unmount();
+    expect(mockEmit).toBeNull();
+  });
+});

--- a/src/hooks/useConnectivity.ts
+++ b/src/hooks/useConnectivity.ts
@@ -1,0 +1,64 @@
+/**
+ * useConnectivity — reactive connectivity state for the UI (TASK-40 / R-03).
+ *
+ * Reads through the platform `ConnectivityAdapter` (PLAN-12 DR-7) so the same
+ * hook works on mobile (NetInfo) and on the extension/web target
+ * (`navigator.onLine`) without either target importing the other's module.
+ *
+ * This is a passive observer only: it never gates or cancels a fetch. Gating
+ * network work on offline state is TASK-191, which depends on this adapter.
+ */
+
+import { useEffect, useState } from 'react';
+import { connectivity, isOffline as computeIsOffline } from '@/platform';
+import type { ConnectivityState } from '@/platform';
+
+/**
+ * Optimistic default. Assuming online until the adapter reports otherwise
+ * avoids flashing an offline banner during the first frames of a cold boot,
+ * before NetInfo's first probe has settled.
+ */
+const ASSUMED_ONLINE: ConnectivityState = {
+  isConnected: true,
+  isInternetReachable: null,
+  type: 'unknown',
+};
+
+export interface Connectivity extends ConnectivityState {
+  /** True when the device cannot reach the network. */
+  isOffline: boolean;
+}
+
+export function useConnectivity(): Connectivity {
+  const [state, setState] = useState<ConnectivityState>(ASSUMED_ONLINE);
+
+  useEffect(() => {
+    let active = true;
+
+    // Both adapters emit the current state on subscribe, but subscribing can
+    // fail on platforms without the underlying API; the explicit fetch keeps a
+    // first value flowing in that case.
+    const unsubscribe = connectivity.subscribe((next) => {
+      if (active) setState(next);
+    });
+
+    connectivity
+      .getState()
+      .then((next) => {
+        if (active) setState(next);
+      })
+      .catch(() => {
+        // Unable to determine connectivity — stay optimistic rather than
+        // claiming the user is offline.
+      });
+
+    return () => {
+      active = false;
+      unsubscribe();
+    };
+  }, []);
+
+  return { ...state, isOffline: computeIsOffline(state) };
+}
+
+export default useConnectivity;

--- a/src/platform/__tests__/connectivity.test.ts
+++ b/src/platform/__tests__/connectivity.test.ts
@@ -1,0 +1,250 @@
+/**
+ * ConnectivityAdapter tests (TASK-40 / PLAN-12 DR-7).
+ *
+ * The adapter exists so NetInfo — a NATIVE module — never reaches the
+ * extension/web bundle. These tests cover both implementations plus the shared
+ * `isOffline()` predicate that decides what "offline" means on both targets.
+ */
+
+import { ExtensionConnectivityAdapter } from '../extension/connectivity';
+import { isOffline } from '../index';
+import type { ConnectivityState } from '../types';
+
+describe('isOffline', () => {
+  const base: ConnectivityState = {
+    isConnected: true,
+    isInternetReachable: null,
+    type: 'wifi',
+  };
+
+  it('is offline when no interface is up', () => {
+    expect(isOffline({ ...base, isConnected: false })).toBe(true);
+  });
+
+  it('is offline when the interface is up but the internet is unreachable', () => {
+    // The captive-portal / dead-uplink case: NetInfo reports a connected
+    // interface, but nothing is actually reachable.
+    expect(isOffline({ ...base, isInternetReachable: false })).toBe(true);
+  });
+
+  it('is online when reachability is unknown but an interface is up', () => {
+    // `null` = "cannot determine". Treating it as offline would flash the
+    // banner on every cold boot and on every browser (which can never answer).
+    expect(isOffline({ ...base, isInternetReachable: null })).toBe(false);
+  });
+
+  it('is online when reachability is confirmed', () => {
+    expect(isOffline({ ...base, isInternetReachable: true })).toBe(false);
+  });
+
+  it('lets confirmed reachability win over a stale interface flag', () => {
+    // Contradictory but observable during a transport switch; if the internet
+    // is demonstrably reachable, the user is not offline.
+    expect(
+      isOffline({ ...base, isConnected: false, isInternetReachable: true })
+    ).toBe(false);
+  });
+});
+
+describe('ExtensionConnectivityAdapter', () => {
+  // The jest-expo (react-native) environment has no DOM window/navigator, so
+  // stand up a minimal browser shim. That is also the honest shape of what the
+  // extension target actually provides.
+  const listeners: Record<string, ((e: unknown) => void)[]> = {};
+  let originalWindow: unknown;
+  let originalNavigator: unknown;
+
+  const setOnLine = (value: boolean) => {
+    (globalThis as any).navigator.onLine = value;
+  };
+
+  const dispatch = (type: 'online' | 'offline') => {
+    (listeners[type] ?? []).forEach((fn) => fn({ type }));
+  };
+
+  beforeEach(() => {
+    for (const key of Object.keys(listeners)) delete listeners[key];
+    originalWindow = (globalThis as any).window;
+    originalNavigator = (globalThis as any).navigator;
+
+    (globalThis as any).navigator = { onLine: true };
+    (globalThis as any).window = {
+      addEventListener: (type: string, fn: (e: unknown) => void) => {
+        (listeners[type] ??= []).push(fn);
+      },
+      removeEventListener: (type: string, fn: (e: unknown) => void) => {
+        listeners[type] = (listeners[type] ?? []).filter((f) => f !== fn);
+      },
+    };
+  });
+
+  afterEach(() => {
+    (globalThis as any).window = originalWindow;
+    (globalThis as any).navigator = originalNavigator;
+  });
+
+  it('reads navigator.onLine', async () => {
+    const adapter = new ExtensionConnectivityAdapter();
+
+    setOnLine(true);
+    await expect(adapter.getState()).resolves.toEqual({
+      isConnected: true,
+      isInternetReachable: null,
+      type: 'unknown',
+    });
+
+    setOnLine(false);
+    await expect(adapter.getState()).resolves.toEqual({
+      isConnected: false,
+      isInternetReachable: null,
+      type: 'none',
+    });
+  });
+
+  it('never claims to know internet reachability', async () => {
+    // `navigator.onLine` cannot answer this; guessing would produce a false
+    // "you are offline" on any network with a working interface.
+    setOnLine(true);
+    const state = await new ExtensionConnectivityAdapter().getState();
+    expect(state.isInternetReachable).toBeNull();
+  });
+
+  it('assumes online when navigator is unavailable', async () => {
+    // Service-worker startup / SSR: unknown must not read as offline.
+    (globalThis as any).navigator = undefined;
+    await expect(
+      new ExtensionConnectivityAdapter().getState()
+    ).resolves.toEqual({
+      isConnected: true,
+      isInternetReachable: null,
+      type: 'unknown',
+    });
+  });
+
+  it('emits the current state on subscribe and on every transition', () => {
+    setOnLine(true);
+    const adapter = new ExtensionConnectivityAdapter();
+    const listener = jest.fn();
+
+    const unsubscribe = adapter.subscribe(listener);
+
+    // Primed immediately, matching the mobile adapter's contract.
+    expect(listener).toHaveBeenCalledTimes(1);
+    expect(listener).toHaveBeenLastCalledWith(
+      expect.objectContaining({ isConnected: true })
+    );
+
+    setOnLine(false);
+    dispatch('offline');
+    expect(listener).toHaveBeenLastCalledWith(
+      expect.objectContaining({ isConnected: false, type: 'none' })
+    );
+
+    setOnLine(true);
+    dispatch('online');
+    expect(listener).toHaveBeenLastCalledWith(
+      expect.objectContaining({ isConnected: true })
+    );
+
+    unsubscribe();
+  });
+
+  it('stops emitting after unsubscribe, and unsubscribing twice is safe', () => {
+    setOnLine(true);
+    const adapter = new ExtensionConnectivityAdapter();
+    const listener = jest.fn();
+
+    const unsubscribe = adapter.subscribe(listener);
+    listener.mockClear();
+
+    unsubscribe();
+    unsubscribe();
+
+    setOnLine(false);
+    dispatch('offline');
+    expect(listener).not.toHaveBeenCalled();
+  });
+
+  it('is a no-op subscription when there is no window to listen on', () => {
+    (globalThis as any).window = undefined;
+    const unsubscribe = new ExtensionConnectivityAdapter().subscribe(jest.fn());
+    expect(() => unsubscribe()).not.toThrow();
+  });
+});
+
+describe('MobileConnectivityAdapter', () => {
+  const addEventListener = jest.fn();
+  const fetchState = jest.fn();
+
+  beforeEach(() => {
+    jest.resetModules();
+    addEventListener.mockReset();
+    fetchState.mockReset();
+    jest.doMock('@react-native-community/netinfo', () => ({
+      __esModule: true,
+      default: { addEventListener, fetch: fetchState },
+    }));
+  });
+
+  afterEach(() => {
+    jest.dontMock('@react-native-community/netinfo');
+  });
+
+  const loadAdapter = () => {
+    // eslint-disable-next-line @typescript-eslint/no-require-imports
+    const { MobileConnectivityAdapter } = require('../mobile/connectivity');
+    return new MobileConnectivityAdapter();
+  };
+
+  it('normalizes a NetInfo snapshot', async () => {
+    fetchState.mockResolvedValue({
+      isConnected: false,
+      isInternetReachable: false,
+      type: 'none',
+    });
+
+    await expect(loadAdapter().getState()).resolves.toEqual({
+      isConnected: false,
+      isInternetReachable: false,
+      type: 'none',
+    });
+  });
+
+  it('treats an undetermined isConnected as connected', async () => {
+    // NetInfo reports null before its first probe settles; reporting that as
+    // offline would flash the banner on every cold boot.
+    fetchState.mockResolvedValue({
+      isConnected: null,
+      isInternetReachable: null,
+      type: 'unknown',
+    });
+
+    await expect(loadAdapter().getState()).resolves.toEqual({
+      isConnected: true,
+      isInternetReachable: null,
+      type: 'unknown',
+    });
+  });
+
+  it('forwards normalized states to subscribers and unsubscribes once', () => {
+    const netInfoUnsubscribe = jest.fn();
+    addEventListener.mockReturnValue(netInfoUnsubscribe);
+
+    const adapter = loadAdapter();
+    const listener = jest.fn();
+    const unsubscribe = adapter.subscribe(listener);
+
+    const emit = addEventListener.mock.calls[0][0];
+    emit({ isConnected: true, isInternetReachable: false, type: 'wifi' });
+
+    expect(listener).toHaveBeenCalledWith({
+      isConnected: true,
+      isInternetReachable: false,
+      type: 'wifi',
+    });
+
+    unsubscribe();
+    unsubscribe();
+    expect(netInfoUnsubscribe).toHaveBeenCalledTimes(1);
+  });
+});

--- a/src/platform/extension/connectivity.ts
+++ b/src/platform/extension/connectivity.ts
@@ -1,0 +1,69 @@
+/**
+ * Extension/Web Connectivity Adapter
+ *
+ * Uses the browser `navigator.onLine` flag plus the `online`/`offline` window
+ * events. This is deliberately NOT NetInfo: NetInfo is a native module and must
+ * not reach the extension/web bundle (PLAN-12 DR-7).
+ *
+ * `navigator.onLine` only reports whether a network interface is up — it cannot
+ * tell whether the internet is actually reachable — so `isInternetReachable` is
+ * always reported as `null` (unknown) rather than guessed.
+ */
+
+import type { ConnectivityAdapter, ConnectivityState } from '../types';
+
+const UNKNOWN_ONLINE: ConnectivityState = {
+  isConnected: true,
+  isInternetReachable: null,
+  type: 'unknown',
+};
+
+function readNavigatorState(): ConnectivityState {
+  // Environments without `navigator` (service worker startup, SSR, tests)
+  // cannot answer, so assume online rather than falsely reporting offline.
+  if (
+    typeof navigator === 'undefined' ||
+    typeof navigator.onLine !== 'boolean'
+  ) {
+    return UNKNOWN_ONLINE;
+  }
+
+  const online = navigator.onLine;
+  return {
+    isConnected: online,
+    isInternetReachable: null,
+    type: online ? 'unknown' : 'none',
+  };
+}
+
+export class ExtensionConnectivityAdapter implements ConnectivityAdapter {
+  async getState(): Promise<ConnectivityState> {
+    return readNavigatorState();
+  }
+
+  subscribe(listener: (state: ConnectivityState) => void): () => void {
+    if (typeof window === 'undefined' || !window.addEventListener) {
+      return () => {};
+    }
+
+    const emit = () => listener(readNavigatorState());
+
+    window.addEventListener('online', emit);
+    window.addEventListener('offline', emit);
+
+    // Match the mobile adapter: deliver the current state on subscribe so
+    // consumers have a value without a separate priming fetch.
+    emit();
+
+    let released = false;
+    return () => {
+      if (released) return;
+      released = true;
+      window.removeEventListener('online', emit);
+      window.removeEventListener('offline', emit);
+    };
+  }
+}
+
+// Singleton instance
+export const extensionConnectivity = new ExtensionConnectivityAdapter();

--- a/src/platform/extension/index.ts
+++ b/src/platform/extension/index.ts
@@ -13,3 +13,7 @@ export { ExtensionBiometricAdapter, extensionBiometrics } from './biometrics';
 export { ExtensionDeviceIdAdapter, extensionDeviceId } from './deviceId';
 export { ExtensionClipboardAdapter, extensionClipboard } from './clipboard';
 export { ExtensionAlertAdapter, extensionAlert } from './alert';
+export {
+  ExtensionConnectivityAdapter,
+  extensionConnectivity,
+} from './connectivity';

--- a/src/platform/index.ts
+++ b/src/platform/index.ts
@@ -23,6 +23,8 @@ import type {
   DeviceIdAdapter,
   ClipboardAdapter,
   AlertAdapter,
+  ConnectivityAdapter,
+  ConnectivityState,
 } from './types';
 
 export * from './types';
@@ -36,6 +38,7 @@ let _biometrics: BiometricAdapter | null = null;
 let _deviceId: DeviceIdAdapter | null = null;
 let _clipboard: ClipboardAdapter | null = null;
 let _alert: AlertAdapter | null = null;
+let _connectivity: ConnectivityAdapter | null = null;
 
 /**
  * Get the crypto adapter for the current platform
@@ -147,6 +150,26 @@ export function getAlert(): AlertAdapter {
     }
   }
   return _alert!;
+}
+
+/**
+ * Get the connectivity adapter for the current platform
+ *
+ * Mobile resolves to NetInfo (a native module); extension/web resolves to the
+ * browser `navigator.onLine` implementation, so the native module never enters
+ * the web bundle (PLAN-12 DR-7).
+ */
+export function getConnectivity(): ConnectivityAdapter {
+  if (!_connectivity) {
+    if (isMobile()) {
+      const { mobileConnectivity } = require('./mobile/connectivity');
+      _connectivity = mobileConnectivity;
+    } else {
+      const { extensionConnectivity } = require('./extension/connectivity');
+      _connectivity = extensionConnectivity;
+    }
+  }
+  return _connectivity!;
 }
 
 // Convenience exports for direct access (use getter functions for lazy loading)
@@ -282,6 +305,28 @@ export const alert = {
 };
 
 /**
+ * Platform-specific connectivity
+ */
+export const connectivity = {
+  getState: (): Promise<ConnectivityState> => getConnectivity().getState(),
+  subscribe: (listener: (state: ConnectivityState) => void): (() => void) =>
+    getConnectivity().subscribe(listener),
+};
+
+/**
+ * True when the snapshot means "the user cannot reach the network".
+ *
+ * `isInternetReachable` is authoritative when the platform can answer it;
+ * `null` (unknown — NetInfo before its first probe, or any browser) falls back
+ * to the interface flag. Kept here rather than in each consumer so the mobile
+ * and extension targets agree on what "offline" means.
+ */
+export function isOffline(state: ConnectivityState): boolean {
+  if (state.isInternetReachable !== null) return !state.isInternetReachable;
+  return !state.isConnected;
+}
+
+/**
  * Reset all cached adapters (for testing)
  */
 export function resetAdapters(): void {
@@ -292,4 +337,5 @@ export function resetAdapters(): void {
   _deviceId = null;
   _clipboard = null;
   _alert = null;
+  _connectivity = null;
 }

--- a/src/platform/mobile/connectivity.ts
+++ b/src/platform/mobile/connectivity.ts
@@ -1,0 +1,52 @@
+/**
+ * Mobile Connectivity Adapter
+ *
+ * Wraps `@react-native-community/netinfo`, which is a NATIVE module. It is
+ * deliberately reachable only through the platform adapter (`@/platform`) —
+ * importing it directly from shared code would pull the native module into the
+ * extension/web bundle (PLAN-12 DR-7).
+ *
+ * OTA-safe (PLAN-12 DR-8): `react-native-netinfo (11.4.1)` is already in
+ * `ios/Podfile.lock`, so the native module is present in shipped binaries and
+ * adding this import is a JS-only change.
+ */
+
+import NetInfo, { type NetInfoState } from '@react-native-community/netinfo';
+import type { ConnectivityAdapter, ConnectivityState } from '../types';
+
+function toConnectivityState(state: NetInfoState): ConnectivityState {
+  return {
+    // NetInfo types `isConnected` as `boolean | null` — null means "not yet
+    // determined". Treating that as offline would flash the banner on every
+    // cold boot, so an undetermined interface is optimistically "connected"
+    // and the reachability field carries the uncertainty instead.
+    isConnected: state.isConnected ?? true,
+    isInternetReachable: state.isInternetReachable ?? null,
+    type: state.type ?? 'unknown',
+  };
+}
+
+export class MobileConnectivityAdapter implements ConnectivityAdapter {
+  async getState(): Promise<ConnectivityState> {
+    const state = await NetInfo.fetch();
+    return toConnectivityState(state);
+  }
+
+  subscribe(listener: (state: ConnectivityState) => void): () => void {
+    // NetInfo emits the current state immediately on subscribe, so callers do
+    // not need a separate priming fetch.
+    const unsubscribe = NetInfo.addEventListener((state) => {
+      listener(toConnectivityState(state));
+    });
+
+    let released = false;
+    return () => {
+      if (released) return;
+      released = true;
+      unsubscribe();
+    };
+  }
+}
+
+// Singleton instance
+export const mobileConnectivity = new MobileConnectivityAdapter();

--- a/src/platform/mobile/index.ts
+++ b/src/platform/mobile/index.ts
@@ -13,3 +13,4 @@ export { MobileBiometricAdapter, mobileBiometrics } from './biometrics';
 export { MobileDeviceIdAdapter, mobileDeviceId } from './deviceId';
 export { MobileClipboardAdapter, mobileClipboard } from './clipboard';
 export { MobileAlertAdapter, mobileAlert } from './alert';
+export { MobileConnectivityAdapter, mobileConnectivity } from './connectivity';

--- a/src/platform/types.ts
+++ b/src/platform/types.ts
@@ -170,6 +170,41 @@ export interface AlertAdapter {
   alert(title: string, message?: string): void;
 }
 
+// Connectivity Adapter Interface
+/**
+ * Normalized connectivity snapshot.
+ *
+ * The two platform sources report different things, so the shape is the
+ * intersection of what both can honestly answer:
+ *  - mobile (`@react-native-community/netinfo`) knows both whether an
+ *    interface is up AND whether the internet is actually reachable;
+ *  - extension/web (`navigator.onLine`) only knows whether an interface is up.
+ */
+export interface ConnectivityState {
+  /** A network interface is up. Does NOT imply the internet is reachable. */
+  isConnected: boolean;
+  /**
+   * Whether the internet is actually reachable, or `null` when the platform
+   * cannot determine it. NetInfo reports `null` until its first reachability
+   * probe settles; `navigator.onLine` can never answer this, so the
+   * extension/web adapter always reports `null` rather than guessing.
+   */
+  isInternetReachable: boolean | null;
+  /** Coarse transport label, e.g. 'wifi' | 'cellular' | 'none' | 'unknown'. */
+  type: string;
+}
+
+export interface ConnectivityAdapter {
+  /** Read the current connectivity snapshot. */
+  getState(): Promise<ConnectivityState>;
+  /**
+   * Subscribe to connectivity changes. Returns an unsubscribe function.
+   * Implementations must invoke the listener on every transition, and must
+   * tolerate being unsubscribed more than once.
+   */
+  subscribe(listener: (state: ConnectivityState) => void): () => void;
+}
+
 // Platform capabilities check
 export interface PlatformCapabilities {
   hasBiometrics: boolean;

--- a/src/screens/wallet/AssetDetailScreen.tsx
+++ b/src/screens/wallet/AssetDetailScreen.tsx
@@ -214,6 +214,11 @@ export default function AssetDetailScreen() {
   // slot; without it a failure rendered as an empty list (TASK-40 / U-03).
   const [networkTransactionsError, setNetworkTransactionsError] =
     useState<unknown>(null);
+  // Distinguishes "this screen has not fetched yet" from "this asset has no
+  // activity". The scope gate below starts the list empty, and the store only
+  // flips `isTransactionsLoading` after an await, so without this the
+  // definitive empty state would flash before the fetch even registers.
+  const [hasAttemptedLoad, setHasAttemptedLoad] = useState(false);
 
   useEffect(() => {
     if (!networkId) {
@@ -430,6 +435,9 @@ export default function AssetDetailScreen() {
     } catch (error) {
       console.error('Failed to load transactions:', error);
       setNetworkTransactionsError(error);
+    } finally {
+      // Always set, even on failure, so a spinner can never wedge.
+      setHasAttemptedLoad(true);
     }
   }, [
     accountId,
@@ -867,9 +875,11 @@ export default function AssetDetailScreen() {
 
   // `isLoadingNetworkTransactions` was another write-only flag; it is what
   // distinguishes "still fetching" from "nothing to show" on the networkId path.
-  const isLoadingTransactions = networkId
-    ? isLoadingNetworkTransactions
-    : accountState.isTransactionsLoading;
+  const isLoadingTransactions =
+    !hasAttemptedLoad ||
+    (networkId
+      ? isLoadingNetworkTransactions
+      : accountState.isTransactionsLoading);
 
   const handleLoadMore = React.useCallback(() => {
     // The store only flips `isLoadingMore` after an await, so guard on an

--- a/src/screens/wallet/AssetDetailScreen.tsx
+++ b/src/screens/wallet/AssetDetailScreen.tsx
@@ -218,7 +218,11 @@ export default function AssetDetailScreen() {
   // activity". The scope gate below starts the list empty, and the store only
   // flips `isTransactionsLoading` after an await, so without this the
   // definitive empty state would flash before the fetch even registers.
-  const [hasAttemptedLoad, setHasAttemptedLoad] = useState(false);
+  //
+  // Stored as the resource that was attempted rather than a boolean, and
+  // compared during render: resetting a boolean from an effect would leave one
+  // frame in which a newly-selected asset still looked "already loaded".
+  const [attemptedLoadKey, setAttemptedLoadKey] = useState<string | null>(null);
 
   useEffect(() => {
     if (!networkId) {
@@ -387,6 +391,10 @@ export default function AssetDetailScreen() {
     return undefined;
   }, [networkId, isMultiNetworkView, multiNetworkBalance, mappingId, assetId]);
 
+  // Identity of what this screen is currently showing.
+  const loadKey = `${accountId}|${assetId}|${networkId ?? ''}`;
+  const hasAttemptedLoad = attemptedLoadKey === loadKey;
+
   const loadTransactions = React.useCallback(async () => {
     try {
       // Determine if this is an ARC-200 token
@@ -437,7 +445,7 @@ export default function AssetDetailScreen() {
       setNetworkTransactionsError(error);
     } finally {
       // Always set, even on failure, so a spinner can never wedge.
-      setHasAttemptedLoad(true);
+      setAttemptedLoadKey(loadKey);
     }
   }, [
     accountId,
@@ -446,6 +454,7 @@ export default function AssetDetailScreen() {
     networkId,
     currentAccount,
     loadAssetTransactions,
+    loadKey,
   ]);
 
   useEffect(() => {

--- a/src/screens/wallet/AssetDetailScreen.tsx
+++ b/src/screens/wallet/AssetDetailScreen.tsx
@@ -20,6 +20,7 @@ import { TransactionInfo, AccountBalance, AssetBalance } from '@/types/wallet';
 import { MappedAsset } from '@/services/token-mapping/types';
 import { useAuth } from '@/contexts/AuthContext';
 import {
+  assetTransactionsScope,
   useWalletStore,
   useAccountState,
   useAccountBalance,
@@ -852,7 +853,7 @@ export default function AssetDetailScreen() {
       (a.assetType === 'arc200' && a.contractId === assetId)
   );
   const isArc200 = asset?.assetType === 'arc200';
-  const assetKey = `${assetId}_${isArc200 ? 'arc200' : 'asa'}`;
+  const assetKey = assetTransactionsScope(assetId, isArc200);
   const pagination = accountState.assetTransactionsPagination?.[assetKey];
 
   const handleLoadMore = React.useCallback(() => {
@@ -873,11 +874,15 @@ export default function AssetDetailScreen() {
     });
   }, [assetId, accountId, pagination, isArc200, loadMoreAssetTransactions]);
 
-  // The networkId path fetches outside the store and keeps its own error; the
-  // default path reads the account's transaction-scoped error.
+  // The networkId path fetches outside the store and keeps its own error. The
+  // default path reads the store error only when it belongs to THIS asset —
+  // the account-wide history loader writes into the same field, and rendering
+  // its failure here would blame the wrong list (TASK-40).
   const transactionsError = networkId
     ? networkTransactionsError
-    : accountState.transactionsError;
+    : accountState.transactionsError?.scope === assetKey
+      ? accountState.transactionsError.message
+      : null;
 
   // Only the store path paginates. On the networkId path the whole list is one
   // fetch, so "try again" means reloading it.

--- a/src/screens/wallet/AssetDetailScreen.tsx
+++ b/src/screens/wallet/AssetDetailScreen.tsx
@@ -47,6 +47,7 @@ import { BlurredContainer } from '@/components/common/BlurredContainer';
 import { GlassCard } from '@/components/common/GlassCard';
 import { ListEmptyState } from '@/components/common/ListEmptyState';
 import { ListFooterSpinner } from '@/components/common/ListFooterSpinner';
+import { ErrorStateView } from '@/components/common/ErrorStateView';
 import { NFTBackground } from '@/components/common/NFTBackground';
 import { useTheme } from '@/contexts/ThemeContext';
 import { SwapService } from '@/services/swap';
@@ -86,17 +87,15 @@ export default function AssetDetailScreen() {
     : currentNetworkConfig;
 
   const { updateActivity } = useAuth();
-  const loadAllTransactions = useWalletStore(
-    (state) => state.loadAllTransactions
-  );
+  // NOTE: `loadAllTransactions` / `loadMoreTransactions` used to be selected
+  // here too. They were left behind by the FlatList conversion (TASK-39) and
+  // were never called — dead store subscriptions that re-rendered the screen
+  // for nothing. This screen paginates via `loadMoreAssetTransactions`.
   const loadAssetTransactions = useWalletStore(
     (state) => state.loadAssetTransactions
   );
   const loadMoreAssetTransactions = useWalletStore(
     (state) => state.loadMoreAssetTransactions
-  );
-  const loadMoreTransactions = useWalletStore(
-    (state) => state.loadMoreTransactions
   );
   const loadMultiNetworkBalance = useWalletStore(
     (state) => state.loadMultiNetworkBalance
@@ -207,6 +206,10 @@ export default function AssetDetailScreen() {
     useState<TransactionInfo[]>([]);
   const [isLoadingNetworkTransactions, setIsLoadingNetworkTransactions] =
     useState(false);
+  // The networkId path fetches outside the store, so it needs its own error
+  // slot; without it a failure rendered as an empty list (TASK-40 / U-03).
+  const [networkTransactionsError, setNetworkTransactionsError] =
+    useState<unknown>(null);
 
   useEffect(() => {
     if (!networkId) {
@@ -375,50 +378,65 @@ export default function AssetDetailScreen() {
     return undefined;
   }, [networkId, isMultiNetworkView, multiNetworkBalance, mappingId, assetId]);
 
-  useEffect(() => {
-    const loadTransactions = async () => {
-      try {
-        // Determine if this is an ARC-200 token
-        const asset = effectiveBalance?.assets?.find(
-          (a) =>
-            a.assetId === assetId ||
-            (a.assetType === 'arc200' && a.contractId === assetId)
-        );
-        const isArc200 = asset?.assetType === 'arc200';
+  const loadTransactions = React.useCallback(async () => {
+    try {
+      // Determine if this is an ARC-200 token
+      const asset = effectiveBalance?.assets?.find(
+        (a) =>
+          a.assetId === assetId ||
+          (a.assetType === 'arc200' && a.contractId === assetId)
+      );
+      const isArc200 = asset?.assetType === 'arc200';
 
-        // If networkId is provided, fetch transactions from that specific network
-        if (networkId && currentAccount) {
-          setIsLoadingNetworkTransactions(true);
-          try {
-            const networkService = NetworkService.getInstance(
-              networkId as NetworkId
-            );
-            const result = await networkService.getAssetTransactionHistory(
-              currentAccount.address,
-              assetId,
-              isArc200
-            );
-            setNetworkSpecificTransactions(
-              dedupeTransactions(result.transactions)
-            );
-          } catch (error) {
-            console.error(
-              `Failed to load transactions from ${networkId}:`,
-              error
-            );
-            setNetworkSpecificTransactions([]);
-          } finally {
-            setIsLoadingNetworkTransactions(false);
-          }
-        } else {
-          // Use wallet store for current network
-          await loadAssetTransactions(accountId, assetId, isArc200);
+      // If networkId is provided, fetch transactions from that specific network
+      if (networkId && currentAccount) {
+        setIsLoadingNetworkTransactions(true);
+        setNetworkTransactionsError(null);
+        try {
+          const networkService = NetworkService.getInstance(
+            networkId as NetworkId
+          );
+          const result = await networkService.getAssetTransactionHistory(
+            currentAccount.address,
+            assetId,
+            isArc200
+          );
+          setNetworkSpecificTransactions(
+            dedupeTransactions(result.transactions)
+          );
+          setNetworkTransactionsError(null);
+        } catch (error) {
+          console.error(
+            `Failed to load transactions from ${networkId}:`,
+            error
+          );
+          // Clear the list: this path also runs on a network switch, and
+          // leaving the previous network's rows up would attribute them to the
+          // wrong chain. The error state (not the empty state) is what renders
+          // for the now-empty list, so the failure is still explicit.
+          setNetworkSpecificTransactions([]);
+          setNetworkTransactionsError(error);
+        } finally {
+          setIsLoadingNetworkTransactions(false);
         }
-      } catch (error) {
-        console.error('Failed to load transactions:', error);
+      } else {
+        // Use wallet store for current network (records its own error)
+        await loadAssetTransactions(accountId, assetId, isArc200);
       }
-    };
+    } catch (error) {
+      console.error('Failed to load transactions:', error);
+      setNetworkTransactionsError(error);
+    }
+  }, [
+    accountId,
+    assetId,
+    effectiveBalance,
+    networkId,
+    currentAccount,
+    loadAssetTransactions,
+  ]);
 
+  useEffect(() => {
     loadTransactions();
     updateActivity();
     // eslint-disable-next-line react-hooks/exhaustive-deps
@@ -460,11 +478,13 @@ export default function AssetDetailScreen() {
             setNetworkSpecificTransactions(
               dedupeTransactions(result.transactions)
             );
+            setNetworkTransactionsError(null);
           } catch (error) {
             console.error(
               `Failed to refresh transactions from ${networkId}:`,
               error
             );
+            setNetworkTransactionsError(error);
           }
         })()
       );
@@ -853,6 +873,22 @@ export default function AssetDetailScreen() {
     });
   }, [assetId, accountId, pagination, isArc200, loadMoreAssetTransactions]);
 
+  // The networkId path fetches outside the store and keeps its own error; the
+  // default path reads the account's transaction-scoped error.
+  const transactionsError = networkId
+    ? networkTransactionsError
+    : accountState.transactionsError;
+
+  // Only the store path paginates. On the networkId path the whole list is one
+  // fetch, so "try again" means reloading it.
+  const retryMoreTransactions = React.useCallback(() => {
+    if (networkId) {
+      void loadTransactions();
+    } else {
+      handleLoadMore();
+    }
+  }, [networkId, loadTransactions, handleLoadMore]);
+
   // Index-suffixed for the same reason as TransactionHistoryScreen: indexer
   // payloads can repeat an id, and duplicate keys drop rows from a FlatList.
   const keyExtractor = React.useCallback(
@@ -1207,26 +1243,59 @@ export default function AssetDetailScreen() {
   // All assets now use assetTransactionsPagination (including native VOI).
   // Memoized: an unstable component identity makes VirtualizedList remount the
   // footer/empty subtree on every render.
-  const renderListFooter = React.useCallback(
-    () => (
+  const renderListFooter = React.useCallback(() => {
+    // A failed next page used to end pagination silently.
+    if (transactionsError && filteredTransactions.length > 0) {
+      return (
+        <ErrorStateView
+          variant="inline"
+          error={transactionsError}
+          fallbackMessage="Couldn't load more transactions."
+          onRetry={retryMoreTransactions}
+          style={styles.transactionsFooterError}
+          testID="asset-transactions-footer-error"
+        />
+      );
+    }
+
+    return (
       <ListFooterSpinner
         visible={!!pagination?.hasMore && !!pagination?.isLoadingMore}
       />
-    ),
-    [pagination?.hasMore, pagination?.isLoadingMore]
-  );
+    );
+  }, [
+    pagination?.hasMore,
+    pagination?.isLoadingMore,
+    transactionsError,
+    filteredTransactions.length,
+    retryMoreTransactions,
+    styles.transactionsFooterError,
+  ]);
 
-  const renderListEmpty = React.useCallback(
-    () => (
+  // Never render the "no transactions yet" empty state for a FAILED fetch —
+  // it is indistinguishable from an asset with no activity (TASK-40 / U-03).
+  const renderListEmpty = React.useCallback(() => {
+    if (transactionsError) {
+      return (
+        <ErrorStateView
+          error={transactionsError}
+          fallbackMessage="Couldn't load transactions for this asset."
+          onRetry={loadTransactions}
+          style={styles.emptyTransactions}
+          testID="asset-transactions-error"
+        />
+      );
+    }
+
+    return (
       <ListEmptyState
         icon="receipt-outline"
         title="No transactions yet"
         subtitle="Transactions for this asset will appear here when they occur."
         style={styles.emptyTransactions}
       />
-    ),
-    [styles.emptyTransactions]
-  );
+    );
+  }, [transactionsError, loadTransactions, styles.emptyTransactions]);
 
   return (
     <NFTBackground>
@@ -1449,6 +1518,9 @@ const createStyles = (theme: Theme) =>
     },
     emptyTransactions: {
       paddingVertical: theme.spacing.xl,
+    },
+    transactionsFooterError: {
+      marginVertical: theme.spacing.sm,
     },
     transactionItem: {
       padding: theme.spacing.lg,

--- a/src/screens/wallet/AssetDetailScreen.tsx
+++ b/src/screens/wallet/AssetDetailScreen.tsx
@@ -64,6 +64,9 @@ interface AssetDetailRouteParams {
   networkId?: string; // Optional network filter for multi-network context
 }
 
+// Stable empty reference so a scope mismatch does not churn list identity.
+const EMPTY_TRANSACTIONS: TransactionInfo[] = [];
+
 export default function AssetDetailScreen() {
   const styles = useThemedStyles(createStyles);
   const themeColors = useThemeColors();
@@ -709,16 +712,22 @@ export default function AssetDetailScreen() {
     return formatCurrency(usdValue);
   };
 
-  const getFilteredTransactions = () => {
+  const getFilteredTransactions = (scope: string) => {
     // If viewing a specific network, use network-specific transactions
     if (networkId) {
       return networkSpecificTransactions;
     }
 
-    // Otherwise use transactions from wallet store
+    // Otherwise use transactions from wallet store. The store keeps ONE array
+    // shared with the account-wide history, so only read it while it actually
+    // holds THIS asset's transactions — otherwise Home's account-wide history
+    // would render here as if it were the asset's, and a failed asset fetch
+    // would look like a partially-successful one (TASK-40).
     // Transactions are already filtered by the NetworkService at the API level
-    // No client-side filtering needed anymore
-    return accountState.recentTransactions || [];
+    // when the scope matches, so no client-side filtering is needed.
+    return accountState.recentTransactionsScope === scope
+      ? accountState.recentTransactions || []
+      : EMPTY_TRANSACTIONS;
   };
 
   const handleOptOut = async () => {
@@ -845,8 +854,6 @@ export default function AssetDetailScreen() {
     return false;
   };
 
-  const filteredTransactions = getFilteredTransactions();
-
   const asset = effectiveBalance?.assets?.find(
     (a) =>
       a.assetId === assetId ||
@@ -855,6 +862,14 @@ export default function AssetDetailScreen() {
   const isArc200 = asset?.assetType === 'arc200';
   const assetKey = assetTransactionsScope(assetId, isArc200);
   const pagination = accountState.assetTransactionsPagination?.[assetKey];
+
+  const filteredTransactions = getFilteredTransactions(assetKey);
+
+  // `isLoadingNetworkTransactions` was another write-only flag; it is what
+  // distinguishes "still fetching" from "nothing to show" on the networkId path.
+  const isLoadingTransactions = networkId
+    ? isLoadingNetworkTransactions
+    : accountState.isTransactionsLoading;
 
   const handleLoadMore = React.useCallback(() => {
     // The store only flips `isLoadingMore` after an await, so guard on an
@@ -1278,7 +1293,9 @@ export default function AssetDetailScreen() {
   ]);
 
   // Never render the "no transactions yet" empty state for a FAILED fetch —
-  // it is indistinguishable from an asset with no activity (TASK-40 / U-03).
+  // it is indistinguishable from an asset with no activity (TASK-40 / U-03) —
+  // and never for an IN-FLIGHT one either, now that the list is scope-gated and
+  // starts empty until this asset's own transactions land.
   const renderListEmpty = React.useCallback(() => {
     if (transactionsError) {
       return (
@@ -1292,6 +1309,15 @@ export default function AssetDetailScreen() {
       );
     }
 
+    if (isLoadingTransactions) {
+      return (
+        <ListFooterSpinner
+          text="Loading transactions..."
+          style={styles.emptyTransactions}
+        />
+      );
+    }
+
     return (
       <ListEmptyState
         icon="receipt-outline"
@@ -1300,7 +1326,12 @@ export default function AssetDetailScreen() {
         style={styles.emptyTransactions}
       />
     );
-  }, [transactionsError, loadTransactions, styles.emptyTransactions]);
+  }, [
+    transactionsError,
+    isLoadingTransactions,
+    loadTransactions,
+    styles.emptyTransactions,
+  ]);
 
   return (
     <NFTBackground>

--- a/src/screens/wallet/HomeScreen.tsx
+++ b/src/screens/wallet/HomeScreen.tsx
@@ -266,6 +266,12 @@ export default function HomeScreen() {
   const loadMultiNetworkBalance = useWalletStore(
     (state) => state.loadMultiNetworkBalance
   );
+  // Retry must FORCE: the hook's `reload` is unforced and `loadAccountBalance`
+  // returns early on a fresh cached balance, so after a failed forced refresh
+  // (e.g. post-transaction) an unforced retry would be a silent no-op.
+  const loadAccountBalance = useWalletStore(
+    (state) => state.loadAccountBalance
+  );
   const loadTokenMappings = useWalletStore((state) => state.loadTokenMappings);
 
   // Asset filter settings - use individual hooks to avoid unnecessary re-renders
@@ -359,11 +365,17 @@ export default function HomeScreen() {
     : !!accountBalance;
   const retryBalance = React.useCallback(() => {
     if (isMultiNetworkView) {
+      // The multi-network hook's reload already forces.
       void reloadMultiNetworkBalance();
-    } else {
-      void reloadBalance();
+    } else if (activeAccount?.id) {
+      void loadAccountBalance(activeAccount.id, true);
     }
-  }, [isMultiNetworkView, reloadMultiNetworkBalance, reloadBalance]);
+  }, [
+    isMultiNetworkView,
+    reloadMultiNetworkBalance,
+    loadAccountBalance,
+    activeAccount?.id,
+  ]);
 
   // Load wallet data and mark activity once when Home mounts. Kept separate from
   // the remote-signer effect below so that the remote-signer store flipping

--- a/src/screens/wallet/HomeScreen.tsx
+++ b/src/screens/wallet/HomeScreen.tsx
@@ -82,13 +82,19 @@ import { useUpdates } from 'expo-updates';
 import OnboardingOptionsModal from '@/components/onboarding/OnboardingOptionsModal';
 import SignerModeBanner from '@/components/remoteSigner/SignerModeBanner';
 import { useAppMode, useRemoteSignerStore } from '@/store/remoteSignerStore';
+import { ErrorStateView } from '@/components/common/ErrorStateView';
+import { toErrorAlert } from '@/utils/errorMapping';
+import { useConnectivity } from '@/hooks/useConnectivity';
 
 const AnimatedPressable = Animated.createAnimatedComponent(Pressable);
 
 export default function HomeScreen() {
+  // `networkStatus` used to be written twice and read nowhere (TASK-40 / R-03).
+  // It, and the health-check failure below, now drive the network notice.
   const [networkStatus, setNetworkStatus] = useState<NetworkStatus | null>(
     null
   );
+  const [networkStatusError, setNetworkStatusError] = useState<unknown>(null);
   const [refreshing, setRefreshing] = useState(false);
   const [loading, setLoading] = useState(true);
   const [isAccountModalVisible, setIsAccountModalVisible] = useState(false);
@@ -235,6 +241,9 @@ export default function HomeScreen() {
     balance: accountBalance,
     isLoading: isBalanceLoading,
     isBackgroundRefreshing,
+    // Exposed by the store since forever but destructured by no consumer, so
+    // balance failures rendered as "no balance" (TASK-40 / U-03).
+    error: balanceError,
     reload: reloadBalance,
   } = useActiveAccountBalance();
   const {
@@ -251,6 +260,8 @@ export default function HomeScreen() {
   const {
     balance: multiNetworkBalance,
     isLoading: isMultiNetworkBalanceLoading,
+    error: multiNetworkBalanceError,
+    reload: reloadMultiNetworkBalance,
   } = useMultiNetworkBalance(activeAccount?.id || '');
   const loadMultiNetworkBalance = useWalletStore(
     (state) => state.loadMultiNetworkBalance
@@ -301,6 +312,58 @@ export default function HomeScreen() {
       assetNativeTokensFirst,
     ]
   );
+
+  // Connectivity (TASK-40). The app-wide OfflineBanner already owns the "you
+  // are offline" message, so Home only uses this to avoid stacking a redundant
+  // second notice for the same condition.
+  const { isOffline } = useConnectivity();
+
+  // The node/indexer being down while the device is online is a distinct
+  // failure from being offline, and was previously invisible: `networkStatus`
+  // was written twice and read nowhere.
+  //
+  // `fallbackMessage` carries the wording for the derived (non-thrown) cases —
+  // the mapper owns the phrasing whenever there is a real error to classify,
+  // and falls back to this sentence when there is nothing to classify.
+  const networkNotice = React.useMemo((): {
+    error: unknown;
+    fallbackMessage: string;
+  } | null => {
+    if (isOffline) return null;
+    if (networkStatusError) {
+      return {
+        error: networkStatusError,
+        fallbackMessage: "Can't reach the Voi network right now.",
+      };
+    }
+    if (!networkStatus) return null;
+    if (!networkStatus.isConnected) {
+      const message = "Can't reach the Voi network right now.";
+      return { error: message, fallbackMessage: message };
+    }
+    if (!networkStatus.indexerHealth) {
+      const message =
+        'The transaction indexer is unavailable, so balances and history may be out of date.';
+      return { error: message, fallbackMessage: message };
+    }
+    return null;
+  }, [isOffline, networkStatus, networkStatusError]);
+
+  // The balance card and assets card render different sources depending on view
+  // mode, so resolve which error / data / retry applies to what is on screen.
+  const activeBalanceError = isMultiNetworkView
+    ? multiNetworkBalanceError
+    : balanceError;
+  const hasBalanceData = isMultiNetworkView
+    ? !!multiNetworkBalance
+    : !!accountBalance;
+  const retryBalance = React.useCallback(() => {
+    if (isMultiNetworkView) {
+      void reloadMultiNetworkBalance();
+    } else {
+      void reloadBalance();
+    }
+  }, [isMultiNetworkView, reloadMultiNetworkBalance, reloadBalance]);
 
   // Load wallet data and mark activity once when Home mounts. Kept separate from
   // the remote-signer effect below so that the remote-signer store flipping
@@ -385,10 +448,17 @@ export default function HomeScreen() {
               activeAccountIdRef.current === accountId
             ) {
               setNetworkStatus(status);
+              setNetworkStatusError(null);
             }
           })
           .catch((error) => {
             console.warn('[HomeScreen] Network health check failed:', error);
+            if (
+              viewModeRef.current === currentViewMode &&
+              activeAccountIdRef.current === accountId
+            ) {
+              setNetworkStatusError(error);
+            }
           });
 
         // Check if view mode or account changed while loading
@@ -442,7 +512,16 @@ export default function HomeScreen() {
           networkHealthPromise,
         ]);
       } catch (error) {
+        // The store loaders record their own per-account error, so this outer
+        // catch only ever sees failures outside them (e.g. loadTokenMappings).
+        // It used to be console-only; surface it so the screen is never silent.
         console.error('Failed to load account data:', error);
+        if (
+          viewModeRef.current === currentViewMode &&
+          activeAccountIdRef.current === accountId
+        ) {
+          setNetworkStatusError(error);
+        }
       }
     };
 
@@ -891,7 +970,13 @@ export default function HomeScreen() {
       await initialize();
     } catch (error) {
       console.error('Failed to initialize wallet:', error);
-      Alert.alert('Error', 'Failed to load wallet data');
+      // Was a hardcoded generic alert; now routed through the central mapper
+      // (TASK-41) so the user gets a real reason and a next step.
+      const { title, message } = toErrorAlert(error, {
+        fallbackMessage: 'Failed to load wallet data.',
+        fallbackTitle: 'Error',
+      });
+      Alert.alert(title, message);
     } finally {
       setLoading(false);
     }
@@ -909,6 +994,15 @@ export default function HomeScreen() {
 
       if (networkHealth.status === 'fulfilled') {
         setNetworkStatus(networkHealth.value);
+        setNetworkStatusError(null);
+      } else {
+        // Previously there was no else branch at all, so a failed health probe
+        // during pull-to-refresh was discarded entirely (TASK-40 / U-03).
+        console.warn(
+          '[HomeScreen] Network health refresh failed:',
+          networkHealth.reason
+        );
+        setNetworkStatusError(networkHealth.reason);
       }
 
       // Load balance and transactions through the store
@@ -916,9 +1010,16 @@ export default function HomeScreen() {
       await Promise.all([
         loadAccountTransactions(activeAccount.id),
         loadEnvoiName(activeAccount.id),
+        // Multi-network aggregate is what the assets card renders in
+        // multi-network view; refreshing it here keeps pull-to-refresh honest
+        // in both view modes.
+        isMultiNetworkView
+          ? loadMultiNetworkBalance(activeAccount.id, true)
+          : Promise.resolve(),
       ]);
     } catch (error) {
       console.error('Failed to load account data:', error);
+      setNetworkStatusError(error);
     }
   };
 
@@ -1294,6 +1395,20 @@ export default function HomeScreen() {
                 />
               )}
 
+              {/* Network health notice — the device is online but the node or
+                  indexer is not answering. Suppressed while offline, where the
+                  app-wide OfflineBanner already says it better. */}
+              {!!networkNotice && (
+                <ErrorStateView
+                  variant="inline"
+                  error={networkNotice.error}
+                  fallbackMessage={networkNotice.fallbackMessage}
+                  onRetry={onRefresh}
+                  style={styles.networkNotice}
+                  testID="home-network-notice"
+                />
+              )}
+
               <Animated.View
                 style={[styles.balanceContainerWrapper, balanceAnimatedStyle]}
               >
@@ -1324,7 +1439,17 @@ export default function HomeScreen() {
                       )}
                     </View>
                   </View>
-                  {isBalanceLoading && !accountBalance ? (
+                  {activeBalanceError && !hasBalanceData ? (
+                    // A failed balance load used to render as a plain "$0.00",
+                    // which in a wallet reads as lost funds (TASK-40 / U-03).
+                    <ErrorStateView
+                      error={activeBalanceError}
+                      fallbackMessage="Couldn't load your balance."
+                      onRetry={retryBalance}
+                      style={styles.balanceErrorState}
+                      testID="home-balance-error"
+                    />
+                  ) : isBalanceLoading && !accountBalance ? (
                     appMode === 'signer' ? (
                       // In signer mode, show offline fallback instead of spinner
                       <View style={styles.loadingBalance}>
@@ -1369,6 +1494,18 @@ export default function HomeScreen() {
                             </Text>
                           </View>
                         </View>
+                      )}
+                      {!!activeBalanceError && (
+                        // Data on screen is cached and a refresh failed — say
+                        // so rather than presenting stale numbers as current.
+                        <ErrorStateView
+                          variant="inline"
+                          error={activeBalanceError}
+                          fallbackMessage="Couldn't refresh your balance."
+                          onRetry={retryBalance}
+                          style={styles.balanceStaleNotice}
+                          testID="home-balance-stale"
+                        />
                       )}
                     </>
                   )}
@@ -1531,7 +1668,16 @@ export default function HomeScreen() {
                     </View>
                   </View>
 
-                  {isMultiNetworkView ? (
+                  {activeBalanceError && !hasBalanceData ? (
+                    // Never show "No assets found" for a FAILED load — that is
+                    // indistinguishable from an empty account (TASK-40 / U-03).
+                    <ErrorStateView
+                      error={activeBalanceError}
+                      fallbackMessage="Couldn't load your assets."
+                      onRetry={retryBalance}
+                      testID="home-assets-error"
+                    />
+                  ) : isMultiNetworkView ? (
                     // Multi-network view
                     isMultiNetworkBalanceLoading && !multiNetworkBalance ? (
                       <View style={styles.loadingAssets}>
@@ -1738,6 +1884,16 @@ const createStyles = (theme: Theme) =>
       alignItems: 'center',
       justifyContent: 'center',
       paddingVertical: theme.spacing.xl,
+    },
+    // Error / degraded-network surfaces (TASK-40)
+    networkNotice: {
+      marginBottom: theme.spacing.md,
+    },
+    balanceErrorState: {
+      paddingVertical: theme.spacing.md,
+    },
+    balanceStaleNotice: {
+      marginTop: theme.spacing.md,
     },
     // Balance Section
     balanceContainerWrapper: {

--- a/src/screens/wallet/TransactionHistoryScreen.tsx
+++ b/src/screens/wallet/TransactionHistoryScreen.tsx
@@ -27,6 +27,7 @@ import { serializeTransactionForNavigation } from '@/utils/navigationParams';
 import { BlurredContainer } from '@/components/common/BlurredContainer';
 import { ListEmptyState } from '@/components/common/ListEmptyState';
 import { ListFooterSpinner } from '@/components/common/ListFooterSpinner';
+import { ErrorStateView } from '@/components/common/ErrorStateView';
 import { NFTBackground } from '@/components/common/NFTBackground';
 import { useTheme } from '@/contexts/ThemeContext';
 import { useCurrentNetwork } from '@/store/networkStore';
@@ -57,6 +58,11 @@ export default function TransactionHistoryScreen() {
   const assetMetadataCache = useWalletStore(
     (state) => state.assetMetadataCache
   );
+
+  const allTransactions = accountState.recentTransactions || [];
+  // Transaction-scoped, not the shared `lastError`: every other loader clears
+  // that field, so it cannot be trusted to mean "this list failed" (TASK-40).
+  const transactionsError = accountState.transactionsError;
 
   useEffect(() => {
     if (activeAccount) {
@@ -94,7 +100,9 @@ export default function TransactionHistoryScreen() {
     // transaction list reference hasn't changed (cache is network-scoped).
   }, [accountState.recentTransactions, loadAssetMetadata, currentNetwork]);
 
-  const loadTransactions = async () => {
+  // Stable identity: it is a dependency of the memoized empty/error component,
+  // and an unstable one would remount that subtree on every render.
+  const loadTransactions = useCallback(async () => {
     if (!activeAccount) return;
 
     try {
@@ -102,7 +110,7 @@ export default function TransactionHistoryScreen() {
     } catch (error) {
       console.error('Failed to load transaction history:', error);
     }
-  };
+  }, [activeAccount, loadAllTransactions]);
 
   const onRefresh = async () => {
     setRefreshing(true);
@@ -234,18 +242,53 @@ export default function TransactionHistoryScreen() {
     ]
   );
 
-  const renderFooter = useCallback(
-    () => (
+  const renderFooter = useCallback(() => {
+    // A page that failed to load used to just stop pagination silently.
+    if (transactionsError && allTransactions.length > 0) {
+      return (
+        <ErrorStateView
+          variant="inline"
+          error={transactionsError}
+          fallbackMessage="Couldn't load more transactions."
+          onRetry={handleLoadMore}
+          style={styles.footerError}
+          testID="transactions-footer-error"
+        />
+      );
+    }
+
+    return (
       <ListFooterSpinner
         visible={!!accountState.transactionsPagination?.isLoadingMore}
         text="Loading more transactions..."
       />
-    ),
-    [accountState.transactionsPagination?.isLoadingMore]
-  );
+    );
+  }, [
+    accountState.transactionsPagination?.isLoadingMore,
+    transactionsError,
+    allTransactions.length,
+    handleLoadMore,
+    styles.footerError,
+  ]);
 
-  const renderEmptyState = useCallback(
-    () => (
+  // The core audit finding (U-03): a FAILED fetch used to fall through to the
+  // "No Transactions" empty state, which is indistinguishable from a genuinely
+  // empty account and reads as lost history. An error must look like an error
+  // and must offer a retry.
+  const renderEmptyState = useCallback(() => {
+    if (transactionsError) {
+      return (
+        <ErrorStateView
+          error={transactionsError}
+          fallbackMessage="Couldn't load your transaction history."
+          onRetry={loadTransactions}
+          style={styles.emptyContainer}
+          testID="transactions-error"
+        />
+      );
+    }
+
+    return (
       <ListEmptyState
         icon="receipt-outline"
         iconColor={styles.emptyIcon.color}
@@ -253,16 +296,18 @@ export default function TransactionHistoryScreen() {
         subtitle="Your transaction history will appear here when you start using your wallet."
         style={styles.emptyContainer}
       />
-    ),
-    [styles.emptyContainer, styles.emptyIcon.color]
-  );
+    );
+  }, [
+    transactionsError,
+    loadTransactions,
+    styles.emptyContainer,
+    styles.emptyIcon.color,
+  ]);
 
   const keyExtractor = useCallback(
     (item: TransactionInfo, index: number) => `${item.id}-${index}`,
     []
   );
-
-  const allTransactions = accountState.recentTransactions || [];
 
   if (!activeAccount) {
     return (
@@ -398,5 +443,9 @@ const createStyles = (theme: Theme) =>
     },
     emptyIcon: {
       color: theme.colors.textSecondary,
+    },
+    footerError: {
+      marginHorizontal: theme.spacing.md,
+      marginVertical: theme.spacing.sm,
     },
   });

--- a/src/screens/wallet/TransactionHistoryScreen.tsx
+++ b/src/screens/wallet/TransactionHistoryScreen.tsx
@@ -33,6 +33,9 @@ import { NFTBackground } from '@/components/common/NFTBackground';
 import { useTheme } from '@/contexts/ThemeContext';
 import { useCurrentNetwork } from '@/store/networkStore';
 
+// Stable empty reference so a scope mismatch does not churn list identity.
+const EMPTY_TRANSACTIONS: TransactionInfo[] = [];
+
 export default function TransactionHistoryScreen() {
   const [refreshing, setRefreshing] = useState(false);
   const loadMoreInFlightRef = useRef(false);
@@ -60,7 +63,13 @@ export default function TransactionHistoryScreen() {
     (state) => state.assetMetadataCache
   );
 
-  const allTransactions = accountState.recentTransactions || [];
+  // Read the shared `recentTransactions` array only while it holds the
+  // ACCOUNT-WIDE history — AssetDetailScreen loads a single asset's history
+  // into the same array, and rendering that here would be the wrong list.
+  const allTransactions =
+    accountState.recentTransactionsScope === ALL_TRANSACTIONS_SCOPE
+      ? accountState.recentTransactions || []
+      : EMPTY_TRANSACTIONS;
   // Not the shared `lastError` (every other loader clears it) and not any
   // transaction error either — only an ACCOUNT-WIDE one. AssetDetailScreen
   // writes asset-scoped failures into the same field, and rendering those here
@@ -79,7 +88,7 @@ export default function TransactionHistoryScreen() {
 
   // Load token metadata for ARC-200 transactions
   useEffect(() => {
-    const transactions = accountState.recentTransactions || [];
+    const transactions = allTransactions;
     const arc200ContractIds = transactions
       .filter((tx) => tx.isArc200 && tx.contractId)
       .map((tx) => tx.contractId!)
@@ -88,12 +97,12 @@ export default function TransactionHistoryScreen() {
     if (arc200ContractIds.length > 0) {
       loadTokenMetadata(arc200ContractIds);
     }
-  }, [accountState.recentTransactions, loadTokenMetadata]);
+  }, [allTransactions, loadTokenMetadata]);
 
   // Resolve ASA params for transactions whose asset isn't in current holdings,
   // so amounts render with correct decimals instead of a 0-decimals fallback.
   useEffect(() => {
-    const transactions = accountState.recentTransactions || [];
+    const transactions = allTransactions;
     const asaAssetIds = transactions
       .filter((tx) => !tx.isArc200 && tx.assetId && tx.assetId !== 0)
       .map((tx) => tx.assetId!)
@@ -104,7 +113,7 @@ export default function TransactionHistoryScreen() {
     }
     // currentNetwork: re-resolve for the new network after a switch even if the
     // transaction list reference hasn't changed (cache is network-scoped).
-  }, [accountState.recentTransactions, loadAssetMetadata, currentNetwork]);
+  }, [allTransactions, loadAssetMetadata, currentNetwork]);
 
   // Stable identity: it is a dependency of the memoized empty/error component,
   // and an unstable one would remount that subtree on every render.

--- a/src/screens/wallet/TransactionHistoryScreen.tsx
+++ b/src/screens/wallet/TransactionHistoryScreen.tsx
@@ -42,7 +42,13 @@ export default function TransactionHistoryScreen() {
   // transactions". Needed because the scope gate below starts the list empty
   // and the store only flips `isTransactionsLoading` after an await, leaving a
   // window in which the definitive empty state would otherwise be shown.
-  const [hasAttemptedLoad, setHasAttemptedLoad] = useState(false);
+  //
+  // Stored as the account that was attempted rather than a boolean, and
+  // compared during render, so switching accounts cannot leave a frame in
+  // which the new account looks "already loaded".
+  const [attemptedAccountId, setAttemptedAccountId] = useState<string | null>(
+    null
+  );
   const loadMoreInFlightRef = useRef(false);
   const navigation = useNavigation<StackNavigationProp<any>>();
   const styles = useThemedStyles(createStyles);
@@ -125,13 +131,14 @@ export default function TransactionHistoryScreen() {
   const loadTransactions = useCallback(async () => {
     if (!activeAccount) return;
 
+    const accountId = activeAccount.id;
     try {
-      await loadAllTransactions(activeAccount.id);
+      await loadAllTransactions(accountId);
     } catch (error) {
       console.error('Failed to load transaction history:', error);
     } finally {
       // Always set, even on failure/early-return, so a spinner can never wedge.
-      setHasAttemptedLoad(true);
+      setAttemptedAccountId(accountId);
     }
   }, [activeAccount, loadAllTransactions]);
 
@@ -311,7 +318,10 @@ export default function TransactionHistoryScreen() {
       );
     }
 
-    if (!hasAttemptedLoad || accountState.isTransactionsLoading) {
+    if (
+      attemptedAccountId !== activeAccount?.id ||
+      accountState.isTransactionsLoading
+    ) {
       return (
         <ListFooterSpinner
           text="Loading transactions..."
@@ -331,7 +341,8 @@ export default function TransactionHistoryScreen() {
     );
   }, [
     transactionsError,
-    hasAttemptedLoad,
+    attemptedAccountId,
+    activeAccount?.id,
     accountState.isTransactionsLoading,
     loadTransactions,
     styles.emptyContainer,

--- a/src/screens/wallet/TransactionHistoryScreen.tsx
+++ b/src/screens/wallet/TransactionHistoryScreen.tsx
@@ -16,6 +16,7 @@ import type { StackNavigationProp } from '@react-navigation/stack';
 import { TransactionInfo } from '@/types/wallet';
 import { useAuth } from '@/contexts/AuthContext';
 import {
+  ALL_TRANSACTIONS_SCOPE,
   useActiveAccount,
   useAccountState,
   useWalletStore,
@@ -60,9 +61,14 @@ export default function TransactionHistoryScreen() {
   );
 
   const allTransactions = accountState.recentTransactions || [];
-  // Transaction-scoped, not the shared `lastError`: every other loader clears
-  // that field, so it cannot be trusted to mean "this list failed" (TASK-40).
-  const transactionsError = accountState.transactionsError;
+  // Not the shared `lastError` (every other loader clears it) and not any
+  // transaction error either — only an ACCOUNT-WIDE one. AssetDetailScreen
+  // writes asset-scoped failures into the same field, and rendering those here
+  // would blame the wrong list (TASK-40).
+  const transactionsError =
+    accountState.transactionsError?.scope === ALL_TRANSACTIONS_SCOPE
+      ? accountState.transactionsError.message
+      : null;
 
   useEffect(() => {
     if (activeAccount) {

--- a/src/screens/wallet/TransactionHistoryScreen.tsx
+++ b/src/screens/wallet/TransactionHistoryScreen.tsx
@@ -38,6 +38,11 @@ const EMPTY_TRANSACTIONS: TransactionInfo[] = [];
 
 export default function TransactionHistoryScreen() {
   const [refreshing, setRefreshing] = useState(false);
+  // Distinguishes "this screen has not fetched yet" from "the account has no
+  // transactions". Needed because the scope gate below starts the list empty
+  // and the store only flips `isTransactionsLoading` after an await, leaving a
+  // window in which the definitive empty state would otherwise be shown.
+  const [hasAttemptedLoad, setHasAttemptedLoad] = useState(false);
   const loadMoreInFlightRef = useRef(false);
   const navigation = useNavigation<StackNavigationProp<any>>();
   const styles = useThemedStyles(createStyles);
@@ -124,6 +129,9 @@ export default function TransactionHistoryScreen() {
       await loadAllTransactions(activeAccount.id);
     } catch (error) {
       console.error('Failed to load transaction history:', error);
+    } finally {
+      // Always set, even on failure/early-return, so a spinner can never wedge.
+      setHasAttemptedLoad(true);
     }
   }, [activeAccount, loadAllTransactions]);
 
@@ -303,6 +311,15 @@ export default function TransactionHistoryScreen() {
       );
     }
 
+    if (!hasAttemptedLoad || accountState.isTransactionsLoading) {
+      return (
+        <ListFooterSpinner
+          text="Loading transactions..."
+          style={styles.emptyContainer}
+        />
+      );
+    }
+
     return (
       <ListEmptyState
         icon="receipt-outline"
@@ -314,6 +331,8 @@ export default function TransactionHistoryScreen() {
     );
   }, [
     transactionsError,
+    hasAttemptedLoad,
+    accountState.isTransactionsLoading,
     loadTransactions,
     styles.emptyContainer,
     styles.emptyIcon.color,

--- a/src/screens/wallet/__tests__/TransactionHistoryScreen.errorState.test.tsx
+++ b/src/screens/wallet/__tests__/TransactionHistoryScreen.errorState.test.tsx
@@ -18,10 +18,11 @@ const mockLoadAllTransactions = jest.fn(async () => {});
 
 // Mutable account UI state driven per test.
 let mockAccountState: Record<string, unknown> = {};
+let mockActiveAccountId = 'acct-1';
 
 jest.mock('@/store/walletStore', () => ({
   ALL_TRANSACTIONS_SCOPE: 'all',
-  useActiveAccount: () => ({ id: 'acct-1', address: 'ADDR1' }),
+  useActiveAccount: () => ({ id: mockActiveAccountId, address: 'ADDR1' }),
   useAccountState: () => mockAccountState,
   useWalletStore: (selector: (s: any) => unknown) =>
     selector({
@@ -110,6 +111,7 @@ const baseState = {
 
 beforeEach(() => {
   mockLoadAllTransactions.mockClear();
+  mockActiveAccountId = 'acct-1';
   mockAccountState = { ...baseState };
   // Keep the theme import referenced so the mock factory's require resolves the
   // same module instance the screen renders against.
@@ -137,6 +139,20 @@ describe('TransactionHistoryScreen error surfacing', () => {
     expect(queryByText('No Transactions')).toBeNull();
     expect(getByText('Loading transactions...')).toBeTruthy();
 
+    await settle();
+  });
+
+  it('goes back to loading when the active account changes', async () => {
+    // The "already attempted" marker is keyed by account, so a newly selected
+    // account cannot inherit the previous one's "definitely empty" verdict.
+    const { getByText, rerender } = render(<TransactionHistoryScreen />);
+    await settle();
+    expect(getByText('No Transactions')).toBeTruthy();
+
+    mockActiveAccountId = 'acct-2';
+    rerender(<TransactionHistoryScreen />);
+
+    expect(getByText('Loading transactions...')).toBeTruthy();
     await settle();
   });
 

--- a/src/screens/wallet/__tests__/TransactionHistoryScreen.errorState.test.tsx
+++ b/src/screens/wallet/__tests__/TransactionHistoryScreen.errorState.test.tsx
@@ -1,0 +1,170 @@
+/**
+ * Regression tests for the core finding of TASK-40 / U-03.
+ *
+ * TransactionHistoryScreen used to catch load errors with `console.error` only
+ * and then render its "No Transactions" empty state. In a wallet that is
+ * actively alarming: a failed indexer fetch is indistinguishable from an
+ * account whose history has vanished. A failed fetch must render as a failure,
+ * with a retry, and must never render the empty state.
+ */
+
+import React from 'react';
+import { render, fireEvent } from '@testing-library/react-native';
+
+import TransactionHistoryScreen from '../TransactionHistoryScreen';
+import { lightTheme } from '@/constants/themes';
+
+const mockLoadAllTransactions = jest.fn(async () => {});
+
+// Mutable account UI state driven per test.
+let mockAccountState: Record<string, unknown> = {};
+
+jest.mock('@/store/walletStore', () => ({
+  useActiveAccount: () => ({ id: 'acct-1', address: 'ADDR1' }),
+  useAccountState: () => mockAccountState,
+  useWalletStore: (selector: (s: any) => unknown) =>
+    selector({
+      loadAllTransactions: mockLoadAllTransactions,
+      loadMoreTransactions: jest.fn(async () => {}),
+      loadTokenMetadata: jest.fn(),
+      getTokenMetadata: () => null,
+      loadAssetMetadata: jest.fn(),
+      getAssetMetadata: () => null,
+      assetMetadataCache: {},
+    }),
+}));
+
+jest.mock('@/store/networkStore', () => ({
+  useCurrentNetwork: () => 'voi-mainnet',
+}));
+
+jest.mock('@/contexts/AuthContext', () => ({
+  useAuth: () => ({ updateActivity: jest.fn() }),
+}));
+
+jest.mock('@/contexts/ThemeContext', () => ({
+  // eslint-disable-next-line @typescript-eslint/no-require-imports
+  useTheme: () => ({ theme: require('@/constants/themes').lightTheme }),
+}));
+
+jest.mock('@react-navigation/native', () => ({
+  useNavigation: () => ({ navigate: jest.fn(), goBack: jest.fn() }),
+}));
+
+jest.mock(
+  '@expo/vector-icons',
+  () => ({
+    Ionicons: () => null,
+  }),
+  { virtual: true }
+);
+
+jest.mock('react-native-safe-area-context', () => ({
+  SafeAreaView: ({ children }: { children: React.ReactNode }) => children,
+  initialWindowMetrics: null,
+}));
+
+jest.mock('@/components/common/NFTBackground', () => ({
+  NFTBackground: ({ children }: { children: React.ReactNode }) => children,
+}));
+
+jest.mock('@/components/common/BlurredContainer', () => {
+  // eslint-disable-next-line @typescript-eslint/no-require-imports
+  const { View } = require('react-native');
+  return {
+    BlurredContainer: ({ children }: { children: React.ReactNode }) => (
+      <View>{children}</View>
+    ),
+  };
+});
+
+jest.mock('@/components/transaction/TransactionListItem', () => {
+  // eslint-disable-next-line @typescript-eslint/no-require-imports
+  const { Text } = require('react-native');
+  return {
+    __esModule: true,
+    default: ({ transaction }: { transaction: { id: string } }) => (
+      <Text>{`tx-${transaction.id}`}</Text>
+    ),
+  };
+});
+
+const baseState = {
+  isLoading: false,
+  lastError: null,
+  balanceError: null,
+  transactionsError: null,
+  multiNetworkBalanceError: null,
+  recentTransactions: [],
+  isBalanceLoading: false,
+  isBackgroundRefreshing: false,
+  balanceLastUpdated: 0,
+  isTransactionsLoading: false,
+  isEnvoiLoading: false,
+  isMultiNetworkBalanceLoading: false,
+  multiNetworkBalanceLastUpdated: 0,
+  transactionsPagination: { hasMore: false, isLoadingMore: false },
+};
+
+beforeEach(() => {
+  mockLoadAllTransactions.mockClear();
+  mockAccountState = { ...baseState };
+  // Keep the theme import referenced so the mock factory's require resolves the
+  // same module instance the screen renders against.
+  expect(lightTheme).toBeDefined();
+});
+
+describe('TransactionHistoryScreen error surfacing', () => {
+  it('shows the empty state when the account genuinely has no transactions', () => {
+    const { getByText, queryByTestId } = render(<TransactionHistoryScreen />);
+
+    expect(getByText('No Transactions')).toBeTruthy();
+    expect(queryByTestId('transactions-error')).toBeNull();
+  });
+
+  it('shows an error state instead of "No Transactions" when the fetch failed', () => {
+    mockAccountState = {
+      ...baseState,
+      transactionsError: 'Network request failed',
+    };
+
+    const { queryByText, getByTestId } = render(<TransactionHistoryScreen />);
+
+    // The whole point of the fix: a failure must not look like an empty account.
+    expect(queryByText('No Transactions')).toBeNull();
+    expect(getByTestId('transactions-error')).toBeTruthy();
+  });
+
+  it('offers a retry that re-runs the load', () => {
+    mockAccountState = {
+      ...baseState,
+      transactionsError: 'Network request failed',
+    };
+
+    const { getByTestId } = render(<TransactionHistoryScreen />);
+    mockLoadAllTransactions.mockClear();
+
+    fireEvent.press(getByTestId('transactions-error-retry'));
+
+    expect(mockLoadAllTransactions).toHaveBeenCalledWith('acct-1');
+  });
+
+  it('keeps loaded rows and surfaces a footer error when a later page fails', () => {
+    mockAccountState = {
+      ...baseState,
+      recentTransactions: [{ id: 'a' }, { id: 'b' }],
+      transactionsError: 'Network request failed',
+      transactionsPagination: { hasMore: true, isLoadingMore: false },
+    };
+
+    const { getByText, getByTestId, queryByTestId } = render(
+      <TransactionHistoryScreen />
+    );
+
+    // Already-loaded rows are still valid — only the next page failed.
+    expect(getByText('tx-a')).toBeTruthy();
+    expect(getByTestId('transactions-footer-error')).toBeTruthy();
+    // ...and the whole-screen error state is NOT used for a partial failure.
+    expect(queryByTestId('transactions-error')).toBeNull();
+  });
+});

--- a/src/screens/wallet/__tests__/TransactionHistoryScreen.errorState.test.tsx
+++ b/src/screens/wallet/__tests__/TransactionHistoryScreen.errorState.test.tsx
@@ -97,6 +97,7 @@ const baseState = {
   transactionsError: null,
   multiNetworkBalanceError: null,
   recentTransactions: [],
+  recentTransactionsScope: 'all',
   isBalanceLoading: false,
   isBackgroundRefreshing: false,
   balanceLastUpdated: 0,
@@ -162,6 +163,22 @@ describe('TransactionHistoryScreen error surfacing', () => {
 
     expect(getByText('No Transactions')).toBeTruthy();
     expect(queryByTestId('transactions-error')).toBeNull();
+  });
+
+  it('ignores rows the store is currently holding for a different resource', () => {
+    // AssetDetailScreen loads a single asset's history into the SAME array.
+    // Rendering those rows here would present another list's transactions as
+    // this account's full history.
+    mockAccountState = {
+      ...baseState,
+      recentTransactions: [{ id: 'a' }, { id: 'b' }],
+      recentTransactionsScope: '42_asa',
+    };
+
+    const { queryByText, getByText } = render(<TransactionHistoryScreen />);
+
+    expect(queryByText('tx-a')).toBeNull();
+    expect(getByText('No Transactions')).toBeTruthy();
   });
 
   it('keeps loaded rows and surfaces a footer error when a later page fails', () => {

--- a/src/screens/wallet/__tests__/TransactionHistoryScreen.errorState.test.tsx
+++ b/src/screens/wallet/__tests__/TransactionHistoryScreen.errorState.test.tsx
@@ -20,6 +20,7 @@ const mockLoadAllTransactions = jest.fn(async () => {});
 let mockAccountState: Record<string, unknown> = {};
 
 jest.mock('@/store/walletStore', () => ({
+  ALL_TRANSACTIONS_SCOPE: 'all',
   useActiveAccount: () => ({ id: 'acct-1', address: 'ADDR1' }),
   useAccountState: () => mockAccountState,
   useWalletStore: (selector: (s: any) => unknown) =>
@@ -125,7 +126,7 @@ describe('TransactionHistoryScreen error surfacing', () => {
   it('shows an error state instead of "No Transactions" when the fetch failed', () => {
     mockAccountState = {
       ...baseState,
-      transactionsError: 'Network request failed',
+      transactionsError: { scope: 'all', message: 'Network request failed' },
     };
 
     const { queryByText, getByTestId } = render(<TransactionHistoryScreen />);
@@ -138,7 +139,7 @@ describe('TransactionHistoryScreen error surfacing', () => {
   it('offers a retry that re-runs the load', () => {
     mockAccountState = {
       ...baseState,
-      transactionsError: 'Network request failed',
+      transactionsError: { scope: 'all', message: 'Network request failed' },
     };
 
     const { getByTestId } = render(<TransactionHistoryScreen />);
@@ -149,11 +150,25 @@ describe('TransactionHistoryScreen error surfacing', () => {
     expect(mockLoadAllTransactions).toHaveBeenCalledWith('acct-1');
   });
 
+  it('ignores an asset-scoped error and still shows the genuine empty state', () => {
+    // AssetDetailScreen writes into the same field; blaming this list for its
+    // failure would be wrong, and hiding a real empty state behind it worse.
+    mockAccountState = {
+      ...baseState,
+      transactionsError: { scope: '42_asa', message: 'asset fetch failed' },
+    };
+
+    const { getByText, queryByTestId } = render(<TransactionHistoryScreen />);
+
+    expect(getByText('No Transactions')).toBeTruthy();
+    expect(queryByTestId('transactions-error')).toBeNull();
+  });
+
   it('keeps loaded rows and surfaces a footer error when a later page fails', () => {
     mockAccountState = {
       ...baseState,
       recentTransactions: [{ id: 'a' }, { id: 'b' }],
-      transactionsError: 'Network request failed',
+      transactionsError: { scope: 'all', message: 'Network request failed' },
       transactionsPagination: { hasMore: true, isLoadingMore: false },
     };
 

--- a/src/screens/wallet/__tests__/TransactionHistoryScreen.errorState.test.tsx
+++ b/src/screens/wallet/__tests__/TransactionHistoryScreen.errorState.test.tsx
@@ -9,7 +9,7 @@
  */
 
 import React from 'react';
-import { render, fireEvent } from '@testing-library/react-native';
+import { render, fireEvent, act } from '@testing-library/react-native';
 
 import TransactionHistoryScreen from '../TransactionHistoryScreen';
 import { lightTheme } from '@/constants/themes';
@@ -116,42 +116,61 @@ beforeEach(() => {
   expect(lightTheme).toBeDefined();
 });
 
+// The mount effect fetches; settle it so assertions run after the first load
+// attempt has registered.
+const settle = () => act(async () => {});
+
 describe('TransactionHistoryScreen error surfacing', () => {
-  it('shows the empty state when the account genuinely has no transactions', () => {
+  it('shows the empty state when the account genuinely has no transactions', async () => {
     const { getByText, queryByTestId } = render(<TransactionHistoryScreen />);
+    await settle();
 
     expect(getByText('No Transactions')).toBeTruthy();
     expect(queryByTestId('transactions-error')).toBeNull();
   });
 
-  it('shows an error state instead of "No Transactions" when the fetch failed', () => {
+  it('shows a loading state, not the empty state, before the first fetch settles', async () => {
+    // The store only flips `isTransactionsLoading` after an await, so the
+    // definitive "No Transactions" copy must not be reachable in the meantime.
+    const { queryByText, getByText } = render(<TransactionHistoryScreen />);
+
+    expect(queryByText('No Transactions')).toBeNull();
+    expect(getByText('Loading transactions...')).toBeTruthy();
+
+    await settle();
+  });
+
+  it('shows an error state instead of "No Transactions" when the fetch failed', async () => {
     mockAccountState = {
       ...baseState,
       transactionsError: { scope: 'all', message: 'Network request failed' },
     };
 
     const { queryByText, getByTestId } = render(<TransactionHistoryScreen />);
+    await settle();
 
     // The whole point of the fix: a failure must not look like an empty account.
     expect(queryByText('No Transactions')).toBeNull();
     expect(getByTestId('transactions-error')).toBeTruthy();
   });
 
-  it('offers a retry that re-runs the load', () => {
+  it('offers a retry that re-runs the load', async () => {
     mockAccountState = {
       ...baseState,
       transactionsError: { scope: 'all', message: 'Network request failed' },
     };
 
     const { getByTestId } = render(<TransactionHistoryScreen />);
+    await settle();
     mockLoadAllTransactions.mockClear();
 
     fireEvent.press(getByTestId('transactions-error-retry'));
+    await settle();
 
     expect(mockLoadAllTransactions).toHaveBeenCalledWith('acct-1');
   });
 
-  it('ignores an asset-scoped error and still shows the genuine empty state', () => {
+  it('ignores an asset-scoped error and still shows the genuine empty state', async () => {
     // AssetDetailScreen writes into the same field; blaming this list for its
     // failure would be wrong, and hiding a real empty state behind it worse.
     mockAccountState = {
@@ -160,12 +179,13 @@ describe('TransactionHistoryScreen error surfacing', () => {
     };
 
     const { getByText, queryByTestId } = render(<TransactionHistoryScreen />);
+    await settle();
 
     expect(getByText('No Transactions')).toBeTruthy();
     expect(queryByTestId('transactions-error')).toBeNull();
   });
 
-  it('ignores rows the store is currently holding for a different resource', () => {
+  it('ignores rows the store is currently holding for a different resource', async () => {
     // AssetDetailScreen loads a single asset's history into the SAME array.
     // Rendering those rows here would present another list's transactions as
     // this account's full history.
@@ -176,12 +196,13 @@ describe('TransactionHistoryScreen error surfacing', () => {
     };
 
     const { queryByText, getByText } = render(<TransactionHistoryScreen />);
+    await settle();
 
     expect(queryByText('tx-a')).toBeNull();
     expect(getByText('No Transactions')).toBeTruthy();
   });
 
-  it('keeps loaded rows and surfaces a footer error when a later page fails', () => {
+  it('keeps loaded rows and surfaces a footer error when a later page fails', async () => {
     mockAccountState = {
       ...baseState,
       recentTransactions: [{ id: 'a' }, { id: 'b' }],
@@ -192,6 +213,7 @@ describe('TransactionHistoryScreen error surfacing', () => {
     const { getByText, getByTestId, queryByTestId } = render(
       <TransactionHistoryScreen />
     );
+    await settle();
 
     // Already-loaded rows are still valid — only the next page failed.
     expect(getByText('tx-a')).toBeTruthy();

--- a/src/store/__tests__/accountErrorScoping.test.ts
+++ b/src/store/__tests__/accountErrorScoping.test.ts
@@ -1,0 +1,156 @@
+// TASK-40 / U-03: per-account errors must be OPERATION-SCOPED.
+//
+// `lastError` was written in ~20 places and read by nothing. Simply reading it
+// would not have worked either: every loader clears it on start, so a balance
+// refresh landing after a failed transaction fetch would erase the transaction
+// error and the history screen would silently fall back to its "No
+// Transactions" empty state — the exact defect this task fixes. These tests pin
+// the scoping: a balance failure must not look like a transaction failure, and
+// neither must be erased by the other's success.
+//
+// The heavy service graph is mocked; only the two dependencies these loaders
+// drive (NetworkService + MultiAccountWalletService) carry behavior.
+
+const mockGetAccountBalance = jest.fn();
+const mockGetTransactionHistory = jest.fn();
+const mockGetAllTransactionHistory = jest.fn();
+const mockGetCurrentNetworkId = jest.fn(() => 'voi-mainnet');
+const mockGetAccount = jest.fn(async (id: string) => ({
+  id,
+  address: `ADDR-${id}`,
+  type: 'standard',
+}));
+
+jest.mock('@/services/network', () => ({
+  NetworkService: {
+    getInstance: () => ({
+      getAccountBalance: (...args: unknown[]) => mockGetAccountBalance(...args),
+      getTransactionHistory: (...args: unknown[]) =>
+        mockGetTransactionHistory(...args),
+      getAllTransactionHistory: (...args: unknown[]) =>
+        mockGetAllTransactionHistory(...args),
+      getCurrentNetworkId: () => mockGetCurrentNetworkId(),
+    }),
+  },
+  VoiNetworkService: {},
+}));
+
+jest.mock('@/services/wallet', () => ({
+  MultiAccountWalletService: {
+    getAccount: (id: string) => mockGetAccount(id),
+    updateAccountMetadata: jest.fn(async () => {}),
+  },
+}));
+
+jest.mock('@/services/wallet/rekeyManager', () => ({
+  __esModule: true,
+  default: { updateAccountWithRekeyInfo: jest.fn() },
+}));
+
+jest.mock('@/services/envoi', () => ({ __esModule: true, default: {} }));
+jest.mock('@/services/mimir', () => ({ MimirApiService: {} }));
+jest.mock('@/services/token-mapping', () => ({
+  __esModule: true,
+  default: {},
+  TokenMappingService: {},
+}));
+jest.mock('@/services/network/multi-network', () => ({
+  MultiNetworkBalanceService: {},
+}));
+jest.mock('@/services/notifications', () => ({
+  notificationService: {},
+  DEFAULT_NOTIFICATION_PREFERENCES: {},
+}));
+jest.mock('@/services/realtime', () => ({ realtimeService: {} }));
+
+jest.mock('@react-native-async-storage/async-storage', () => ({
+  __esModule: true,
+  default: {
+    getItem: jest.fn(async () => null),
+    setItem: jest.fn(async () => {}),
+    removeItem: jest.fn(async () => {}),
+    multiGet: jest.fn(async () => []),
+    multiSet: jest.fn(async () => {}),
+  },
+}));
+
+import { useWalletStore } from '../walletStore';
+
+const accountState = (id: string) =>
+  useWalletStore.getState().accountStates[id];
+
+describe('operation-scoped account errors (TASK-40)', () => {
+  beforeEach(() => {
+    mockGetAccountBalance.mockReset();
+    mockGetTransactionHistory.mockReset();
+    mockGetAllTransactionHistory.mockReset();
+    mockGetAccount.mockClear();
+    mockGetCurrentNetworkId.mockReset();
+    mockGetCurrentNetworkId.mockReturnValue('voi-mainnet');
+    useWalletStore.setState({ accountStates: {}, wallet: null });
+  });
+
+  it('records a balance failure under balanceError, not transactionsError', async () => {
+    mockGetAccountBalance.mockRejectedValue(new Error('algod is down'));
+
+    await useWalletStore.getState().loadAccountBalance('acc-1', true);
+
+    expect(accountState('acc-1').balanceError).toBe('algod is down');
+    expect(accountState('acc-1').transactionsError).toBeNull();
+  });
+
+  it('records a transaction failure under transactionsError, not balanceError', async () => {
+    mockGetTransactionHistory.mockRejectedValue(new Error('indexer is down'));
+
+    await useWalletStore.getState().loadAccountTransactions('acc-1');
+
+    expect(accountState('acc-1').transactionsError).toBe('indexer is down');
+    expect(accountState('acc-1').balanceError).toBeNull();
+  });
+
+  it('does not let a successful balance refresh erase a transaction failure', async () => {
+    // The regression that makes `lastError` unusable for this: the history
+    // screen would drop back to "No Transactions" as soon as a balance poll
+    // landed, even though the history fetch had genuinely failed.
+    mockGetAllTransactionHistory.mockRejectedValue(new Error('indexer 503'));
+    await useWalletStore.getState().loadAllTransactions('acc-1');
+    expect(accountState('acc-1').transactionsError).toBe('indexer 503');
+
+    mockGetAccountBalance.mockResolvedValue({});
+    await useWalletStore.getState().loadAccountBalance('acc-1', true);
+
+    expect(accountState('acc-1').transactionsError).toBe('indexer 503');
+    expect(accountState('acc-1').balanceError).toBeNull();
+  });
+
+  it('clears the transaction error on a successful reload', async () => {
+    mockGetAllTransactionHistory.mockRejectedValueOnce(
+      new Error('indexer 503')
+    );
+    await useWalletStore.getState().loadAllTransactions('acc-1');
+    expect(accountState('acc-1').transactionsError).toBe('indexer 503');
+
+    mockGetAllTransactionHistory.mockResolvedValueOnce({
+      transactions: [],
+      nextToken: undefined,
+    });
+    await useWalletStore.getState().loadAllTransactions('acc-1');
+
+    expect(accountState('acc-1').transactionsError).toBeNull();
+  });
+
+  it('clearAccountError clears every scoped field', async () => {
+    mockGetAccountBalance.mockRejectedValue(new Error('algod is down'));
+    mockGetTransactionHistory.mockRejectedValue(new Error('indexer is down'));
+
+    await useWalletStore.getState().loadAccountBalance('acc-1', true);
+    await useWalletStore.getState().loadAccountTransactions('acc-1');
+
+    useWalletStore.getState().clearAccountError('acc-1');
+
+    expect(accountState('acc-1').lastError).toBeNull();
+    expect(accountState('acc-1').balanceError).toBeNull();
+    expect(accountState('acc-1').transactionsError).toBeNull();
+    expect(accountState('acc-1').multiNetworkBalanceError).toBeNull();
+  });
+});

--- a/src/store/__tests__/accountErrorScoping.test.ts
+++ b/src/store/__tests__/accountErrorScoping.test.ts
@@ -14,6 +14,7 @@
 const mockGetAccountBalance = jest.fn();
 const mockGetTransactionHistory = jest.fn();
 const mockGetAllTransactionHistory = jest.fn();
+const mockGetAssetTransactionHistory = jest.fn();
 const mockGetCurrentNetworkId = jest.fn(() => 'voi-mainnet');
 const mockGetAccount = jest.fn(async (id: string) => ({
   id,
@@ -29,6 +30,8 @@ jest.mock('@/services/network', () => ({
         mockGetTransactionHistory(...args),
       getAllTransactionHistory: (...args: unknown[]) =>
         mockGetAllTransactionHistory(...args),
+      getAssetTransactionHistory: (...args: unknown[]) =>
+        mockGetAssetTransactionHistory(...args),
       getCurrentNetworkId: () => mockGetCurrentNetworkId(),
     }),
   },
@@ -74,7 +77,11 @@ jest.mock('@react-native-async-storage/async-storage', () => ({
   },
 }));
 
-import { useWalletStore } from '../walletStore';
+import {
+  ALL_TRANSACTIONS_SCOPE,
+  assetTransactionsScope,
+  useWalletStore,
+} from '../walletStore';
 
 const accountState = (id: string) =>
   useWalletStore.getState().accountStates[id];
@@ -84,6 +91,7 @@ describe('operation-scoped account errors (TASK-40)', () => {
     mockGetAccountBalance.mockReset();
     mockGetTransactionHistory.mockReset();
     mockGetAllTransactionHistory.mockReset();
+    mockGetAssetTransactionHistory.mockReset();
     mockGetAccount.mockClear();
     mockGetCurrentNetworkId.mockReset();
     mockGetCurrentNetworkId.mockReturnValue('voi-mainnet');
@@ -104,7 +112,10 @@ describe('operation-scoped account errors (TASK-40)', () => {
 
     await useWalletStore.getState().loadAccountTransactions('acc-1');
 
-    expect(accountState('acc-1').transactionsError).toBe('indexer is down');
+    expect(accountState('acc-1').transactionsError).toEqual({
+      scope: ALL_TRANSACTIONS_SCOPE,
+      message: 'indexer is down',
+    });
     expect(accountState('acc-1').balanceError).toBeNull();
   });
 
@@ -114,12 +125,16 @@ describe('operation-scoped account errors (TASK-40)', () => {
     // landed, even though the history fetch had genuinely failed.
     mockGetAllTransactionHistory.mockRejectedValue(new Error('indexer 503'));
     await useWalletStore.getState().loadAllTransactions('acc-1');
-    expect(accountState('acc-1').transactionsError).toBe('indexer 503');
+    expect(accountState('acc-1').transactionsError?.message).toBe(
+      'indexer 503'
+    );
 
     mockGetAccountBalance.mockResolvedValue({});
     await useWalletStore.getState().loadAccountBalance('acc-1', true);
 
-    expect(accountState('acc-1').transactionsError).toBe('indexer 503');
+    expect(accountState('acc-1').transactionsError?.message).toBe(
+      'indexer 503'
+    );
     expect(accountState('acc-1').balanceError).toBeNull();
   });
 
@@ -128,7 +143,9 @@ describe('operation-scoped account errors (TASK-40)', () => {
       new Error('indexer 503')
     );
     await useWalletStore.getState().loadAllTransactions('acc-1');
-    expect(accountState('acc-1').transactionsError).toBe('indexer 503');
+    expect(accountState('acc-1').transactionsError?.message).toBe(
+      'indexer 503'
+    );
 
     mockGetAllTransactionHistory.mockResolvedValueOnce({
       transactions: [],
@@ -137,6 +154,23 @@ describe('operation-scoped account errors (TASK-40)', () => {
     await useWalletStore.getState().loadAllTransactions('acc-1');
 
     expect(accountState('acc-1').transactionsError).toBeNull();
+  });
+
+  it('tags an asset-history failure with the asset scope, not the account-wide one', async () => {
+    // Both loaders write into the SAME `recentTransactions` array and the same
+    // error field, so without a scope tag an asset failure would render as the
+    // full-history screen's failure (and vice versa).
+    mockGetAssetTransactionHistory.mockRejectedValue(new Error('asset 500'));
+
+    await useWalletStore.getState().loadAssetTransactions('acc-1', 42, false);
+
+    expect(accountState('acc-1').transactionsError).toEqual({
+      scope: assetTransactionsScope(42, false),
+      message: 'asset 500',
+    });
+    expect(accountState('acc-1').transactionsError?.scope).not.toBe(
+      ALL_TRANSACTIONS_SCOPE
+    );
   });
 
   it('clearAccountError clears every scoped field', async () => {

--- a/src/store/__tests__/accountErrorScoping.test.ts
+++ b/src/store/__tests__/accountErrorScoping.test.ts
@@ -173,6 +173,29 @@ describe('operation-scoped account errors (TASK-40)', () => {
     );
   });
 
+  it('tags the shared transaction array with the resource it holds', async () => {
+    // AssetDetailScreen and TransactionHistoryScreen read the SAME array; the
+    // tag is what lets each tell whether the rows are actually theirs.
+    mockGetAllTransactionHistory.mockResolvedValue({
+      transactions: [{ id: 'a' }],
+      nextToken: undefined,
+    });
+    await useWalletStore.getState().loadAllTransactions('acc-1');
+    expect(accountState('acc-1').recentTransactionsScope).toBe(
+      ALL_TRANSACTIONS_SCOPE
+    );
+
+    mockGetAssetTransactionHistory.mockResolvedValue({
+      transactions: [{ id: 'b' }],
+      nextToken: undefined,
+      hasMore: false,
+    });
+    await useWalletStore.getState().loadAssetTransactions('acc-1', 42, false);
+    expect(accountState('acc-1').recentTransactionsScope).toBe(
+      assetTransactionsScope(42, false)
+    );
+  });
+
   it('clearAccountError clears every scoped field', async () => {
     mockGetAccountBalance.mockRejectedValue(new Error('algod is down'));
     mockGetTransactionHistory.mockRejectedValue(new Error('indexer is down'));

--- a/src/store/__tests__/accountErrorScoping.test.ts
+++ b/src/store/__tests__/accountErrorScoping.test.ts
@@ -304,6 +304,46 @@ describe('operation-scoped account errors (TASK-40)', () => {
     expect(accountState('acc-1').multiNetworkBalance).toBeDefined();
   });
 
+  it('does not strand the spinner when a superseded request resumes late', async () => {
+    // A stale request that re-raises `isTransactionsLoading` after a newer one
+    // finished would leave the list spinning forever, because its own response
+    // is (correctly) discarded further down.
+    let releaseAccount!: () => void;
+    mockGetAccount.mockImplementationOnce(
+      () =>
+        new Promise((resolve) => {
+          releaseAccount = () =>
+            resolve({ id: 'acc-1', address: 'ADDR-acc-1', type: 'standard' });
+        })
+    );
+    mockGetAssetTransactionHistory.mockResolvedValue({
+      transactions: [{ id: 'asset-1' }],
+      nextToken: undefined,
+      hasMore: false,
+    });
+    mockGetAllTransactionHistory.mockResolvedValue({
+      transactions: [],
+      nextToken: undefined,
+    });
+
+    // Account-wide request is parked inside getAccount...
+    const allLoad = useWalletStore.getState().loadAllTransactions('acc-1');
+    await new Promise((resolve) => setTimeout(resolve, 0));
+
+    // ...a newer asset request supersedes it and completes.
+    await useWalletStore.getState().loadAssetTransactions('acc-1', 42, false);
+    expect(accountState('acc-1').isTransactionsLoading).toBe(false);
+
+    // The stale request resumes and must write nothing at all.
+    releaseAccount();
+    await allLoad;
+
+    expect(accountState('acc-1').isTransactionsLoading).toBe(false);
+    expect(accountState('acc-1').recentTransactionsScope).toBe(
+      assetTransactionsScope(42, false)
+    );
+  });
+
   it('clearAccountError clears every scoped field', async () => {
     mockGetAccountBalance.mockRejectedValue(new Error('algod is down'));
     mockGetTransactionHistory.mockRejectedValue(new Error('indexer is down'));

--- a/src/store/__tests__/accountErrorScoping.test.ts
+++ b/src/store/__tests__/accountErrorScoping.test.ts
@@ -15,6 +15,7 @@ const mockGetAccountBalance = jest.fn();
 const mockGetTransactionHistory = jest.fn();
 const mockGetAllTransactionHistory = jest.fn();
 const mockGetAssetTransactionHistory = jest.fn();
+const mockGetAggregatedBalance = jest.fn();
 const mockGetCurrentNetworkId = jest.fn(() => 'voi-mainnet');
 const mockGetAccount = jest.fn(async (id: string) => ({
   id,
@@ -58,7 +59,10 @@ jest.mock('@/services/token-mapping', () => ({
   TokenMappingService: {},
 }));
 jest.mock('@/services/network/multi-network', () => ({
-  MultiNetworkBalanceService: {},
+  MultiNetworkBalanceService: {
+    getAggregatedBalance: (...args: unknown[]) =>
+      mockGetAggregatedBalance(...args),
+  },
 }));
 jest.mock('@/services/notifications', () => ({
   notificationService: {},
@@ -92,6 +96,7 @@ describe('operation-scoped account errors (TASK-40)', () => {
     mockGetTransactionHistory.mockReset();
     mockGetAllTransactionHistory.mockReset();
     mockGetAssetTransactionHistory.mockReset();
+    mockGetAggregatedBalance.mockReset();
     mockGetAccount.mockClear();
     mockGetCurrentNetworkId.mockReset();
     mockGetCurrentNetworkId.mockReturnValue('voi-mainnet');
@@ -266,6 +271,37 @@ describe('operation-scoped account errors (TASK-40)', () => {
     expect(accountState('acc-1').recentTransactions).toEqual([
       { id: 'asset-1' },
     ]);
+  });
+
+  it('does not let a stale multi-network failure overwrite a newer success', async () => {
+    // Retry and pull-to-refresh both force a load, so two can overlap. An older
+    // failure landing last must not replace fresh balances with an error banner.
+    let rejectFirst!: (reason: unknown) => void;
+    mockGetAggregatedBalance
+      .mockImplementationOnce(
+        () =>
+          new Promise((_resolve, reject) => {
+            rejectFirst = reject;
+          })
+      )
+      .mockResolvedValueOnce({ address: 'ADDR-acc-1', assets: [] });
+
+    // Non-empty so the loader does not detour through loadTokenMappings.
+    useWalletStore.setState({ tokenMappings: [{} as never] });
+
+    const first = useWalletStore
+      .getState()
+      .loadMultiNetworkBalance('acc-1', true);
+    await new Promise((resolve) => setTimeout(resolve, 0));
+
+    await useWalletStore.getState().loadMultiNetworkBalance('acc-1', true);
+    expect(accountState('acc-1').multiNetworkBalance).toBeDefined();
+
+    rejectFirst(new Error('aggregate 500'));
+    await first;
+
+    expect(accountState('acc-1').multiNetworkBalanceError).toBeNull();
+    expect(accountState('acc-1').multiNetworkBalance).toBeDefined();
   });
 
   it('clearAccountError clears every scoped field', async () => {

--- a/src/store/__tests__/accountErrorScoping.test.ts
+++ b/src/store/__tests__/accountErrorScoping.test.ts
@@ -230,6 +230,44 @@ describe('operation-scoped account errors (TASK-40)', () => {
     await assetLoad;
   });
 
+  it('drops a stale response so it cannot overwrite a newer scope', async () => {
+    // Both scopes write the SAME array, so the last response used to win
+    // regardless of which view the user is actually on.
+    let resolveAll!: (value: unknown) => void;
+    mockGetAllTransactionHistory.mockImplementation(
+      () =>
+        new Promise((resolve) => {
+          resolveAll = resolve as (value: unknown) => void;
+        })
+    );
+    mockGetAssetTransactionHistory.mockResolvedValue({
+      transactions: [{ id: 'asset-1' }],
+      nextToken: undefined,
+      hasMore: false,
+    });
+
+    // Account-wide load starts first and is still in flight...
+    const allLoad = useWalletStore.getState().loadAllTransactions('acc-1');
+    await new Promise((resolve) => setTimeout(resolve, 0));
+
+    // ...then the user opens an asset, whose load supersedes it and completes.
+    await useWalletStore.getState().loadAssetTransactions('acc-1', 42, false);
+    expect(accountState('acc-1').recentTransactionsScope).toBe(
+      assetTransactionsScope(42, false)
+    );
+
+    // The older account-wide response lands last and must be discarded.
+    resolveAll({ transactions: [{ id: 'all-1' }], nextToken: undefined });
+    await allLoad;
+
+    expect(accountState('acc-1').recentTransactionsScope).toBe(
+      assetTransactionsScope(42, false)
+    );
+    expect(accountState('acc-1').recentTransactions).toEqual([
+      { id: 'asset-1' },
+    ]);
+  });
+
   it('clearAccountError clears every scoped field', async () => {
     mockGetAccountBalance.mockRejectedValue(new Error('algod is down'));
     mockGetTransactionHistory.mockRejectedValue(new Error('indexer is down'));

--- a/src/store/__tests__/accountErrorScoping.test.ts
+++ b/src/store/__tests__/accountErrorScoping.test.ts
@@ -196,6 +196,40 @@ describe('operation-scoped account errors (TASK-40)', () => {
     );
   });
 
+  it('does not skip a load for a DIFFERENT resource that is already in flight', async () => {
+    // The skip guard dedupes identical requests. Skipping a different scope
+    // would mean that screen never fetches at all, and — since the shared array
+    // is scope-gated on read — it would sit on a permanent false empty state.
+    let resolveAsset!: (value: unknown) => void;
+    mockGetAssetTransactionHistory.mockImplementation(
+      () =>
+        new Promise((resolve) => {
+          resolveAsset = resolve as (value: unknown) => void;
+        })
+    );
+    mockGetAllTransactionHistory.mockResolvedValue({
+      transactions: [],
+      nextToken: undefined,
+    });
+
+    const assetLoad = useWalletStore
+      .getState()
+      .loadAssetTransactions('acc-1', 42, false);
+    await new Promise((resolve) => setTimeout(resolve, 0));
+    expect(accountState('acc-1').isTransactionsLoading).toBe(true);
+
+    await useWalletStore.getState().loadAllTransactions('acc-1');
+
+    // The account-wide request actually ran instead of being swallowed.
+    expect(mockGetAllTransactionHistory).toHaveBeenCalledTimes(1);
+    expect(accountState('acc-1').recentTransactionsScope).toBe(
+      ALL_TRANSACTIONS_SCOPE
+    );
+
+    resolveAsset({ transactions: [], nextToken: undefined, hasMore: false });
+    await assetLoad;
+  });
+
   it('clearAccountError clears every scoped field', async () => {
     mockGetAccountBalance.mockRejectedValue(new Error('algod is down'));
     mockGetTransactionHistory.mockRejectedValue(new Error('indexer is down'));

--- a/src/store/walletStore.ts
+++ b/src/store/walletStore.ts
@@ -114,6 +114,13 @@ interface AccountUIState {
   isBackgroundRefreshing: boolean;
   balanceLastUpdated: number;
   isTransactionsLoading: boolean;
+  /**
+   * Which resource the in-flight transaction load is fetching. The skip guard
+   * dedupes IDENTICAL requests; skipping a request for a DIFFERENT resource
+   * would silently never fetch it, leaving that screen showing another scope's
+   * (filtered-out) rows as an empty list forever.
+   */
+  transactionsLoadScope: string | null;
   envoiName?: EnvoiNameInfo | null;
   isEnvoiLoading: boolean;
   // Pagination state for transactions
@@ -287,6 +294,7 @@ const createInitialAccountState = (): AccountUIState => ({
   isBackgroundRefreshing: false,
   balanceLastUpdated: 0,
   isTransactionsLoading: false,
+  transactionsLoadScope: null,
   envoiName: null,
   isEnvoiLoading: false,
   transactionsPagination: {
@@ -1279,8 +1287,11 @@ export const useWalletStore = create<WalletState>()(
 
         console.log(`Loading transactions for account: ${accountId}`);
 
-        // Skip if already loading transactions for this account
-        if (accountState.isTransactionsLoading) {
+        // Skip only a duplicate of the SAME scope — see transactionsLoadScope.
+        if (
+          accountState.isTransactionsLoading &&
+          accountState.transactionsLoadScope === ALL_TRANSACTIONS_SCOPE
+        ) {
           console.log(
             `Transactions already loading for account: ${accountId}, skipping`
           );
@@ -1296,6 +1307,7 @@ export const useWalletStore = create<WalletState>()(
             [accountId]: {
               ...accountState,
               isTransactionsLoading: true,
+              transactionsLoadScope: ALL_TRANSACTIONS_SCOPE,
               lastError: null,
               transactionsError: null,
             },
@@ -1356,8 +1368,12 @@ export const useWalletStore = create<WalletState>()(
           `Loading asset transactions for account: ${accountId}, assetId: ${assetId}, isArc200: ${isArc200}`
         );
 
-        // Skip if already loading transactions for this account
-        if (accountState.isTransactionsLoading) {
+        // Skip only a duplicate of the SAME scope — see transactionsLoadScope.
+        if (
+          accountState.isTransactionsLoading &&
+          accountState.transactionsLoadScope ===
+            assetTransactionsScope(assetId, isArc200)
+        ) {
           console.log(
             `Transactions already loading for account: ${accountId}, skipping`
           );
@@ -1373,6 +1389,7 @@ export const useWalletStore = create<WalletState>()(
             [accountId]: {
               ...accountState,
               isTransactionsLoading: true,
+              transactionsLoadScope: assetTransactionsScope(assetId, isArc200),
               lastError: null,
               transactionsError: null,
             },
@@ -1560,8 +1577,11 @@ export const useWalletStore = create<WalletState>()(
 
         console.log(`Loading all transactions for account: ${accountId}`);
 
-        // Skip if already loading transactions for this account
-        if (accountState.isTransactionsLoading) {
+        // Skip only a duplicate of the SAME scope — see transactionsLoadScope.
+        if (
+          accountState.isTransactionsLoading &&
+          accountState.transactionsLoadScope === ALL_TRANSACTIONS_SCOPE
+        ) {
           console.log(
             `Transactions already loading for account: ${accountId}, skipping`
           );
@@ -1577,6 +1597,7 @@ export const useWalletStore = create<WalletState>()(
             [accountId]: {
               ...accountState,
               isTransactionsLoading: true,
+              transactionsLoadScope: ALL_TRANSACTIONS_SCOPE,
               lastError: null,
               transactionsError: null,
             },
@@ -2804,6 +2825,7 @@ const EMPTY_ACCOUNT_UI_STATE: Readonly<AccountUIState> = Object.freeze({
   isBackgroundRefreshing: false,
   balanceLastUpdated: 0,
   isTransactionsLoading: false,
+  transactionsLoadScope: null,
   envoiName: null,
   isEnvoiLoading: false,
   multiNetworkBalance: undefined,

--- a/src/store/walletStore.ts
+++ b/src/store/walletStore.ts
@@ -102,6 +102,14 @@ interface AccountUIState {
   multiNetworkBalanceError: string | null;
   balance?: AccountBalance;
   recentTransactions: TransactionInfo[];
+  /**
+   * Which resource `recentTransactions` currently holds — `'all'` or an asset
+   * scope. The account-wide and per-asset loaders share ONE array, so without
+   * this tag AssetDetailScreen renders the account-wide history as the asset's
+   * own (and a failed asset fetch looks like a partial success). Consumers read
+   * the array only when the tag matches what they are showing.
+   */
+  recentTransactionsScope: string | null;
   isBalanceLoading: boolean;
   isBackgroundRefreshing: boolean;
   balanceLastUpdated: number;
@@ -274,6 +282,7 @@ const createInitialAccountState = (): AccountUIState => ({
   transactionsError: null,
   multiNetworkBalanceError: null,
   recentTransactions: [],
+  recentTransactionsScope: null,
   isBalanceLoading: false,
   isBackgroundRefreshing: false,
   balanceLastUpdated: 0,
@@ -1305,6 +1314,7 @@ export const useWalletStore = create<WalletState>()(
             [accountId]: {
               ...get().accountStates[accountId],
               recentTransactions: dedupedTransactions,
+              recentTransactionsScope: ALL_TRANSACTIONS_SCOPE,
               isTransactionsLoading: false,
             },
           },
@@ -1390,6 +1400,7 @@ export const useWalletStore = create<WalletState>()(
             [accountId]: {
               ...get().accountStates[accountId],
               recentTransactions: uniqueTransactions,
+              recentTransactionsScope: assetKey,
               isTransactionsLoading: false,
               assetTransactionsPagination: {
                 ...get().accountStates[accountId]?.assetTransactionsPagination,
@@ -1494,6 +1505,7 @@ export const useWalletStore = create<WalletState>()(
             [accountId]: {
               ...get().accountStates[accountId],
               recentTransactions: updatedTransactions,
+              recentTransactionsScope: assetKey,
               assetTransactionsPagination: {
                 ...get().accountStates[accountId]?.assetTransactionsPagination,
                 [assetKey]: {
@@ -1585,6 +1597,7 @@ export const useWalletStore = create<WalletState>()(
             [accountId]: {
               ...get().accountStates[accountId],
               recentTransactions: uniqueTransactions,
+              recentTransactionsScope: ALL_TRANSACTIONS_SCOPE,
               isTransactionsLoading: false,
               transactionsPagination: {
                 nextToken: result.nextToken,
@@ -1676,6 +1689,7 @@ export const useWalletStore = create<WalletState>()(
             [accountId]: {
               ...get().accountStates[accountId],
               recentTransactions: updatedTransactions,
+              recentTransactionsScope: ALL_TRANSACTIONS_SCOPE,
               transactionsPagination: {
                 nextToken: result.nextToken,
                 hasMore: !!result.nextToken,
@@ -2785,6 +2799,7 @@ const EMPTY_ACCOUNT_UI_STATE: Readonly<AccountUIState> = Object.freeze({
   transactionsError: null,
   multiNetworkBalanceError: null,
   recentTransactions: [],
+  recentTransactionsScope: null,
   isBalanceLoading: false,
   isBackgroundRefreshing: false,
   balanceLastUpdated: 0,

--- a/src/store/walletStore.ts
+++ b/src/store/walletStore.ts
@@ -52,7 +52,22 @@ import { realtimeService } from '@/services/realtime';
 // Account-specific state for UI
 interface AccountUIState {
   isLoading: boolean;
+  /**
+   * Most recent failure for this account, whatever the operation. Kept as the
+   * coarse "something went wrong here" signal.
+   */
   lastError: string | null;
+  /**
+   * Operation-scoped failures (TASK-40 / U-03). `lastError` alone cannot drive
+   * a per-surface error state: every loader clears it on start, so a balance
+   * refresh would erase a transaction-load failure and the transaction list
+   * would silently fall back to its "No Transactions" empty state — exactly the
+   * indistinguishable-from-empty defect being fixed. Each surface therefore
+   * reads its own field.
+   */
+  balanceError: string | null;
+  transactionsError: string | null;
+  multiNetworkBalanceError: string | null;
   balance?: AccountBalance;
   recentTransactions: TransactionInfo[];
   isBalanceLoading: boolean;
@@ -223,6 +238,9 @@ interface WalletState {
 const createInitialAccountState = (): AccountUIState => ({
   isLoading: false,
   lastError: null,
+  balanceError: null,
+  transactionsError: null,
+  multiNetworkBalanceError: null,
   recentTransactions: [],
   isBalanceLoading: false,
   isBackgroundRefreshing: false,
@@ -1070,6 +1088,7 @@ export const useWalletStore = create<WalletState>()(
                 isBalanceLoading: shouldShowLoading,
                 isBackgroundRefreshing: shouldShowBackgroundRefresh,
                 lastError: null,
+                balanceError: null,
               },
             },
           });
@@ -1188,6 +1207,10 @@ export const useWalletStore = create<WalletState>()(
                   error instanceof Error
                     ? error.message
                     : 'Failed to load balance',
+                balanceError:
+                  error instanceof Error
+                    ? error.message
+                    : 'Failed to load balance',
                 isBalanceLoading: false,
                 isBackgroundRefreshing: false,
               },
@@ -1233,6 +1256,7 @@ export const useWalletStore = create<WalletState>()(
               ...accountState,
               isTransactionsLoading: true,
               lastError: null,
+              transactionsError: null,
             },
           },
         });
@@ -1261,6 +1285,10 @@ export const useWalletStore = create<WalletState>()(
             [accountId]: {
               ...accountStates[accountId],
               lastError:
+                error instanceof Error
+                  ? error.message
+                  : 'Failed to load transactions',
+              transactionsError:
                 error instanceof Error
                   ? error.message
                   : 'Failed to load transactions',
@@ -1303,6 +1331,7 @@ export const useWalletStore = create<WalletState>()(
               ...accountState,
               isTransactionsLoading: true,
               lastError: null,
+              transactionsError: null,
             },
           },
         });
@@ -1351,6 +1380,10 @@ export const useWalletStore = create<WalletState>()(
                 error instanceof Error
                   ? error.message
                   : 'Failed to load asset transactions',
+              transactionsError:
+                error instanceof Error
+                  ? error.message
+                  : 'Failed to load asset transactions',
               isTransactionsLoading: false,
             },
           },
@@ -1385,6 +1418,7 @@ export const useWalletStore = create<WalletState>()(
             ...accountStates,
             [accountId]: {
               ...accountState,
+              transactionsError: null,
               assetTransactionsPagination: {
                 ...accountState.assetTransactionsPagination,
                 [assetKey]: {
@@ -1445,6 +1479,12 @@ export const useWalletStore = create<WalletState>()(
             ...accountStates,
             [accountId]: {
               ...accountStates[accountId],
+              // See loadMoreTransactions: a failed page is surfaced as a
+              // retryable footer instead of silently ending pagination.
+              transactionsError:
+                error instanceof Error
+                  ? error.message
+                  : 'Failed to load more asset transactions',
               assetTransactionsPagination: {
                 ...accountStates[accountId]?.assetTransactionsPagination,
                 [assetKey]: {
@@ -1491,6 +1531,7 @@ export const useWalletStore = create<WalletState>()(
               ...accountState,
               isTransactionsLoading: true,
               lastError: null,
+              transactionsError: null,
             },
           },
         });
@@ -1529,6 +1570,10 @@ export const useWalletStore = create<WalletState>()(
                 error instanceof Error
                   ? error.message
                   : 'Failed to load all transactions',
+              transactionsError:
+                error instanceof Error
+                  ? error.message
+                  : 'Failed to load all transactions',
               isTransactionsLoading: false,
             },
           },
@@ -1559,6 +1604,7 @@ export const useWalletStore = create<WalletState>()(
             ...accountStates,
             [accountId]: {
               ...accountState,
+              transactionsError: null,
               transactionsPagination: {
                 ...accountState.transactionsPagination,
                 isLoadingMore: true,
@@ -1609,6 +1655,14 @@ export const useWalletStore = create<WalletState>()(
             ...accountStates,
             [accountId]: {
               ...accountStates[accountId],
+              // Surfaced as a retryable list footer rather than a whole-screen
+              // error: the already-loaded page is still valid, only the next
+              // page failed. Previously this was console-only, so pagination
+              // just silently stopped.
+              transactionsError:
+                error instanceof Error
+                  ? error.message
+                  : 'Failed to load more transactions',
               transactionsPagination: {
                 hasMore: true,
                 ...accountStates[accountId]?.transactionsPagination,
@@ -1678,6 +1732,7 @@ export const useWalletStore = create<WalletState>()(
             updatedAccountStates[accountId] = {
               ...currentState,
               lastError: error,
+              balanceError: error,
               isBalanceLoading: false,
               isBackgroundRefreshing: false,
             };
@@ -1690,6 +1745,7 @@ export const useWalletStore = create<WalletState>()(
               isBackgroundRefreshing: false,
               balanceLastUpdated: now,
               lastError: null,
+              balanceError: null,
             };
 
             // Collect rekey updates for later processing
@@ -2319,6 +2375,7 @@ export const useWalletStore = create<WalletState>()(
               ...accountState,
               isMultiNetworkBalanceLoading: shouldShowLoading,
               lastError: null,
+              multiNetworkBalanceError: null,
             },
           },
         });
@@ -2364,6 +2421,10 @@ export const useWalletStore = create<WalletState>()(
             [accountId]: {
               ...accountState,
               lastError:
+                error instanceof Error
+                  ? error.message
+                  : 'Failed to load multi-network balance',
+              multiNetworkBalanceError:
                 error instanceof Error
                   ? error.message
                   : 'Failed to load multi-network balance',
@@ -2516,7 +2577,13 @@ export const useWalletStore = create<WalletState>()(
         set({
           accountStates: {
             ...accountStates,
-            [accountId]: { ...accountStates[accountId], lastError: null },
+            [accountId]: {
+              ...accountStates[accountId],
+              lastError: null,
+              balanceError: null,
+              transactionsError: null,
+              multiNetworkBalanceError: null,
+            },
           },
         });
       }
@@ -2677,6 +2744,9 @@ const EMPTY_SIGNABLE_ACCOUNTS: (
 const EMPTY_ACCOUNT_UI_STATE: Readonly<AccountUIState> = Object.freeze({
   isLoading: false,
   lastError: null,
+  balanceError: null,
+  transactionsError: null,
+  multiNetworkBalanceError: null,
   recentTransactions: [],
   isBalanceLoading: false,
   isBackgroundRefreshing: false,
@@ -2841,7 +2911,9 @@ export const useAccountBalance = (accountId: string) =>
       balance: accountState.balance,
       isLoading: accountState.isBalanceLoading,
       isBackgroundRefreshing: accountState.isBackgroundRefreshing,
-      error: accountState.lastError,
+      // Balance-scoped (TASK-40): `lastError` is clobbered by every other
+      // loader, so it cannot drive a balance error state.
+      error: accountState.balanceError,
       reload: reloadFunction,
     });
 
@@ -2910,7 +2982,7 @@ export const useActiveAccountBalance = () =>
         balance: accountState.balance,
         isLoading: accountState.isBalanceLoading,
         isBackgroundRefreshing: accountState.isBackgroundRefreshing,
-        error: accountState.lastError,
+        error: accountState.balanceError,
         reload: activeAccountReloadFunction,
       });
     }
@@ -2929,6 +3001,7 @@ export const clearWalletUICache = () => {
   balanceReloadFunctions.clear();
   envoiNameCache.clear();
   multiNetworkBalanceCache.clear();
+  multiNetworkReloadFunctions.clear();
 
   // Reset active account cache
   lastActiveAccountId = undefined;
@@ -3061,9 +3134,15 @@ const multiNetworkBalanceCache = new Map<
       balance: MultiNetworkBalance | undefined;
       isLoading: boolean;
       lastUpdated: number;
+      error: string | null;
+      reload: () => Promise<void>;
     };
   }
 >();
+
+// Stable reload functions for the multi-network balance, keyed by account, so
+// the hook result keeps a stable identity across renders.
+const multiNetworkReloadFunctions = new Map<string, () => Promise<void>>();
 
 export const useMultiNetworkBalance = (accountId: string) =>
   useWalletStore((state) => {
@@ -3075,11 +3154,21 @@ export const useMultiNetworkBalance = (accountId: string) =>
       return cached.result;
     }
 
+    let reloadFunction = multiNetworkReloadFunctions.get(accountId);
+    if (!reloadFunction) {
+      reloadFunction = () => state.loadMultiNetworkBalance(accountId, true);
+      multiNetworkReloadFunctions.set(accountId, reloadFunction);
+    }
+
     // Create new result and cache it
     const result = {
       balance: accountState?.multiNetworkBalance,
       isLoading: accountState?.isMultiNetworkBalanceLoading ?? false,
       lastUpdated: accountState?.multiNetworkBalanceLastUpdated ?? 0,
+      // TASK-40: this hook previously had no error field at all, so a failed
+      // aggregate-balance load was indistinguishable from an empty wallet.
+      error: accountState?.multiNetworkBalanceError ?? null,
+      reload: reloadFunction,
     } as const;
 
     multiNetworkBalanceCache.set(accountId, { accountState, result });

--- a/src/store/walletStore.ts
+++ b/src/store/walletStore.ts
@@ -67,6 +67,33 @@ export const assetTransactionsScope = (
   isArc200: boolean
 ): string => `${assetId}_${isArc200 ? 'arc200' : 'asa'}`;
 
+/**
+ * Monotonic per-account request counter for transaction loads.
+ *
+ * `recentTransactions` is a single array shared by the account-wide and
+ * per-asset loaders, so two loads of DIFFERENT scopes can be in flight at once
+ * (they must be — deduping them away means a screen never fetches at all).
+ * Whichever response landed last used to win, which could leave the newest
+ * requested view showing another scope's result. Every load takes a token and
+ * applies its result only while that token is still the newest, so a stale
+ * response can never overwrite a fresher one.
+ *
+ * This mirrors the generation counter already used for network health probes
+ * in `services/network`.
+ */
+const transactionsRequestSeq = new Map<string, number>();
+
+const nextTransactionsRequest = (accountId: string): number => {
+  const next = (transactionsRequestSeq.get(accountId) ?? 0) + 1;
+  transactionsRequestSeq.set(accountId, next);
+  return next;
+};
+
+const isLatestTransactionsRequest = (
+  accountId: string,
+  token: number
+): boolean => transactionsRequestSeq.get(accountId) === token;
+
 const toTransactionsError = (
   error: unknown,
   scope: string,
@@ -1280,6 +1307,9 @@ export const useWalletStore = create<WalletState>()(
     },
 
     loadAccountTransactions: async (accountId: string) => {
+      // 0 = not yet issued, so a failure before the request was taken out
+      // (e.g. account resolution) still reports against the current view.
+      let requestToken = 0;
       try {
         const { accountStates } = get();
         const accountState =
@@ -1297,6 +1327,8 @@ export const useWalletStore = create<WalletState>()(
           );
           return;
         }
+
+        requestToken = nextTransactionsRequest(accountId);
 
         // Resolve account fresh from service (repairs missing addresses if needed)
         const account = await MultiAccountWalletService.getAccount(accountId);
@@ -1320,6 +1352,8 @@ export const useWalletStore = create<WalletState>()(
         );
         const dedupedTransactions = dedupeTransactions(transactions);
 
+        if (!isLatestTransactionsRequest(accountId, requestToken)) return;
+
         set({
           accountStates: {
             ...get().accountStates,
@@ -1332,6 +1366,13 @@ export const useWalletStore = create<WalletState>()(
           },
         });
       } catch (error) {
+        // A superseded request must not blame the view that replaced it.
+        if (
+          requestToken &&
+          !isLatestTransactionsRequest(accountId, requestToken)
+        ) {
+          return;
+        }
         const { accountStates } = get();
         set({
           accountStates: {
@@ -1359,6 +1400,9 @@ export const useWalletStore = create<WalletState>()(
       assetId: number,
       isArc200: boolean = false
     ) => {
+      // 0 = not yet issued, so a failure before the request was taken out
+      // (e.g. account resolution) still reports against the current view.
+      let requestToken = 0;
       try {
         const { accountStates } = get();
         const accountState =
@@ -1379,6 +1423,8 @@ export const useWalletStore = create<WalletState>()(
           );
           return;
         }
+
+        requestToken = nextTransactionsRequest(accountId);
 
         // Resolve account fresh from service
         const account = await MultiAccountWalletService.getAccount(accountId);
@@ -1411,6 +1457,8 @@ export const useWalletStore = create<WalletState>()(
         // Deduplicate transactions by ID (in case API returns duplicates)
         const uniqueTransactions = dedupeTransactions(result.transactions);
 
+        if (!isLatestTransactionsRequest(accountId, requestToken)) return;
+
         set({
           accountStates: {
             ...get().accountStates,
@@ -1431,6 +1479,13 @@ export const useWalletStore = create<WalletState>()(
           },
         });
       } catch (error) {
+        // A superseded request must not blame the view that replaced it.
+        if (
+          requestToken &&
+          !isLatestTransactionsRequest(accountId, requestToken)
+        ) {
+          return;
+        }
         const { accountStates } = get();
         set({
           accountStates: {
@@ -1458,6 +1513,8 @@ export const useWalletStore = create<WalletState>()(
       assetId: number,
       isArc200: boolean = false
     ) => {
+      // 0 = not yet issued; see nextTransactionsRequest.
+      let requestToken = 0;
       try {
         const { accountStates } = get();
         const accountState =
@@ -1470,6 +1527,11 @@ export const useWalletStore = create<WalletState>()(
         if (!pagination?.hasMore || pagination?.isLoadingMore) {
           return;
         }
+
+        // This appends into the shared array, so it takes a request token too:
+        // a page that lands after the view has switched scope must be dropped
+        // rather than mixed into the new scope's list.
+        requestToken = nextTransactionsRequest(accountId);
 
         // Resolve account fresh from service
         const account = await MultiAccountWalletService.getAccount(accountId);
@@ -1516,6 +1578,8 @@ export const useWalletStore = create<WalletState>()(
           ...newTransactions,
         ]);
 
+        if (!isLatestTransactionsRequest(accountId, requestToken)) return;
+
         set({
           accountStates: {
             ...get().accountStates,
@@ -1543,12 +1607,17 @@ export const useWalletStore = create<WalletState>()(
             [accountId]: {
               ...accountStates[accountId],
               // See loadMoreTransactions: a failed page is surfaced as a
-              // retryable footer instead of silently ending pagination.
-              transactionsError: toTransactionsError(
-                error,
-                assetKey,
-                'Failed to load more asset transactions'
-              ),
+              // retryable footer instead of silently ending pagination — but
+              // only while this is still the request the view is waiting on.
+              ...(isLatestTransactionsRequest(accountId, requestToken)
+                ? {
+                    transactionsError: toTransactionsError(
+                      error,
+                      assetKey,
+                      'Failed to load more asset transactions'
+                    ),
+                  }
+                : {}),
               assetTransactionsPagination: {
                 ...accountStates[accountId]?.assetTransactionsPagination,
                 [assetKey]: {
@@ -1570,6 +1639,9 @@ export const useWalletStore = create<WalletState>()(
     },
 
     loadAllTransactions: async (accountId: string) => {
+      // 0 = not yet issued, so a failure before the request was taken out
+      // (e.g. account resolution) still reports against the current view.
+      let requestToken = 0;
       try {
         const { accountStates } = get();
         const accountState =
@@ -1587,6 +1659,8 @@ export const useWalletStore = create<WalletState>()(
           );
           return;
         }
+
+        requestToken = nextTransactionsRequest(accountId);
 
         // Resolve account fresh from service
         const account = await MultiAccountWalletService.getAccount(accountId);
@@ -1612,6 +1686,8 @@ export const useWalletStore = create<WalletState>()(
 
         const uniqueTransactions = dedupeTransactions(result.transactions);
 
+        if (!isLatestTransactionsRequest(accountId, requestToken)) return;
+
         set({
           accountStates: {
             ...get().accountStates,
@@ -1629,6 +1705,13 @@ export const useWalletStore = create<WalletState>()(
           },
         });
       } catch (error) {
+        // A superseded request must not blame the view that replaced it.
+        if (
+          requestToken &&
+          !isLatestTransactionsRequest(accountId, requestToken)
+        ) {
+          return;
+        }
         const { accountStates } = get();
         set({
           accountStates: {
@@ -1652,6 +1735,8 @@ export const useWalletStore = create<WalletState>()(
     },
 
     loadMoreTransactions: async (accountId: string) => {
+      // 0 = not yet issued; see nextTransactionsRequest.
+      let requestToken = 0;
       try {
         const { accountStates } = get();
         const accountState =
@@ -1664,6 +1749,10 @@ export const useWalletStore = create<WalletState>()(
         ) {
           return;
         }
+
+        // See loadMoreAssetTransactions: appends into the shared array, so a
+        // page landing after a scope switch must be dropped.
+        requestToken = nextTransactionsRequest(accountId);
 
         // Resolve account fresh from service
         const account = await MultiAccountWalletService.getAccount(accountId);
@@ -1704,6 +1793,8 @@ export const useWalletStore = create<WalletState>()(
           ...newTransactions,
         ]);
 
+        if (!isLatestTransactionsRequest(accountId, requestToken)) return;
+
         set({
           accountStates: {
             ...get().accountStates,
@@ -1729,12 +1820,16 @@ export const useWalletStore = create<WalletState>()(
               // Surfaced as a retryable list footer rather than a whole-screen
               // error: the already-loaded page is still valid, only the next
               // page failed. Previously this was console-only, so pagination
-              // just silently stopped.
-              transactionsError: toTransactionsError(
-                error,
-                ALL_TRANSACTIONS_SCOPE,
-                'Failed to load more transactions'
-              ),
+              // just silently stopped. Only blame the current view.
+              ...(isLatestTransactionsRequest(accountId, requestToken)
+                ? {
+                    transactionsError: toTransactionsError(
+                      error,
+                      ALL_TRANSACTIONS_SCOPE,
+                      'Failed to load more transactions'
+                    ),
+                  }
+                : {}),
               transactionsPagination: {
                 hasMore: true,
                 ...accountStates[accountId]?.transactionsPagination,

--- a/src/store/walletStore.ts
+++ b/src/store/walletStore.ts
@@ -94,6 +94,25 @@ const isLatestTransactionsRequest = (
   token: number
 ): boolean => transactionsRequestSeq.get(accountId) === token;
 
+/**
+ * Same generation guard as `transactionsRequestSeq`, for the aggregate
+ * multi-network balance. Retry and pull-to-refresh both force a load, so two
+ * can overlap; without this an older failure landing after a newer success
+ * would replace fresh balances with a stale error banner.
+ */
+const multiNetworkRequestSeq = new Map<string, number>();
+
+const nextMultiNetworkRequest = (accountId: string): number => {
+  const next = (multiNetworkRequestSeq.get(accountId) ?? 0) + 1;
+  multiNetworkRequestSeq.set(accountId, next);
+  return next;
+};
+
+const isLatestMultiNetworkRequest = (
+  accountId: string,
+  token: number
+): boolean => multiNetworkRequestSeq.get(accountId) === token;
+
 const toTransactionsError = (
   error: unknown,
   scope: string,
@@ -2511,6 +2530,8 @@ export const useWalletStore = create<WalletState>()(
       accountId: string,
       forceRefresh = false
     ) => {
+      // 0 = not yet issued; see nextMultiNetworkRequest.
+      let requestToken = 0;
       try {
         const { accountStates, tokenMappings } = get();
         const accountState =
@@ -2527,6 +2548,8 @@ export const useWalletStore = create<WalletState>()(
         if (!forceRefresh && hasExistingBalance && !isCacheExpired) {
           return;
         }
+
+        requestToken = nextMultiNetworkRequest(accountId);
 
         // Get account address
         const account = await MultiAccountWalletService.getAccount(accountId);
@@ -2558,6 +2581,8 @@ export const useWalletStore = create<WalletState>()(
             account.address
           );
 
+        if (!isLatestMultiNetworkRequest(accountId, requestToken)) return;
+
         set({
           accountStates: {
             ...get().accountStates,
@@ -2579,6 +2604,17 @@ export const useWalletStore = create<WalletState>()(
           );
         }, 0);
       } catch (error) {
+        // A superseded request must not replace a newer success with an error.
+        if (
+          requestToken &&
+          !isLatestMultiNetworkRequest(accountId, requestToken)
+        ) {
+          console.error(
+            '[WalletStore] Stale multi-network balance load failed:',
+            error
+          );
+          return;
+        }
         const { accountStates } = get();
         const accountState =
           accountStates[accountId] || createInitialAccountState();

--- a/src/store/walletStore.ts
+++ b/src/store/walletStore.ts
@@ -49,6 +49,33 @@ import {
 } from '@/services/notifications';
 import { realtimeService } from '@/services/realtime';
 
+/**
+ * A transaction-load failure, tagged with the resource it belongs to:
+ * `'all'` for the account-wide history, or `${assetId}_asa|arc200` for a
+ * single asset's history (the same key used by `assetTransactionsPagination`).
+ */
+export interface TransactionsError {
+  scope: string;
+  message: string;
+}
+
+/** Account-wide transaction history, as opposed to a single asset's. */
+export const ALL_TRANSACTIONS_SCOPE = 'all';
+
+export const assetTransactionsScope = (
+  assetId: number,
+  isArc200: boolean
+): string => `${assetId}_${isArc200 ? 'arc200' : 'asa'}`;
+
+const toTransactionsError = (
+  error: unknown,
+  scope: string,
+  fallback: string
+): TransactionsError => ({
+  scope,
+  message: error instanceof Error ? error.message : fallback,
+});
+
 // Account-specific state for UI
 interface AccountUIState {
   isLoading: boolean;
@@ -66,7 +93,12 @@ interface AccountUIState {
    * reads its own field.
    */
   balanceError: string | null;
-  transactionsError: string | null;
+  /**
+   * Scoped so an asset-history failure is not rendered as an account-history
+   * failure (and vice versa) — both loaders write into the SAME
+   * `recentTransactions` array, so an unscoped field leaks across screens.
+   */
+  transactionsError: TransactionsError | null;
   multiNetworkBalanceError: string | null;
   balance?: AccountBalance;
   recentTransactions: TransactionInfo[];
@@ -1288,10 +1320,11 @@ export const useWalletStore = create<WalletState>()(
                 error instanceof Error
                   ? error.message
                   : 'Failed to load transactions',
-              transactionsError:
-                error instanceof Error
-                  ? error.message
-                  : 'Failed to load transactions',
+              transactionsError: toTransactionsError(
+                error,
+                ALL_TRANSACTIONS_SCOPE,
+                'Failed to load transactions'
+              ),
               isTransactionsLoading: false,
             },
           },
@@ -1346,7 +1379,7 @@ export const useWalletStore = create<WalletState>()(
         );
 
         // Create asset key for pagination tracking
-        const assetKey = `${assetId}_${isArc200 ? 'arc200' : 'asa'}`;
+        const assetKey = assetTransactionsScope(assetId, isArc200);
 
         // Deduplicate transactions by ID (in case API returns duplicates)
         const uniqueTransactions = dedupeTransactions(result.transactions);
@@ -1380,10 +1413,11 @@ export const useWalletStore = create<WalletState>()(
                 error instanceof Error
                   ? error.message
                   : 'Failed to load asset transactions',
-              transactionsError:
-                error instanceof Error
-                  ? error.message
-                  : 'Failed to load asset transactions',
+              transactionsError: toTransactionsError(
+                error,
+                assetTransactionsScope(assetId, isArc200),
+                'Failed to load asset transactions'
+              ),
               isTransactionsLoading: false,
             },
           },
@@ -1401,7 +1435,7 @@ export const useWalletStore = create<WalletState>()(
         const accountState =
           accountStates[accountId] || createInitialAccountState();
 
-        const assetKey = `${assetId}_${isArc200 ? 'arc200' : 'asa'}`;
+        const assetKey = assetTransactionsScope(assetId, isArc200);
         const pagination = accountState.assetTransactionsPagination?.[assetKey];
 
         // Don't load more if already loading or no more data
@@ -1473,7 +1507,7 @@ export const useWalletStore = create<WalletState>()(
         });
       } catch (error) {
         const { accountStates } = get();
-        const assetKey = `${assetId}_${isArc200 ? 'arc200' : 'asa'}`;
+        const assetKey = assetTransactionsScope(assetId, isArc200);
         set({
           accountStates: {
             ...accountStates,
@@ -1481,10 +1515,11 @@ export const useWalletStore = create<WalletState>()(
               ...accountStates[accountId],
               // See loadMoreTransactions: a failed page is surfaced as a
               // retryable footer instead of silently ending pagination.
-              transactionsError:
-                error instanceof Error
-                  ? error.message
-                  : 'Failed to load more asset transactions',
+              transactionsError: toTransactionsError(
+                error,
+                assetKey,
+                'Failed to load more asset transactions'
+              ),
               assetTransactionsPagination: {
                 ...accountStates[accountId]?.assetTransactionsPagination,
                 [assetKey]: {
@@ -1570,10 +1605,11 @@ export const useWalletStore = create<WalletState>()(
                 error instanceof Error
                   ? error.message
                   : 'Failed to load all transactions',
-              transactionsError:
-                error instanceof Error
-                  ? error.message
-                  : 'Failed to load all transactions',
+              transactionsError: toTransactionsError(
+                error,
+                ALL_TRANSACTIONS_SCOPE,
+                'Failed to load all transactions'
+              ),
               isTransactionsLoading: false,
             },
           },
@@ -1659,10 +1695,11 @@ export const useWalletStore = create<WalletState>()(
               // error: the already-loaded page is still valid, only the next
               // page failed. Previously this was console-only, so pagination
               // just silently stopped.
-              transactionsError:
-                error instanceof Error
-                  ? error.message
-                  : 'Failed to load more transactions',
+              transactionsError: toTransactionsError(
+                error,
+                ALL_TRANSACTIONS_SCOPE,
+                'Failed to load more transactions'
+              ),
               transactionsPagination: {
                 hasMore: true,
                 ...accountStates[accountId]?.transactionsPagination,

--- a/src/store/walletStore.ts
+++ b/src/store/walletStore.ts
@@ -1352,11 +1352,18 @@ export const useWalletStore = create<WalletState>()(
         // Resolve account fresh from service (repairs missing addresses if needed)
         const account = await MultiAccountWalletService.getAccount(accountId);
 
+        // Freshness must be re-checked BEFORE any write: a newer scope may have
+        // completed during the await above, and re-raising the loading flag from
+        // this stale snapshot would strand the UI in a spinner (this request's
+        // own response is dropped by the guard further down).
+        if (!isLatestTransactionsRequest(accountId, requestToken)) return;
+        const currentState = get().accountStates[accountId] ?? accountState;
+
         set({
           accountStates: {
-            ...accountStates,
+            ...get().accountStates,
             [accountId]: {
-              ...accountState,
+              ...currentState,
               isTransactionsLoading: true,
               transactionsLoadScope: ALL_TRANSACTIONS_SCOPE,
               lastError: null,
@@ -1448,11 +1455,18 @@ export const useWalletStore = create<WalletState>()(
         // Resolve account fresh from service
         const account = await MultiAccountWalletService.getAccount(accountId);
 
+        // Freshness must be re-checked BEFORE any write: a newer scope may have
+        // completed during the await above, and re-raising the loading flag from
+        // this stale snapshot would strand the UI in a spinner (this request's
+        // own response is dropped by the guard further down).
+        if (!isLatestTransactionsRequest(accountId, requestToken)) return;
+        const currentState = get().accountStates[accountId] ?? accountState;
+
         set({
           accountStates: {
-            ...accountStates,
+            ...get().accountStates,
             [accountId]: {
-              ...accountState,
+              ...currentState,
               isTransactionsLoading: true,
               transactionsLoadScope: assetTransactionsScope(assetId, isArc200),
               lastError: null,
@@ -1555,12 +1569,14 @@ export const useWalletStore = create<WalletState>()(
         // Resolve account fresh from service
         const account = await MultiAccountWalletService.getAccount(accountId);
 
+        if (!isLatestTransactionsRequest(accountId, requestToken)) return;
+
         // Set loading more state
         set({
           accountStates: {
-            ...accountStates,
+            ...get().accountStates,
             [accountId]: {
-              ...accountState,
+              ...(get().accountStates[accountId] ?? accountState),
               transactionsError: null,
               assetTransactionsPagination: {
                 ...accountState.assetTransactionsPagination,
@@ -1684,11 +1700,18 @@ export const useWalletStore = create<WalletState>()(
         // Resolve account fresh from service
         const account = await MultiAccountWalletService.getAccount(accountId);
 
+        // Freshness must be re-checked BEFORE any write: a newer scope may have
+        // completed during the await above, and re-raising the loading flag from
+        // this stale snapshot would strand the UI in a spinner (this request's
+        // own response is dropped by the guard further down).
+        if (!isLatestTransactionsRequest(accountId, requestToken)) return;
+        const currentState = get().accountStates[accountId] ?? accountState;
+
         set({
           accountStates: {
-            ...accountStates,
+            ...get().accountStates,
             [accountId]: {
-              ...accountState,
+              ...currentState,
               isTransactionsLoading: true,
               transactionsLoadScope: ALL_TRANSACTIONS_SCOPE,
               lastError: null,
@@ -1776,12 +1799,14 @@ export const useWalletStore = create<WalletState>()(
         // Resolve account fresh from service
         const account = await MultiAccountWalletService.getAccount(accountId);
 
+        if (!isLatestTransactionsRequest(accountId, requestToken)) return;
+
         // Set loading more state
         set({
           accountStates: {
-            ...accountStates,
+            ...get().accountStates,
             [accountId]: {
-              ...accountState,
+              ...(get().accountStates[accountId] ?? accountState),
               transactionsError: null,
               transactionsPagination: {
                 ...accountState.transactionsPagination,
@@ -2554,15 +2579,20 @@ export const useWalletStore = create<WalletState>()(
         // Get account address
         const account = await MultiAccountWalletService.getAccount(accountId);
 
+        // Same reasoning as the transaction loaders: re-check freshness before
+        // any write, or a stale request re-raises the loading flag and its own
+        // response is then discarded, stranding the UI in a spinner.
+        if (!isLatestMultiNetworkRequest(accountId, requestToken)) return;
+
         // Determine loading state based on cache availability
         const shouldShowLoading = !hasExistingBalance || forceRefresh;
 
         // Set loading state
         set({
           accountStates: {
-            ...accountStates,
+            ...get().accountStates,
             [accountId]: {
-              ...accountState,
+              ...(get().accountStates[accountId] ?? accountState),
               isMultiNetworkBalanceLoading: shouldShowLoading,
               lastError: null,
               multiNetworkBalanceError: null,


### PR DESCRIPTION
Closes audit findings **U-03** and **R-03** (TASK-40, PLAN-12 Phase 1 Wave 2).

## The problem

Data-load failures were caught with `console.error` only, so a failed fetch rendered *exactly* like a successful fetch of an empty account. "No Transactions" on an account you know has history reads as lost funds — the single most alarming thing a wallet can show. There was also no connectivity awareness at all: `@react-native-community/netinfo` was a declared dependency imported nowhere in `src/`, so a dropped connection produced stale balances, no banner, and a pull-to-refresh that silently did nothing.

Most of the state needed to fix this already existed and was simply never read:

- `HomeScreen`'s `networkStatus` was written twice and read **zero** times.
- Per-account `lastError` was written in ~20 places in `walletStore` and read by nothing.
- `useActiveAccountBalance` exposed `error`; no consumer destructured it.
- `useMultiNetworkBalance` had no error field at all.

## Connectivity (DR-7 / DR-8)

- **`ConnectivityAdapter`** added to `src/platform/`, following the existing adapter pattern exactly. Mobile resolves to NetInfo; extension/web resolves to `navigator.onLine` + `online`/`offline` events, so the native module never enters the web bundle. A shared `isOffline()` keeps both targets agreeing on what "offline" means.
- **`useConnectivity()`** hook + app-wide **`OfflineBanner`**, mounted at the App root above `NavigationContainer` so it survives every navigation including the pre-auth screens.
  - *On the `AuthProvider` caveat:* the banner consumes connectivity only — no auth or wallet state — which is exactly why it can sit outside `AuthProvider`. Moving it inside `AppNavigator` would buy access to state it does not want and lose coverage of the pre-auth screens.
  - *On safe area:* there is no `SafeAreaProvider` at the App root (each navigator makes its own via React Navigation's `SafeAreaProviderCompat`), so rather than restructure the provider tree app-wide for one bar it reads the static `initialWindowMetrics` insets — the same fallback `SafeAreaProviderCompat` itself uses. The app is portrait-locked, so these do not change at runtime.
- **JS-only / OTA-safe (DR-8):** `react-native-netinfo (11.4.1)` is already in `ios/Podfile.lock`, so the native module ships in existing binaries. No `app.config.js`, native config, or version changes.
- **Extension/web target verified** by running `npx expo export -p web` before and after.

## Error state

`walletStore` gains operation-scoped error fields (`balanceError`, `transactionsError`, `multiNetworkBalanceError`). `lastError` alone could never have driven a per-surface error state: every loader clears it on start, so a balance refresh would erase a transaction failure and the list would drop back to its empty state — the exact defect being fixed. `lastError` is left intact as the coarse signal.

`useMultiNetworkBalance` now exposes `error` and a stable `reload`; the balance hooks' `error` is scoped to the balance load.

## Screens

- New shared **`ErrorStateView`** renders every failure through the central mapper from TASK-41 (`mapError`), always with a retry affordance.
- **TransactionHistory / AssetDetail** never render their empty state for a failed fetch, and show a retryable footer when a *later page* fails instead of silently ending pagination.
- **Home** consumes the balance and multi-network errors it previously ignored, renders the `networkStatus` that was dead state, no longer discards the `Promise.allSettled` health-probe rejection, and routes its init alert through the mapper.

## Folded in

- The cleanup noted on the task: dead `loadAllTransactions` / `loadMoreTransactions` zustand selectors left in `AssetDetailScreen` by the TASK-39 FlatList conversion (dead subscriptions causing needless re-renders).
- `isLoadingNetworkTransactions` was another write-only flag; it now drives AssetDetail's loading state.

## Discovered during Codex review (9 rounds, all folded in)

Surfacing these errors exposed a pre-existing store hazard: `recentTransactions` is **one array** shared by the account-wide and per-asset loaders. Once the UI branches on load state, that sharing becomes visible.

1. **Errors leaked across screens** — a failed asset fetch rendered as a full-history failure, and vice versa. Transaction errors are now tagged with the resource they belong to.
2. **Rows leaked across screens** — AssetDetail rendered Home's account-wide history as the asset's own. The array now carries the scope it holds and each screen reads it only when it matches.
3. **A load for a different resource was silently skipped** — the dedupe guard bailed on *any* in-flight load, so a screen could never fetch and sit on a permanent false empty state. It now dedupes only genuine duplicates.
4. **Last-response-wins on the shared array** — a slower response could replace the view the user is actually on. Per-account monotonic request tokens (the same generation-counter pattern already used for network health probes) mean a load applies its result, and reports its error, only while it is still the newest.
5. **Stale requests could strand a spinner** — freshness is now re-checked before *every* write, not just around the response.
6. **`loadMultiNetworkBalance` had no versioning** — retry and pull-to-refresh both force a load, so an older failure could replace fresh balances with an error banner.
7. **Balance retry could be a no-op** — the hook's `reload` is unforced and `loadAccountBalance` returns early on a fresh cache, so after a failed *forced* refresh the retry did nothing. Retry now forces.
8. Loading states added where the scope gate would otherwise flash a definitive empty state, keyed to the loaded resource so an account/asset switch cannot inherit the previous verdict.

## Gates

| | |
|---|---|
| `npm run typecheck` | 0 errors |
| `npm run lint` | 0 errors (683 warnings vs 681 baseline — 2 new React Compiler memoization notices from added `useCallback`s) |
| `npm test -- --ci` | **1356 passing / 80 suites** (baseline 1319 / 76) |
| Extension/web | `expo export -p web` succeeds |
| Codex review | **CLEAN** after 9 rounds |

New tests cover the connectivity adapters on both targets, the offline banner, the store's error/list scoping and request versioning, and the core acceptance criterion — a failed transaction fetch must never render "No Transactions".

Not covered: manual device testing (batched pre-release, per plan).
