### PR TITLE
feat(a11y): labels/roles/state on shared components + reactive reduce-motion (TASK-42)

### DIFF
--- a/src/components/account/AccountRecipientModal.tsx
+++ b/src/components/account/AccountRecipientModal.tsx
@@ -156,6 +156,10 @@ export default function AccountRecipientModal({
         style={styles.accountItem}
         onPress={() => handleAccountSelect(item)}
         activeOpacity={0.7}
+        accessible
+        accessibilityRole="button"
+        accessibilityLabel={`${item.label || `Account ${item.address.slice(0, 6)}`}, ${formatAddress(item.address)}`}
+        accessibilityHint="Selects this account as the recipient"
       >
         <AccountAvatar address={item.address} account={item} size={40} />
         <View style={styles.accountInfo}>
@@ -183,6 +187,10 @@ export default function AccountRecipientModal({
         style={styles.accountItem}
         onPress={() => handleFriendSelect(item)}
         activeOpacity={0.7}
+        accessible
+        accessibilityRole="button"
+        accessibilityLabel={`${item.envoiName}${item.isFavorite ? ', favorite' : ''}, ${formatAddress(item.address)}`}
+        accessibilityHint="Selects this contact as the recipient"
       >
         {item.avatar ? (
           <Image
@@ -273,6 +281,8 @@ export default function AccountRecipientModal({
                 onPress={onClose}
                 style={styles.closeButton}
                 hitSlop={{ top: 10, bottom: 10, left: 10, right: 10 }}
+                accessibilityRole="button"
+                accessibilityLabel="Close recipient picker"
               >
                 <Ionicons
                   name="close"
@@ -287,6 +297,9 @@ export default function AccountRecipientModal({
                 style={[styles.tab, isAccountsTab && styles.tabActive]}
                 onPress={() => setActiveTab('accounts')}
                 activeOpacity={0.7}
+                accessibilityRole="tab"
+                accessibilityLabel="My accounts"
+                accessibilityState={{ selected: isAccountsTab }}
               >
                 <Ionicons
                   name="wallet-outline"
@@ -311,6 +324,9 @@ export default function AccountRecipientModal({
                 style={[styles.tab, !isAccountsTab && styles.tabActive]}
                 onPress={() => setActiveTab('friends')}
                 activeOpacity={0.7}
+                accessibilityRole="tab"
+                accessibilityLabel="Contacts"
+                accessibilityState={{ selected: !isAccountsTab }}
               >
                 <Ionicons
                   name="people-outline"
@@ -355,6 +371,8 @@ export default function AccountRecipientModal({
                     onPress={() => setSearchQuery('')}
                     style={styles.clearButton}
                     hitSlop={{ top: 10, bottom: 10, left: 10, right: 10 }}
+                    accessibilityRole="button"
+                    accessibilityLabel="Clear search"
                   >
                     <Ionicons
                       name="close-circle"

--- a/src/components/claimable/ClaimableBanner.tsx
+++ b/src/components/claimable/ClaimableBanner.tsx
@@ -16,6 +16,7 @@ import Animated, {
 import { useThemedStyles } from '@/hooks/useThemedStyles';
 import { Theme } from '@/constants/themes';
 import { GlassCard } from '@/components/common/GlassCard';
+import { useReducedMotion } from '@/hooks/useReducedMotion';
 
 interface ClaimableBannerProps {
   /** Number of claimable tokens */
@@ -30,9 +31,15 @@ export default function ClaimableBanner({
 }: ClaimableBannerProps) {
   const styles = useThemedStyles(createStyles);
   const iconScale = useSharedValue(1);
+  const reducedMotion = useReducedMotion();
 
   // Subtle pulsing animation on the icon
   useEffect(() => {
+    // DR-13: the loop must stop entirely under Reduce Motion, not just shorten.
+    if (reducedMotion) {
+      iconScale.value = 1;
+      return;
+    }
     iconScale.value = withRepeat(
       withSequence(
         withTiming(1.1, { duration: 800 }),
@@ -41,7 +48,7 @@ export default function ClaimableBanner({
       -1, // Repeat indefinitely
       true // Reverse each cycle
     );
-  }, [iconScale]);
+  }, [iconScale, reducedMotion]);
 
   const iconAnimatedStyle = useAnimatedStyle(() => ({
     transform: [{ scale: iconScale.value }],
@@ -65,6 +72,8 @@ export default function ClaimableBanner({
         borderGlow
         glowColor={styles.glowColor.color}
         padding="md"
+        accessibilityLabel={getMessage()}
+        accessibilityHint="Opens the claimable tokens list"
       >
         <View style={styles.content}>
           <Animated.View style={[styles.iconContainer, iconAnimatedStyle]}>

--- a/src/components/common/BlurredContainer.tsx
+++ b/src/components/common/BlurredContainer.tsx
@@ -7,6 +7,20 @@ import { GlassEffect } from '@/constants/themes';
 
 export type BlurVariant = 'light' | 'medium' | 'heavy' | 'chromatic';
 
+/**
+ * Props for the purely decorative glass layers (overlay tint, top highlight,
+ * inner border). They carry no information and are already non-interactive, so
+ * they are removed from the accessibility tree rather than left as stray
+ * focusable/announceable nodes (TASK-42). The `content` wrapper that holds the
+ * caller's children is deliberately NOT marked — hiding it would hide the whole
+ * subtree on all ~20 call sites.
+ */
+const DECORATIVE_LAYER_PROPS = {
+  pointerEvents: 'none' as const,
+  accessibilityElementsHidden: true,
+  importantForAccessibility: 'no-hide-descendants' as const,
+};
+
 interface BlurredContainerProps {
   children: React.ReactNode;
   /** Glass intensity variant - uses theme presets */
@@ -186,13 +200,13 @@ export const BlurredContainer: React.FC<BlurredContainerProps> = ({
             ]}
             start={{ x: 0, y: 0 }}
             end={{ x: 0, y: 1 }}
-            pointerEvents="none"
+            {...DECORATIVE_LAYER_PROPS}
           />
         )}
 
         {/* Inner border */}
         {innerBorderStyle && (
-          <View style={innerBorderStyle} pointerEvents="none" />
+          <View style={innerBorderStyle} {...DECORATIVE_LAYER_PROPS} />
         )}
 
         {/* Content */}
@@ -223,7 +237,7 @@ export const BlurredContainer: React.FC<BlurredContainerProps> = ({
             backgroundColor: overlayBackgroundColor,
           },
         ]}
-        pointerEvents="none"
+        {...DECORATIVE_LAYER_PROPS}
       />
 
       {/* Top highlight gradient for glass depth effect */}
@@ -239,13 +253,13 @@ export const BlurredContainer: React.FC<BlurredContainerProps> = ({
           ]}
           start={{ x: 0, y: 0 }}
           end={{ x: 0, y: 1 }}
-          pointerEvents="none"
+          {...DECORATIVE_LAYER_PROPS}
         />
       )}
 
       {/* Inner border for glass edge effect */}
       {innerBorderStyle && (
-        <View style={innerBorderStyle} pointerEvents="none" />
+        <View style={innerBorderStyle} {...DECORATIVE_LAYER_PROPS} />
       )}
 
       {/* Content - positioned above overlay */}

--- a/src/components/common/GlassButton.tsx
+++ b/src/components/common/GlassButton.tsx
@@ -14,6 +14,7 @@ import {
   ViewStyle,
   TextStyle,
   StyleProp,
+  AccessibilityRole,
 } from 'react-native';
 import { LinearGradient } from 'expo-linear-gradient';
 import { Ionicons } from '@expo/vector-icons';
@@ -30,6 +31,7 @@ import { useTheme } from '@/contexts/ThemeContext';
 import { SafeBlurView } from './SafeBlurView';
 import { springConfigs, timingConfigs } from '@/utils/animations';
 import { hapticImpact } from '@/utils/haptics';
+import { useReducedMotion } from '@/hooks/useReducedMotion';
 
 export type ButtonVariant = 'primary' | 'secondary' | 'ghost' | 'danger';
 export type ButtonSize = 'sm' | 'md' | 'lg';
@@ -67,6 +69,15 @@ interface GlassButtonProps {
   labelStyle?: StyleProp<TextStyle>;
   /** Test ID */
   testID?: string;
+  /**
+   * Accessible name. Defaults to `label`; override when the visible text is an
+   * abbreviation or otherwise reads poorly to a screen reader.
+   */
+  accessibilityLabel?: string;
+  /** Describes the outcome of activating the button. */
+  accessibilityHint?: string;
+  /** Defaults to `button`; override for e.g. `link` or `tab` semantics. */
+  accessibilityRole?: AccessibilityRole;
 }
 
 const AnimatedPressable = Animated.createAnimatedComponent(Pressable);
@@ -89,9 +100,13 @@ export const GlassButton: React.FC<GlassButtonProps> = ({
   style,
   labelStyle,
   testID,
+  accessibilityLabel,
+  accessibilityHint,
+  accessibilityRole = 'button',
 }) => {
   const { theme } = useTheme();
   const hasNFTBackground = !!theme.backgroundImageUrl;
+  const reducedMotion = useReducedMotion();
 
   // Animation values
   const scale = useSharedValue(1);
@@ -100,7 +115,7 @@ export const GlassButton: React.FC<GlassButtonProps> = ({
 
   // Start glow pulse if enabled
   useEffect(() => {
-    if (glow && !disabled && !loading) {
+    if (glow && !disabled && !loading && !reducedMotion) {
       glowOpacity.value = withRepeat(
         withSequence(
           withTiming(0.6, {
@@ -112,10 +127,14 @@ export const GlassButton: React.FC<GlassButtonProps> = ({
         -1,
         false
       );
+    } else if (glow && !disabled && !loading) {
+      // DR-13: under Reduce Motion the glow stays on, but static — the infinite
+      // pulse never starts, so it costs nothing and never animates.
+      glowOpacity.value = 0.4;
     } else {
       glowOpacity.value = withTiming(0, timingConfigs.normal);
     }
-  }, [glow, disabled, loading, glowOpacity]);
+  }, [glow, disabled, loading, reducedMotion, glowOpacity]);
 
   // Size configurations
   const sizeConfig = useMemo(() => {
@@ -408,6 +427,13 @@ export const GlassButton: React.FC<GlassButtonProps> = ({
       disabled={disabled || loading}
       style={[containerStyles, animatedContainerStyle]}
       testID={testID}
+      accessible
+      accessibilityRole={accessibilityRole}
+      accessibilityLabel={accessibilityLabel ?? label}
+      accessibilityHint={accessibilityHint}
+      // `loading` swaps the label for a spinner and blocks presses, so it must
+      // be announced as both busy and unavailable — not silently inert.
+      accessibilityState={{ disabled: disabled || loading, busy: loading }}
     >
       {renderContent()}
     </AnimatedPressable>

--- a/src/components/common/GlassCard.tsx
+++ b/src/components/common/GlassCard.tsx
@@ -14,6 +14,8 @@ import {
   Pressable,
   ViewStyle,
   StyleProp,
+  AccessibilityActionEvent,
+  AccessibilityActionInfo,
   AccessibilityRole,
   AccessibilityState,
 } from 'react-native';
@@ -70,9 +72,13 @@ interface GlassCardProps {
   testID?: string;
   /**
    * Groups the card's children into a single accessibility element. Defaults to
-   * `true` for the pressable variant (a tappable card should be one target) and
-   * is left unset for the static variant so its inner text stays individually
-   * navigable.
+   * `true` for the pressable variant (a tappable card should be one target;
+   * this also matches RN `Pressable`'s own default) and is left unset for the
+   * static variant so its inner text stays individually navigable.
+   *
+   * NOTE: a grouped card makes nested controls unreachable to a screen reader.
+   * If the card contains a secondary action, expose it through
+   * `accessibilityActions` rather than relying on the nested touchable.
    */
   accessible?: boolean;
   /**
@@ -89,6 +95,14 @@ interface GlassCardProps {
   accessibilityRole?: AccessibilityRole;
   /** e.g. `{ selected: true }` / `{ disabled: true }` for stateful cards. */
   accessibilityState?: AccessibilityState;
+  /**
+   * Secondary actions the card offers (e.g. dismiss). Required whenever a
+   * pressable card visually nests another control, because grouping makes that
+   * nested control unreachable via a screen reader.
+   */
+  accessibilityActions?: AccessibilityActionInfo[];
+  /** Handles the actions declared in `accessibilityActions`. */
+  onAccessibilityAction?: (event: AccessibilityActionEvent) => void;
 }
 
 const AnimatedPressable = Animated.createAnimatedComponent(Pressable);
@@ -112,6 +126,8 @@ export const GlassCard: React.FC<GlassCardProps> = ({
   accessibilityHint,
   accessibilityRole,
   accessibilityState,
+  accessibilityActions,
+  onAccessibilityAction,
 }) => {
   const { theme } = useTheme();
   const hasNFTBackground = !!theme.backgroundImageUrl;
@@ -285,6 +301,8 @@ export const GlassCard: React.FC<GlassCardProps> = ({
         accessibilityLabel={accessibilityLabel}
         accessibilityHint={accessibilityHint}
         accessibilityState={accessibilityState}
+        accessibilityActions={accessibilityActions}
+        onAccessibilityAction={onAccessibilityAction}
       >
         {renderContent()}
       </AnimatedPressable>

--- a/src/components/common/GlassCard.tsx
+++ b/src/components/common/GlassCard.tsx
@@ -14,6 +14,8 @@ import {
   Pressable,
   ViewStyle,
   StyleProp,
+  AccessibilityRole,
+  AccessibilityState,
 } from 'react-native';
 import { LinearGradient } from 'expo-linear-gradient';
 import Animated, {
@@ -27,6 +29,17 @@ import { SafeBlurView } from './SafeBlurView';
 import { springConfigs, timingConfigs } from '@/utils/animations';
 
 export type GlassVariant = 'light' | 'medium' | 'heavy' | 'chromatic';
+
+/**
+ * Decorative glass layers (tint overlay, top highlight, inner edge) carry no
+ * information and are non-interactive, so they are removed from the a11y tree
+ * (TASK-42). The `content` wrapper holding the caller's children is untouched.
+ */
+const DECORATIVE_LAYER_PROPS = {
+  pointerEvents: 'none' as const,
+  accessibilityElementsHidden: true,
+  importantForAccessibility: 'no-hide-descendants' as const,
+};
 
 interface GlassCardProps {
   /** Glass intensity variant */
@@ -55,6 +68,27 @@ interface GlassCardProps {
   borderColor?: string;
   /** Test ID for testing */
   testID?: string;
+  /**
+   * Groups the card's children into a single accessibility element. Defaults to
+   * `true` for the pressable variant (a tappable card should be one target) and
+   * is left unset for the static variant so its inner text stays individually
+   * navigable.
+   */
+  accessible?: boolean;
+  /**
+   * Accessible name. Strongly recommended whenever `onPress`/`onLongPress` is
+   * given — without it a pressable card is an unlabeled leaf.
+   */
+  accessibilityLabel?: string;
+  /** Describes the outcome of activating the card. */
+  accessibilityHint?: string;
+  /**
+   * Defaults to `button` when the card is pressable, and is unset otherwise.
+   * Override for e.g. `link`, `checkbox` or `radio` semantics.
+   */
+  accessibilityRole?: AccessibilityRole;
+  /** e.g. `{ selected: true }` / `{ disabled: true }` for stateful cards. */
+  accessibilityState?: AccessibilityState;
 }
 
 const AnimatedPressable = Animated.createAnimatedComponent(Pressable);
@@ -73,6 +107,11 @@ export const GlassCard: React.FC<GlassCardProps> = ({
   noHighlight = false,
   borderColor,
   testID,
+  accessible,
+  accessibilityLabel,
+  accessibilityHint,
+  accessibilityRole,
+  accessibilityState,
 }) => {
   const { theme } = useTheme();
   const hasNFTBackground = !!theme.backgroundImageUrl;
@@ -193,7 +232,7 @@ export const GlassCard: React.FC<GlassCardProps> = ({
       {/* Semi-transparent overlay for consistent glass effect */}
       <View
         style={[styles.overlay, { backgroundColor: overlayBackgroundColor }]}
-        pointerEvents="none"
+        {...DECORATIVE_LAYER_PROPS}
       />
 
       {/* Top highlight gradient for glass depth effect */}
@@ -208,7 +247,7 @@ export const GlassCard: React.FC<GlassCardProps> = ({
         ]}
         start={{ x: 0, y: 0 }}
         end={{ x: 0, y: 1 }}
-        pointerEvents="none"
+        {...DECORATIVE_LAYER_PROPS}
       />
 
       {/* Inner border highlight for glass edge effect */}
@@ -219,7 +258,7 @@ export const GlassCard: React.FC<GlassCardProps> = ({
             borderColor: theme.colors.glassHighlight,
           },
         ]}
-        pointerEvents="none"
+        {...DECORATIVE_LAYER_PROPS}
       />
 
       {/* Content */}
@@ -239,18 +278,31 @@ export const GlassCard: React.FC<GlassCardProps> = ({
         onPressOut={handlePressOut}
         style={[containerStyles, animatedContainerStyle]}
         testID={testID}
+        // A tappable card is a single target: group its children so a screen
+        // reader announces one control instead of walking loose text nodes.
+        accessible={accessible ?? true}
+        accessibilityRole={accessibilityRole ?? 'button'}
+        accessibilityLabel={accessibilityLabel}
+        accessibilityHint={accessibilityHint}
+        accessibilityState={accessibilityState}
       >
         {renderContent()}
       </AnimatedPressable>
     );
   }
 
-  // Non-pressable version
+  // Non-pressable version — a static card is a container, so it stays
+  // transparent to the a11y tree unless a caller opts into grouping/labelling.
   if (animated) {
     return (
       <Animated.View
         style={[containerStyles, animatedContainerStyle]}
         testID={testID}
+        accessible={accessible}
+        accessibilityRole={accessibilityRole}
+        accessibilityLabel={accessibilityLabel}
+        accessibilityHint={accessibilityHint}
+        accessibilityState={accessibilityState}
       >
         {renderContent()}
       </Animated.View>
@@ -258,7 +310,15 @@ export const GlassCard: React.FC<GlassCardProps> = ({
   }
 
   return (
-    <View style={containerStyles} testID={testID}>
+    <View
+      style={containerStyles}
+      testID={testID}
+      accessible={accessible}
+      accessibilityRole={accessibilityRole}
+      accessibilityLabel={accessibilityLabel}
+      accessibilityHint={accessibilityHint}
+      accessibilityState={accessibilityState}
+    >
       {renderContent()}
     </View>
   );

--- a/src/components/common/NFTBackground.tsx
+++ b/src/components/common/NFTBackground.tsx
@@ -82,9 +82,18 @@ export const NFTBackground: React.FC<NFTBackgroundProps> = ({
     <View
       style={[styles.container, { backgroundColor: theme.colors.background }]}
     >
-      {/* NFT Background Image - only render if enabled and available */}
+      {/* NFT Background Image - only render if enabled and available.
+          Purely decorative chrome: the image and every gradient/vignette layer
+          are grouped in one a11y-hidden, non-interactive layer so VoiceOver /
+          TalkBack never stop on them (they carry no information and are already
+          `pointerEvents="none"`). The `content` sibling below is untouched. */}
       {hasNFTBackground && (
-        <>
+        <View
+          style={StyleSheet.absoluteFill}
+          pointerEvents="none"
+          accessibilityElementsHidden
+          importantForAccessibility="no-hide-descendants"
+        >
           <Image
             source={{ uri: theme.backgroundImageUrl }}
             style={styles.backgroundImage}
@@ -172,7 +181,7 @@ export const NFTBackground: React.FC<NFTBackgroundProps> = ({
               />
             </>
           )}
-        </>
+        </View>
       )}
 
       {/* Content */}

--- a/src/components/common/UniversalHeader.tsx
+++ b/src/components/common/UniversalHeader.tsx
@@ -29,6 +29,17 @@ interface UniversalHeaderProps {
   showBorder?: boolean;
   /** Large title style */
   largeTitle?: boolean;
+  /** Test ID for the header container */
+  testID?: string;
+  /**
+   * Accessible name for the back button. Defaults to "Go back" — override when
+   * the destination is worth naming (e.g. "Back to accounts").
+   */
+  backAccessibilityLabel?: string;
+  /** Hint for the back button. */
+  backAccessibilityHint?: string;
+  /** Test ID for the back button. */
+  backButtonTestID?: string;
 }
 
 const AnimatedPressable = Animated.createAnimatedComponent(Pressable);
@@ -44,6 +55,10 @@ export default function UniversalHeader({
   floating = false,
   showBorder = false,
   largeTitle = false,
+  testID,
+  backAccessibilityLabel = 'Go back',
+  backAccessibilityHint,
+  backButtonTestID,
 }: UniversalHeaderProps) {
   const styles = useThemedStyles(createStyles);
   const themeColors = useThemeColors();
@@ -91,6 +106,13 @@ export default function UniversalHeader({
           onPressIn={handleBackPressIn}
           onPressOut={handleBackPressOut}
           hitSlop={{ top: 10, bottom: 10, left: 10, right: 10 }}
+          // Icon-only control: without an explicit name this is an unlabeled
+          // leaf on every one of the ~40 screens that mount this header.
+          accessible
+          accessibilityRole="button"
+          accessibilityLabel={backAccessibilityLabel}
+          accessibilityHint={backAccessibilityHint}
+          testID={backButtonTestID}
         >
           <View
             style={[
@@ -114,6 +136,7 @@ export default function UniversalHeader({
             { color: themeColors.text },
           ]}
           numberOfLines={1}
+          accessibilityRole="header"
         >
           {title}
         </Text>
@@ -165,6 +188,7 @@ export default function UniversalHeader({
             borderBottomWidth: showBorder ? 1 : 0,
           },
         ]}
+        testID={testID}
       >
         {/* Glass overlay */}
         <View
@@ -201,6 +225,7 @@ export default function UniversalHeader({
           borderBottomWidth: showBorder ? 1 : 0,
         },
       ]}
+      testID={testID}
     >
       {headerContent}
     </View>

--- a/src/components/common/__tests__/GlassButton.a11y.test.tsx
+++ b/src/components/common/__tests__/GlassButton.a11y.test.tsx
@@ -1,0 +1,145 @@
+/**
+ * GlassButton accessibility + reduce-motion tests (TASK-42).
+ *
+ * GlassButton is imported at ~18 sites. Its `label` was already enough for RN
+ * to infer a name, but `disabled`/`loading` were never surfaced as
+ * `accessibilityState`, so a busy or unavailable button was announced as a
+ * perfectly ordinary one. It is also DR-13's loudest offender: an infinite
+ * `withRepeat` glow with hardcoded 1200ms durations that bypasses the shared
+ * animation configs entirely.
+ */
+
+import React from 'react';
+import { render } from '@testing-library/react-native';
+
+import { GlassButton } from '../GlassButton';
+
+jest.mock('@/contexts/ThemeContext', () => ({
+  // eslint-disable-next-line @typescript-eslint/no-require-imports
+  useTheme: () => ({ theme: require('@/constants/themes').lightTheme }),
+}));
+
+jest.mock(
+  '@expo/vector-icons',
+  () => ({
+    Ionicons: () => null,
+  }),
+  { virtual: true }
+);
+
+jest.mock('@/utils/haptics', () => ({
+  hapticImpact: jest.fn(),
+}));
+
+const mockUseReducedMotion = jest.fn(() => false);
+jest.mock('@/hooks/useReducedMotion', () => ({
+  useReducedMotion: () => mockUseReducedMotion(),
+}));
+
+const mockWithRepeat = jest.fn();
+jest.mock('react-native-reanimated', () => {
+  const actual = jest.requireActual('react-native-reanimated/mock');
+  return {
+    ...actual,
+    __esModule: true,
+    default: actual.default ?? actual,
+    withRepeat: (...args: unknown[]) => {
+      mockWithRepeat(...args);
+      return 0;
+    },
+  };
+});
+
+beforeEach(() => {
+  mockUseReducedMotion.mockReturnValue(false);
+  mockWithRepeat.mockClear();
+});
+
+describe('GlassButton accessibility', () => {
+  it('exposes the visible label as the accessible name with a button role', () => {
+    const { getByTestId } = render(
+      <GlassButton label="Send" onPress={() => {}} testID="btn" />
+    );
+
+    const button = getByTestId('btn');
+    expect(button.props.accessibilityLabel).toBe('Send');
+    expect(button.props.accessibilityRole).toBe('button');
+  });
+
+  it('lets callers override the accessible name and add a hint', () => {
+    const { getByTestId } = render(
+      <GlassButton
+        label="Max"
+        accessibilityLabel="Send maximum spendable amount"
+        accessibilityHint="Fills the amount field with your full balance"
+        onPress={() => {}}
+        testID="btn"
+      />
+    );
+
+    const button = getByTestId('btn');
+    expect(button.props.accessibilityLabel).toBe(
+      'Send maximum spendable amount'
+    );
+    expect(button.props.accessibilityHint).toBe(
+      'Fills the amount field with your full balance'
+    );
+  });
+
+  it('surfaces `disabled` as accessibilityState', () => {
+    const { getByTestId } = render(
+      <GlassButton label="Send" disabled onPress={() => {}} testID="btn" />
+    );
+
+    expect(getByTestId('btn').props.accessibilityState).toEqual({
+      disabled: true,
+      busy: false,
+    });
+  });
+
+  it('surfaces `loading` as both busy and disabled', () => {
+    const { getByTestId } = render(
+      <GlassButton label="Send" loading onPress={() => {}} testID="btn" />
+    );
+
+    expect(getByTestId('btn').props.accessibilityState).toEqual({
+      disabled: true,
+      busy: true,
+    });
+  });
+
+  it('reports neither busy nor disabled in the resting state', () => {
+    const { getByTestId } = render(
+      <GlassButton label="Send" onPress={() => {}} testID="btn" />
+    );
+
+    expect(getByTestId('btn').props.accessibilityState).toEqual({
+      disabled: false,
+      busy: false,
+    });
+  });
+});
+
+describe('GlassButton reduce-motion (DR-13)', () => {
+  it('starts the infinite glow pulse when motion is allowed', () => {
+    render(<GlassButton label="Send" glow onPress={() => {}} testID="btn" />);
+
+    expect(mockWithRepeat).toHaveBeenCalled();
+    // -1 == repeat forever; that is precisely what Reduce Motion must suppress.
+    expect(mockWithRepeat.mock.calls[0][1]).toBe(-1);
+  });
+
+  it('never starts the infinite glow pulse under Reduce Motion', () => {
+    mockUseReducedMotion.mockReturnValue(true);
+
+    render(<GlassButton label="Send" glow onPress={() => {}} testID="btn" />);
+
+    expect(mockWithRepeat).not.toHaveBeenCalled();
+  });
+
+  it('does not start a pulse when `glow` is off, regardless of the preference', () => {
+    render(<GlassButton label="Send" onPress={() => {}} testID="btn" />);
+
+    expect(mockWithRepeat).not.toHaveBeenCalled();
+  });
+});

--- a/src/components/common/__tests__/GlassCard.a11y.test.tsx
+++ b/src/components/common/__tests__/GlassCard.a11y.test.tsx
@@ -1,0 +1,117 @@
+/**
+ * GlassCard accessibility tests (TASK-42).
+ *
+ * GlassCard is imported at ~30 sites and silently becomes an `AnimatedPressable`
+ * whenever `onPress`/`onLongPress` is supplied — previously with no
+ * `accessibilityRole` and no way to pass a name, so every tappable card in the
+ * app was an unlabeled accessibility leaf. The static variant must stay
+ * transparent to the a11y tree so its inner text remains individually
+ * navigable.
+ */
+
+import React from 'react';
+import { Text } from 'react-native';
+import { render } from '@testing-library/react-native';
+
+import { GlassCard } from '../GlassCard';
+
+jest.mock('@/contexts/ThemeContext', () => ({
+  // eslint-disable-next-line @typescript-eslint/no-require-imports
+  useTheme: () => ({ theme: require('@/constants/themes').lightTheme }),
+}));
+
+const child = <Text>Balance</Text>;
+
+describe('GlassCard accessibility', () => {
+  it('gives a pressable card a button role and groups its children', () => {
+    const { getByTestId } = render(
+      <GlassCard
+        onPress={() => {}}
+        testID="card"
+        accessibilityLabel="Voi asset"
+      >
+        {child}
+      </GlassCard>
+    );
+
+    const card = getByTestId('card');
+    expect(card.props.accessibilityRole).toBe('button');
+    expect(card.props.accessible).toBe(true);
+    expect(card.props.accessibilityLabel).toBe('Voi asset');
+  });
+
+  it('treats a long-press-only card as pressable too', () => {
+    const { getByTestId } = render(
+      <GlassCard
+        onLongPress={() => {}}
+        testID="card"
+        accessibilityLabel="Asset"
+      >
+        {child}
+      </GlassCard>
+    );
+
+    expect(getByTestId('card').props.accessibilityRole).toBe('button');
+  });
+
+  it('forwards an overridden role, hint and state', () => {
+    const { getByTestId } = render(
+      <GlassCard
+        onPress={() => {}}
+        testID="card"
+        accessibilityRole="checkbox"
+        accessibilityLabel="Include this account"
+        accessibilityHint="Toggles the account in the export"
+        accessibilityState={{ checked: true }}
+      >
+        {child}
+      </GlassCard>
+    );
+
+    const card = getByTestId('card');
+    expect(card.props.accessibilityRole).toBe('checkbox');
+    expect(card.props.accessibilityHint).toBe(
+      'Toggles the account in the export'
+    );
+    expect(card.props.accessibilityState).toEqual({ checked: true });
+  });
+
+  it('lets a caller opt out of grouping on a pressable card', () => {
+    const { getByTestId } = render(
+      <GlassCard onPress={() => {}} testID="card" accessible={false}>
+        {child}
+      </GlassCard>
+    );
+
+    expect(getByTestId('card').props.accessible).toBe(false);
+  });
+
+  it('leaves a static card transparent to the a11y tree by default', () => {
+    const { getByTestId } = render(
+      <GlassCard testID="card" animated={false}>
+        {child}
+      </GlassCard>
+    );
+
+    const card = getByTestId('card');
+    expect(card.props.accessibilityRole).toBeUndefined();
+    expect(card.props.accessible).toBeUndefined();
+  });
+
+  it('still lets a static card opt into a label when it is a meaningful group', () => {
+    const { getByTestId } = render(
+      <GlassCard
+        testID="card"
+        animated={false}
+        accessible
+        accessibilityLabel="Total balance 12 VOI"
+      >
+        {child}
+      </GlassCard>
+    );
+
+    const card = getByTestId('card');
+    expect(card.props.accessible).toBe(true);
+    expect(card.props.accessibilityLabel).toBe('Total balance 12 VOI');
+  });
+});

--- a/src/components/common/__tests__/GlassCard.a11y.test.tsx
+++ b/src/components/common/__tests__/GlassCard.a11y.test.tsx
@@ -76,6 +76,31 @@ describe('GlassCard accessibility', () => {
     expect(card.props.accessibilityState).toEqual({ checked: true });
   });
 
+  it('forwards custom accessibility actions, the escape hatch for nested controls', () => {
+    const onAction = jest.fn();
+    const { getByTestId } = render(
+      <GlassCard
+        onPress={() => {}}
+        testID="card"
+        accessibilityLabel="Update available"
+        accessibilityActions={[{ name: 'dismiss', label: 'Dismiss update' }]}
+        onAccessibilityAction={onAction}
+      >
+        {child}
+      </GlassCard>
+    );
+
+    const card = getByTestId('card');
+    expect(card.props.accessibilityActions).toEqual([
+      { name: 'dismiss', label: 'Dismiss update' },
+    ]);
+
+    card.props.onAccessibilityAction({
+      nativeEvent: { actionName: 'dismiss' },
+    });
+    expect(onAction).toHaveBeenCalled();
+  });
+
   it('lets a caller opt out of grouping on a pressable card', () => {
     const { getByTestId } = render(
       <GlassCard onPress={() => {}} testID="card" accessible={false}>

--- a/src/components/common/__tests__/UniversalHeader.a11y.test.tsx
+++ b/src/components/common/__tests__/UniversalHeader.a11y.test.tsx
@@ -1,0 +1,92 @@
+/**
+ * UniversalHeader accessibility tests (TASK-42).
+ *
+ * UniversalHeader is imported at ~41 sites, and its back button was an
+ * icon-only `AnimatedPressable` with no accessible name — i.e. the primary
+ * navigation control on nearly every screen was unlabeled.
+ */
+
+import React from 'react';
+import { render } from '@testing-library/react-native';
+
+import UniversalHeader from '../UniversalHeader';
+
+jest.mock('@/contexts/ThemeContext', () => ({
+  // eslint-disable-next-line @typescript-eslint/no-require-imports
+  useTheme: () => ({ theme: require('@/constants/themes').lightTheme }),
+}));
+
+jest.mock(
+  '@expo/vector-icons',
+  () => ({
+    Ionicons: () => null,
+  }),
+  { virtual: true }
+);
+
+jest.mock('@/components/account/AccountSelector', () => () => null);
+
+describe('UniversalHeader accessibility', () => {
+  it('labels the back button by default', () => {
+    const { getByLabelText } = render(
+      <UniversalHeader
+        title="Send"
+        showBackButton
+        showAccountSelector={false}
+        onBackPress={() => {}}
+        backButtonTestID="back"
+      />
+    );
+
+    const back = getByLabelText('Go back');
+    expect(back.props.accessibilityRole).toBe('button');
+  });
+
+  it('lets a screen name the destination and add a hint', () => {
+    const { getByTestId } = render(
+      <UniversalHeader
+        title="NFT Details"
+        showBackButton
+        showAccountSelector={false}
+        onBackPress={() => {}}
+        backAccessibilityLabel="Back to collection"
+        backAccessibilityHint="Returns to the NFT collection list"
+        backButtonTestID="back"
+      />
+    );
+
+    const back = getByTestId('back');
+    expect(back.props.accessibilityLabel).toBe('Back to collection');
+    expect(back.props.accessibilityHint).toBe(
+      'Returns to the NFT collection list'
+    );
+  });
+
+  it('marks the title as a header landmark', () => {
+    const { getByText } = render(
+      <UniversalHeader title="Settings" showAccountSelector={false} />
+    );
+
+    expect(getByText('Settings').props.accessibilityRole).toBe('header');
+  });
+
+  it('forwards a testID to the header container', () => {
+    const { getByTestId } = render(
+      <UniversalHeader
+        title="Settings"
+        showAccountSelector={false}
+        testID="screen-header"
+      />
+    );
+
+    expect(getByTestId('screen-header')).toBeTruthy();
+  });
+
+  it('renders no back button when it is not requested', () => {
+    const { queryByLabelText } = render(
+      <UniversalHeader title="Home" showAccountSelector={false} />
+    );
+
+    expect(queryByLabelText('Go back')).toBeNull();
+  });
+});

--- a/src/components/common/__tests__/decorativeLayers.a11y.test.tsx
+++ b/src/components/common/__tests__/decorativeLayers.a11y.test.tsx
@@ -1,0 +1,126 @@
+/**
+ * Decorative-layer accessibility tests (TASK-42).
+ *
+ * `NFTBackground` (~29 sites) and `BlurredContainer` (~20 sites) both wrap the
+ * caller's children, so the risk when hiding their chrome from the
+ * accessibility tree is hiding the *content* along with it. These tests pin
+ * both halves of the contract: the decorative layers are hidden, and the
+ * children stay reachable.
+ */
+
+import React from 'react';
+import { Text, View } from 'react-native';
+import { render } from '@testing-library/react-native';
+
+import { BlurredContainer } from '../BlurredContainer';
+import { NFTBackground } from '../NFTBackground';
+import { lightTheme } from '@/constants/themes';
+
+const mockTheme = {
+  theme: lightTheme,
+  nftBackgroundEnabled: true,
+  nftOverlayIntensity: 0.5,
+};
+
+jest.mock('@/contexts/ThemeContext', () => ({
+  useTheme: () => mockThemeValue(),
+}));
+
+const mockThemeValue = jest.fn(() => mockTheme);
+
+jest.mock('expo-image', () => ({
+  // eslint-disable-next-line @typescript-eslint/no-require-imports
+  Image: require('react-native').View,
+}));
+
+const withNFTTheme = () => {
+  mockThemeValue.mockReturnValue({
+    ...mockTheme,
+    theme: {
+      ...lightTheme,
+      backgroundImageUrl: 'https://example.test/nft.png',
+    },
+  });
+};
+
+beforeEach(() => {
+  mockThemeValue.mockReturnValue(mockTheme);
+});
+
+/** All descendants (inclusive) carrying an explicit a11y-hidden marker. */
+const hiddenNodes = (root: { findAll: (p: (n: any) => boolean) => any[] }) =>
+  root.findAll(
+    (node: any) =>
+      node.props?.importantForAccessibility === 'no-hide-descendants' ||
+      node.props?.accessibilityElementsHidden === true
+  );
+
+describe('NFTBackground decorative layers', () => {
+  it('hides the whole decorative layer stack from the a11y tree', () => {
+    withNFTTheme();
+    const { UNSAFE_root } = render(
+      <NFTBackground>
+        <Text>Balance</Text>
+      </NFTBackground>
+    );
+
+    const hidden = hiddenNodes(UNSAFE_root);
+    expect(hidden.length).toBeGreaterThan(0);
+    expect(
+      hidden.every(
+        (node: any) =>
+          node.props.accessibilityElementsHidden === true &&
+          node.props.importantForAccessibility === 'no-hide-descendants'
+      )
+    ).toBe(true);
+  });
+
+  it('keeps its children reachable', () => {
+    withNFTTheme();
+    const { getByText } = render(
+      <NFTBackground>
+        <Text>Balance</Text>
+      </NFTBackground>
+    );
+
+    expect(getByText('Balance')).toBeTruthy();
+  });
+
+  it('renders no decorative layers at all without an NFT theme', () => {
+    const { UNSAFE_root, getByText } = render(
+      <NFTBackground>
+        <Text>Balance</Text>
+      </NFTBackground>
+    );
+
+    expect(hiddenNodes(UNSAFE_root)).toHaveLength(0);
+    expect(getByText('Balance')).toBeTruthy();
+  });
+});
+
+describe('BlurredContainer decorative layers', () => {
+  it('hides the highlight and inner-border chrome but not the content', () => {
+    const { UNSAFE_root, getByText } = render(
+      <BlurredContainer showHighlight showInnerBorder>
+        <View>
+          <Text>Recipient</Text>
+        </View>
+      </BlurredContainer>
+    );
+
+    expect(hiddenNodes(UNSAFE_root).length).toBeGreaterThan(0);
+    expect(getByText('Recipient')).toBeTruthy();
+  });
+
+  it('hides the tint overlay on the NFT-themed (blurred) branch', () => {
+    withNFTTheme();
+    const { UNSAFE_root, getByText } = render(
+      <BlurredContainer>
+        <Text>Recipient</Text>
+      </BlurredContainer>
+    );
+
+    expect(hiddenNodes(UNSAFE_root).length).toBeGreaterThan(0);
+    expect(getByText('Recipient')).toBeTruthy();
+  });
+});

--- a/src/components/ledger/AccountImport.tsx
+++ b/src/components/ledger/AccountImport.tsx
@@ -72,6 +72,9 @@ const RangeControls: React.FC<RangeControlsProps> = ({
             style={styles.rangeButton}
             onPress={() => handleIncrement(onChangeStart, startIndex, -5)}
             disabled={startIndex === 0 || isScanning}
+            accessibilityRole="button"
+            accessibilityLabel="Decrease start index by 5"
+            accessibilityState={{ disabled: startIndex === 0 || isScanning }}
           >
             <Ionicons name="remove" size={18} color={colors.textSecondary} />
           </TouchableOpacity>
@@ -80,6 +83,9 @@ const RangeControls: React.FC<RangeControlsProps> = ({
             style={styles.rangeButton}
             onPress={() => handleIncrement(onChangeStart, startIndex, 5)}
             disabled={isScanning}
+            accessibilityRole="button"
+            accessibilityLabel="Increase start index by 5"
+            accessibilityState={{ disabled: isScanning }}
           >
             <Ionicons name="add" size={18} color={colors.textSecondary} />
           </TouchableOpacity>
@@ -92,6 +98,9 @@ const RangeControls: React.FC<RangeControlsProps> = ({
             style={styles.rangeButton}
             onPress={() => handleIncrement(onChangeCount, count, -1)}
             disabled={count <= 1 || isScanning}
+            accessibilityRole="button"
+            accessibilityLabel="Decrease account count by 1"
+            accessibilityState={{ disabled: count <= 1 || isScanning }}
           >
             <Ionicons name="remove" size={18} color={colors.textSecondary} />
           </TouchableOpacity>
@@ -100,6 +109,9 @@ const RangeControls: React.FC<RangeControlsProps> = ({
             style={styles.rangeButton}
             onPress={() => handleIncrement(onChangeCount, count, 1)}
             disabled={isScanning}
+            accessibilityRole="button"
+            accessibilityLabel="Increase account count by 1"
+            accessibilityState={{ disabled: isScanning }}
           >
             <Ionicons name="add" size={18} color={colors.textSecondary} />
           </TouchableOpacity>
@@ -109,6 +121,9 @@ const RangeControls: React.FC<RangeControlsProps> = ({
         style={[styles.scanButton, isScanning && styles.scanButtonDisabled]}
         onPress={onScan}
         disabled={isScanning}
+        accessibilityRole="button"
+        accessibilityLabel={isScanning ? 'Scanning accounts' : 'Scan accounts'}
+        accessibilityState={{ disabled: isScanning, busy: isScanning }}
       >
         {isScanning ? (
           <ActivityIndicator size="small" color={colors.buttonText} />
@@ -166,6 +181,15 @@ const LedgerAccountList: React.FC<LedgerAccountListProps> = ({
               onPreviewAccount?.(item);
             }}
             activeOpacity={0.8}
+            accessible
+            accessibilityRole="checkbox"
+            accessibilityLabel={`Account number ${item.derivationIndex}, ${item.address}${
+              isImported ? ', already imported' : ''
+            }`}
+            accessibilityState={{
+              checked: isSelected && !isImported,
+              disabled: isImported,
+            }}
           >
             <View style={styles.accountRowLeft}>
               <View

--- a/src/components/ledger/AccountImport.tsx
+++ b/src/components/ledger/AccountImport.tsx
@@ -182,14 +182,17 @@ const LedgerAccountList: React.FC<LedgerAccountListProps> = ({
             }}
             activeOpacity={0.8}
             accessible
-            accessibilityRole="checkbox"
+            // An already-imported row is not a selectable checkbox — it is
+            // still actionable (it opens the account preview), so it must not
+            // be announced as disabled or a screen reader cannot activate it.
+            accessibilityRole={isImported ? 'button' : 'checkbox'}
             accessibilityLabel={`Account number ${item.derivationIndex}, ${item.address}${
               isImported ? ', already imported' : ''
             }`}
-            accessibilityState={{
-              checked: isSelected && !isImported,
-              disabled: isImported,
-            }}
+            accessibilityHint={isImported ? 'Opens this account' : undefined}
+            accessibilityState={
+              isImported ? undefined : { checked: isSelected }
+            }
           >
             <View style={styles.accountRowLeft}>
               <View

--- a/src/components/navigation/FABRadialMenu.tsx
+++ b/src/components/navigation/FABRadialMenu.tsx
@@ -145,6 +145,7 @@ const FABMenuItem: React.FC<FABMenuItemProps> = ({
         variant="medium"
         padding="sm"
         onPress={onPress}
+        accessibilityLabel={item.label}
         borderRadius={16}
         style={styles.menuItemCard}
         borderColor={theme.colors.border}

--- a/src/components/remoteSigner/SignerModeBanner.tsx
+++ b/src/components/remoteSigner/SignerModeBanner.tsx
@@ -19,6 +19,7 @@ import Animated, {
 import { useThemedStyles } from '@/hooks/useThemedStyles';
 import { Theme } from '@/constants/themes';
 import { GlassCard } from '@/components/common/GlassCard';
+import { useReducedMotion } from '@/hooks/useReducedMotion';
 
 interface SignerModeBannerProps {
   /** Called when scan button is pressed */
@@ -30,9 +31,15 @@ export default function SignerModeBanner({
 }: SignerModeBannerProps) {
   const styles = useThemedStyles(createStyles);
   const iconPulse = useSharedValue(1);
+  const reducedMotion = useReducedMotion();
 
   // Subtle pulsing animation on the shield icon
   useEffect(() => {
+    // DR-13: no infinite pulse under Reduce Motion — park at rest scale.
+    if (reducedMotion) {
+      iconPulse.value = 1;
+      return;
+    }
     iconPulse.value = withRepeat(
       withSequence(
         withTiming(1.05, { duration: 1200 }),
@@ -41,7 +48,7 @@ export default function SignerModeBanner({
       -1,
       true
     );
-  }, [iconPulse]);
+  }, [iconPulse, reducedMotion]);
 
   const iconAnimatedStyle = useAnimatedStyle(() => ({
     transform: [{ scale: iconPulse.value }],
@@ -81,6 +88,9 @@ export default function SignerModeBanner({
             style={styles.scanButton}
             onPress={onScanPress}
             activeOpacity={0.8}
+            accessibilityRole="button"
+            accessibilityLabel="Scan signing request"
+            accessibilityHint="Opens the camera to scan an air-gapped signing request"
           >
             <Ionicons
               name="scan-outline"

--- a/src/components/update/UpdateBanner.tsx
+++ b/src/components/update/UpdateBanner.tsx
@@ -23,6 +23,7 @@ import Animated, {
 import { useThemedStyles } from '@/hooks/useThemedStyles';
 import { Theme } from '@/constants/themes';
 import { GlassCard } from '@/components/common/GlassCard';
+import { useReducedMotion } from '@/hooks/useReducedMotion';
 
 interface UpdateBannerProps {
   /** Called when user taps to download and install the update */
@@ -43,12 +44,14 @@ export default function UpdateBanner({
 }: UpdateBannerProps) {
   const styles = useThemedStyles(createStyles);
   const iconScale = useSharedValue(1);
+  const reducedMotion = useReducedMotion();
 
   const isBusy = isDownloading || isInstalling;
 
-  // Subtle pulsing animation on the icon (only when not busy)
+  // Subtle pulsing animation on the icon (only when not busy).
+  // DR-13: Reduce Motion suppresses the infinite loop entirely.
   useEffect(() => {
-    if (!isBusy) {
+    if (!isBusy && !reducedMotion) {
       iconScale.value = withRepeat(
         withSequence(
           withTiming(1.1, { duration: 800 }),
@@ -60,7 +63,7 @@ export default function UpdateBanner({
     } else {
       iconScale.value = 1;
     }
-  }, [iconScale, isBusy]);
+  }, [iconScale, isBusy, reducedMotion]);
 
   const iconAnimatedStyle = useAnimatedStyle(() => ({
     transform: [{ scale: iconScale.value }],
@@ -103,6 +106,8 @@ export default function UpdateBanner({
         borderGlow
         glowColor={styles.glowColor.color}
         padding="md"
+        accessibilityLabel={`${getTitle()}. ${getSubtitle()}`}
+        accessibilityState={{ disabled: isBusy, busy: isBusy }}
       >
         <View style={styles.content}>
           <Animated.View style={[styles.iconContainer, iconAnimatedStyle]}>
@@ -121,6 +126,8 @@ export default function UpdateBanner({
               onPress={handleDismiss}
               style={styles.dismissButton}
               hitSlop={{ top: 10, bottom: 10, left: 10, right: 10 }}
+              accessibilityRole="button"
+              accessibilityLabel="Dismiss update banner"
             >
               <Ionicons
                 name="close"

--- a/src/components/update/UpdateBanner.tsx
+++ b/src/components/update/UpdateBanner.tsx
@@ -9,6 +9,7 @@ import {
   StyleSheet,
   TouchableOpacity,
   ActivityIndicator,
+  type AccessibilityActionEvent,
 } from 'react-native';
 import { Ionicons } from '@expo/vector-icons';
 import Animated, {
@@ -81,6 +82,18 @@ export default function UpdateBanner({
     }
   };
 
+  // The whole banner is one accessibility group (a pressable GlassCard), which
+  // makes the nested dismiss button unreachable to a screen reader. Expose it
+  // as a custom action on the group instead, so "Dismiss" is available from the
+  // rotor / actions menu without changing the visual layout.
+  const accessibilityActions = isBusy
+    ? undefined
+    : [{ name: 'dismiss', label: 'Dismiss update' }];
+
+  const handleAccessibilityAction = (event: AccessibilityActionEvent): void => {
+    if (event.nativeEvent.actionName === 'dismiss') handleDismiss();
+  };
+
   // Determine title and subtitle based on state
   const getTitle = () => {
     if (isDownloading) return 'Downloading update...';
@@ -108,6 +121,8 @@ export default function UpdateBanner({
         padding="md"
         accessibilityLabel={`${getTitle()}. ${getSubtitle()}`}
         accessibilityState={{ disabled: isBusy, busy: isBusy }}
+        accessibilityActions={accessibilityActions}
+        onAccessibilityAction={handleAccessibilityAction}
       >
         <View style={styles.content}>
           <Animated.View style={[styles.iconContainer, iconAnimatedStyle]}>
@@ -126,8 +141,10 @@ export default function UpdateBanner({
               onPress={handleDismiss}
               style={styles.dismissButton}
               hitSlop={{ top: 10, bottom: 10, left: 10, right: 10 }}
-              accessibilityRole="button"
-              accessibilityLabel="Dismiss update banner"
+              // Unreachable inside the grouped card; the equivalent screen
+              // reader path is the `dismiss` accessibility action above.
+              accessibilityElementsHidden
+              importantForAccessibility="no-hide-descendants"
             >
               <Ionicons
                 name="close"

--- a/src/components/update/__tests__/UpdateBanner.a11y.test.tsx
+++ b/src/components/update/__tests__/UpdateBanner.a11y.test.tsx
@@ -1,0 +1,108 @@
+/**
+ * UpdateBanner accessibility + reduce-motion tests (TASK-42).
+ *
+ * The banner is the one place in the app where a secondary control (dismiss)
+ * is nested inside a pressable GlassCard. Because a pressable card is a single
+ * accessibility group, that nested button is unreachable to a screen reader —
+ * so the dismiss path must be exposed as a custom accessibility action on the
+ * group instead. These tests pin that contract.
+ */
+
+import React from 'react';
+import { render } from '@testing-library/react-native';
+
+import UpdateBanner from '../UpdateBanner';
+
+jest.mock('@/contexts/ThemeContext', () => ({
+  // eslint-disable-next-line @typescript-eslint/no-require-imports
+  useTheme: () => ({ theme: require('@/constants/themes').lightTheme }),
+}));
+
+jest.mock(
+  '@expo/vector-icons',
+  () => ({
+    Ionicons: () => null,
+  }),
+  { virtual: true }
+);
+
+const mockUseReducedMotion = jest.fn(() => false);
+jest.mock('@/hooks/useReducedMotion', () => ({
+  useReducedMotion: () => mockUseReducedMotion(),
+}));
+
+const mockWithRepeat = jest.fn();
+jest.mock('react-native-reanimated', () => {
+  const actual = jest.requireActual('react-native-reanimated/mock');
+  return {
+    ...actual,
+    __esModule: true,
+    default: actual.default ?? actual,
+    withRepeat: (...args: unknown[]) => {
+      mockWithRepeat(...args);
+      return 0;
+    },
+  };
+});
+
+const findCard = (root: { findAll: (p: (n: any) => boolean) => any[] }) =>
+  root.findAll(
+    (node: any) => Array.isArray(node.props?.accessibilityActions) === true
+  )[0];
+
+beforeEach(() => {
+  mockUseReducedMotion.mockReturnValue(false);
+  mockWithRepeat.mockClear();
+});
+
+describe('UpdateBanner accessibility', () => {
+  it('exposes dismiss as a custom action on the grouped card', () => {
+    const onDismiss = jest.fn();
+    const { UNSAFE_root } = render(
+      <UpdateBanner onInstall={jest.fn()} onDismiss={onDismiss} />
+    );
+
+    const card = findCard(UNSAFE_root);
+    expect(card.props.accessibilityActions).toEqual([
+      { name: 'dismiss', label: 'Dismiss update' },
+    ]);
+
+    card.props.onAccessibilityAction({
+      nativeEvent: { actionName: 'dismiss' },
+    });
+    expect(onDismiss).toHaveBeenCalledTimes(1);
+  });
+
+  it('ignores unrelated accessibility actions', () => {
+    const onDismiss = jest.fn();
+    const { UNSAFE_root } = render(
+      <UpdateBanner onInstall={jest.fn()} onDismiss={onDismiss} />
+    );
+
+    findCard(UNSAFE_root).props.onAccessibilityAction({
+      nativeEvent: { actionName: 'activate' },
+    });
+    expect(onDismiss).not.toHaveBeenCalled();
+  });
+
+  it('drops the dismiss action while the update is busy', () => {
+    const { UNSAFE_root } = render(
+      <UpdateBanner onInstall={jest.fn()} onDismiss={jest.fn()} isInstalling />
+    );
+
+    expect(findCard(UNSAFE_root)).toBeUndefined();
+  });
+});
+
+describe('UpdateBanner reduce-motion (DR-13)', () => {
+  it('pulses the icon when motion is allowed', () => {
+    render(<UpdateBanner onInstall={jest.fn()} onDismiss={jest.fn()} />);
+    expect(mockWithRepeat).toHaveBeenCalled();
+  });
+
+  it('never starts the infinite pulse under Reduce Motion', () => {
+    mockUseReducedMotion.mockReturnValue(true);
+    render(<UpdateBanner onInstall={jest.fn()} onDismiss={jest.fn()} />);
+    expect(mockWithRepeat).not.toHaveBeenCalled();
+  });
+});

--- a/src/hooks/__tests__/useReducedMotion.test.tsx
+++ b/src/hooks/__tests__/useReducedMotion.test.tsx
@@ -1,0 +1,187 @@
+/**
+ * useReducedMotion tests (TASK-42 / PLAN-12 DR-13).
+ *
+ * DR-13's whole point is that the preference must be *reactive*: Reanimated's
+ * own `useReducedMotion()` snapshots the value at module load and never
+ * updates. So the guards that matter here are (a) the initial async read is
+ * honored, (b) a later `reduceMotionChanged` event re-renders consumers, and
+ * (c) the native listener is a single shared subscription that is torn down
+ * when the last consumer unmounts.
+ */
+
+import React from 'react';
+import { AccessibilityInfo, Text } from 'react-native';
+import { act, render } from '@testing-library/react-native';
+
+import {
+  __resetReducedMotionForTests,
+  getReducedMotionSnapshot,
+  subscribeToReducedMotion,
+  useReducedMotion,
+} from '../useReducedMotion';
+
+type ChangeHandler = (enabled: boolean) => void;
+
+const mockRemove = jest.fn();
+let mockHandlers: ChangeHandler[] = [];
+let mockInitial = false;
+let mockAddEventListener: jest.SpyInstance;
+let mockIsReduceMotionEnabled: jest.SpyInstance;
+
+function emitChange(enabled: boolean) {
+  for (const handler of [...mockHandlers]) handler(enabled);
+}
+
+// Imported statically (not via `jest.isolateModules`) so the hook shares the
+// renderer's React instance; the module singleton is reset in `afterEach`.
+function Probe() {
+  const reduced = useReducedMotion();
+  return <Text>{reduced ? 'reduced' : 'full'}</Text>;
+}
+
+beforeEach(() => {
+  mockHandlers = [];
+  mockRemove.mockClear();
+  mockInitial = false;
+
+  mockAddEventListener = jest
+    .spyOn(AccessibilityInfo, 'addEventListener')
+    .mockImplementation(((event: string, handler: ChangeHandler) => {
+      if (event === 'reduceMotionChanged') mockHandlers.push(handler);
+      return { remove: mockRemove };
+    }) as never);
+
+  mockIsReduceMotionEnabled = jest
+    .spyOn(AccessibilityInfo, 'isReduceMotionEnabled')
+    .mockImplementation(() => Promise.resolve(mockInitial));
+});
+
+afterEach(() => {
+  __resetReducedMotionForTests();
+  jest.restoreAllMocks();
+});
+
+describe('useReducedMotion', () => {
+  it('defaults to false (motion allowed) before the OS value settles', () => {
+    const { getByText } = render(<Probe />);
+    expect(getByText('full')).toBeTruthy();
+  });
+
+  it('adopts the initial OS value once the async read resolves', async () => {
+    mockInitial = true;
+
+    const { getByText } = render(<Probe />);
+    await act(async () => {
+      await Promise.resolve();
+    });
+
+    expect(mockIsReduceMotionEnabled).toHaveBeenCalled();
+    expect(getByText('reduced')).toBeTruthy();
+  });
+
+  it('stays reactive: a later reduceMotionChanged event re-renders consumers', async () => {
+    const { getByText } = render(<Probe />);
+    await act(async () => {
+      await Promise.resolve();
+    });
+    expect(getByText('full')).toBeTruthy();
+
+    act(() => emitChange(true));
+    expect(getByText('reduced')).toBeTruthy();
+
+    // ...and back again, so the gate is not one-way.
+    act(() => emitChange(false));
+    expect(getByText('full')).toBeTruthy();
+  });
+
+  it('subscribes to the reduceMotionChanged event exactly once for many consumers', () => {
+    render(
+      <>
+        <Probe />
+        <Probe />
+        <Probe />
+      </>
+    );
+
+    expect(mockAddEventListener).toHaveBeenCalledTimes(1);
+    expect(mockAddEventListener).toHaveBeenCalledWith(
+      'reduceMotionChanged',
+      expect.any(Function)
+    );
+  });
+
+  it('removes the native listener only after the last consumer unmounts', () => {
+    const first = render(<Probe />);
+    const second = render(<Probe />);
+
+    first.unmount();
+    expect(mockRemove).not.toHaveBeenCalled();
+
+    second.unmount();
+    expect(mockRemove).toHaveBeenCalledTimes(1);
+  });
+
+  it('re-subscribes after a full teardown', () => {
+    render(<Probe />).unmount();
+    render(<Probe />);
+
+    expect(mockAddEventListener).toHaveBeenCalledTimes(2);
+  });
+
+  it('still subscribes only once when the platform returns no subscription handle', () => {
+    // react-native-web's AccessibilityInfo returns `undefined` from
+    // addEventListener when the runtime has no matchMedia; the guard must not
+    // key off the returned handle or every consumer re-registers.
+    mockAddEventListener.mockImplementation((() => undefined) as never);
+
+    render(
+      <>
+        <Probe />
+        <Probe />
+      </>
+    );
+
+    expect(mockAddEventListener).toHaveBeenCalledTimes(1);
+  });
+
+  it('keeps motion enabled when the platform cannot report the preference', async () => {
+    mockAddEventListener.mockImplementation(() => {
+      throw new Error('unsupported on this target');
+    });
+    mockIsReduceMotionEnabled.mockImplementation(() =>
+      Promise.reject(new Error('unsupported on this target'))
+    );
+
+    const { getByText } = render(<Probe />);
+    await act(async () => {
+      await Promise.resolve();
+    });
+
+    // Never crash the render, and never falsely claim Reduce Motion is on.
+    expect(getByText('full')).toBeTruthy();
+  });
+
+  it('exposes the settled value to non-React callers via the snapshot', async () => {
+    mockInitial = true;
+    const { unmount } = render(<Probe />);
+    await act(async () => {
+      await Promise.resolve();
+    });
+
+    expect(getReducedMotionSnapshot()).toBe(true);
+    unmount();
+  });
+
+  it('notifies imperative subscribers and stops after unsubscribe', () => {
+    const listener = jest.fn();
+    const unsubscribe = subscribeToReducedMotion(listener);
+
+    emitChange(true);
+    expect(listener).toHaveBeenCalledWith(true);
+
+    unsubscribe();
+    listener.mockClear();
+    emitChange(false);
+    expect(listener).not.toHaveBeenCalled();
+  });
+});

--- a/src/hooks/useReducedMotion.ts
+++ b/src/hooks/useReducedMotion.ts
@@ -1,0 +1,136 @@
+/**
+ * useReducedMotion — reactive OS "Reduce Motion" preference (TASK-42 / PLAN-12 DR-13).
+ *
+ * Why not `react-native-reanimated`'s `useReducedMotion()`? Because it snapshots
+ * the system value once at module-load time and explicitly documents that
+ * "changing the reduced motion system setting doesn't cause your components to
+ * rerender". DR-13 requires the preference to be honored *reactively*, so this
+ * hook reads `AccessibilityInfo.isReduceMotionEnabled()` on first subscribe and
+ * then stays subscribed to the `reduceMotionChanged` event.
+ *
+ * Reanimated's own animation primitives already default to
+ * `ReduceMotion.System`, which disables *finite* animations when the OS
+ * preference is on. What it does NOT do is prevent an infinite `withRepeat`
+ * loop from being scheduled at all — it merely lets the first repetition
+ * settle. Components that drive continuous/looping motion therefore need to
+ * read this hook and skip starting the loop entirely (DR-13 item 3).
+ *
+ * Implementation note: the subscription is a refcounted module-level singleton
+ * so that the ~90 components that consume it share a single native listener
+ * rather than each registering their own.
+ */
+
+import { useSyncExternalStore } from 'react';
+import { AccessibilityInfo } from 'react-native';
+
+type Listener = (enabled: boolean) => void;
+
+/**
+ * Assume motion is allowed until the OS says otherwise. The first read is
+ * async; defaulting to `false` means the app looks normal for users who have
+ * the setting off (the overwhelming majority) and settles within a frame or two
+ * for users who have it on.
+ */
+let currentValue = false;
+let subscribers: Listener[] = [];
+let nativeSubscription: { remove: () => void } | null = null;
+/**
+ * Tracked separately from `nativeSubscription` because react-native-web's
+ * `AccessibilityInfo.addEventListener` returns `undefined` when the runtime has
+ * no `matchMedia`. Keying the guard off the returned handle alone would then
+ * re-register a listener for every additional consumer.
+ */
+let nativeSubscriptionStarted = false;
+
+function publish(next: boolean): void {
+  if (next === currentValue) return;
+  currentValue = next;
+  // Copy first: a listener may unsubscribe during notification.
+  for (const listener of [...subscribers]) listener(next);
+}
+
+function startNativeSubscription(): void {
+  if (nativeSubscriptionStarted) return;
+  nativeSubscriptionStarted = true;
+
+  try {
+    nativeSubscription =
+      AccessibilityInfo.addEventListener(
+        'reduceMotionChanged',
+        (enabled: boolean) => publish(!!enabled)
+      ) ?? null;
+  } catch {
+    // Targets without the event (older web/extension runtimes) simply never
+    // update after the initial read below.
+    nativeSubscription = null;
+  }
+
+  try {
+    const pending = AccessibilityInfo.isReduceMotionEnabled?.();
+    if (pending && typeof pending.then === 'function') {
+      pending
+        .then((enabled) => publish(!!enabled))
+        .catch(() => {
+          // Unable to determine the preference — keep animations enabled
+          // rather than degrading the UI on a query failure.
+        });
+    }
+  } catch {
+    // Same rationale: a throwing/absent API must not break rendering.
+  }
+}
+
+function stopNativeSubscription(): void {
+  nativeSubscription?.remove();
+  nativeSubscription = null;
+  nativeSubscriptionStarted = false;
+}
+
+/**
+ * Subscribe to the reduced-motion preference outside of React.
+ * Returns an unsubscribe function.
+ */
+export function subscribeToReducedMotion(listener: Listener): () => void {
+  subscribers.push(listener);
+  startNativeSubscription();
+
+  let active = true;
+  return () => {
+    if (!active) return;
+    active = false;
+    subscribers = subscribers.filter((entry) => entry !== listener);
+    if (subscribers.length === 0) stopNativeSubscription();
+  };
+}
+
+/** Last known value of the preference, without subscribing. */
+export function getReducedMotionSnapshot(): boolean {
+  return currentValue;
+}
+
+/**
+ * Reactive OS "Reduce Motion" preference.
+ *
+ * Components driving looping or decorative motion should skip starting the
+ * animation when this is `true`; one-shot transitions can rely on Reanimated's
+ * built-in `ReduceMotion.System` handling.
+ */
+export function useReducedMotion(): boolean {
+  // `useSyncExternalStore` is the right primitive here: it subscribes without a
+  // setState-in-effect, and it re-reads the snapshot after subscribing, so a
+  // value that settles between render and commit cannot be missed.
+  return useSyncExternalStore(
+    subscribeToReducedMotion,
+    getReducedMotionSnapshot,
+    getReducedMotionSnapshot
+  );
+}
+
+/** Test-only: drop all state so each case starts from a clean singleton. */
+export function __resetReducedMotionForTests(): void {
+  stopNativeSubscription();
+  subscribers = [];
+  currentValue = false;
+}
+
+export default useReducedMotion;

--- a/src/screens/remoteSigner/AirgapHomeScreen.tsx
+++ b/src/screens/remoteSigner/AirgapHomeScreen.tsx
@@ -49,6 +49,7 @@ import {
   useWalletStore,
 } from '@/store/walletStore';
 import { AccountMetadata, AccountType } from '@/types/wallet';
+import { useReducedMotion } from '@/hooks/useReducedMotion';
 
 // AirgapHomeScreen is the AirgapHome route of the Airgap stack, and can also
 // navigate up to the parent tab navigator (e.g. the Settings tab).
@@ -82,8 +83,15 @@ export default function AirgapHomeScreen() {
 
   // Animation for the shield icon
   const iconPulse = useSharedValue(1);
+  const reducedMotion = useReducedMotion();
 
   useEffect(() => {
+    // DR-13: this is a resting screen with a permanent pulse — under Reduce
+    // Motion it must not run at all.
+    if (reducedMotion) {
+      iconPulse.value = 1;
+      return;
+    }
     iconPulse.value = withRepeat(
       withSequence(
         withTiming(1.08, { duration: 1500 }),
@@ -92,7 +100,7 @@ export default function AirgapHomeScreen() {
       -1,
       true
     );
-  }, [iconPulse]);
+  }, [iconPulse, reducedMotion]);
 
   const iconAnimatedStyle = useAnimatedStyle(() => ({
     transform: [{ scale: iconPulse.value }],

--- a/src/screens/remoteSigner/ExportAccountsScreen.tsx
+++ b/src/screens/remoteSigner/ExportAccountsScreen.tsx
@@ -346,7 +346,13 @@ export default function ExportAccountsScreen() {
               onPress={() => toggleAccount(account.id)}
               accessible
               accessibilityRole="checkbox"
-              accessibilityLabel={`${account.label || formatAddress(account.address)}, ${formatAddress(account.address)}`}
+              // The row renders the label above the address, but falls back to
+              // the address for both when unlabeled — announce it once.
+              accessibilityLabel={
+                account.label
+                  ? `${account.label}, ${formatAddress(account.address)}`
+                  : formatAddress(account.address)
+              }
               accessibilityState={{
                 checked: selectedAccountIds.has(account.id),
               }}

--- a/src/screens/remoteSigner/ExportAccountsScreen.tsx
+++ b/src/screens/remoteSigner/ExportAccountsScreen.tsx
@@ -212,6 +212,8 @@ export default function ExportAccountsScreen() {
           <TouchableOpacity
             style={styles.backButton}
             onPress={() => navigation.goBack()}
+            accessibilityRole="button"
+            accessibilityLabel="Go back"
           >
             <Ionicons name="arrow-back" size={24} color={theme.colors.text} />
           </TouchableOpacity>
@@ -239,6 +241,8 @@ export default function ExportAccountsScreen() {
           <TouchableOpacity
             style={styles.backButton}
             onPress={() => navigation.goBack()}
+            accessibilityRole="button"
+            accessibilityLabel="Go back"
           >
             <Ionicons name="arrow-back" size={24} color={theme.colors.text} />
           </TouchableOpacity>
@@ -266,6 +270,8 @@ export default function ExportAccountsScreen() {
         <TouchableOpacity
           style={styles.backButton}
           onPress={() => navigation.goBack()}
+          accessibilityRole="button"
+          accessibilityLabel="Go back"
         >
           <Ionicons name="arrow-back" size={24} color={theme.colors.text} />
         </TouchableOpacity>
@@ -310,12 +316,19 @@ export default function ExportAccountsScreen() {
               {signableAccounts.length})
             </Text>
             <View style={styles.selectButtons}>
-              <TouchableOpacity onPress={selectAll} style={styles.selectButton}>
+              <TouchableOpacity
+                onPress={selectAll}
+                style={styles.selectButton}
+                accessibilityRole="button"
+                accessibilityLabel="Select all accounts"
+              >
                 <Text style={styles.selectButtonText}>All</Text>
               </TouchableOpacity>
               <TouchableOpacity
                 onPress={selectNone}
                 style={styles.selectButton}
+                accessibilityRole="button"
+                accessibilityLabel="Deselect all accounts"
               >
                 <Text style={styles.selectButtonText}>None</Text>
               </TouchableOpacity>
@@ -331,6 +344,12 @@ export default function ExportAccountsScreen() {
                   styles.accountItemSelected,
               ]}
               onPress={() => toggleAccount(account.id)}
+              accessible
+              accessibilityRole="checkbox"
+              accessibilityLabel={`${account.label || formatAddress(account.address)}, ${formatAddress(account.address)}`}
+              accessibilityState={{
+                checked: selectedAccountIds.has(account.id),
+              }}
             >
               <View style={styles.accountCheckbox}>
                 {selectedAccountIds.has(account.id) ? (
@@ -369,6 +388,11 @@ export default function ExportAccountsScreen() {
             ]}
             onPress={handleGeneratePress}
             disabled={isGenerating}
+            accessibilityRole="button"
+            accessibilityLabel={
+              isGenerating ? 'Generating pairing QR' : 'Generate pairing QR'
+            }
+            accessibilityState={{ disabled: isGenerating, busy: isGenerating }}
           >
             {isGenerating ? (
               <ActivityIndicator size="small" color={theme.colors.buttonText} />

--- a/src/screens/social/FriendsScreen.tsx
+++ b/src/screens/social/FriendsScreen.tsx
@@ -178,6 +178,8 @@ export default function FriendsScreen() {
             <TouchableOpacity
               style={styles.profileButton}
               onPress={handleMyProfile}
+              accessibilityRole="button"
+              accessibilityLabel="My profile"
             >
               <Ionicons
                 name="person-circle-outline"
@@ -202,7 +204,11 @@ export default function FriendsScreen() {
               autoCorrect={false}
             />
             {searchQuery.length > 0 && (
-              <TouchableOpacity onPress={() => setSearchQuery('')}>
+              <TouchableOpacity
+                onPress={() => setSearchQuery('')}
+                accessibilityRole="button"
+                accessibilityLabel="Clear search"
+              >
                 <Ionicons
                   name="close-circle"
                   size={20}
@@ -219,6 +225,8 @@ export default function FriendsScreen() {
                   initialQuery: searchQuery.trim(),
                 })
               }
+              accessibilityRole="button"
+              accessibilityLabel={`Search Envoi for ${searchQuery.trim()}`}
             >
               <Ionicons
                 name="person-add-outline"
@@ -266,6 +274,8 @@ export default function FriendsScreen() {
           style={styles.fab}
           onPress={handleAddFriend}
           activeOpacity={0.8}
+          accessibilityRole="button"
+          accessibilityLabel="Add contact"
         >
           <Ionicons name="person-add" size={24} color="#FFFFFF" />
         </TouchableOpacity>

--- a/src/screens/social/MessagesInboxScreen.tsx
+++ b/src/screens/social/MessagesInboxScreen.tsx
@@ -360,6 +360,10 @@ export default function MessagesInboxScreen() {
               hideThread(friendAddress);
             }
           }}
+          accessibilityRole="button"
+          accessibilityLabel={
+            isHidden ? 'Unhide conversation' : 'Hide conversation'
+          }
         >
           <Ionicons
             name={isHidden ? 'eye-outline' : 'eye-off-outline'}
@@ -403,6 +407,14 @@ export default function MessagesInboxScreen() {
             onLongPress={() => handleThreadLongPress(thread)}
             activeOpacity={0.7}
             delayLongPress={500}
+            accessible
+            accessibilityRole="button"
+            accessibilityLabel={`Conversation with ${friendInfo.name}${
+              hasUnread
+                ? `, ${thread.unreadCount} unread message${thread.unreadCount === 1 ? '' : 's'}`
+                : ''
+            }`}
+            accessibilityHint="Opens the conversation. Long press for more options"
           >
             <View style={styles.avatarContainer}>
               {friendInfo.avatar ? (
@@ -644,6 +656,13 @@ export default function MessagesInboxScreen() {
                   <TouchableOpacity
                     style={styles.headerActionButton}
                     onPress={toggleShowHiddenThreads}
+                    accessibilityRole="button"
+                    accessibilityLabel={
+                      showHiddenThreads
+                        ? 'Hide hidden conversations'
+                        : 'Show hidden conversations'
+                    }
+                    accessibilityState={{ selected: showHiddenThreads }}
                   >
                     <Ionicons
                       name={
@@ -673,6 +692,8 @@ export default function MessagesInboxScreen() {
                 <TouchableOpacity
                   style={styles.headerActionButton}
                   onPress={handleNewMessage}
+                  accessibilityRole="button"
+                  accessibilityLabel="New message"
                 >
                   <Ionicons
                     name="create-outline"
@@ -704,7 +725,11 @@ export default function MessagesInboxScreen() {
                 autoCorrect={false}
               />
               {searchQuery.length > 0 && (
-                <TouchableOpacity onPress={() => setSearchQuery('')}>
+                <TouchableOpacity
+                  onPress={() => setSearchQuery('')}
+                  accessibilityRole="button"
+                  accessibilityLabel="Clear search"
+                >
                   <Ionicons
                     name="close-circle"
                     size={20}

--- a/src/screens/social/MessagesInboxScreen.tsx
+++ b/src/screens/social/MessagesInboxScreen.tsx
@@ -662,7 +662,10 @@ export default function MessagesInboxScreen() {
                         ? 'Hide hidden conversations'
                         : 'Show hidden conversations'
                     }
-                    accessibilityState={{ selected: showHiddenThreads }}
+                    // A disclosure toggle: it reveals/collapses the hidden
+                    // threads rather than selecting anything, so `expanded` is
+                    // the state a screen reader should announce.
+                    accessibilityState={{ expanded: showHiddenThreads }}
                   >
                     <Ionicons
                       name={

--- a/src/screens/wallet/AccountSearchScreen.tsx
+++ b/src/screens/wallet/AccountSearchScreen.tsx
@@ -234,6 +234,10 @@ export default function AccountSearchScreen() {
             style={styles.resultItem}
             onPress={() => handleResultPress(item)}
             activeOpacity={0.7}
+            accessible
+            accessibilityRole="button"
+            accessibilityLabel={`${item.name ? `${item.name}, ` : ''}${formatAddress(item.address)}`}
+            accessibilityHint="Opens this account's profile"
           >
             {renderAvatar(item)}
             <View style={styles.resultInfo}>
@@ -262,6 +266,12 @@ export default function AccountSearchScreen() {
               ]}
               onPress={() => handleToggleFriend(item)}
               activeOpacity={0.7}
+              accessibilityRole="button"
+              accessibilityLabel={
+                isCurrentlyFriend
+                  ? `Remove ${item.name || formatAddress(item.address)} from contacts`
+                  : `Add ${item.name || formatAddress(item.address)} to contacts`
+              }
             >
               <Ionicons
                 name={isCurrentlyFriend ? 'person-remove' : 'person-add'}
@@ -336,6 +346,8 @@ export default function AccountSearchScreen() {
           <TouchableOpacity
             style={styles.backButton}
             onPress={() => navigation.goBack()}
+            accessibilityRole="button"
+            accessibilityLabel="Go back"
           >
             <Ionicons
               name="chevron-back"
@@ -370,6 +382,8 @@ export default function AccountSearchScreen() {
                   setSearchResults([]);
                   setHasSearched(false);
                 }}
+                accessibilityRole="button"
+                accessibilityLabel="Clear search"
               >
                 <Ionicons
                   name="close-circle"
@@ -383,6 +397,12 @@ export default function AccountSearchScreen() {
             style={styles.searchButton}
             onPress={handleSearchSubmit}
             disabled={isLoading || searchQuery.trim().length === 0}
+            accessibilityRole="button"
+            accessibilityLabel="Search accounts"
+            accessibilityState={{
+              disabled: isLoading || searchQuery.trim().length === 0,
+              busy: isLoading,
+            }}
           >
             <Text style={styles.searchButtonText}>Search</Text>
           </TouchableOpacity>

--- a/src/screens/wallet/ClaimableTokensScreen.tsx
+++ b/src/screens/wallet/ClaimableTokensScreen.tsx
@@ -49,6 +49,7 @@ import {
   useClaimableLoading,
 } from '@/store/claimableStore';
 import { useActiveAccount } from '@/store/walletStore';
+import { useReducedMotion } from '@/hooks/useReducedMotion';
 import { ClaimableItem, toSerializableClaimableItem } from '@/types/claimable';
 import type { WalletStackParamList } from '@/navigation/AppNavigator';
 
@@ -82,6 +83,7 @@ export default function ClaimableTokensScreen() {
   const isLoading = useClaimableLoading();
 
   // Animation for pending refresh indicator
+  const reducedMotion = useReducedMotion();
   const pulseOpacity = useSharedValue(1);
   const pulseAnimatedStyle = useAnimatedStyle(() => ({
     opacity: pulseOpacity.value,
@@ -108,12 +110,16 @@ export default function ClaimableTokensScreen() {
       pendingRefreshHandled.current = true;
       setIsPendingRefresh(true);
 
-      // Start pulsing animation
-      pulseOpacity.value = withRepeat(
-        withTiming(0.4, { duration: 800 }),
-        -1,
-        true
-      );
+      // Start pulsing animation. DR-13: skipped entirely under Reduce Motion —
+      // `isPendingRefresh` still drives the visible "refreshing" copy, so the
+      // state remains conveyed without the loop.
+      if (!reducedMotion) {
+        pulseOpacity.value = withRepeat(
+          withTiming(0.4, { duration: 800 }),
+          -1,
+          true
+        );
+      }
 
       // Clear the params immediately to prevent re-triggering
       navigation.setParams({
@@ -155,6 +161,7 @@ export default function ClaimableTokensScreen() {
     fetchApprovals,
     navigation,
     pulseOpacity,
+    reducedMotion,
   ]);
 
   // Cleanup timeout on unmount only (separate effect with empty deps)

--- a/src/screens/wallet/ClaimableTokensScreen.tsx
+++ b/src/screens/wallet/ClaimableTokensScreen.tsx
@@ -164,6 +164,16 @@ export default function ClaimableTokensScreen() {
     reducedMotion,
   ]);
 
+  // DR-13: the effect above is short-circuited by `pendingRefreshHandled`, so a
+  // pulse that was already running when the user switched Reduce Motion ON
+  // would otherwise keep looping until the delayed refresh finishes. Stop it
+  // from its own effect, which has no such guard.
+  useEffect(() => {
+    if (!reducedMotion) return;
+    cancelAnimation(pulseOpacity);
+    pulseOpacity.value = 1;
+  }, [reducedMotion, pulseOpacity]);
+
   // Cleanup timeout on unmount only (separate effect with empty deps)
   useEffect(() => {
     return () => {

--- a/src/screens/wallet/HomeScreen.tsx
+++ b/src/screens/wallet/HomeScreen.tsx
@@ -1525,6 +1525,7 @@ export default function HomeScreen() {
                 <GlassCard
                   variant="light"
                   onPress={handleQRScan}
+                  accessibilityLabel="Scan QR code"
                   style={styles.qrButtonTopRight}
                   borderRadius={theme.borderRadius.md}
                   padding="none"
@@ -1644,6 +1645,7 @@ export default function HomeScreen() {
                       <GlassCard
                         variant="light"
                         onPress={handleOpenAssetFilter}
+                        accessibilityLabel="Filter assets"
                         style={styles.headerIconButton}
                         borderRadius={theme.borderRadius.md}
                         padding="none"
@@ -1662,6 +1664,7 @@ export default function HomeScreen() {
                       <GlassCard
                         variant="light"
                         onPress={handleAddAsset}
+                        accessibilityLabel="Add asset"
                         style={styles.headerIconButton}
                         borderRadius={theme.borderRadius.md}
                         padding="none"

--- a/src/screens/wallet/NFTDetailScreen.tsx
+++ b/src/screens/wallet/NFTDetailScreen.tsx
@@ -171,7 +171,12 @@ export default function NFTDetailScreen() {
           },
         ]}
       >
-        <TouchableOpacity style={styles.backButton} onPress={handleBackPress}>
+        <TouchableOpacity
+          style={styles.backButton}
+          onPress={handleBackPress}
+          accessibilityRole="button"
+          accessibilityLabel="Go back"
+        >
           <Ionicons name="arrow-back" size={24} color={theme.colors.primary} />
         </TouchableOpacity>
         <Text style={[styles.headerTitle, { color: theme.colors.text }]}>
@@ -183,6 +188,12 @@ export default function NFTDetailScreen() {
               style={styles.actionButton}
               onPress={handleSetAsTheme}
               disabled={isSettingTheme}
+              accessibilityRole="button"
+              accessibilityLabel="Set this NFT as app theme"
+              accessibilityState={{
+                disabled: isSettingTheme,
+                busy: isSettingTheme,
+              }}
             >
               {isSettingTheme ? (
                 <ActivityIndicator size="small" color={theme.colors.primary} />
@@ -195,7 +206,12 @@ export default function NFTDetailScreen() {
               )}
             </TouchableOpacity>
           )}
-          <TouchableOpacity style={styles.actionButton} onPress={handleSend}>
+          <TouchableOpacity
+            style={styles.actionButton}
+            onPress={handleSend}
+            accessibilityRole="button"
+            accessibilityLabel="Send this NFT"
+          >
             <Ionicons
               name="send-outline"
               size={22}
@@ -205,6 +221,8 @@ export default function NFTDetailScreen() {
           <TouchableOpacity
             style={styles.actionButton}
             onPress={handleShareNFT}
+            accessibilityRole="button"
+            accessibilityLabel="Share this NFT"
           >
             <Ionicons
               name="share-outline"
@@ -287,7 +305,11 @@ export default function NFTDetailScreen() {
               >
                 Contract ID:
               </Text>
-              <TouchableOpacity onPress={handleCopyContractId}>
+              <TouchableOpacity
+                onPress={handleCopyContractId}
+                accessibilityRole="button"
+                accessibilityLabel={`Copy contract ID ${nft.contractId}`}
+              >
                 <Text
                   style={[styles.infoValue, { color: theme.colors.primary }]}
                 >
@@ -305,7 +327,11 @@ export default function NFTDetailScreen() {
               >
                 Token ID:
               </Text>
-              <TouchableOpacity onPress={handleCopyTokenId}>
+              <TouchableOpacity
+                onPress={handleCopyTokenId}
+                accessibilityRole="button"
+                accessibilityLabel={`Copy token ID ${nft.tokenId}`}
+              >
                 <Text
                   style={[styles.infoValue, { color: theme.colors.primary }]}
                 >

--- a/src/screens/wallet/ReceiveScreen.tsx
+++ b/src/screens/wallet/ReceiveScreen.tsx
@@ -191,6 +191,8 @@ export default function ReceiveScreen() {
                   variant="light"
                   style={styles.addressBox}
                   onPress={copyAddress}
+                  accessibilityLabel={`Your address, ${activeAccount.address}`}
+                  accessibilityHint="Copies the address to the clipboard"
                 >
                   <Text style={[styles.address, { color: theme.colors.text }]}>
                     {activeAccount.address}

--- a/src/screens/wallet/SendScreen.tsx
+++ b/src/screens/wallet/SendScreen.tsx
@@ -2063,8 +2063,11 @@ export default function SendScreen() {
                     accessible
                     accessibilityRole="radio"
                     accessibilityLabel={`${asset.name}, ${asset.symbol}`}
+                    // A radio reports its chosen state through `checked`;
+                    // `selected` is for tabs/list selection and is not
+                    // announced for this role.
                     accessibilityState={{
-                      selected: effectiveAssetId === asset.id,
+                      checked: effectiveAssetId === asset.id,
                     }}
                   >
                     <View style={styles.assetOptionContent}>

--- a/src/screens/wallet/SendScreen.tsx
+++ b/src/screens/wallet/SendScreen.tsx
@@ -1695,6 +1695,9 @@ export default function SendScreen() {
                     style={styles.inputButton}
                     onPress={handleAccountRecipientModalOpen}
                     disabled={isSending}
+                    accessibilityRole="button"
+                    accessibilityLabel="Choose recipient from accounts and contacts"
+                    accessibilityState={{ disabled: isSending }}
                   >
                     <Ionicons
                       name="people"
@@ -1706,6 +1709,9 @@ export default function SendScreen() {
                     style={styles.inputButton}
                     onPress={handleQRScan}
                     disabled={isSending}
+                    accessibilityRole="button"
+                    accessibilityLabel="Scan recipient QR code"
+                    accessibilityState={{ disabled: isSending }}
                   >
                     <Ionicons
                       name="qr-code"
@@ -1758,6 +1764,10 @@ export default function SendScreen() {
                       ]}
                       onPress={() => handleSearchResultSelect(result)}
                       activeOpacity={0.8}
+                      accessible
+                      accessibilityRole="button"
+                      accessibilityLabel={`${result.name}, ${result.address}`}
+                      accessibilityHint="Selects this address as the recipient"
                     >
                       {result.avatar ? (
                         <Image
@@ -1826,6 +1836,9 @@ export default function SendScreen() {
                       )
                     }
                     disabled={isSending}
+                    accessibilityRole="button"
+                    accessibilityLabel="Send maximum spendable amount"
+                    accessibilityState={{ disabled: isSending }}
                   >
                     <Text style={styles.maxButton}>
                       Max:{' '}
@@ -2026,6 +2039,8 @@ export default function SendScreen() {
                   onPress={() => setShowAssetSelector(false)}
                   style={styles.modalCloseButton}
                   hitSlop={{ top: 10, bottom: 10, left: 10, right: 10 }}
+                  accessibilityRole="button"
+                  accessibilityLabel="Close asset selector"
                 >
                   <Ionicons
                     name="close"
@@ -2045,6 +2060,12 @@ export default function SendScreen() {
                         styles.assetOptionSelected,
                     ]}
                     onPress={() => handleAssetSelect(Number(asset.id))}
+                    accessible
+                    accessibilityRole="radio"
+                    accessibilityLabel={`${asset.name}, ${asset.symbol}`}
+                    accessibilityState={{
+                      selected: effectiveAssetId === asset.id,
+                    }}
                   >
                     <View style={styles.assetOptionContent}>
                       <Text style={styles.assetOptionName}>{asset.name}</Text>

--- a/src/utils/animations.ts
+++ b/src/utils/animations.ts
@@ -13,10 +13,27 @@ import {
   withRepeat,
   interpolate,
   Easing,
+  ReduceMotion,
   SharedValue,
   WithSpringConfig,
   WithTimingConfig,
 } from 'react-native-reanimated';
+import { useReducedMotion } from '@/hooks/useReducedMotion';
+
+/**
+ * Reduce Motion policy for the shared configs (PLAN-12 DR-13, item 2).
+ *
+ * `ReduceMotion.System` makes Reanimated consult the OS accessibility setting
+ * and skip the animation (jumping straight to the target value) when it is on.
+ * It is Reanimated's default, but every shared config states it explicitly so
+ * that the policy is visible at the choke point rather than implied — and so a
+ * future config never silently opts out by omission.
+ *
+ * NOTE: this only covers animations that *flow through* these configs. Direct
+ * `withRepeat` loops with inline durations bypass them entirely and must gate
+ * themselves on `useReducedMotion()` — see DR-13 item 3.
+ */
+const REDUCE_MOTION_POLICY = ReduceMotion.System;
 
 // Spring configurations for different interaction types
 export const springConfigs = {
@@ -25,24 +42,28 @@ export const springConfigs = {
     damping: 20,
     stiffness: 400,
     mass: 0.8,
+    reduceMotion: REDUCE_MOTION_POLICY,
   } as WithSpringConfig,
   // Smooth movement for cards and modals
   smooth: {
     damping: 25,
     stiffness: 200,
     mass: 1,
+    reduceMotion: REDUCE_MOTION_POLICY,
   } as WithSpringConfig,
   // Bouncy for playful interactions
   bouncy: {
     damping: 12,
     stiffness: 180,
     mass: 0.8,
+    reduceMotion: REDUCE_MOTION_POLICY,
   } as WithSpringConfig,
   // Gentle for subtle movements
   gentle: {
     damping: 30,
     stiffness: 150,
     mass: 1.2,
+    reduceMotion: REDUCE_MOTION_POLICY,
   } as WithSpringConfig,
 };
 
@@ -51,23 +72,28 @@ export const timingConfigs = {
   instant: {
     duration: 100,
     easing: Easing.ease,
+    reduceMotion: REDUCE_MOTION_POLICY,
   } as WithTimingConfig,
   fast: {
     duration: 150,
     easing: Easing.out(Easing.ease),
+    reduceMotion: REDUCE_MOTION_POLICY,
   } as WithTimingConfig,
   normal: {
     duration: 250,
     easing: Easing.inOut(Easing.ease),
+    reduceMotion: REDUCE_MOTION_POLICY,
   } as WithTimingConfig,
   slow: {
     duration: 400,
     easing: Easing.inOut(Easing.cubic),
+    reduceMotion: REDUCE_MOTION_POLICY,
   } as WithTimingConfig,
   // For shimmer effects
   shimmer: {
     duration: 1500,
     easing: Easing.linear,
+    reduceMotion: REDUCE_MOTION_POLICY,
   } as WithTimingConfig,
 };
 
@@ -118,23 +144,34 @@ export function useGlowPulse(
   duration: number = 2000
 ) {
   const glowOpacity = useSharedValue(minOpacity);
+  const reducedMotion = useReducedMotion();
 
   const startPulse = useCallback(() => {
+    // DR-13: an infinite pulse must not start at all under Reduce Motion —
+    // park the value at its resting opacity instead.
+    if (reducedMotion) {
+      glowOpacity.value = minOpacity;
+      return;
+    }
     glowOpacity.value = withRepeat(
       withSequence(
         withTiming(maxOpacity, {
           duration: duration / 2,
           easing: Easing.inOut(Easing.ease),
+          reduceMotion: REDUCE_MOTION_POLICY,
         }),
         withTiming(minOpacity, {
           duration: duration / 2,
           easing: Easing.inOut(Easing.ease),
+          reduceMotion: REDUCE_MOTION_POLICY,
         })
       ),
       -1, // Repeat infinitely
-      false // Don't reverse
+      false, // Don't reverse
+      undefined,
+      REDUCE_MOTION_POLICY
     );
-  }, [glowOpacity, minOpacity, maxOpacity, duration]);
+  }, [glowOpacity, minOpacity, maxOpacity, duration, reducedMotion]);
 
   const stopPulse = useCallback(() => {
     glowOpacity.value = withTiming(minOpacity, timingConfigs.normal);
@@ -226,14 +263,26 @@ export function useNumberTransition(
  */
 export function useShimmer(duration: number = 1500) {
   const shimmerPosition = useSharedValue(-1);
+  const reducedMotion = useReducedMotion();
 
   const startShimmer = useCallback(() => {
+    // DR-13: skip the infinite sweep entirely under Reduce Motion.
+    if (reducedMotion) {
+      shimmerPosition.value = -1;
+      return;
+    }
     shimmerPosition.value = withRepeat(
-      withTiming(1, { duration, easing: Easing.linear }),
+      withTiming(1, {
+        duration,
+        easing: Easing.linear,
+        reduceMotion: REDUCE_MOTION_POLICY,
+      }),
       -1,
-      false
+      false,
+      undefined,
+      REDUCE_MOTION_POLICY
     );
-  }, [shimmerPosition, duration]);
+  }, [shimmerPosition, duration, reducedMotion]);
 
   const stopShimmer = useCallback(() => {
     shimmerPosition.value = -1;


### PR DESCRIPTION
Implements **TASK-42** (PLAN-12 Phase 2, Wave 3) — resolves audit finding **U-01**.

Brings the app from effectively-zero accessibility support to a usable VoiceOver/TalkBack baseline, and makes the OS **Reduce Motion** preference actually honored.

## Shared components first (~89 import sites in three edits)

| Component | Sites | Before | After |
|---|---|---|---|
| `UniversalHeader` | 41 | icon-only back button with **no accessible name**, no a11y props at all | `accessibilityRole="button"` + label (`"Go back"`, overridable) + optional hint; `accessibilityRole="header"` on the title; `testID` / `backButtonTestID` passthrough |
| `GlassCard` | 30 | silently becomes an `AnimatedPressable` when `onPress`/`onLongPress` is given, with **no role** — every tappable card an unlabeled a11y leaf | pressable variant defaults to `role="button"` + `accessible`; accepts `accessibilityLabel` / `Hint` / `Role` / `State` / `Actions`. Static variant stays transparent to the a11y tree so inner text remains individually navigable |
| `GlassButton` | 18 | `label` gave RN a name, but `disabled`/`loading` were **never** surfaced | `accessibilityState={{ disabled, busy }}`, overridable name/hint/role |

Icon-only sweep in the listed offenders: `ExportAccountsScreen`, `NFTDetailScreen`, `ledger/AccountImport`, `AccountRecipientModal`, `SendScreen`, `AccountSearchScreen`, `MessagesInboxScreen`, `FriendsScreen` — following the existing correct patterns in `AccountSelector` / `ViewModeToggle` / `TransactionDangerBanner` / `PassphraseStrengthMeter` rather than inventing a new convention.

Decorative chrome in `NFTBackground` (29 sites) and `BlurredContainer` (20 sites) — background image, vignettes, tint overlays, highlight gradients, inner borders — is removed from the a11y tree via `accessibilityElementsHidden` + `importantForAccessibility="no-hide-descendants"`. **The content wrappers are deliberately untouched**; hiding those would have hidden every screen. There is a regression test pinning both halves of that contract.

### Coverage

| | before | after |
|---|---|---|
| `accessibilityLabel` | 8 | 71 |
| `accessibilityRole` | 8 | 72 |
| `accessibilityHint` | 2 | 22 |
| `accessibilityState` | 3 | 30 |
| **total** | **21** | **195** |
| files with a11y props | 6 | 24 |

(Counts exclude tests; the "after" figure includes the prop declarations on the three shared components, which is where the leverage over ~89 call sites comes from.)

## Reduce motion — DR-13

The obvious approach does not work, exactly as DR-13 predicted:

1. **A real, reactive source of truth.** New `src/hooks/useReducedMotion.ts` reads `AccessibilityInfo.isReduceMotionEnabled()` **and** subscribes to `reduceMotionChanged`. Reanimated ships its own `useReducedMotion()` but it snapshots the value at module-load time and explicitly documents that changing the setting *"doesn't cause your components to rerender"* — so it cannot satisfy the acceptance criterion and is not used. Implemented as a refcounted module singleton behind `useSyncExternalStore`, so ~90 consumers share **one** native listener; defensive against targets where the API is absent or returns no subscription handle (react-native-web returns `undefined` without `matchMedia`).
2. **Propagation.** `animations.ts` now states `ReduceMotion.System` explicitly on every shared spring/timing config — Reanimated's default, but recorded at the choke point so a future config cannot silently opt out by omission. Its own two infinite loops (`useGlowPulse`, `useShimmer`) now no-op under the preference.
3. **Direct loops that bypass the shared configs stop, not shorten.** `GlassButton`'s glow (`withRepeat(withSequence(withTiming(…)))` with hardcoded 1200ms durations, never touching the shared configs), `ClaimableBanner`, `SignerModeBanner`, `UpdateBanner`, `AirgapHomeScreen`, and the `ClaimableTokensScreen` refresh pulse. Each parks its shared value at rest instead of scheduling the loop, and each re-runs when the preference flips, so turning Reduce Motion on **stops an already-running loop**.

### Coordination with TASK-196 (PLAN-193)

TASK-196 targets these same infinite `withRepeat` icon pulses for **performance**. This PR does **not** subsume it: the loops still run at full cost for the (large) majority of users who do not have Reduce Motion enabled. What it does provide is (a) the shared `useReducedMotion` hook TASK-196 can reuse, and (b) an established shape for gating these loops — the six call sites now each have a single guarded `useEffect`, so a performance gate can extend the same condition rather than re-discovering the sites. Whoever picks up TASK-196 should treat these files as already-touched and rebase accordingly.

## Explicitly out of scope

- **Font scaling (revised DR-3).** No `allowFontScaling`, no `maxFontSizeMultiplier`, no `Text.defaultProps` — untouched repo-wide. That work moved wholesale to PLAN-223.
- **Manual VoiceOver/TalkBack pass** on Home → Send → Receive, which is folded into the batched pre-release verification per the acceptance criteria.

## Folded in

Small in-scope defects found during the Codex review loop:

- **Nested control unreachable behind an a11y group.** A pressable `GlassCard` is a single accessibility group (RN's `Pressable` already defaults `accessible={true}`, so this predates the PR), which made `UpdateBanner`'s nested dismiss button unreachable to a screen reader — install was the only available action. `GlassCard` now forwards `accessibilityActions` / `onAccessibilityAction`, and the banner exposes *"Dismiss update"* as a custom action on the group with no visual change.
- **Wrong state key for a radio.** `SendScreen`'s asset options declared `accessibilityRole="radio"` but reported `accessibilityState.selected`; a radio announces its chosen state through `checked`.
- **Actionable row announced as disabled.** An already-imported Ledger row still opens the account preview on press, but was announced as a disabled checkbox, blocking screen-reader activation. Imported rows now use plain button semantics with a hint; only selectable rows keep checkbox role and `checked`.
- **Loop survived the preference flip.** `ClaimableTokensScreen`'s pulse effect is short-circuited by a `pendingRefreshHandled` ref, so a loop started while motion was allowed kept running after the user enabled Reduce Motion. Cancelled from a dedicated effect with no such guard.
- **Unlabeled icon-only pressable cards.** Home's scan-QR / filter-assets / add-asset cards, the FAB radial menu items, and the Receive address card had no text for RN to derive a name from.
- **Duplicated address in an accessible name.** Unlabeled rows in `ExportAccountsScreen` announced the formatted address twice.
- **Disclosure toggle announced as a selection.** The hidden-conversations toggle in `MessagesInboxScreen` reports `expanded`, not `selected`.

## Testing

+6 suites / +40 tests, with the reduce-motion hook covered in depth per the task note (initial async read, reactivity in both directions, single shared listener, teardown/re-subscribe, and graceful degradation when the platform cannot report the preference).

## Gates

- `npm run typecheck` — **0 errors**
- `npm run lint` — **0 errors** (684 warnings vs. 681 baseline; the three additions are pre-existing-pattern `react-hooks/immutability` warnings on Reanimated shared-value writes, which account for the large majority of the existing 681)
- `npm test -- --ci` — **1396 passing / 86 suites** (baseline 1356 / 80) — no regressions
- Codex review: **CLEAN**, on both the working diff and a second pass over the PR diff. Six rounds produced genuine, steadily narrowing findings (P1 → P2 → P2 → P2 → P3 → P2, all listed above) before converging; the extra rounds past the nominal budget are flagged deliberately because each one surfaced a real semantic defect rather than churn.

## Cross-target note

The extension/web target adds no new dependency: the only new platform API is `AccessibilityInfo`, which react-native-web implements over `matchMedia('(prefers-reduced-motion: reduce)')`, and `ReduceMotion` is a plain enum from Reanimated's shared entry point. The hook degrades to "motion allowed" if either is unavailable. A full `expo export -p web` could not be run from this isolated worktree (Metro will not resolve a symlinked `node_modules`), so the web bundle should be built once on `main` after merge if a stronger signal is wanted.

Closes TASK-42.
