### PR TITLE
refactor(theme): consolidate palettes, migrate hardcoded hex to theme tokens (TASK-43)

### DIFF
--- a/src/components/NetworkBadge.tsx
+++ b/src/components/NetworkBadge.tsx
@@ -90,7 +90,9 @@ const createStyles = (theme: Theme) =>
       backgroundColor: 'transparent',
     },
 
-    // Text styles by variant
+    // Text styles by variant.
+    // Fixed white ink: the filled variant is painted with the network's brand
+    // colour (networkConfig.color), not a theme surface.
     textFilled: {
       color: '#FFFFFF',
       fontWeight: '600',

--- a/src/components/account/AccountAvatar.tsx
+++ b/src/components/account/AccountAvatar.tsx
@@ -9,7 +9,7 @@ import {
   AccountType,
   RekeyedAccountMetadata,
 } from '@/types/wallet';
-import { useThemedStyles } from '@/hooks/useThemedStyles';
+import { useThemedStyles, useThemeColors } from '@/hooks/useThemedStyles';
 import { Theme } from '@/constants/themes';
 import { useWalletStore } from '@/store/walletStore';
 
@@ -117,6 +117,9 @@ const generatePattern = (safeAddress: string, size: number) => {
   return patterns;
 };
 
+// Not theme-derived on purpose: picks a contrasting ink for the deterministic
+// identicon background generated from the address, which is independent of the
+// active theme palette.
 const getReadableTextColor = (color: string): string => {
   const hslMatch = color.match(
     /hsl\(\s*(-?\d+(?:\.\d+)?),\s*(-?\d+(?:\.\d+)?)%,\s*(-?\d+(?:\.\d+)?)%\s*\)/i
@@ -143,6 +146,7 @@ export default function AccountAvatar({
   style,
 }: AccountAvatarProps) {
   const styles = useThemedStyles(createStyles);
+  const themeColors = useThemeColors();
   const [envoiAvatarUrl, setEnvoiAvatarUrl] = useState<string | null>(null);
   const [avatarError, setAvatarError] = useState<boolean>(false);
   const [isLoading, setIsLoading] = useState<boolean>(false);
@@ -295,7 +299,8 @@ export default function AccountAvatar({
     const rekeyedAccount = account as RekeyedAccountMetadata;
     return {
       iconName: rekeyedAccount.canSign ? 'key' : 'lock-closed',
-      color: rekeyedAccount.canSign ? '#10B981' : '#F59E0B', // Green if we can sign, amber if we can't
+      // Success if we hold signing authority, warning if we do not
+      color: rekeyedAccount.canSign ? themeColors.success : themeColors.warning,
     };
   };
 
@@ -414,6 +419,8 @@ export default function AccountAvatar({
             },
           ]}
         >
+          {/* Fixed white glyph: sits on the semantic success/warning badge
+              fill, not on a theme surface, so buttonText is the wrong ink. */}
           <Ionicons
             name={rekeyIndicator.iconName as any}
             size={size * 0.2}
@@ -461,7 +468,7 @@ const createStyles = (theme: Theme) =>
       borderColor: theme.colors.card,
     },
     checkmark: {
-      color: '#FFFFFF',
+      color: theme.colors.buttonText,
       fontWeight: 'bold',
     },
     rekeyIndicator: {

--- a/src/components/account/AccountImportItem.tsx
+++ b/src/components/account/AccountImportItem.tsx
@@ -99,21 +99,29 @@ export default function AccountImportItem({
                   styles.typeBadge,
                   {
                     backgroundColor:
-                      account.type === 'standard' ? '#EBF4FF' : '#F0FDF4',
+                      account.type === 'standard'
+                        ? theme.colors.infoLight
+                        : theme.colors.successLight,
                   },
                 ]}
               >
                 <Ionicons
                   name={getTypeIcon()}
                   size={12}
-                  color={account.type === 'standard' ? '#3B82F6' : '#10B981'}
+                  color={
+                    account.type === 'standard'
+                      ? colors.infoColor
+                      : colors.successColor
+                  }
                 />
                 <Text
                   style={[
                     styles.typeText,
                     {
                       color:
-                        account.type === 'standard' ? '#3B82F6' : '#10B981',
+                        account.type === 'standard'
+                          ? colors.infoColor
+                          : colors.successColor,
                     },
                   ]}
                 >

--- a/src/components/account/AccountListItem.tsx
+++ b/src/components/account/AccountListItem.tsx
@@ -40,6 +40,8 @@ export default function AccountListItem({
   shouldLoadBalance = true,
   hideBalance = false,
 }: AccountListItemProps) {
+  const styles = useThemedStyles(createStyles);
+  const colors = useThemeColors();
   const setActiveAccount = useWalletStore((state) => state.setActiveAccount);
   const walletAccounts = useWalletStore((state) => state.wallet?.accounts);
   const accountBalanceData = useAccountBalance(account.id);
@@ -121,13 +123,13 @@ export default function AccountListItem({
     if (rekeyedAccount.canSign) {
       return {
         name: 'key' as const,
-        color: '#10B981', // Green - we can sign
+        color: colors.success, // We have signing authority
         tooltip: 'Rekeyed account - you have signing authority',
       };
     } else {
       return {
         name: 'lock-closed' as const,
-        color: '#F59E0B', // Amber - we cannot sign
+        color: colors.warning, // We do not have signing authority
         tooltip: 'Rekeyed account - you do not have signing authority',
       };
     }
@@ -180,8 +182,6 @@ export default function AccountListItem({
 
   const typeLabel = getAccountTypeLabel(account);
   const rekeyIcon = getRekeyStatusIcon(account);
-  const styles = useThemedStyles(createStyles);
-  const colors = useThemeColors();
 
   return (
     <TouchableOpacity
@@ -278,10 +278,7 @@ const createStyles = (theme: Theme) =>
       marginVertical: theme.spacing.xs,
     },
     activeContainer: {
-      backgroundColor:
-        theme.mode === 'light'
-          ? 'rgba(59, 130, 246, 0.1)'
-          : 'rgba(10, 132, 255, 0.15)',
+      backgroundColor: theme.colors.primaryLight,
       borderLeftWidth: 3,
       borderLeftColor: theme.colors.primary,
     },

--- a/src/components/account/AccountListModal.tsx
+++ b/src/components/account/AccountListModal.tsx
@@ -381,7 +381,7 @@ const createStyles = (theme: Theme) =>
       // No extra margin needed with gap
     },
     compactAddText: {
-      color: '#FFFFFF',
+      color: theme.colors.buttonText,
       fontSize: 14,
       fontWeight: '600',
     },

--- a/src/components/account/AddAccountModal.tsx
+++ b/src/components/account/AddAccountModal.tsx
@@ -243,8 +243,7 @@ const createStyles = (theme: Theme) =>
       width: 40,
       height: 40,
       borderRadius: 20,
-      backgroundColor:
-        theme.mode === 'light' ? '#EBF4FF' : 'rgba(10, 132, 255, 0.2)',
+      backgroundColor: theme.colors.primaryLight,
       justifyContent: 'center',
       alignItems: 'center',
       marginRight: theme.spacing.md,

--- a/src/components/account/RenameAccountModal.tsx
+++ b/src/components/account/RenameAccountModal.tsx
@@ -125,7 +125,10 @@ export default function RenameAccountModal({
                 disabled={!isNameValid || isSubmitting}
               >
                 {isSubmitting ? (
-                  <ActivityIndicator size="small" color="#FFFFFF" />
+                  <ActivityIndicator
+                    size="small"
+                    color={theme.colors.buttonText}
+                  />
                 ) : (
                   <Text style={styles.confirmButtonText}>Save</Text>
                 )}

--- a/src/components/assets/MultiNetworkAssetItem.tsx
+++ b/src/components/assets/MultiNetworkAssetItem.tsx
@@ -334,6 +334,7 @@ const createStyles = (theme: Theme) =>
       paddingVertical: 2,
       borderRadius: 10,
     },
+    // Fixed white ink: the pill is filled with the network's brand colour.
     networkBadgeText: {
       fontSize: 10,
       fontWeight: '600',

--- a/src/components/auth-account/AuthAccountPreview.tsx
+++ b/src/components/auth-account/AuthAccountPreview.tsx
@@ -258,10 +258,7 @@ const createStyles = (theme: Theme) =>
     },
     infoBox: {
       flexDirection: 'row',
-      backgroundColor:
-        theme.mode === 'light'
-          ? 'rgba(0, 122, 255, 0.08)'
-          : 'rgba(10, 132, 255, 0.18)',
+      backgroundColor: theme.colors.primaryLight,
       borderRadius: theme.borderRadius.lg,
       padding: theme.spacing.md,
       gap: theme.spacing.sm,

--- a/src/components/backup/BackupProgressModal.tsx
+++ b/src/components/backup/BackupProgressModal.tsx
@@ -75,9 +75,16 @@ export default function BackupProgressModal({
                     ]}
                   >
                     {isCompleted ? (
-                      <Ionicons name="checkmark" size={14} color="#FFFFFF" />
+                      <Ionicons
+                        name="checkmark"
+                        size={14}
+                        color={colors.buttonText}
+                      />
                     ) : isCurrent ? (
-                      <ActivityIndicator size="small" color="#FFFFFF" />
+                      <ActivityIndicator
+                        size="small"
+                        color={colors.buttonText}
+                      />
                     ) : (
                       <Text style={styles.stepNumber}>{index + 1}</Text>
                     )}

--- a/src/components/backup/PasswordInputModal.tsx
+++ b/src/components/backup/PasswordInputModal.tsx
@@ -253,7 +253,7 @@ export default function PasswordInputModal({
                 disabled={!isValid || isSubmitting}
               >
                 {isSubmitting ? (
-                  <ActivityIndicator size="small" color="#FFFFFF" />
+                  <ActivityIndicator size="small" color={colors.buttonText} />
                 ) : (
                   <Text style={styles.confirmButtonText}>
                     {mode === 'create' ? 'Create Backup' : 'Decrypt'}
@@ -303,8 +303,7 @@ const createStyles = (theme: Theme) =>
     warningContainer: {
       flexDirection: 'row',
       alignItems: 'flex-start',
-      backgroundColor:
-        theme.mode === 'dark' ? 'rgba(255, 159, 10, 0.1)' : '#FFF3CD',
+      backgroundColor: theme.colors.warningLight,
       padding: theme.spacing.md,
       borderRadius: theme.borderRadius.lg,
       marginBottom: theme.spacing.lg,
@@ -315,7 +314,7 @@ const createStyles = (theme: Theme) =>
       flex: 1,
       marginLeft: theme.spacing.sm,
       fontSize: 13,
-      color: theme.mode === 'dark' ? theme.colors.warning : '#856404',
+      color: theme.colors.text,
       lineHeight: 18,
     },
     inputContainer: {

--- a/src/components/backup/RestoreConfirmationModal.tsx
+++ b/src/components/backup/RestoreConfirmationModal.tsx
@@ -162,7 +162,11 @@ export default function RestoreConfirmationModal({
               style={[styles.button, styles.confirmButton]}
               onPress={onConfirm}
             >
-              <Ionicons name="cloud-download" size={18} color="#FFFFFF" />
+              <Ionicons
+                name="cloud-download"
+                size={18}
+                color={colors.buttonText}
+              />
               <Text style={styles.confirmButtonText}>Restore</Text>
             </TouchableOpacity>
           </View>
@@ -255,8 +259,7 @@ const createStyles = (theme: Theme) =>
     warningContainer: {
       flexDirection: 'row',
       alignItems: 'flex-start',
-      backgroundColor:
-        theme.mode === 'dark' ? 'rgba(239, 68, 68, 0.1)' : '#FEE2E2',
+      backgroundColor: theme.colors.errorLight,
       padding: theme.spacing.md,
       borderRadius: theme.borderRadius.lg,
       marginBottom: theme.spacing.md,
@@ -267,14 +270,13 @@ const createStyles = (theme: Theme) =>
       flex: 1,
       marginLeft: theme.spacing.sm,
       fontSize: 13,
-      color: theme.mode === 'dark' ? theme.colors.error : '#991B1B',
+      color: theme.colors.text,
       lineHeight: 18,
     },
     ledgerWarningContainer: {
       flexDirection: 'row',
       alignItems: 'flex-start',
-      backgroundColor:
-        theme.mode === 'dark' ? 'rgba(255, 159, 10, 0.1)' : '#FFF3CD',
+      backgroundColor: theme.colors.warningLight,
       padding: theme.spacing.md,
       borderRadius: theme.borderRadius.lg,
       marginBottom: theme.spacing.lg,
@@ -285,7 +287,7 @@ const createStyles = (theme: Theme) =>
       flex: 1,
       marginLeft: theme.spacing.sm,
       fontSize: 13,
-      color: theme.mode === 'dark' ? theme.colors.warning : '#856404',
+      color: theme.colors.text,
       lineHeight: 18,
     },
     buttons: {
@@ -318,7 +320,7 @@ const createStyles = (theme: Theme) =>
       backgroundColor: theme.colors.primary,
     },
     confirmButtonText: {
-      color: '#FFFFFF',
+      color: theme.colors.buttonText,
       fontSize: 15,
       fontWeight: '600',
       marginLeft: theme.spacing.sm,

--- a/src/components/common/GlassButton.tsx
+++ b/src/components/common/GlassButton.tsx
@@ -234,11 +234,15 @@ export const GlassButton: React.FC<GlassButtonProps> = ({
       },
       danger: {
         backgroundColor: theme.colors.error,
-        // Fixed white ink + darkened red gradient stop: both are keyed to the
-        // error fill, not to primary, so buttonText is the wrong reference.
+        // Fixed white ink: this sits on the error fill, and buttonText is
+        // contrast-checked against primary, so it is the wrong reference here.
         textColor: '#FFFFFF',
         borderColor: 'transparent',
         glowColor: theme.colors.glowError,
+        // Pre-existing: the second stop is a fixed dark red and is NOT derived
+        // from theme.colors.error, so under an NFT theme whose generated error
+        // is not red the two stops can disagree. Left as-is — there is no
+        // errorDark token and no darken helper available here (see TASK-228).
         gradientColors: [theme.colors.error, '#CC3629'] as [string, string],
         useGradient: true,
         tintGradient: null as [string, string] | null,

--- a/src/components/common/GlassButton.tsx
+++ b/src/components/common/GlassButton.tsx
@@ -57,7 +57,7 @@ interface GlassButtonProps {
   fullWidth?: boolean;
   /** Use pill shape (full rounded) */
   pill?: boolean;
-  /** Color tint for secondary buttons (e.g., '#007AFF' or 'rgba(0, 122, 255, 0.15)') */
+  /** Color tint for secondary buttons (e.g. theme.colors.primary, or an rgba tint) */
   tint?: string;
   /** Press handler */
   onPress: () => void;
@@ -204,7 +204,7 @@ export const GlassButton: React.FC<GlassButtonProps> = ({
     const configs = {
       primary: {
         backgroundColor: theme.colors.primary,
-        textColor: '#FFFFFF',
+        textColor: theme.colors.buttonText,
         borderColor: 'transparent',
         glowColor: theme.colors.glowPrimary,
         gradientColors: theme.gradients.primary as [string, string],
@@ -234,6 +234,8 @@ export const GlassButton: React.FC<GlassButtonProps> = ({
       },
       danger: {
         backgroundColor: theme.colors.error,
+        // Fixed white ink + darkened red gradient stop: both are keyed to the
+        // error fill, not to primary, so buttonText is the wrong reference.
         textColor: '#FFFFFF',
         borderColor: 'transparent',
         glowColor: theme.colors.glowError,

--- a/src/components/common/OfflineBanner.tsx
+++ b/src/components/common/OfflineBanner.tsx
@@ -93,6 +93,8 @@ const createStyles = (theme: Theme) =>
       justifyContent: 'center',
       gap: theme.spacing.xs,
     },
+    // Fixed dark ink: this banner is filled with theme.colors.warning (amber in
+    // every palette), where a theme text colour would lose contrast.
     icon: {
       color: '#1C1C1E',
     },

--- a/src/components/common/OfflineBanner.tsx
+++ b/src/components/common/OfflineBanner.tsx
@@ -93,8 +93,9 @@ const createStyles = (theme: Theme) =>
       justifyContent: 'center',
       gap: theme.spacing.xs,
     },
-    // Fixed dark ink: this banner is filled with theme.colors.warning (amber in
-    // every palette), where a theme text colour would lose contrast.
+    // Fixed dark ink: this banner is filled with theme.colors.warning, which is
+    // a mid-lightness hue in the static palettes and in generated NFT themes
+    // alike, so a theme text colour would lose contrast against it.
     icon: {
       color: '#1C1C1E',
     },

--- a/src/components/common/PassphraseStrengthMeter.tsx
+++ b/src/components/common/PassphraseStrengthMeter.tsx
@@ -43,11 +43,11 @@ export function PassphraseStrengthMeter({ secret, minLength }: Props) {
       case 1:
         return theme.colors.error;
       case 2:
-        return theme.colors.warning ?? '#E0A100';
+        return theme.colors.warning;
       case 3:
         return theme.colors.primary;
       default:
-        return theme.colors.success ?? '#22A06B';
+        return theme.colors.success;
     }
   };
 

--- a/src/components/envoi/EnvoiProfileCard.tsx
+++ b/src/components/envoi/EnvoiProfileCard.tsx
@@ -151,6 +151,8 @@ const SocialLinkButton: React.FC<SocialLinkProps> = ({ platform, url }) => {
     return 'link';
   };
 
+  // Social-network brand colours below are deliberately literal: they identify
+  // third-party services and must not shift with the app/NFT palette.
   const getColor = () => {
     const normalizedPlatform = platform.toLowerCase();
 
@@ -185,7 +187,7 @@ const SocialLinkButton: React.FC<SocialLinkProps> = ({ platform, url }) => {
       return '#1877F2';
     }
 
-    return '#007AFF';
+    return themeColors.primary;
   };
 
   return (

--- a/src/components/ledger/AccountPreview.tsx
+++ b/src/components/ledger/AccountPreview.tsx
@@ -263,10 +263,7 @@ const createStyles = (theme: Theme) =>
     },
     deviceInfo: {
       borderRadius: theme.borderRadius.md,
-      backgroundColor:
-        theme.mode === 'light'
-          ? 'rgba(0, 122, 255, 0.08)'
-          : 'rgba(10, 132, 255, 0.18)',
+      backgroundColor: theme.colors.primaryLight,
       padding: theme.spacing.md,
     },
     devicesLabel: {

--- a/src/components/ledger/ConnectionModal.tsx
+++ b/src/components/ledger/ConnectionModal.tsx
@@ -347,10 +347,7 @@ const createStyles = (theme: Theme) =>
       lineHeight: 20,
     },
     permissionBanner: {
-      backgroundColor:
-        theme.mode === 'light'
-          ? 'rgba(255, 149, 0, 0.1)'
-          : 'rgba(255, 159, 10, 0.22)',
+      backgroundColor: theme.colors.warningLight,
       borderRadius: theme.borderRadius.md,
       padding: theme.spacing.md,
       marginBottom: theme.spacing.md,
@@ -369,10 +366,7 @@ const createStyles = (theme: Theme) =>
       marginTop: theme.spacing.md,
       padding: theme.spacing.md,
       borderRadius: theme.borderRadius.md,
-      backgroundColor:
-        theme.mode === 'light'
-          ? 'rgba(255, 59, 48, 0.1)'
-          : 'rgba(255, 69, 58, 0.22)',
+      backgroundColor: theme.colors.errorLight,
     },
     errorText: {
       color: theme.colors.error,
@@ -409,11 +403,11 @@ const createStyles = (theme: Theme) =>
     debugButton: {
       backgroundColor: theme.colors.background,
       borderWidth: 1,
-      borderColor: '#007AFF',
+      borderColor: theme.colors.primary,
       flex: 0.7, // Make debug button smaller
     },
     debugButtonText: {
-      color: '#007AFF',
+      color: theme.colors.primary,
       fontWeight: '500',
       fontSize: 14,
     },

--- a/src/components/ledger/DeviceDiscovery.tsx
+++ b/src/components/ledger/DeviceDiscovery.tsx
@@ -374,10 +374,7 @@ const createStyles = (theme: Theme) =>
     },
     deviceRowSelected: {
       borderColor: theme.colors.primary,
-      backgroundColor:
-        theme.mode === 'light'
-          ? 'rgba(0, 122, 255, 0.08)'
-          : 'rgba(10, 132, 255, 0.2)',
+      backgroundColor: theme.colors.primaryLight,
     },
     deviceInfo: {
       flex: 1,
@@ -420,10 +417,7 @@ const createStyles = (theme: Theme) =>
       marginTop: theme.spacing.md,
       padding: theme.spacing.md,
       borderRadius: theme.borderRadius.md,
-      backgroundColor:
-        theme.mode === 'light'
-          ? 'rgba(255, 59, 48, 0.08)'
-          : 'rgba(255, 69, 58, 0.18)',
+      backgroundColor: theme.colors.errorLight,
     },
     errorText: {
       color: theme.colors.error,

--- a/src/components/ledger/RekeyToLedger.tsx
+++ b/src/components/ledger/RekeyToLedger.tsx
@@ -44,10 +44,15 @@ type LedgerStatusMap = Record<string, LedgerSigningInfo | null>;
 type StatusIntent = 'connected' | 'available' | 'unavailable';
 type StatusIconName = 'radio-button-on' | 'alert-circle' | 'close-circle';
 
-const statusIntentColors: Record<StatusIntent, string> = {
-  connected: '#10B981',
-  available: '#F59E0B',
-  unavailable: '#EF4444',
+// Semantic theme-colour keys per status intent. Resolved against the active
+// theme so NFT-generated palettes stay consistent.
+const statusIntentColorKeys: Record<
+  StatusIntent,
+  'success' | 'warning' | 'error'
+> = {
+  connected: 'success',
+  available: 'warning',
+  unavailable: 'error',
 };
 
 const statusIntentIcons: Record<StatusIntent, StatusIconName> = {
@@ -241,7 +246,7 @@ const RekeyToLedger: React.FC<RekeyToLedgerProps> = ({
     (account: LedgerAccountMetadata) => {
       const status = statusMap[account.id];
       const intent = resolveStatusIntent(status);
-      const color = statusIntentColors[intent];
+      const color = colors[statusIntentColorKeys[intent]];
       const icon = statusIntentIcons[intent];
 
       let label = 'Device unavailable';
@@ -261,7 +266,7 @@ const RekeyToLedger: React.FC<RekeyToLedgerProps> = ({
         </View>
       );
     },
-    [resolveStatusIntent, statusMap, styles, theme.colors.surface]
+    [colors, resolveStatusIntent, statusMap, styles, theme.colors.surface]
   );
 
   if (ledgerAccounts.length === 0) {
@@ -401,7 +406,9 @@ const RekeyToLedger: React.FC<RekeyToLedgerProps> = ({
                   <View
                     style={[
                       styles.intentDot,
-                      { backgroundColor: statusIntentColors[intent] },
+                      {
+                        backgroundColor: colors[statusIntentColorKeys[intent]],
+                      },
                     ]}
                   />
                   <Text

--- a/src/components/ledger/SigningPrompt.tsx
+++ b/src/components/ledger/SigningPrompt.tsx
@@ -220,10 +220,7 @@ const createStyles = (theme: Theme) =>
       color: theme.colors.error,
     },
     errorContainer: {
-      backgroundColor:
-        theme.mode === 'light'
-          ? 'rgba(255, 59, 48, 0.1)'
-          : 'rgba(255, 69, 58, 0.22)',
+      backgroundColor: theme.colors.errorLight,
       borderRadius: theme.borderRadius.md,
       padding: theme.spacing.md,
       marginVertical: theme.spacing.sm,

--- a/src/components/ledger/TransactionVerification.tsx
+++ b/src/components/ledger/TransactionVerification.tsx
@@ -338,17 +338,11 @@ const createStyles = (theme: Theme) =>
       borderRadius: theme.borderRadius.sm,
     },
     signingBadgeReady: {
-      backgroundColor:
-        theme.mode === 'light'
-          ? 'rgba(52, 199, 89, 0.12)'
-          : 'rgba(48, 209, 88, 0.24)',
+      backgroundColor: theme.colors.successLight,
       color: theme.colors.success,
     },
     signingBadgeWarning: {
-      backgroundColor:
-        theme.mode === 'light'
-          ? 'rgba(255, 149, 0, 0.12)'
-          : 'rgba(255, 159, 10, 0.24)',
+      backgroundColor: theme.colors.warningLight,
       color: theme.colors.warning,
     },
     totalRow: {
@@ -378,10 +372,7 @@ const createStyles = (theme: Theme) =>
       lineHeight: 18,
     },
     ledgerHint: {
-      backgroundColor:
-        theme.mode === 'light'
-          ? 'rgba(0, 122, 255, 0.08)'
-          : 'rgba(10, 132, 255, 0.18)',
+      backgroundColor: theme.colors.primaryLight,
       borderRadius: theme.borderRadius.md,
       padding: theme.spacing.md,
     },

--- a/src/components/navigation/FABRadialMenu.tsx
+++ b/src/components/navigation/FABRadialMenu.tsx
@@ -356,7 +356,7 @@ export const FABRadialMenu: React.FC<FABRadialMenuProps> = ({
             <View
               style={[
                 styles.unreadBadge,
-                { backgroundColor: theme.colors.error || '#EF4444' },
+                { backgroundColor: theme.colors.error },
               ]}
             >
               <Text style={styles.unreadBadgeText}>

--- a/src/components/network/NetworkIndicator.tsx
+++ b/src/components/network/NetworkIndicator.tsx
@@ -137,6 +137,7 @@ const createStyles = (theme: Theme) =>
     networkPill: {
       // Size and color set dynamically
     },
+    // Fixed white ink: pills are filled with the network's brand colour.
     pillText: {
       color: '#FFFFFF',
       fontWeight: '600',

--- a/src/components/social/FriendListItem.tsx
+++ b/src/components/social/FriendListItem.tsx
@@ -82,6 +82,8 @@ export default function FriendListItem({
           )}
           {friend.isFavorite && (
             <View style={styles.favoriteBadge}>
+              {/* Favourite gold — not a semantic theme role; kept literal so an
+                  NFT-generated palette cannot recolour the star. */}
               <Ionicons name="star" size={12} color="#FFA500" />
             </View>
           )}

--- a/src/components/social/MessageBubble.tsx
+++ b/src/components/social/MessageBubble.tsx
@@ -40,7 +40,7 @@ export default function MessageBubble({
   const isFailed = message.status === 'failed';
   const isPending = message.status === 'pending';
   const isConfirmed = message.status === 'confirmed';
-  const errorColor = theme.colors.error || '#EF4444';
+  const errorColor = theme.colors.error;
 
   const formatTime = (timestamp: number): string => {
     const date = new Date(timestamp);

--- a/src/components/social/MessageInput.tsx
+++ b/src/components/social/MessageInput.tsx
@@ -329,7 +329,7 @@ export default function MessageInput({
             <Text
               style={[
                 styles.charCounter,
-                isOverLimit && { color: theme.colors.error || '#EF4444' },
+                isOverLimit && { color: theme.colors.error },
               ]}
             >
               {message.length}/{MAX_MESSAGE_LENGTH}
@@ -477,7 +477,7 @@ const createStyles = (theme: Theme) =>
       justifyContent: 'center',
     },
     inputContainerError: {
-      borderColor: theme.colors.error || '#EF4444',
+      borderColor: theme.colors.error,
     },
     input: {
       fontSize: 15,

--- a/src/components/social/MessagingInfoModal.tsx
+++ b/src/components/social/MessagingInfoModal.tsx
@@ -87,7 +87,7 @@ export default function MessagingInfoModal({
                   icon="lock-closed"
                   title="End-to-End Encrypted"
                   description="Messages are encrypted before being sent. Only you and the recipient can read them."
-                  iconColor={theme.colors.success || '#10B981'}
+                  iconColor={theme.colors.success}
                 />
 
                 <InfoItem
@@ -100,7 +100,7 @@ export default function MessagingInfoModal({
                   icon="wallet-outline"
                   title={`Transaction Fee: ${MESSAGE_FEE_DISPLAY}`}
                   description="A small network fee is charged for each message you send. This fee goes to network validators."
-                  iconColor={theme.colors.warning || '#F59E0B'}
+                  iconColor={theme.colors.warning}
                 />
 
                 <InfoItem

--- a/src/components/transaction/TransactionListItem.tsx
+++ b/src/components/transaction/TransactionListItem.tsx
@@ -229,18 +229,18 @@ const TransactionListItem = React.memo(
 
       // Fallback icons based on asset type
       let iconName: keyof typeof Ionicons.glyphMap;
-      let iconColor = '#007AFF';
+      let iconColor = themeColors.primary;
 
       if (transaction.isArc200) {
         iconName = 'contract';
         iconColor = '#8B5CF6'; // Purple for ARC-200
       } else if (transaction.assetId && transaction.assetId !== 0) {
         iconName = 'diamond';
-        iconColor = '#F59E0B'; // Amber for ASA
+        iconColor = themeColors.warning; // Amber for ASA
       } else {
         // This shouldn't happen for VOI since we have the image above
         iconName = 'logo-bitcoin';
-        iconColor = '#007AFF';
+        iconColor = themeColors.primary;
       }
 
       return (

--- a/src/components/wallet/MnemonicDisplay.tsx
+++ b/src/components/wallet/MnemonicDisplay.tsx
@@ -152,8 +152,7 @@ const createStyles = (theme: Theme) =>
       alignItems: 'center',
       paddingHorizontal: theme.spacing.sm,
       paddingVertical: 6,
-      backgroundColor:
-        theme.mode === 'dark' ? 'rgba(10, 132, 255, 0.1)' : '#F0F9FF',
+      backgroundColor: theme.colors.primaryLight,
       borderRadius: theme.borderRadius.md,
     },
     revealButtonText: {

--- a/src/screens/account/AddWatchAccountScreen.tsx
+++ b/src/screens/account/AddWatchAccountScreen.tsx
@@ -324,7 +324,7 @@ export default function AddWatchAccountScreen() {
             disabled={!isAddressValid || isLoading}
           >
             {isLoading ? (
-              <ActivityIndicator color="#FFF" />
+              <ActivityIndicator color={theme.colors.buttonText} />
             ) : (
               <>
                 <Ionicons

--- a/src/screens/account/QRAccountImportScreen.tsx
+++ b/src/screens/account/QRAccountImportScreen.tsx
@@ -249,6 +249,7 @@ export default function QRAccountImportScreen({ navigation }: Props) {
 
   return (
     <SafeAreaView
+      // Camera viewfinder chrome is fixed black/white regardless of theme
       style={[styles.container, { backgroundColor: '#000000' }]}
       edges={['top', 'bottom']}
     >

--- a/src/screens/app/AppInfoModal.tsx
+++ b/src/screens/app/AppInfoModal.tsx
@@ -258,7 +258,7 @@ export default function AppInfoModal() {
           showAccountSelector={false}
         />
         <View style={styles.errorContainer}>
-          <Ionicons name="alert-circle" size={48} color="#EF4444" />
+          <Ionicons name="alert-circle" size={48} color={colors.error} />
           <Text style={styles.errorTitle}>Failed to Load</Text>
           <Text style={styles.errorMessage}>{error}</Text>
           <TouchableOpacity style={styles.retryButton} onPress={loadAppInfo}>
@@ -482,7 +482,7 @@ const createStyles = (theme: Theme) =>
       marginTop: 8,
     },
     retryButtonText: {
-      color: '#FFFFFF',
+      color: theme.colors.buttonText,
       fontWeight: '600',
     },
     scrollView: {
@@ -624,6 +624,6 @@ const createStyles = (theme: Theme) =>
     closeButtonText: {
       fontSize: 16,
       fontWeight: '600',
-      color: '#FFFFFF',
+      color: theme.colors.buttonText,
     },
   });

--- a/src/screens/auth/LockScreen.tsx
+++ b/src/screens/auth/LockScreen.tsx
@@ -620,11 +620,10 @@ const createStyles = (theme: Theme) =>
       alignItems: 'center',
       paddingVertical: theme.spacing.md,
       paddingHorizontal: theme.spacing.lg,
-      backgroundColor:
-        theme.mode === 'light' ? '#FFF5F5' : theme.colors.surface,
+      backgroundColor: theme.colors.errorLight,
       borderRadius: theme.borderRadius.lg,
       borderWidth: 1,
-      borderColor: theme.mode === 'light' ? '#FFE5E5' : theme.colors.error,
+      borderColor: theme.colors.error,
     },
     resetButtonText: {
       fontSize: 14,

--- a/src/screens/remoteSigner/ExportAccountsScreen.tsx
+++ b/src/screens/remoteSigner/ExportAccountsScreen.tsx
@@ -442,6 +442,7 @@ export default function ExportAccountsScreen() {
                   value={session.encoded}
                   size={220}
                   backgroundColor="white"
+                  // QR modules must stay pure black on white to scan
                   color="#000000"
                 />
               )}

--- a/src/screens/settings/AboutScreen.tsx
+++ b/src/screens/settings/AboutScreen.tsx
@@ -16,7 +16,7 @@ import { Ionicons } from '@expo/vector-icons';
 import Constants from 'expo-constants';
 import * as Updates from 'expo-updates';
 import * as Application from 'expo-application';
-import { useThemedStyles } from '@/hooks/useThemedStyles';
+import { useThemedStyles, useThemeColors } from '@/hooks/useThemedStyles';
 import { Theme } from '@/constants/themes';
 import UniversalHeader from '@/components/common/UniversalHeader';
 import { useUpdateStore } from '@/store/updateStore';
@@ -38,6 +38,7 @@ const getUpdateInfo = () => {
 export default function AboutScreen() {
   const navigation = useNavigation();
   const styles = useThemedStyles(createStyles);
+  const colors = useThemeColors();
   const updateInfo = getUpdateInfo();
   const { checkForUpdate, isChecking } = useUpdateStore();
 
@@ -138,6 +139,7 @@ export default function AboutScreen() {
             style={styles.linkItem}
             onPress={handleTwitterPress}
           >
+            {/* Brand colour, deliberately not theme-derived. */}
             <Ionicons name="logo-twitter" size={24} color="#1DA1F2" />
             <View style={styles.linkTextContainer}>
               <Text style={styles.linkTitle}>Follow us on Twitter</Text>
@@ -154,7 +156,7 @@ export default function AboutScreen() {
             style={styles.linkItem}
             onPress={handleWebsitePress}
           >
-            <Ionicons name="globe-outline" size={24} color="#007AFF" />
+            <Ionicons name="globe-outline" size={24} color={colors.primary} />
             <View style={styles.linkTextContainer}>
               <Text style={styles.linkTitle}>Visit our website</Text>
               <Text style={styles.linkSubtitle}>getvoi.app</Text>
@@ -174,7 +176,11 @@ export default function AboutScreen() {
             style={styles.linkItem}
             onPress={handleCompanyPress}
           >
-            <Ionicons name="business-outline" size={24} color="#6B7280" />
+            <Ionicons
+              name="business-outline"
+              size={24}
+              color={colors.textSecondary}
+            />
             <View style={styles.linkTextContainer}>
               <Text style={styles.linkTitle}>Perpetual Software, LLC</Text>
               <Text style={styles.linkSubtitle}>perpetualsoftware.org</Text>

--- a/src/screens/settings/BackupWalletScreen.tsx
+++ b/src/screens/settings/BackupWalletScreen.tsx
@@ -286,7 +286,7 @@ export default function BackupWalletScreen() {
                 style={styles.createButton}
                 onPress={handleSaveLocal}
               >
-                <Ionicons name="folder" size={20} color="#FFFFFF" />
+                <Ionicons name="folder" size={20} color={colors.buttonText} />
                 <Text style={styles.createButtonText}>
                   {backupSaved ? 'Save Another Copy' : 'Save to Device'}
                 </Text>
@@ -314,7 +314,11 @@ export default function BackupWalletScreen() {
                 style={styles.createButton}
                 onPress={handleSaveLocal}
               >
-                <Ionicons name="share-outline" size={20} color="#FFFFFF" />
+                <Ionicons
+                  name="share-outline"
+                  size={20}
+                  color={colors.buttonText}
+                />
                 <Text style={styles.createButtonText}>
                   {backupSaved ? 'Export Another Copy' : 'Export Backup'}
                 </Text>
@@ -462,7 +466,7 @@ export default function BackupWalletScreen() {
           onPress={handleStartBackup}
           disabled={accounts.length === 0}
         >
-          <Ionicons name="download" size={20} color="#FFFFFF" />
+          <Ionicons name="download" size={20} color={colors.buttonText} />
           <Text style={styles.createButtonText}>Create Backup</Text>
         </TouchableOpacity>
       </ScrollView>
@@ -586,8 +590,7 @@ const createStyles = (theme: Theme) =>
     warningContainer: {
       flexDirection: 'row',
       alignItems: 'flex-start',
-      backgroundColor:
-        theme.mode === 'dark' ? 'rgba(255, 159, 10, 0.1)' : '#FFF3CD',
+      backgroundColor: theme.colors.warningLight,
       padding: theme.spacing.md,
       borderRadius: theme.borderRadius.lg,
       marginBottom: theme.spacing.xl,
@@ -598,7 +601,7 @@ const createStyles = (theme: Theme) =>
       flex: 1,
       marginLeft: theme.spacing.sm,
       fontSize: 13,
-      color: theme.mode === 'dark' ? theme.colors.warning : '#856404',
+      color: theme.colors.text,
       lineHeight: 18,
     },
     createButton: {
@@ -610,7 +613,7 @@ const createStyles = (theme: Theme) =>
       borderRadius: theme.borderRadius.lg,
     },
     createButtonText: {
-      color: '#FFFFFF',
+      color: theme.colors.buttonText,
       fontSize: 16,
       fontWeight: '600',
       marginLeft: theme.spacing.sm,

--- a/src/screens/settings/RestoreWalletScreen.tsx
+++ b/src/screens/settings/RestoreWalletScreen.tsx
@@ -324,7 +324,7 @@ export default function RestoreWalletScreen() {
           style={styles.selectButton}
           onPress={handleSelectFile}
         >
-          <Ionicons name="folder-open" size={20} color="#FFFFFF" />
+          <Ionicons name="folder-open" size={20} color={colors.buttonText} />
           <Text style={styles.selectButtonText}>Select Backup File</Text>
         </TouchableOpacity>
       </ScrollView>
@@ -421,8 +421,7 @@ const createStyles = (theme: Theme) =>
     warningContainer: {
       flexDirection: 'row',
       alignItems: 'flex-start',
-      backgroundColor:
-        theme.mode === 'dark' ? 'rgba(239, 68, 68, 0.1)' : '#FEE2E2',
+      backgroundColor: theme.colors.errorLight,
       padding: theme.spacing.md,
       borderRadius: theme.borderRadius.lg,
       marginBottom: theme.spacing.lg,
@@ -433,7 +432,7 @@ const createStyles = (theme: Theme) =>
       flex: 1,
       marginLeft: theme.spacing.sm,
       fontSize: 13,
-      color: theme.mode === 'dark' ? theme.colors.error : '#991B1B',
+      color: theme.colors.text,
       lineHeight: 18,
     },
     fileCard: {
@@ -483,7 +482,7 @@ const createStyles = (theme: Theme) =>
     stepNumberText: {
       fontSize: 12,
       fontWeight: '600',
-      color: '#FFFFFF',
+      color: theme.colors.buttonText,
     },
     stepText: {
       flex: 1,
@@ -500,7 +499,7 @@ const createStyles = (theme: Theme) =>
       borderRadius: theme.borderRadius.lg,
     },
     selectButtonText: {
-      color: '#FFFFFF',
+      color: theme.colors.buttonText,
       fontSize: 16,
       fontWeight: '600',
       marginLeft: theme.spacing.sm,

--- a/src/screens/settings/SecuritySettingsScreen.tsx
+++ b/src/screens/settings/SecuritySettingsScreen.tsx
@@ -518,17 +518,17 @@ const createStyles = (theme: Theme) =>
     noticeTitle: {
       fontSize: 16,
       fontWeight: '600',
-      color: '#333',
+      color: theme.colors.text,
       marginBottom: 10,
     },
     noticeText: {
       fontSize: 14,
-      color: '#666',
+      color: theme.colors.textSecondary,
       lineHeight: 20,
     },
     warningText: {
       fontSize: 14,
-      color: '#FF9500',
+      color: theme.colors.warning,
       marginTop: 10,
       lineHeight: 20,
     },

--- a/src/screens/settings/ShowRecoveryPhraseScreen.tsx
+++ b/src/screens/settings/ShowRecoveryPhraseScreen.tsx
@@ -348,8 +348,7 @@ const createStyles = (theme: Theme) =>
     warningContainer: {
       flexDirection: 'row',
       alignItems: 'center',
-      backgroundColor:
-        theme.mode === 'dark' ? 'rgba(255, 159, 10, 0.1)' : '#FFF3CD',
+      backgroundColor: theme.colors.warningLight,
       padding: theme.spacing.md,
       borderRadius: theme.borderRadius.lg,
       marginBottom: theme.spacing.lg,
@@ -360,7 +359,7 @@ const createStyles = (theme: Theme) =>
       flex: 1,
       marginLeft: theme.spacing.sm,
       fontSize: 14,
-      color: theme.mode === 'dark' ? theme.colors.warning : '#856404',
+      color: theme.colors.text,
       fontWeight: '500',
     },
     loadingContainer: {

--- a/src/screens/social/ChatScreen.tsx
+++ b/src/screens/social/ChatScreen.tsx
@@ -519,7 +519,7 @@ const createStyles = (theme: Theme) =>
       flex: 1,
     },
     warningBanner: {
-      backgroundColor: '#DC2626',
+      backgroundColor: theme.colors.error,
       flexDirection: 'row',
       alignItems: 'center',
       justifyContent: 'center',

--- a/src/screens/social/FriendProfileScreen.tsx
+++ b/src/screens/social/FriendProfileScreen.tsx
@@ -287,6 +287,7 @@ export default function FriendProfileScreen() {
               <Ionicons
                 name={friend.isFavorite ? 'star' : 'star-outline'}
                 size={24}
+                // Favourite gold is not a semantic theme role; kept literal.
                 color={friend.isFavorite ? '#FFA500' : theme.colors.text}
               />
             </TouchableOpacity>

--- a/src/screens/social/FriendsScreen.tsx
+++ b/src/screens/social/FriendsScreen.tsx
@@ -277,7 +277,11 @@ export default function FriendsScreen() {
           accessibilityRole="button"
           accessibilityLabel="Add contact"
         >
-          <Ionicons name="person-add" size={24} color="#FFFFFF" />
+          <Ionicons
+            name="person-add"
+            size={24}
+            color={theme.colors.buttonText}
+          />
         </TouchableOpacity>
       </SafeAreaView>
     </NFTBackground>

--- a/src/screens/social/MessagesInboxScreen.tsx
+++ b/src/screens/social/MessagesInboxScreen.tsx
@@ -351,7 +351,11 @@ export default function MessagesInboxScreen() {
         <TouchableOpacity
           style={[
             styles.swipeAction,
-            { backgroundColor: isHidden ? theme.colors.primary : '#DC2626' },
+            {
+              backgroundColor: isHidden
+                ? theme.colors.primary
+                : theme.colors.error,
+            },
           ]}
           onPress={() => {
             if (isHidden) {
@@ -376,7 +380,14 @@ export default function MessagesInboxScreen() {
         </TouchableOpacity>
       );
     },
-    [hiddenThreads, hideThread, unhideThread, styles, theme.colors.primary]
+    [
+      hiddenThreads,
+      hideThread,
+      unhideThread,
+      styles,
+      theme.colors.primary,
+      theme.colors.error,
+    ]
   );
 
   // Render thread item

--- a/src/screens/transaction/AppCallConfirmScreen.tsx
+++ b/src/screens/transaction/AppCallConfirmScreen.tsx
@@ -324,7 +324,11 @@ export default function AppCallConfirmScreen() {
           </View>
           {isTemplateUri && (
             <View style={styles.infoBanner}>
-              <Ionicons name="information-circle" size={16} color="#3B82F6" />
+              <Ionicons
+                name="information-circle"
+                size={16}
+                color={colors.info}
+              />
               <Text style={styles.infoText}>
                 Using your active account as sender
               </Text>
@@ -332,7 +336,7 @@ export default function AppCallConfirmScreen() {
           )}
           {!account && senderAddress && (
             <View style={styles.warningBanner}>
-              <Ionicons name="warning" size={16} color="#F59E0B" />
+              <Ionicons name="warning" size={16} color={colors.warning} />
               <Text style={styles.warningText}>
                 This address is not in your wallet
               </Text>
@@ -364,7 +368,7 @@ export default function AppCallConfirmScreen() {
 
         {/* Warning */}
         <View style={styles.warningCard}>
-          <Ionicons name="alert-triangle" size={24} color="#F59E0B" />
+          <Ionicons name="alert-triangle" size={24} color={colors.warning} />
           <Text style={styles.warningCardText}>
             Application calls can execute smart contract code. Only proceed if
             you trust the source of this request.
@@ -373,7 +377,7 @@ export default function AppCallConfirmScreen() {
 
         {error && (
           <View style={styles.errorBanner}>
-            <Ionicons name="alert-circle" size={20} color="#EF4444" />
+            <Ionicons name="alert-circle" size={20} color={colors.error} />
             <Text style={styles.errorText}>{error}</Text>
           </View>
         )}
@@ -517,42 +521,42 @@ const createStyles = (theme: Theme) =>
     infoBanner: {
       flexDirection: 'row',
       alignItems: 'center',
-      backgroundColor: 'rgba(59, 130, 246, 0.15)',
+      backgroundColor: theme.colors.infoLight,
       padding: 12,
       borderRadius: 8,
       marginTop: 12,
       gap: 8,
     },
     infoText: {
-      color: '#3B82F6',
+      color: theme.colors.info,
       fontSize: 13,
       flex: 1,
     },
     warningBanner: {
       flexDirection: 'row',
       alignItems: 'center',
-      backgroundColor: 'rgba(245, 158, 11, 0.15)',
+      backgroundColor: theme.colors.warningLight,
       padding: 12,
       borderRadius: 8,
       marginTop: 12,
       gap: 8,
     },
     warningText: {
-      color: '#F59E0B',
+      color: theme.colors.warning,
       fontSize: 13,
       flex: 1,
     },
     warningCard: {
       flexDirection: 'row',
       alignItems: 'flex-start',
-      backgroundColor: 'rgba(245, 158, 11, 0.1)',
+      backgroundColor: theme.colors.warningLight,
       padding: 16,
       borderRadius: 12,
       marginBottom: 16,
       gap: 12,
     },
     warningCardText: {
-      color: '#F59E0B',
+      color: theme.colors.warning,
       fontSize: 14,
       flex: 1,
       lineHeight: 20,
@@ -560,14 +564,14 @@ const createStyles = (theme: Theme) =>
     errorBanner: {
       flexDirection: 'row',
       alignItems: 'center',
-      backgroundColor: 'rgba(239, 68, 68, 0.15)',
+      backgroundColor: theme.colors.errorLight,
       padding: 12,
       borderRadius: 8,
       marginTop: 8,
       gap: 8,
     },
     errorText: {
-      color: '#EF4444',
+      color: theme.colors.error,
       fontSize: 13,
       flex: 1,
     },
@@ -602,7 +606,7 @@ const createStyles = (theme: Theme) =>
     confirmButtonText: {
       fontSize: 16,
       fontWeight: '600',
-      color: '#FFFFFF',
+      color: theme.colors.buttonText,
     },
     disabledButton: {
       opacity: 0.5,

--- a/src/screens/transaction/KeyregConfirmScreen.tsx
+++ b/src/screens/transaction/KeyregConfirmScreen.tsx
@@ -208,7 +208,7 @@ export default function KeyregConfirmScreen() {
             <Ionicons
               name={params.isOnline ? 'cloud-upload' : 'cloud-offline'}
               size={20}
-              color={params.isOnline ? '#10B981' : '#EF4444'}
+              color={params.isOnline ? colors.success : colors.error}
             />
             <Text
               style={[
@@ -247,7 +247,7 @@ export default function KeyregConfirmScreen() {
           </View>
           {!account && (
             <View style={styles.warningBanner}>
-              <Ionicons name="warning" size={16} color="#F59E0B" />
+              <Ionicons name="warning" size={16} color={colors.warning} />
               <Text style={styles.warningText}>
                 This address is not in your wallet
               </Text>
@@ -319,7 +319,7 @@ export default function KeyregConfirmScreen() {
 
         {error && (
           <View style={styles.errorBanner}>
-            <Ionicons name="alert-circle" size={20} color="#EF4444" />
+            <Ionicons name="alert-circle" size={20} color={colors.error} />
             <Text style={styles.errorText}>{error}</Text>
           </View>
         )}
@@ -382,20 +382,20 @@ const createStyles = (theme: Theme) =>
       gap: 8,
     },
     onlineBadge: {
-      backgroundColor: 'rgba(16, 185, 129, 0.15)',
+      backgroundColor: theme.colors.successLight,
     },
     offlineBadge: {
-      backgroundColor: 'rgba(239, 68, 68, 0.15)',
+      backgroundColor: theme.colors.errorLight,
     },
     statusText: {
       fontSize: 16,
       fontWeight: '600',
     },
     onlineStatusText: {
-      color: '#10B981',
+      color: theme.colors.success,
     },
     offlineStatusText: {
-      color: '#EF4444',
+      color: theme.colors.error,
     },
     card: {
       marginBottom: 16,
@@ -437,28 +437,28 @@ const createStyles = (theme: Theme) =>
     warningBanner: {
       flexDirection: 'row',
       alignItems: 'center',
-      backgroundColor: 'rgba(245, 158, 11, 0.15)',
+      backgroundColor: theme.colors.warningLight,
       padding: 12,
       borderRadius: 8,
       marginTop: 12,
       gap: 8,
     },
     warningText: {
-      color: '#F59E0B',
+      color: theme.colors.warning,
       fontSize: 13,
       flex: 1,
     },
     errorBanner: {
       flexDirection: 'row',
       alignItems: 'center',
-      backgroundColor: 'rgba(239, 68, 68, 0.15)',
+      backgroundColor: theme.colors.errorLight,
       padding: 12,
       borderRadius: 8,
       marginTop: 8,
       gap: 8,
     },
     errorText: {
-      color: '#EF4444',
+      color: theme.colors.error,
       fontSize: 13,
       flex: 1,
     },
@@ -493,7 +493,7 @@ const createStyles = (theme: Theme) =>
     confirmButtonText: {
       fontSize: 16,
       fontWeight: '600',
-      color: '#FFFFFF',
+      color: theme.colors.buttonText,
     },
     disabledButton: {
       opacity: 0.5,

--- a/src/screens/wallet/AccountInfoScreen.tsx
+++ b/src/screens/wallet/AccountInfoScreen.tsx
@@ -276,6 +276,8 @@ export default function AccountInfoScreen() {
     if (!multiNetworkBalance) return [];
 
     const data: AssetDistribution[] = [];
+    // Categorical chart palette: these encode series identity, not a semantic
+    // theme role, so they stay independent of the active palette.
     const colors = [
       '#FF6384',
       '#36A2EB',
@@ -1095,7 +1097,7 @@ const createStyles = (theme: Theme) =>
       marginRight: theme.spacing.sm,
     },
     networkBadgeText: {
-      color: '#FFFFFF',
+      color: theme.colors.buttonText,
       fontSize: 12,
       fontWeight: '600',
     },

--- a/src/screens/wallet/AccountSearchScreen.tsx
+++ b/src/screens/wallet/AccountSearchScreen.tsx
@@ -279,7 +279,7 @@ export default function AccountSearchScreen() {
                 color={
                   isCurrentlyFriend
                     ? styles.friendButtonRemoveText.color
-                    : '#FFFFFF'
+                    : styles.friendButtonText.color
                 }
               />
               <Text
@@ -500,7 +500,7 @@ const createStyles = (theme: Theme) =>
       alignItems: 'center',
     },
     searchButtonText: {
-      color: '#FFFFFF',
+      color: theme.colors.buttonText,
       fontSize: 16,
       fontWeight: '600',
     },
@@ -603,7 +603,7 @@ const createStyles = (theme: Theme) =>
     friendButtonText: {
       fontSize: 14,
       fontWeight: '600',
-      color: '#FFFFFF',
+      color: theme.colors.buttonText,
     },
     friendButtonRemove: {
       backgroundColor: 'transparent',

--- a/src/screens/wallet/AssetDetailScreen.tsx
+++ b/src/screens/wallet/AssetDetailScreen.tsx
@@ -1213,7 +1213,7 @@ export default function AssetDetailScreen() {
           size="md"
           icon="send"
           label="Send"
-          tint="#007AFF"
+          tint={themeColors.primary}
           onPress={() =>
             navigation.navigate('Send', {
               assetName,
@@ -1232,6 +1232,7 @@ export default function AssetDetailScreen() {
             size="md"
             icon="swap-horizontal"
             label="Swap"
+            // Accent purple: no semantic theme role maps to it
             tint="#AF52DE"
             onPress={() =>
               navigation.navigate('Swap', {
@@ -1250,7 +1251,7 @@ export default function AssetDetailScreen() {
           size="md"
           icon="download"
           label="Receive"
-          tint="#30D158"
+          tint={themeColors.success}
           onPress={() =>
             navigation.navigate('Receive', {
               assetName,
@@ -1268,7 +1269,11 @@ export default function AssetDetailScreen() {
           onPress={handleOptOut}
           disabled={optingOut}
         >
-          <Ionicons name="remove-circle-outline" size={20} color="#EF4444" />
+          <Ionicons
+            name="remove-circle-outline"
+            size={20}
+            color={themeColors.error}
+          />
           <Text style={styles.optOutButtonText}>
             {optingOut ? 'Removing...' : 'Remove Asset'}
           </Text>
@@ -1539,7 +1544,7 @@ const createStyles = (theme: Theme) =>
     },
     optOutButton: {
       backgroundColor: theme.colors.card,
-      borderColor: '#EF4444',
+      borderColor: theme.colors.error,
       borderWidth: 1,
       flexDirection: 'row',
       alignItems: 'center',
@@ -1552,7 +1557,7 @@ const createStyles = (theme: Theme) =>
       gap: theme.spacing.xs,
     },
     optOutButtonText: {
-      color: '#EF4444',
+      color: theme.colors.error,
       fontSize: 16,
       fontWeight: '600',
     },

--- a/src/screens/wallet/ClaimableTokensScreen.tsx
+++ b/src/screens/wallet/ClaimableTokensScreen.tsx
@@ -239,7 +239,11 @@ export default function ClaimableTokensScreen() {
         <TouchableOpacity
           style={[
             styles.swipeAction,
-            { backgroundColor: isHidden ? theme.colors.primary : '#DC2626' },
+            {
+              backgroundColor: isHidden
+                ? theme.colors.primary
+                : theme.colors.error,
+            },
           ]}
           onPress={() => {
             if (isHidden) {
@@ -266,6 +270,7 @@ export default function ClaimableTokensScreen() {
       unhideApproval,
       styles,
       theme.colors.primary,
+      theme.colors.error,
     ]
   );
 

--- a/src/screens/wallet/CollectionDetailScreen.tsx
+++ b/src/screens/wallet/CollectionDetailScreen.tsx
@@ -184,7 +184,9 @@ export default function CollectionDetailScreen() {
   const displayTokens = activeTab === 'my-nfts' ? myTokens : allTokens;
 
   const renderTabs = () => (
-    <View style={styles.tabContainer}>
+    <View
+      style={[styles.tabContainer, { borderBottomColor: theme.colors.border }]}
+    >
       <TouchableOpacity
         style={[
           styles.tab,
@@ -398,7 +400,7 @@ const styles = StyleSheet.create({
     marginHorizontal: 16,
     paddingHorizontal: 4,
     borderBottomWidth: 1,
-    borderBottomColor: '#e0e0e0',
+    // borderBottomColor supplied from the theme at the call site
   },
   tab: {
     flex: 1,

--- a/src/screens/wallet/HomeScreen.tsx
+++ b/src/screens/wallet/HomeScreen.tsx
@@ -1574,7 +1574,10 @@ export default function HomeScreen() {
                     <View style={styles.addressDetails}>
                       {isEnvoiLoading ? (
                         <View style={styles.envoiLoading}>
-                          <ActivityIndicator size="small" color="#3B82F6" />
+                          <ActivityIndicator
+                            size="small"
+                            color={theme.colors.info}
+                          />
                           <Text style={styles.loadingText}>
                             Looking up name...
                           </Text>
@@ -1614,7 +1617,7 @@ export default function HomeScreen() {
                   label="Send"
                   onPress={handleSend}
                   style={styles.actionButton}
-                  tint="#007AFF"
+                  tint={theme.colors.primary}
                   pill
                 />
                 <GlassButton
@@ -1624,7 +1627,7 @@ export default function HomeScreen() {
                   label="Receive"
                   onPress={handleReceive}
                   style={styles.actionButton}
-                  tint="#30D158"
+                  tint={theme.colors.success}
                   pill
                 />
                 <GlassButton
@@ -1634,6 +1637,7 @@ export default function HomeScreen() {
                   label="History"
                   onPress={handleHistory}
                   style={styles.actionButton}
+                  // Accent purple: no semantic theme role maps to it
                   tint="#AF52DE"
                   pill
                 />
@@ -1721,7 +1725,10 @@ export default function HomeScreen() {
                     // Multi-network view
                     isMultiNetworkBalanceLoading && !multiNetworkBalance ? (
                       <View style={styles.loadingAssets}>
-                        <ActivityIndicator size="small" color="#007AFF" />
+                        <ActivityIndicator
+                          size="small"
+                          color={theme.colors.primary}
+                        />
                         <Text style={styles.loadingText}>
                           Loading assets...
                         </Text>
@@ -2178,6 +2185,6 @@ const createStyles = (theme: Theme) =>
     emptyStateButtonText: {
       fontSize: theme.typography.body.fontSize,
       fontWeight: '600',
-      color: '#FFFFFF',
+      color: theme.colors.buttonText,
     },
   });

--- a/src/screens/wallet/MultiNetworkAssetScreen.tsx
+++ b/src/screens/wallet/MultiNetworkAssetScreen.tsx
@@ -681,7 +681,7 @@ export default function MultiNetworkAssetScreen() {
               size="md"
               icon="send"
               label="Send"
-              tint="#007AFF"
+              tint={theme.colors.primary}
               onPress={handleSend}
               style={styles.actionButton}
             />
@@ -692,6 +692,7 @@ export default function MultiNetworkAssetScreen() {
                 size="md"
                 icon="swap-horizontal"
                 label="Swap"
+                // Accent purple: no semantic theme role maps to it
                 tint="#AF52DE"
                 onPress={handleSwap}
                 style={styles.actionButton}
@@ -703,7 +704,7 @@ export default function MultiNetworkAssetScreen() {
               size="md"
               icon="download"
               label="Receive"
-              tint="#30D158"
+              tint={theme.colors.success}
               onPress={handleReceive}
               style={styles.actionButton}
             />

--- a/src/screens/wallet/ReceiveScreen.tsx
+++ b/src/screens/wallet/ReceiveScreen.tsx
@@ -177,6 +177,7 @@ export default function ReceiveScreen() {
                   value={activeAccount.address}
                   size={180}
                   backgroundColor="white"
+                  // QR modules must stay pure black on white to scan
                   color="#000000"
                 />
               </GlassCard>

--- a/src/screens/wallet/RekeyAccountScreen.tsx
+++ b/src/screens/wallet/RekeyAccountScreen.tsx
@@ -764,7 +764,11 @@ export default function RekeyAccountScreen() {
                   <Ionicons
                     name={canReverseRekey ? 'key' : 'lock-closed'}
                     size={14}
-                    color={canReverseRekey ? '#10B981' : '#F59E0B'}
+                    color={
+                      canReverseRekey
+                        ? theme.colors.success
+                        : theme.colors.warning
+                    }
                   />
                   <Text
                     style={[
@@ -866,7 +870,9 @@ export default function RekeyAccountScreen() {
                 name="swap-horizontal"
                 size={20}
                 color={
-                  rekeyFlow === 'standard' ? theme.colors.primary : '#6B7280'
+                  rekeyFlow === 'standard'
+                    ? theme.colors.primary
+                    : theme.colors.textSecondary
                 }
               />
               <Text
@@ -902,7 +908,9 @@ export default function RekeyAccountScreen() {
                 name="hardware-chip-outline"
                 size={20}
                 color={
-                  rekeyFlow === 'ledger' ? theme.colors.primary : '#6B7280'
+                  rekeyFlow === 'ledger'
+                    ? theme.colors.primary
+                    : theme.colors.textSecondary
                 }
               />
               <Text
@@ -939,7 +947,9 @@ export default function RekeyAccountScreen() {
                   name="phone-portrait-outline"
                   size={20}
                   color={
-                    rekeyFlow === 'airgap' ? theme.colors.primary : '#6B7280'
+                    rekeyFlow === 'airgap'
+                      ? theme.colors.primary
+                      : theme.colors.textSecondary
                   }
                 />
                 <Text
@@ -977,7 +987,9 @@ export default function RekeyAccountScreen() {
                   name="return-up-back"
                   size={20}
                   color={
-                    rekeyFlow === 'reverse' ? theme.colors.primary : '#6B7280'
+                    rekeyFlow === 'reverse'
+                      ? theme.colors.primary
+                      : theme.colors.textSecondary
                   }
                 />
                 <Text
@@ -1076,7 +1088,7 @@ export default function RekeyAccountScreen() {
                     <Ionicons
                       name="checkmark-circle"
                       size={24}
-                      color="#10B981"
+                      color={theme.colors.success}
                     />
                   )}
                 </TouchableOpacity>

--- a/src/screens/wallet/TransactionHistoryScreen.tsx
+++ b/src/screens/wallet/TransactionHistoryScreen.tsx
@@ -375,11 +375,7 @@ export default function TransactionHistoryScreen() {
             onPress={() => navigation.goBack()}
             hitSlop={{ top: 10, bottom: 10, left: 10, right: 10 }}
           >
-            <Ionicons
-              name="arrow-back"
-              size={24}
-              color={theme.mode === 'dark' ? '#FFFFFF' : '#000000'}
-            />
+            <Ionicons name="arrow-back" size={24} color={theme.colors.text} />
           </TouchableOpacity>
           <Text style={styles.headerTitle}>Transaction History</Text>
           <View style={styles.headerSpacer} />


### PR DESCRIPTION
Resolves **TASK-43** (U-06) — Phase 4 of PLAN-12.

## What

Consolidates the two competing colour palettes and migrates hardcoded hex to semantic theme tokens across `src/screens` and `src/components`.

The app defined a canonical iOS-system palette in `constants/themes.ts` (`#007AFF`/`#0A84FF`, `#30D158`, `#FF9F0A`, `#FF453A`) while newer screens hardcoded a Tailwind-ish palette (`#10B981`/`#EF4444`/`#F59E0B`/`#3B82F6`) — several of them inside `createStyles(theme)` factories that already had the theme in hand. Status colours therefore rendered inconsistently between old and new screens, and ignored the flagship NFT theme, which regenerates the whole palette from an image.

## Hardcoded hex counts (`src/screens` + `src/components`)

| | before | after |
|---|---|---|
| excl. tests + `DebugLogsModal` | 181 | **64** |
| excl. tests only | 205 | **88** |

Palette B is **fully gone** from `src/screens`, `src/components` and `src/config` — in both hex and `rgba()` form — except one deliberately-kept instance (below). 20 `rgba()` duplicates of the canonical palette also collapsed onto the tinted tokens.

## No new theme tokens

Everything maps onto tokens that already exist in all four required places (the `Theme` interface, `lightTheme`, `darkTheme`, `themeGenerator.ts`): `success`/`warning`/`error`/`info`, `primaryLight`/`infoLight`/`successLight`/`warningLight`/`errorLight`, `buttonText`, `text`/`textSecondary`. **`constants/themes.ts` and `themeGenerator.ts` are untouched**, so NFT-themed users cannot receive `undefined`.

## Notable decisions

- **Banner body text.** The recurring `theme.mode === 'dark' ? theme.colors.warning : '#856404'` pattern became `theme.colors.text`. Keeping the semantic hue for the text would have meant `warning`-on-`warningLight` ≈ 1.9:1 in light mode; the warning/error signal is still carried by the icon and the coloured left border, and contrast now holds in both modes and under any generated palette.
- **`theme.colors.buttonText`** replaces `#FFFFFF` only where the element sits on a `primary`/`buttonBackground` fill — that is the token's contrast reference. White ink on *error*-, *success*- or *network-brand*-filled surfaces was left literal and annotated, because `buttonText` is checked against `primary` and would be the wrong ink there.
- **`SecuritySettingsScreen`** had `color: '#333'` / `'#666'` inside a themed StyleSheet — i.e. dark-on-dark in dark mode. Now `theme.colors.text` / `textSecondary`. Fixes a real legibility bug.
- **`LockScreen` reset button**: dark mode goes from a neutral `surface` fill to `errorLight`, matching the light-mode intent (pale red) and the red border/text already there. Most visible single change in the diff.
- **`#DC2626` → `theme.colors.error`** on three destructive fills (chat warning banner, two swipe actions). Slightly lighter red; the sibling branch of two of those was already `theme.colors.primary`, so this makes both branches theme-driven with comparable contrast.

## Deliberately left literal (each annotated in place)

- Third-party **brand colours** — Twitter/Discord/Telegram/LinkedIn/Instagram/YouTube/Reddit/Facebook in `EnvoiProfileCard`, Twitter in `AboutScreen`.
- The **categorical chart palette** in `AccountInfoScreen` (encodes series identity, not a semantic role).
- **QR-code and camera-overlay** black/white (`ReceiveScreen`, `ExportAccountsScreen`, `AnimatedQRCode`, `QRScanner`, `QRAccountImportScreen`) — scannability and viewfinder chrome.
- **White ink on network-brand-filled pills** (`NetworkBadge`, `NetworkIndicator`, `MultiNetworkAssetItem`) — the fill is `networkConfig.color`, not a theme surface.
- `AccountAvatar`'s **identicon contrast helper** and the white glyph on its rekey badge.
- The **favourite-star gold** `#FFA500` — no semantic role; mapping it to `warning` would let an NFT palette recolour it.
- `#8B5CF6` (smart-contract accent, 4 sites) and `#AF52DE` (action-button tint, 3 sites) — **no existing token maps to either**, and substituting `secondary` would shift purple→indigo.
- `SettingsScreen:98` `dangerColor` — its comment documents a deliberate darker red for light-mode contrast; `theme.colors.error` would regress it.
- `shadowColor: '#000'` — identical to `theme.colors.shadow` in every theme including the generator; not a theming defect.
- Switch `thumbColor` (platform control convention) and `DebugLogsModal` (debug-only, 24 occurrences).

## Out of scope

Typography / `fontSize` migration is TASK-44 (companion deferred plan). No font sizes touched.

## Gates

- `npm run typecheck` — **0 errors**
- `npm run lint` — **0 errors**, 682 warnings (baseline 683; one pre-existing unused-var warning resolved, none added)
- `npm test -- --ci` — **1476 passed / 95 suites**, matching baseline
- JS-only, OTA-shippable; no native deps, no `platform/` adapter changes, extension/web target unaffected

Not manually visual-tested — batched into the pre-release visual pass.

🤖 Reviewed by Codex (round 1: CLEAN).

https://claude.ai/code/session_01AL4EmUSYAiVXEstBgKqDmv
