### PR TITLE
feat(onboarding): directed recovery-phrase challenge with BIP-39 decoys (TASK-226)

### DIFF
--- a/src/__tests__/fixtures/mnemonicQuiz.ts
+++ b/src/__tests__/fixtures/mnemonicQuiz.ts
@@ -1,0 +1,105 @@
+/**
+ * Test helpers for driving the recovery-phrase challenge (TASK-226).
+ *
+ * The challenge is deliberately non-deterministic — random positions, random
+ * BIP-39 decoys, random chip order — so tests must not pin `Math.random` and
+ * assert fixed chip indices the way the old auto-routing board allowed. Instead
+ * they read the question off the screen and pick the chip that carries the right
+ * word, exactly as a user with a written copy would.
+ *
+ * SECURITY NOTE: these helpers only read what is already rendered. They never
+ * log or persist anything.
+ */
+
+import { fireEvent } from '@testing-library/react-native';
+import { CHALLENGE_OPTION_COUNT } from '@/components/wallet/mnemonicQuiz';
+
+interface QuizNode {
+  props: Record<string, unknown>;
+}
+
+/** Minimal slice of the RTL render result these helpers need. */
+export interface QuizScreen {
+  getByTestId: (testID: string) => QuizNode;
+  queryByTestId: (testID: string) => QuizNode | null;
+}
+
+function textOf(node: QuizNode): string {
+  const children = node.props.children;
+  return Array.isArray(children) ? children.join('') : String(children ?? '');
+}
+
+/** The phrase position (zero-based) the challenge is currently asking about. */
+export function currentQuizPosition(
+  screen: QuizScreen,
+  prefix: string
+): number {
+  const text = textOf(screen.getByTestId(`${prefix}-prompt`));
+  const match = /#(\d+)/.exec(text);
+  if (!match) {
+    throw new Error(`Could not read the challenge prompt: "${text}"`);
+  }
+  return Number(match[1]) - 1;
+}
+
+/** How many questions this attempt asks in total. */
+export function quizQuestionCount(screen: QuizScreen, prefix: string): number {
+  const text = textOf(screen.getByTestId(`${prefix}-progress`));
+  const match = /of (\d+)/.exec(text);
+  if (!match) {
+    throw new Error(`Could not read the challenge progress: "${text}"`);
+  }
+  return Number(match[1]);
+}
+
+/** Press the chip carrying `word`, or throw if it is not on the board. */
+export function pressQuizOption(
+  screen: QuizScreen,
+  prefix: string,
+  word: string
+): void {
+  for (let slot = 0; slot < CHALLENGE_OPTION_COUNT; slot++) {
+    const chip = screen.queryByTestId(`${prefix}-option-${slot}`);
+    if (chip && chip.props.accessibilityLabel === word) {
+      fireEvent.press(chip as never);
+      return;
+    }
+  }
+  throw new Error(`No option chip for "${word}" is on the board`);
+}
+
+/** Press a chip that is NOT the answer to the current question. */
+export function pressWrongQuizOption(
+  screen: QuizScreen,
+  prefix: string,
+  words: string[]
+): void {
+  const answer = words[currentQuizPosition(screen, prefix)];
+  for (let slot = 0; slot < CHALLENGE_OPTION_COUNT; slot++) {
+    const chip = screen.queryByTestId(`${prefix}-option-${slot}`);
+    if (chip && chip.props.accessibilityLabel !== answer) {
+      fireEvent.press(chip as never);
+      return;
+    }
+  }
+  throw new Error('Every chip on the board is the correct answer');
+}
+
+/**
+ * Answer every question correctly, the way a user holding a correct written
+ * phrase would. Returns the positions that were asked.
+ */
+export function completeQuiz(
+  screen: QuizScreen,
+  prefix: string,
+  words: string[]
+): number[] {
+  const total = quizQuestionCount(screen, prefix);
+  const asked: number[] = [];
+  for (let question = 0; question < total; question++) {
+    const position = currentQuizPosition(screen, prefix);
+    asked.push(position);
+    pressQuizOption(screen, prefix, words[position]);
+  }
+  return asked;
+}

--- a/src/components/wallet/MnemonicBackupFlow.tsx
+++ b/src/components/wallet/MnemonicBackupFlow.tsx
@@ -203,8 +203,10 @@ export default function MnemonicBackupFlow({
   };
 
   if (isVerificationStep) {
-    // DR-12: the quiz body lives in MnemonicVerification, whose selection logic
-    // is position-indexed so a phrase with a repeated word stays completable.
+    // The challenge body lives in MnemonicVerification: one directed question at
+    // a time ("which word is #7?") answered from BIP-39 decoys, so a wrong pick
+    // is a real failure (TASK-226). DR-12 still holds — a repeated word is
+    // answerable at every one of its positions.
     return (
       <SafeAreaView
         style={[styles.container, { backgroundColor: theme.colors.background }]}
@@ -245,6 +247,9 @@ export default function MnemonicBackupFlow({
           <MnemonicVerification
             mnemonic={mnemonic}
             onVerified={handleVerified}
+            // TASK-226: too many wrong answers restarts the challenge; send the
+            // user back to the phrase instead of letting them grind guesses.
+            onFailed={() => setIsVerificationStep(false)}
             onSkip={allowSkipVerification ? handleSkipVerification : undefined}
             testIDPrefix="backup-verification"
           />

--- a/src/components/wallet/MnemonicVerification.tsx
+++ b/src/components/wallet/MnemonicVerification.tsx
@@ -103,11 +103,11 @@ export default function MnemonicVerification({
 }: MnemonicVerificationProps) {
   const { theme } = useTheme();
 
-  // One memoised option provider per mount. Each position's board is built once
-  // and then re-presented (reshuffled) for the whole mount, including across a
-  // restart — rebuilding it would let a user intersect two boards for the same
-  // position and read off the answer, since only the answer is guaranteed to
-  // survive a rebuild. See `createOptionProvider`.
+  // A position's board is DERIVED from the phrase, so it is identical on every
+  // presentation — this retry, the next attempt, the next mount. Re-rolling it
+  // would let a user intersect two boards for the same position and read off the
+  // answer, since only the answer is guaranteed to survive a re-roll. Only the
+  // display order is reshuffled. See `createOptionProvider`.
   const [initial] = useState(() => {
     const words = splitMnemonic(mnemonic);
     const optionsFor = createOptionProvider(words);

--- a/src/components/wallet/MnemonicVerification.tsx
+++ b/src/components/wallet/MnemonicVerification.tsx
@@ -36,11 +36,13 @@
  * There is deliberately no permanent lockout: a user holding a correct written
  * phrase must ALWAYS be able to pass, and "Skip for now" already exists as a
  * first-class escape that records `backupVerified: false`. So blind guessing is
- * bounded by friction rather than refusal — with 8 options, 3 questions and 3
- * tolerated mistakes, a user who knows nothing passes an attempt with
- * probability ~2.9%, i.e. ~34 attempts on average, each one bouncing them back
+ * bounded by friction rather than refusal — with 8 options, 3 questions and one
+ * tolerated mistake, a user who knows nothing passes an attempt with probability
+ * ~0.78% (~128 attempts), and one who has memorised the phrase's words but not
+ * their order with ~6.3% (~16 attempts) — each attempt bouncing them back
  * through the phrase they are pretending to have written down. That is strictly
- * more work than reading it, which is the whole point.
+ * more work than reading it, which is the whole point. `MAX_MISTAKES` carries
+ * the arithmetic and is the lever that sets those numbers.
  *
  * ## Residuals, knowingly accepted
  *

--- a/src/components/wallet/MnemonicVerification.tsx
+++ b/src/components/wallet/MnemonicVerification.tsx
@@ -63,11 +63,13 @@ import { View, Text, StyleSheet, TouchableOpacity } from 'react-native';
 import { useTheme } from '@/contexts/ThemeContext';
 import {
   answerCurrentChallenge,
+  createOptionProvider,
   currentPosition,
   remainingMistakes,
   splitMnemonic,
   startQuizAttempt,
   VERIFICATION_WORD_COUNT,
+  type OptionProvider,
   type QuizAttempt,
 } from './mnemonicQuiz';
 
@@ -100,9 +102,19 @@ export default function MnemonicVerification({
 }: MnemonicVerificationProps) {
   const { theme } = useTheme();
 
-  const [attempt, setAttempt] = useState<QuizAttempt>(() =>
-    startQuizAttempt(splitMnemonic(mnemonic))
-  );
+  // One memoised option provider per mount. Each position's board is built once
+  // and then re-presented (reshuffled) for the whole mount, including across a
+  // restart — rebuilding it would let a user intersect two boards for the same
+  // position and read off the answer, since only the answer is guaranteed to
+  // survive a rebuild. See `createOptionProvider`.
+  const [initial] = useState(() => {
+    const words = splitMnemonic(mnemonic);
+    const optionsFor = createOptionProvider(words);
+    return { optionsFor, attempt: startQuizAttempt(words, optionsFor) };
+  });
+  const optionsForRef = useRef<OptionProvider>(initial.optionsFor);
+
+  const [attempt, setAttempt] = useState<QuizAttempt>(initial.attempt);
   const [errorMessage, setErrorMessage] = useState<string | null>(null);
 
   // `attempt` is also mirrored in a ref so a burst of taps is resolved against
@@ -126,7 +138,10 @@ export default function MnemonicVerification({
       isFirstRun.current = false;
       return;
     }
-    applyAttempt(startQuizAttempt(splitMnemonic(mnemonic)));
+    const words = splitMnemonic(mnemonic);
+    // A different phrase means every cached board is stale.
+    optionsForRef.current = createOptionProvider(words);
+    applyAttempt(startQuizAttempt(words, optionsForRef.current));
     setErrorMessage(null);
     // `applyAttempt` is recreated every render by design; the phrase is the only
     // input that should re-run this.
@@ -179,7 +194,12 @@ export default function MnemonicVerification({
     if (askedPosition === null) return;
 
     const words = splitMnemonic(mnemonic);
-    const result = answerCurrentChallenge(board, words, word);
+    const result = answerCurrentChallenge(
+      board,
+      words,
+      word,
+      optionsForRef.current
+    );
 
     switch (result.status) {
       case 'verified':
@@ -187,7 +207,7 @@ export default function MnemonicVerification({
         // cannot fire twice), and a host that keeps this mounted after success —
         // e.g. the user dismisses the confirmation alert — gets a live challenge
         // back instead of an inert board.
-        applyAttempt(startQuizAttempt(words));
+        applyAttempt(startQuizAttempt(words, optionsForRef.current));
         setErrorMessage(null);
         onVerified();
         return;

--- a/src/components/wallet/MnemonicVerification.tsx
+++ b/src/components/wallet/MnemonicVerification.tsx
@@ -1,57 +1,85 @@
 /**
- * MnemonicVerification — the "confirm 3 words" recovery-phrase quiz (TASK-45).
+ * MnemonicVerification — the recovery-phrase confirmation challenge
+ * (TASK-45, strengthened by TASK-226).
  *
  * Renders CONTENT ONLY (no SafeAreaView / header / background) so it can be
- * embedded by both hosts:
- *   - `MnemonicBackupFlow` (add-account), inside its own header + ScrollView
+ * embedded by all three hosts:
  *   - `CreateWalletScreen` (first-wallet onboarding), inside NFTBackground
+ *   - `MnemonicBackupFlow` (add-account), inside its own header + ScrollView
+ *   - `VerifyBackupScreen` (post-hoc "verify my backup"), from the Home banner
  *
- * All selection logic lives in `./mnemonicQuiz` and is position-indexed
- * per DR-12 — see that module for why a value-indexed quiz could hard-lock a
- * user out of onboarding.
+ * ## The challenge
+ *
+ * One DIRECTED question at a time — "which word is #7?" — answered from
+ * {@link CHALLENGE_OPTION_COUNT} chips, exactly one of which is right. Decoys
+ * come from the BIP-39 wordlist, some of them from the phrase's own other words
+ * so a shoulder-surfer cannot tell real words from filler and someone who only
+ * remembers the phrase's word set cannot pick "the familiar one". All selection
+ * and option-building logic lives in `./mnemonicQuiz`; see that module for the
+ * full rationale, including how the DR-12 duplicate-word lockout is now
+ * structurally impossible.
+ *
+ * This replaces the original auto-routing board (fixed in TASK-226): a tapped
+ * chip used to be routed to whichever slot it belonged to, so a wrong tap was a
+ * silent no-op and the bank held only the phrase's own words — meaning the quiz
+ * could be completed by tapping chips at random, without ever having written the
+ * phrase down. `backupVerified` is load-bearing for a fund-loss guarantee, so it
+ * must not be obtainable that way.
+ *
+ * ## Wrong answers, and why there is no lockout
+ *
+ * A wrong pick costs a mistake and re-presents the same position with a fresh
+ * option set. After `MAX_MISTAKES` tolerated mistakes the next wrong pick throws
+ * the whole attempt away and calls `onFailed`, which onboarding uses to send the
+ * user back to re-read the phrase.
+ *
+ * There is deliberately no permanent lockout: a user holding a correct written
+ * phrase must ALWAYS be able to pass, and "Skip for now" already exists as a
+ * first-class escape that records `backupVerified: false`. So blind guessing is
+ * bounded by friction rather than refusal — with 8 options, 3 questions and 3
+ * tolerated mistakes, a user who knows nothing passes an attempt with
+ * probability ~2.9%, i.e. ~34 attempts on average, each one bouncing them back
+ * through the phrase they are pretending to have written down. That is strictly
+ * more work than reading it, which is the whole point.
+ *
+ * ## Residual, knowingly accepted
+ *
+ * A lucky guess teaches the guesser one (word, position) pair, and a long
+ * grinding session accumulates those pairs, so repeated attempts are not fully
+ * independent. Every challenge of this shape — Pera's and MetaMask's included —
+ * has that property: telling the user whether they were right is the whole
+ * mechanism. Closing it would require a permanent lockout, which is explicitly
+ * ruled out above, and it is not worth much anyway: the grinder is bounced back
+ * to the phrase on every reset, and "Skip for now" is a free, honest way to
+ * decline the check without pretending to have passed it.
  *
  * The phrase is only ever held in this component's props (it is already on
- * screen in the host). Nothing here logs, persists, or navigates with it.
- *
- * ## KNOWN LIMITATION — the quiz auto-routes taps
- *
- * A tapped chip is routed to the slot it belongs to, so a wrong tap is a no-op
- * rather than a wrong answer. That means the quiz is passable by tapping chips
- * until the slots fill, WITHOUT having written the phrase down — `verified` is
- * therefore weaker evidence than a Pera/MetaMask-style "pick the word for slot
- * N" challenge, where a wrong pick actually fails.
- *
- * This behaviour is inherited from the pre-existing quiz and is preserved
- * deliberately: DR-12 prescribes exactly "carry {word, index} through selection
- * and disable by index, not value", i.e. keep the auto-routing and fix the
- * duplicate-word lockout. Strengthening the challenge is a separate UX/security
- * decision and is raised as a follow-up rather than taken unilaterally here.
+ * screen in the host). Nothing here logs, persists, or navigates with it, and no
+ * testID or accessibility label exposes which phrase position a chip came from.
  */
 
-import React, { useMemo, useState } from 'react';
+import React, { useEffect, useRef, useState } from 'react';
 import { View, Text, StyleSheet, TouchableOpacity } from 'react-native';
 import { useTheme } from '@/contexts/ThemeContext';
 import {
-  buildWordOptions,
-  clearWordSelection,
-  isVerificationComplete,
-  pickVerificationPositions,
-  selectWordOption,
-  shuffleWordOptions,
+  answerCurrentChallenge,
+  currentPosition,
+  remainingMistakes,
   splitMnemonic,
-  usedOptionIndices,
-  verifySelections,
-  type WordSelections,
+  startQuizAttempt,
+  VERIFICATION_WORD_COUNT,
+  type QuizAttempt,
 } from './mnemonicQuiz';
 
 export interface MnemonicVerificationProps {
   /** The phrase being verified. Display-only; never persisted or logged. */
   mnemonic: string;
-  /** Called once the user selects all target words correctly. */
+  /** Called once the user answers every question correctly. */
   onVerified: () => void;
   /**
-   * Called on a wrong answer. When omitted the component just clears the
-   * selections and lets the user retry in place.
+   * Called when the mistake budget is exhausted and the challenge restarts.
+   * Hosts that can show the phrase again should do so — the component has
+   * already rebuilt itself either way, so this is never a dead end.
    */
   onFailed?: () => void;
   /** When provided, renders a "Skip for now" escape (DR-2). */
@@ -72,42 +100,121 @@ export default function MnemonicVerification({
 }: MnemonicVerificationProps) {
   const { theme } = useTheme();
 
-  const mnemonicWords = useMemo(() => splitMnemonic(mnemonic), [mnemonic]);
-
-  // Both the target positions and the chip order are impure (Math.random), so
-  // they must be memoized on the stable `mnemonic` string — otherwise they would
-  // be recomputed on every render and the quiz would reshuffle under the user's
-  // finger as soon as they tapped a word.
-  const verificationWords = useMemo(
-    () => pickVerificationPositions(mnemonicWords.length),
-    // eslint-disable-next-line react-hooks/exhaustive-deps
-    [mnemonic]
+  const [attempt, setAttempt] = useState<QuizAttempt>(() =>
+    startQuizAttempt(splitMnemonic(mnemonic))
   );
-  const shuffledOptions = useMemo(
-    () => shuffleWordOptions(buildWordOptions(mnemonic)),
-    [mnemonic]
-  );
-
-  const [selections, setSelections] = useState<WordSelections>({});
   const [errorMessage, setErrorMessage] = useState<string | null>(null);
 
-  const used = usedOptionIndices(selections);
-  const complete = isVerificationComplete(verificationWords, selections);
+  // `attempt` is also mirrored in a ref so a burst of taps is resolved against
+  // the LATEST board rather than the one React last painted. Without this, a
+  // user could tap several chips faster than a re-render and have every one of
+  // them scored against the same board — i.e. try multiple options for a single
+  // question at the cost of one mistake. The ref holds only what is already on
+  // screen; the phrase itself is never stored.
+  const attemptRef = useRef(attempt);
+  const applyAttempt = (next: QuizAttempt) => {
+    attemptRef.current = next;
+    setAttempt(next);
+  };
 
-  const handleVerify = () => {
-    if (verifySelections(verificationWords, selections, mnemonicWords)) {
-      setErrorMessage(null);
-      onVerified();
+  // If the host swaps the phrase under us, rebuild rather than keep asking about
+  // a phrase that is no longer on screen — that would be an unwinnable board.
+  // The ref only skips the initial run.
+  const isFirstRun = useRef(true);
+  useEffect(() => {
+    if (isFirstRun.current) {
+      isFirstRun.current = false;
       return;
     }
-    // Wrong answer: always clear so the user gets a clean retry rather than
-    // being stuck staring at a full, rejected board.
-    setSelections({});
-    setErrorMessage(
-      'That does not match your recovery phrase. Check your written copy and try again.'
+    applyAttempt(startQuizAttempt(splitMnemonic(mnemonic)));
+    setErrorMessage(null);
+    // `applyAttempt` is recreated every render by design; the phrase is the only
+    // input that should re-run this.
+  }, [mnemonic]);
+
+  const position = currentPosition(attempt);
+
+  const renderSkip = () =>
+    onSkip ? (
+      <TouchableOpacity
+        testID={`${testIDPrefix}-skip`}
+        accessibilityRole="button"
+        accessibilityLabel={skipLabel}
+        style={styles.skipButton}
+        onPress={onSkip}
+      >
+        <Text style={[styles.skipButtonText, { color: theme.colors.primary }]}>
+          {skipLabel}
+        </Text>
+      </TouchableOpacity>
+    ) : null;
+
+  if (position === null) {
+    // No phrase to ask about. Never silently "pass" — say so and leave the skip
+    // escape available so the user is not stuck.
+    return (
+      <View testID={`${testIDPrefix}-root`}>
+        <Text
+          testID={`${testIDPrefix}-unavailable`}
+          accessibilityRole="alert"
+          style={[styles.error, { color: theme.colors.error }]}
+        >
+          Your recovery phrase is not available to confirm right now.
+        </Text>
+        {renderSkip()}
+      </View>
     );
-    onFailed?.();
+  }
+
+  /**
+   * `board` is the attempt object the pressed chip was rendered from. A chip
+   * belonging to a superseded board is ignored — that is a stale render, not an
+   * answer, and it can never be a correct one (the answer always exists on the
+   * live board). This is the double-tap / burst-tap guard, not an answer path.
+   */
+  const handlePick = (board: QuizAttempt, word: string) => {
+    if (board !== attemptRef.current) return;
+
+    const askedPosition = currentPosition(board);
+    if (askedPosition === null) return;
+
+    const words = splitMnemonic(mnemonic);
+    const result = answerCurrentChallenge(board, words, word);
+
+    switch (result.status) {
+      case 'verified':
+        // Rebuild first: the ref move makes any queued tap stale (so `onVerified`
+        // cannot fire twice), and a host that keeps this mounted after success —
+        // e.g. the user dismisses the confirmation alert — gets a live challenge
+        // back instead of an inert board.
+        applyAttempt(startQuizAttempt(words));
+        setErrorMessage(null);
+        onVerified();
+        return;
+      case 'advanced':
+        setErrorMessage(null);
+        applyAttempt(result.attempt);
+        return;
+      case 'retry': {
+        const untilRestart = remainingMistakes(result.attempt) + 1;
+        applyAttempt(result.attempt);
+        setErrorMessage(
+          `That is not word #${askedPosition + 1}. Check your written copy — ${untilRestart} more wrong ${untilRestart === 1 ? 'answer' : 'answers'} will restart this check.`
+        );
+        return;
+      }
+      case 'reset':
+        applyAttempt(result.attempt);
+        setErrorMessage(
+          'Too many incorrect answers. Check your written recovery phrase — the check has started over.'
+        );
+        onFailed?.();
+        return;
+    }
   };
+
+  const questionNumber = attempt.currentIndex + 1;
+  const totalQuestions = attempt.positions.length || VERIFICATION_WORD_COUNT;
 
   return (
     <View testID={`${testIDPrefix}-root`}>
@@ -115,107 +222,49 @@ export default function MnemonicVerification({
         Confirm your recovery phrase
       </Text>
       <Text style={[styles.subtitle, { color: theme.colors.textSecondary }]}>
-        Tap the words below to fill in the missing positions from your written
-        copy.
+        Using your written copy, pick the word that belongs at each position. A
+        wrong answer does not count.
       </Text>
 
-      <View style={styles.slotsContainer}>
-        {verificationWords.map((position) => {
-          const selection = selections[position];
-          return (
-            <View key={position} style={styles.slotRow}>
-              <Text style={[styles.slotLabel, { color: theme.colors.text }]}>
-                Word #{position + 1}
-              </Text>
-              <TouchableOpacity
-                testID={`${testIDPrefix}-slot-${position}`}
-                accessibilityRole="button"
-                accessibilityLabel={
-                  selection
-                    ? `Word ${position + 1}, ${selection.word}. Tap to clear.`
-                    : `Word ${position + 1}, empty. Select a word below.`
-                }
-                style={[
-                  styles.slot,
-                  {
-                    backgroundColor: theme.colors.card,
-                    borderColor: theme.colors.border,
-                  },
-                  selection !== undefined && {
-                    borderColor: theme.colors.primary,
-                    backgroundColor: theme.colors.primaryLight,
-                  },
-                ]}
-                // Tapping a filled slot clears it — without this, a mis-tap on a
-                // duplicate word would leave the user unable to change an answer.
-                onPress={() =>
-                  setSelections((prev) => clearWordSelection(position, prev))
-                }
-                disabled={selection === undefined}
-              >
-                <Text
-                  style={[
-                    styles.slotText,
-                    { color: theme.colors.textSecondary },
-                    selection !== undefined && { color: theme.colors.primary },
-                  ]}
-                >
-                  {selection?.word ?? 'Tap a word below'}
-                </Text>
-              </TouchableOpacity>
-            </View>
-          );
-        })}
-      </View>
+      <Text
+        testID={`${testIDPrefix}-progress`}
+        style={[styles.progress, { color: theme.colors.textSecondary }]}
+      >
+        {`Question ${questionNumber} of ${totalQuestions}`}
+      </Text>
+
+      <Text
+        testID={`${testIDPrefix}-prompt`}
+        accessibilityRole="header"
+        style={[styles.prompt, { color: theme.colors.text }]}
+      >
+        {`Which word is #${position + 1}?`}
+      </Text>
 
       <View style={styles.optionsContainer}>
-        {shuffledOptions.map((option) => {
-          const isUsed = used.has(option.index);
-          return (
-            <TouchableOpacity
-              // DR-12: keyed and disabled by POSITION, never by word value, so a
-              // repeated word yields two independently addressable chips.
-              key={option.index}
-              testID={`${testIDPrefix}-option-${option.index}`}
-              accessibilityRole="button"
-              accessibilityLabel={option.word}
-              accessibilityState={{ disabled: isUsed }}
-              style={[
-                styles.option,
-                {
-                  backgroundColor: theme.colors.card,
-                  borderColor: theme.colors.border,
-                },
-                isUsed && {
-                  backgroundColor: theme.colors.surface,
-                  borderColor: theme.colors.disabled,
-                },
-              ]}
-              onPress={() => {
-                setErrorMessage(null);
-                setSelections((prev) =>
-                  selectWordOption(
-                    option,
-                    verificationWords,
-                    prev,
-                    mnemonicWords
-                  )
-                );
-              }}
-              disabled={isUsed}
-            >
-              <Text
-                style={[
-                  styles.optionText,
-                  { color: theme.colors.text },
-                  isUsed && { color: theme.colors.textSecondary },
-                ]}
-              >
-                {option.word}
-              </Text>
-            </TouchableOpacity>
-          );
-        })}
+        {attempt.options.map((word, slot) => (
+          <TouchableOpacity
+            // Keyed and identified by the chip's slot on screen, never by the
+            // word or by its position in the phrase — a testID or key carrying
+            // the phrase index would leak the answer into the view tree.
+            key={`${attempt.currentIndex}-${attempt.mistakes}-${slot}`}
+            testID={`${testIDPrefix}-option-${slot}`}
+            accessibilityRole="button"
+            accessibilityLabel={word}
+            style={[
+              styles.option,
+              {
+                backgroundColor: theme.colors.card,
+                borderColor: theme.colors.border,
+              },
+            ]}
+            onPress={() => handlePick(attempt, word)}
+          >
+            <Text style={[styles.optionText, { color: theme.colors.text }]}>
+              {word}
+            </Text>
+          </TouchableOpacity>
+        ))}
       </View>
 
       {errorMessage !== null && (
@@ -228,44 +277,7 @@ export default function MnemonicVerification({
         </Text>
       )}
 
-      <TouchableOpacity
-        testID={`${testIDPrefix}-verify`}
-        accessibilityRole="button"
-        accessibilityLabel="Verify words"
-        accessibilityState={{ disabled: !complete }}
-        style={[
-          styles.verifyButton,
-          {
-            backgroundColor: complete
-              ? theme.colors.primary
-              : theme.colors.disabled,
-          },
-        ]}
-        onPress={handleVerify}
-        disabled={!complete}
-      >
-        <Text
-          style={[styles.verifyButtonText, { color: theme.colors.background }]}
-        >
-          Verify Words
-        </Text>
-      </TouchableOpacity>
-
-      {onSkip && (
-        <TouchableOpacity
-          testID={`${testIDPrefix}-skip`}
-          accessibilityRole="button"
-          accessibilityLabel={skipLabel}
-          style={styles.skipButton}
-          onPress={onSkip}
-        >
-          <Text
-            style={[styles.skipButtonText, { color: theme.colors.primary }]}
-          >
-            {skipLabel}
-          </Text>
-        </TouchableOpacity>
-      )}
+      {renderSkip()}
     </View>
   );
 }
@@ -279,31 +291,21 @@ const styles = StyleSheet.create({
   },
   subtitle: {
     fontSize: 16,
-    marginBottom: 30,
+    marginBottom: 24,
     textAlign: 'center',
     lineHeight: 22,
   },
-  slotsContainer: {
-    marginBottom: 30,
-  },
-  slotRow: {
-    marginBottom: 15,
-  },
-  slotLabel: {
+  progress: {
     fontSize: 14,
     fontWeight: '600',
+    textAlign: 'center',
     marginBottom: 8,
   },
-  slot: {
-    borderWidth: 2,
-    borderStyle: 'dashed',
-    borderRadius: 10,
-    paddingVertical: 15,
-    paddingHorizontal: 20,
-    alignItems: 'center',
-  },
-  slotText: {
-    fontSize: 16,
+  prompt: {
+    fontSize: 20,
+    fontWeight: '700',
+    textAlign: 'center',
+    marginBottom: 24,
   },
   optionsContainer: {
     flexDirection: 'row',
@@ -312,16 +314,16 @@ const styles = StyleSheet.create({
     marginBottom: 20,
   },
   option: {
-    width: '30%',
+    width: '48%',
     borderRadius: 8,
-    paddingVertical: 12,
+    paddingVertical: 14,
     paddingHorizontal: 10,
-    marginBottom: 10,
+    marginBottom: 12,
     alignItems: 'center',
     borderWidth: 1,
   },
   optionText: {
-    fontSize: 14,
+    fontSize: 15,
     fontWeight: '500',
   },
   error: {
@@ -329,16 +331,6 @@ const styles = StyleSheet.create({
     marginBottom: 16,
     textAlign: 'center',
     lineHeight: 20,
-  },
-  verifyButton: {
-    paddingVertical: 15,
-    paddingHorizontal: 30,
-    borderRadius: 10,
-  },
-  verifyButtonText: {
-    fontSize: 18,
-    fontWeight: '600',
-    textAlign: 'center',
   },
   skipButton: {
     paddingVertical: 14,

--- a/src/components/wallet/MnemonicVerification.tsx
+++ b/src/components/wallet/MnemonicVerification.tsx
@@ -42,16 +42,15 @@
  * through the phrase they are pretending to have written down. That is strictly
  * more work than reading it, which is the whole point.
  *
- * ## Residual, knowingly accepted
+ * ## Residuals, knowingly accepted
  *
- * A lucky guess teaches the guesser one (word, position) pair, and a long
- * grinding session accumulates those pairs, so repeated attempts are not fully
- * independent. Every challenge of this shape — Pera's and MetaMask's included —
- * has that property: telling the user whether they were right is the whole
- * mechanism. Closing it would require a permanent lockout, which is explicitly
- * ruled out above, and it is not worth much anyway: the grinder is bounced back
- * to the phrase on every reset, and "Skip for now" is a free, honest way to
- * decline the check without pretending to have passed it.
+ * Attempts are not capped, and a lucky guess teaches the guesser one (word,
+ * position) pair, so repeated attempts are not fully independent. Every
+ * challenge of this shape — Pera's and MetaMask's included — has that property:
+ * telling the user whether they were right is the whole mechanism. Both were
+ * raised by Codex across two review rounds and are retained deliberately; see
+ * "Attempts are NOT capped" in `./mnemonicQuiz` for the full reasoning and for
+ * why a cooldown does not survive this failure path.
  *
  * The phrase is only ever held in this component's props (it is already on
  * screen in the host). Nothing here logs, persists, or navigates with it, and no

--- a/src/components/wallet/__tests__/MnemonicVerification.test.tsx
+++ b/src/components/wallet/__tests__/MnemonicVerification.test.tsx
@@ -148,7 +148,10 @@ describe('MnemonicVerification — directed challenge (TASK-226)', () => {
     );
   });
 
-  it('re-presents a failed question with a freshly built board', () => {
+  it('re-presents a failed question with the SAME chips, not a new set', () => {
+    // Rebuilding the board on retry would leak the answer: it is the only chip
+    // guaranteed to survive a rebuild, so intersecting the two boards names it.
+    // See the intersection-oracle suite in `mnemonicQuiz.test.ts`.
     const { screen } = renderQuiz(LONG);
 
     const readBoard = () =>
@@ -160,13 +163,42 @@ describe('MnemonicVerification — directed challenge (TASK-226)', () => {
       );
 
     const before = readBoard();
+    const position = currentQuizPosition(screen, PREFIX);
     pressWrongQuizOption(screen, PREFIX, LONG_WORDS);
     const after = readBoard();
 
-    // A stable board would let the user eliminate one chip at a time.
-    expect(after).not.toEqual(before);
+    expect(currentQuizPosition(screen, PREFIX)).toBe(position);
+    expect([...after].sort()).toEqual([...before].sort());
     // The answer is still reachable — never a dead end.
-    expect(after).toContain(LONG_WORDS[currentQuizPosition(screen, PREFIX)]);
+    expect(after).toContain(LONG_WORDS[position]);
+  });
+
+  it('keeps a position’s chips stable across a full restart', () => {
+    // Same oracle, across attempts instead of across retries.
+    const { screen } = renderQuiz(LONG);
+
+    const readBoard = () =>
+      Array.from({ length: CHALLENGE_OPTION_COUNT }, (_, slot) =>
+        String(
+          screen.getByTestId(`${PREFIX}-option-${slot}`).props
+            .accessibilityLabel
+        )
+      );
+
+    const boards = new Map<number, string[]>();
+    for (let pick = 0; pick < 12; pick++) {
+      const position = currentQuizPosition(screen, PREFIX);
+      const board = [...readBoard()].sort();
+      const seen = boards.get(position);
+      if (seen) {
+        expect(board).toEqual(seen);
+      } else {
+        boards.set(position, board);
+      }
+      pressWrongQuizOption(screen, PREFIX, LONG_WORDS);
+    }
+    // The walk really did span more than one attempt.
+    expect(boards.size).toBeGreaterThan(1);
   });
 
   it('restarts the whole challenge once the mistake budget runs out', () => {

--- a/src/components/wallet/__tests__/MnemonicVerification.test.tsx
+++ b/src/components/wallet/__tests__/MnemonicVerification.test.tsx
@@ -1,214 +1,372 @@
 /**
- * TASK-45 / DR-12 — component-level regression test for the verification quiz.
+ * TASK-45 / DR-12 + TASK-226 — component-level tests for the recovery-phrase
+ * challenge.
  *
- * `mnemonicQuiz.test.ts` pins the pure logic; this pins the WIRING, which is
- * where the original defect lived: chips were keyed/disabled by word value and
- * resolved with `indexOf`, so tapping the second occurrence of a repeated word
- * did nothing at all and the user could not leave onboarding.
+ * `mnemonicQuiz.test.ts` pins the pure logic; this pins the WIRING:
+ *
+ * - TASK-226: one DIRECTED question at a time, and a wrong pick is a real,
+ *   counted failure. The old board auto-routed taps to the slot they belonged
+ *   to, so a wrong tap did nothing and the quiz could be completed by tapping at
+ *   random without ever having written the phrase down.
+ * - DR-12: a phrase with a repeated word stays answerable at every one of that
+ *   word's positions. The original defect lived exactly here — chips were keyed
+ *   and disabled by word value and resolved with `indexOf`, so tapping the
+ *   second occurrence did nothing and the user could not leave onboarding.
  *
  * SECURITY NOTE: the phrases here are made-up fixtures, not real mnemonics; no
  * key material is derived from them.
  */
 
 import React from 'react';
-import { render, fireEvent } from '@testing-library/react-native';
+import { TouchableOpacity } from 'react-native';
+import { render, fireEvent, act } from '@testing-library/react-native';
 
 import MnemonicVerification from '../MnemonicVerification';
+import {
+  CHALLENGE_OPTION_COUNT,
+  MAX_MISTAKES,
+  VERIFICATION_WORD_COUNT,
+} from '../mnemonicQuiz';
+import {
+  completeQuiz,
+  currentQuizPosition,
+  pressQuizOption,
+  pressWrongQuizOption,
+} from '@/__tests__/fixtures/mnemonicQuiz';
 
 jest.mock('@/contexts/ThemeContext', () => ({
   // eslint-disable-next-line @typescript-eslint/no-require-imports
   useTheme: () => ({ theme: require('@/constants/themes').lightTheme }),
 }));
 
+const PREFIX = 'mnemonic-verification';
+
 // "abandon" occupies positions 0, 3 and 6.
 const REPEATED = 'abandon ability able abandon absent absorb abandon abstract';
-const WORDS = REPEATED.split(' ');
+const REPEATED_WORDS = REPEATED.split(' ');
 
-/**
- * Force the quiz onto a known target triple by pinning Math.random. The
- * component picks positions via `Math.floor(Math.random() * total)`, so feeding
- * it `pos / total` yields exactly `pos`. The shuffle consumes the remaining
- * values; any leftovers just produce some deterministic chip order.
- */
-function withTargets<T>(targets: number[], total: number, run: () => T): T {
-  const queue = targets.map((pos) => pos / total);
-  const spy = jest
-    .spyOn(Math, 'random')
-    .mockImplementation(() => (queue.length > 0 ? queue.shift()! : 0));
-  try {
-    return run();
-  } finally {
-    spy.mockRestore();
-  }
+const LONG = [
+  'abandon',
+  'ability',
+  'able',
+  'about',
+  'above',
+  'absent',
+  'absorb',
+  'abstract',
+  'absurd',
+  'abuse',
+  'access',
+  'accident',
+  'account',
+  'accuse',
+  'achieve',
+  'acid',
+  'acoustic',
+  'acquire',
+  'across',
+  'act',
+  'action',
+  'actor',
+  'actress',
+  'actual',
+  'adapt',
+].join(' ');
+const LONG_WORDS = LONG.split(' ');
+
+/** Shares no word with LONG — used to prove a phrase swap really rebuilds. */
+const DISJOINT =
+  'zone zero youth young yellow year wrong write world work wolf wisdom';
+const DISJOINT_WORDS = DISJOINT.split(' ');
+
+function renderQuiz(
+  mnemonic: string,
+  props: Partial<React.ComponentProps<typeof MnemonicVerification>> = {}
+) {
+  const onVerified = props.onVerified ?? jest.fn();
+  const screen = render(
+    <MnemonicVerification
+      mnemonic={mnemonic}
+      {...props}
+      onVerified={onVerified}
+    />
+  );
+  return { screen, onVerified };
 }
 
-describe('MnemonicVerification — repeated words (DR-12)', () => {
-  it("completes when a repeated word's LATER position is a target", () => {
-    const onVerified = jest.fn();
+describe('MnemonicVerification — directed challenge (TASK-226)', () => {
+  it('asks one position at a time and passes only when all are right', () => {
+    const { screen, onVerified } = renderQuiz(LONG);
 
-    // Targets 1, 4, 6 — position 6 is the THIRD "abandon". Under the old
-    // indexOf() resolution this tap computed position 0, which is not a target,
-    // so nothing was selected and "Verify Words" stayed permanently disabled.
-    const screen = withTargets([1, 4, 6], WORDS.length, () =>
-      render(
-        <MnemonicVerification mnemonic={REPEATED} onVerified={onVerified} />
-      )
+    expect(screen.getByTestId(`${PREFIX}-progress`)).toHaveTextContent(
+      `Question 1 of ${VERIFICATION_WORD_COUNT}`
+    );
+    expect(screen.getByTestId(`${PREFIX}-prompt`)).toHaveTextContent(
+      /Which word is #\d+\?/
     );
 
-    for (const index of [1, 4, 6]) {
-      fireEvent.press(
-        screen.getByTestId(`mnemonic-verification-option-${index}`)
+    const asked = completeQuiz(screen, PREFIX, LONG_WORDS);
+    expect(asked).toHaveLength(VERIFICATION_WORD_COUNT);
+    expect(new Set(asked).size).toBe(VERIFICATION_WORD_COUNT);
+    expect(onVerified).toHaveBeenCalledTimes(1);
+  });
+
+  it('shows exactly one correct chip among BIP-39 decoys', () => {
+    const { screen } = renderQuiz(LONG);
+    const position = currentQuizPosition(screen, PREFIX);
+
+    const labels: string[] = [];
+    for (let slot = 0; slot < CHALLENGE_OPTION_COUNT; slot++) {
+      labels.push(
+        String(
+          screen.getByTestId(`${PREFIX}-option-${slot}`).props
+            .accessibilityLabel
+        )
       );
     }
 
-    // Each slot shows the right word, including the duplicate.
-    expect(
-      screen.getByTestId('mnemonic-verification-slot-6')
-    ).toHaveTextContent('abandon');
-
-    fireEvent.press(screen.getByTestId('mnemonic-verification-verify'));
-    expect(onVerified).toHaveBeenCalledTimes(1);
+    expect(labels).toHaveLength(CHALLENGE_OPTION_COUNT);
+    expect(new Set(labels).size).toBe(CHALLENGE_OPTION_COUNT);
+    expect(labels.filter((w) => w === LONG_WORDS[position])).toHaveLength(1);
+    // Decoys are not restricted to the phrase's own words.
+    expect(labels.some((w) => !LONG_WORDS.includes(w))).toBe(true);
   });
 
-  it('accepts the OTHER duplicate chip for the same slot', () => {
+  it('a wrong pick FAILS — it does not silently fill the slot', () => {
     const onVerified = jest.fn();
+    const { screen } = renderQuiz(LONG, { onVerified });
 
-    // Only position 6 holds a target "abandon", but the user taps the chip at
-    // position 0. The chips are visually identical, so that tap must land.
-    const screen = withTargets([1, 4, 6], WORDS.length, () =>
-      render(
-        <MnemonicVerification mnemonic={REPEATED} onVerified={onVerified} />
-      )
+    const position = currentQuizPosition(screen, PREFIX);
+    pressWrongQuizOption(screen, PREFIX, LONG_WORDS);
+
+    expect(onVerified).not.toHaveBeenCalled();
+    expect(screen.getByTestId(`${PREFIX}-error`)).toBeTruthy();
+    // Same question, still question 1 of N — no progress was made.
+    expect(currentQuizPosition(screen, PREFIX)).toBe(position);
+    expect(screen.getByTestId(`${PREFIX}-progress`)).toHaveTextContent(
+      `Question 1 of ${VERIFICATION_WORD_COUNT}`
     );
+  });
 
-    fireEvent.press(screen.getByTestId('mnemonic-verification-option-1'));
-    fireEvent.press(screen.getByTestId('mnemonic-verification-option-4'));
-    fireEvent.press(screen.getByTestId('mnemonic-verification-option-0'));
+  it('re-presents a failed question with a freshly built board', () => {
+    const { screen } = renderQuiz(LONG);
 
-    expect(
-      screen.getByTestId('mnemonic-verification-slot-6')
-    ).toHaveTextContent('abandon');
+    const readBoard = () =>
+      Array.from({ length: CHALLENGE_OPTION_COUNT }, (_, slot) =>
+        String(
+          screen.getByTestId(`${PREFIX}-option-${slot}`).props
+            .accessibilityLabel
+        )
+      );
 
-    fireEvent.press(screen.getByTestId('mnemonic-verification-verify'));
+    const before = readBoard();
+    pressWrongQuizOption(screen, PREFIX, LONG_WORDS);
+    const after = readBoard();
+
+    // A stable board would let the user eliminate one chip at a time.
+    expect(after).not.toEqual(before);
+    // The answer is still reachable — never a dead end.
+    expect(after).toContain(LONG_WORDS[currentQuizPosition(screen, PREFIX)]);
+  });
+
+  it('restarts the whole challenge once the mistake budget runs out', () => {
+    const onFailed = jest.fn();
+    const onVerified = jest.fn();
+    const { screen } = renderQuiz(LONG, { onFailed, onVerified });
+
+    for (let mistake = 0; mistake < MAX_MISTAKES; mistake++) {
+      pressWrongQuizOption(screen, PREFIX, LONG_WORDS);
+      expect(onFailed).not.toHaveBeenCalled();
+    }
+
+    pressWrongQuizOption(screen, PREFIX, LONG_WORDS);
+
+    expect(onFailed).toHaveBeenCalledTimes(1);
+    expect(onVerified).not.toHaveBeenCalled();
+    expect(screen.getByTestId(`${PREFIX}-error`)).toHaveTextContent(
+      /started over/i
+    );
+    expect(screen.getByTestId(`${PREFIX}-progress`)).toHaveTextContent(
+      `Question 1 of ${VERIFICATION_WORD_COUNT}`
+    );
+  });
+
+  it('a restarted challenge is still winnable by someone with the phrase', () => {
+    // The lockout guard: friction, never refusal.
+    const onVerified = jest.fn();
+    const { screen } = renderQuiz(LONG, { onVerified });
+
+    for (let mistake = 0; mistake <= MAX_MISTAKES; mistake++) {
+      pressWrongQuizOption(screen, PREFIX, LONG_WORDS);
+    }
+    expect(onVerified).not.toHaveBeenCalled();
+
+    completeQuiz(screen, PREFIX, LONG_WORDS);
     expect(onVerified).toHaveBeenCalledTimes(1);
   });
 
-  it('disables only the CONSUMED chip, not every chip with the same word', () => {
-    const screen = withTargets([1, 4, 6], WORDS.length, () =>
-      render(
-        <MnemonicVerification mnemonic={REPEATED} onVerified={jest.fn()} />
-      )
+  it('keeps correct progress when a later question is missed', () => {
+    const { screen } = renderQuiz(LONG);
+
+    pressQuizOption(
+      screen,
+      PREFIX,
+      LONG_WORDS[currentQuizPosition(screen, PREFIX)]
+    );
+    expect(screen.getByTestId(`${PREFIX}-progress`)).toHaveTextContent(
+      `Question 2 of ${VERIFICATION_WORD_COUNT}`
     );
 
-    fireEvent.press(screen.getByTestId('mnemonic-verification-option-6'));
-
-    expect(
-      screen.getByTestId('mnemonic-verification-option-6').props
-        .accessibilityState
-    ).toEqual(expect.objectContaining({ disabled: true }));
-    // The other "abandon" chips remain live.
-    expect(
-      screen.getByTestId('mnemonic-verification-option-0').props
-        .accessibilityState
-    ).toEqual(expect.objectContaining({ disabled: false }));
-    expect(
-      screen.getByTestId('mnemonic-verification-option-3').props
-        .accessibilityState
-    ).toEqual(expect.objectContaining({ disabled: false }));
+    pressWrongQuizOption(screen, PREFIX, LONG_WORDS);
+    // Still on question 2 — a fat-finger does not discard a correct run.
+    expect(screen.getByTestId(`${PREFIX}-progress`)).toHaveTextContent(
+      `Question 2 of ${VERIFICATION_WORD_COUNT}`
+    );
   });
 
-  it('lets the user clear a slot and re-answer', () => {
-    const screen = withTargets([1, 4, 6], WORDS.length, () =>
-      render(
-        <MnemonicVerification mnemonic={REPEATED} onVerified={jest.fn()} />
-      )
+  it('cannot be brute-forced by tapping every chip faster than a re-render', () => {
+    // The burst attack: fire every chip on the painted board before React can
+    // repaint. Only the FIRST tap may be scored; the rest belong to a board that
+    // has already been superseded. Without that guard a user could try all eight
+    // options for the cost of a single mistake.
+    const onVerified = jest.fn();
+    const { screen } = renderQuiz(LONG, { onVerified });
+
+    const answer = LONG_WORDS[currentQuizPosition(screen, PREFIX)];
+    // Reach for the composite instances so we can invoke the raw handlers
+    // together inside ONE act() — `fireEvent.press` flushes React between taps,
+    // which is precisely the repaint a burst outruns.
+    const chips = screen
+      .UNSAFE_getAllByType(TouchableOpacity)
+      .filter((node) =>
+        String(node.props.testID ?? '').startsWith(`${PREFIX}-option-`)
+      );
+    expect(chips).toHaveLength(CHALLENGE_OPTION_COUNT);
+
+    const wrongPresses: (() => void)[] = [];
+    let correctPress: (() => void) | null = null;
+    for (const chip of chips) {
+      const press = chip.props.onPress as () => void;
+      if (chip.props.accessibilityLabel === answer) {
+        correctPress = press;
+      } else {
+        wrongPresses.push(press);
+      }
+    }
+    expect(correctPress).not.toBeNull();
+
+    act(() => {
+      // One wrong tap lands; everything after it — including the right answer —
+      // is a stale board and must be ignored.
+      wrongPresses.forEach((press) => press());
+      (correctPress as () => void)();
+    });
+
+    expect(onVerified).not.toHaveBeenCalled();
+    expect(screen.getByTestId(`${PREFIX}-progress`)).toHaveTextContent(
+      `Question 1 of ${VERIFICATION_WORD_COUNT}`
     );
+    // Exactly ONE mistake was charged for the whole burst.
+    expect(screen.getByTestId(`${PREFIX}-error`)).toHaveTextContent(
+      new RegExp(`${MAX_MISTAKES} more wrong answers`)
+    );
+  });
 
-    fireEvent.press(screen.getByTestId('mnemonic-verification-option-1'));
-    expect(
-      screen.getByTestId('mnemonic-verification-slot-1')
-    ).toHaveTextContent(WORDS[1]);
-
-    fireEvent.press(screen.getByTestId('mnemonic-verification-slot-1'));
-    expect(
-      screen.getByTestId('mnemonic-verification-slot-1')
-    ).toHaveTextContent('Tap a word below');
+  it('never leaks which phrase position a chip came from', () => {
+    // testIDs address the chip's slot on screen only; a testID carrying the
+    // phrase index would put the answer in the view tree.
+    const { screen } = renderQuiz(LONG);
+    for (let slot = 0; slot < CHALLENGE_OPTION_COUNT; slot++) {
+      expect(screen.getByTestId(`${PREFIX}-option-${slot}`)).toBeTruthy();
+    }
+    expect(screen.queryByTestId(`${PREFIX}-option-24`)).toBeNull();
   });
 });
 
-describe('MnemonicVerification — outcomes', () => {
-  it('cannot report success until every slot is filled', () => {
-    const onVerified = jest.fn();
-
-    const screen = withTargets([1, 4, 6], WORDS.length, () =>
-      render(
-        <MnemonicVerification mnemonic={REPEATED} onVerified={onVerified} />
-      )
-    );
-
-    expect(
-      screen.getByTestId('mnemonic-verification-verify').props
-        .accessibilityState
-    ).toEqual(expect.objectContaining({ disabled: true }));
-    fireEvent.press(screen.getByTestId('mnemonic-verification-verify'));
-    expect(onVerified).not.toHaveBeenCalled();
-
-    fireEvent.press(screen.getByTestId('mnemonic-verification-option-1'));
-    fireEvent.press(screen.getByTestId('mnemonic-verification-option-4'));
-    expect(
-      screen.getByTestId('mnemonic-verification-verify').props
-        .accessibilityState
-    ).toEqual(expect.objectContaining({ disabled: true }));
-    fireEvent.press(screen.getByTestId('mnemonic-verification-verify'));
-    expect(onVerified).not.toHaveBeenCalled();
-
-    fireEvent.press(screen.getByTestId('mnemonic-verification-option-6'));
-    fireEvent.press(screen.getByTestId('mnemonic-verification-verify'));
+describe('MnemonicVerification — repeated words (DR-12)', () => {
+  it('is completable for a phrase with a repeated word', () => {
+    const { screen, onVerified } = renderQuiz(REPEATED);
+    completeQuiz(screen, PREFIX, REPEATED_WORDS);
     expect(onVerified).toHaveBeenCalledTimes(1);
   });
 
-  it('tapping a word that belongs to no target slot does nothing', () => {
-    // Documents the auto-routing contract: a non-target chip is inert rather
-    // than filling a slot with a wrong answer. See the KNOWN LIMITATION note on
-    // the component — this is why `verified` is weaker than a pick-for-slot
-    // challenge, and is preserved deliberately per DR-12.
-    const screen = withTargets([1, 4, 6], WORDS.length, () =>
-      render(
-        <MnemonicVerification mnemonic={REPEATED} onVerified={jest.fn()} />
-      )
-    );
+  it('offers exactly one chip for a repeated word, at every position it occupies', () => {
+    // Mount repeatedly until every position of the 8-word fixture has been
+    // asked — including 0, 3 and 6, the three "abandon" positions that used to
+    // be unanswerable. Every question in every run must be unambiguous and
+    // answerable, so this is the wiring-level form of the exhaustive
+    // DR-12 regression in `mnemonicQuiz.test.ts`.
+    const seen = new Set<number>();
+    for (let run = 0; run < 300 && seen.size < REPEATED_WORDS.length; run++) {
+      const { screen, onVerified } = renderQuiz(REPEATED);
 
-    fireEvent.press(screen.getByTestId('mnemonic-verification-option-5'));
-    expect(
-      screen.getByTestId('mnemonic-verification-slot-1')
-    ).toHaveTextContent('Tap a word below');
-    expect(
-      screen.getByTestId('mnemonic-verification-slot-4')
-    ).toHaveTextContent('Tap a word below');
-    expect(
-      screen.getByTestId('mnemonic-verification-slot-6')
-    ).toHaveTextContent('Tap a word below');
+      for (let question = 0; question < VERIFICATION_WORD_COUNT; question++) {
+        const position = currentQuizPosition(screen, PREFIX);
+        seen.add(position);
+
+        const labels = Array.from(
+          { length: CHALLENGE_OPTION_COUNT },
+          (_, slot) =>
+            String(
+              screen.getByTestId(`${PREFIX}-option-${slot}`).props
+                .accessibilityLabel
+            )
+        );
+        expect(
+          labels.filter((w) => w === REPEATED_WORDS[position])
+        ).toHaveLength(1);
+
+        // The answer is accepted at that position, duplicate or not.
+        pressQuizOption(screen, PREFIX, REPEATED_WORDS[position]);
+      }
+
+      expect(onVerified).toHaveBeenCalledTimes(1);
+      screen.unmount();
+    }
+
+    expect([...seen].sort((a, b) => a - b)).toEqual([0, 1, 2, 3, 4, 5, 6, 7]);
   });
+});
 
+describe('MnemonicVerification — escapes and edge cases', () => {
   it('renders a skip control only when onSkip is supplied', () => {
-    const withoutSkip = withTargets([1, 4, 6], WORDS.length, () =>
-      render(
-        <MnemonicVerification mnemonic={REPEATED} onVerified={jest.fn()} />
-      )
-    );
-    expect(withoutSkip.queryByTestId('mnemonic-verification-skip')).toBeNull();
+    const { screen: withoutSkip } = renderQuiz(REPEATED);
+    expect(withoutSkip.queryByTestId(`${PREFIX}-skip`)).toBeNull();
 
     const onSkip = jest.fn();
-    const withSkip = withTargets([1, 4, 6], WORDS.length, () =>
-      render(
-        <MnemonicVerification
-          mnemonic={REPEATED}
-          onVerified={jest.fn()}
-          onSkip={onSkip}
-        />
-      )
-    );
-    fireEvent.press(withSkip.getByTestId('mnemonic-verification-skip'));
+    const { screen: withSkip } = renderQuiz(REPEATED, { onSkip });
+    fireEvent.press(withSkip.getByTestId(`${PREFIX}-skip`));
     expect(onSkip).toHaveBeenCalledTimes(1);
+  });
+
+  it('never auto-passes when there is no phrase to ask about', () => {
+    const onVerified = jest.fn();
+    const onSkip = jest.fn();
+    const { screen } = renderQuiz('', { onVerified, onSkip });
+
+    expect(screen.getByTestId(`${PREFIX}-unavailable`)).toBeTruthy();
+    expect(screen.queryByTestId(`${PREFIX}-prompt`)).toBeNull();
+    expect(onVerified).not.toHaveBeenCalled();
+    // The escape hatch is still reachable, so this is not a dead end.
+    expect(screen.getByTestId(`${PREFIX}-skip`)).toBeTruthy();
+  });
+
+  it('rebuilds the challenge if the host swaps the phrase', () => {
+    // Otherwise the board would keep asking about a phrase that is no longer on
+    // screen — an unwinnable challenge, i.e. exactly the lockout class DR-12
+    // exists to prevent.
+    const onVerified = jest.fn();
+    const screen = render(
+      <MnemonicVerification mnemonic={LONG} onVerified={onVerified} />
+    );
+
+    screen.rerender(
+      <MnemonicVerification mnemonic={DISJOINT} onVerified={onVerified} />
+    );
+
+    // DISJOINT shares no word with LONG, so this only passes if the challenge
+    // was actually rebuilt around the new phrase.
+    completeQuiz(screen, PREFIX, DISJOINT_WORDS);
+    expect(onVerified).toHaveBeenCalledTimes(1);
   });
 });

--- a/src/components/wallet/__tests__/MnemonicVerification.test.tsx
+++ b/src/components/wallet/__tests__/MnemonicVerification.test.tsx
@@ -298,9 +298,10 @@ describe('MnemonicVerification — directed challenge (TASK-226)', () => {
     expect(screen.getByTestId(`${PREFIX}-progress`)).toHaveTextContent(
       `Question 1 of ${VERIFICATION_WORD_COUNT}`
     );
-    // Exactly ONE mistake was charged for the whole burst.
+    // Exactly ONE mistake was charged for the whole burst: the message counts
+    // down from the full budget.
     expect(screen.getByTestId(`${PREFIX}-error`)).toHaveTextContent(
-      new RegExp(`${MAX_MISTAKES} more wrong answers`)
+      new RegExp(`${MAX_MISTAKES} more wrong answers?`)
     );
   });
 

--- a/src/components/wallet/__tests__/mnemonicQuiz.test.ts
+++ b/src/components/wallet/__tests__/mnemonicQuiz.test.ts
@@ -28,6 +28,7 @@ import { BIP39Utils } from '@/utils/bip39';
 import {
   answerCurrentChallenge,
   buildChallengeOptions,
+  createOptionProvider,
   CHALLENGE_OPTION_COUNT,
   currentPosition,
   MAX_MISTAKES,
@@ -75,19 +76,41 @@ const LONG_WORDS = [
   'adapt',
 ];
 
+/**
+ * A memoised board provider, as the component holds one per mount. Boards for a
+ * position must be STABLE across presentations — see the intersection-oracle
+ * suite below.
+ */
+function providerFor(words: string[]) {
+  return createOptionProvider(words);
+}
+
 /** Answer the live question correctly; asserts the attempt is still coherent. */
-function answerCorrectly(attempt: QuizAttempt, words: string[]) {
+function answerCorrectly(
+  attempt: QuizAttempt,
+  words: string[],
+  optionsFor = providerFor(words)
+) {
   const position = currentPosition(attempt);
   expect(position).not.toBeNull();
-  return answerCurrentChallenge(attempt, words, words[position as number]);
+  return answerCurrentChallenge(
+    attempt,
+    words,
+    words[position as number],
+    optionsFor
+  );
 }
 
 /** Answer the live question with some chip that is NOT the right one. */
-function answerWrongly(attempt: QuizAttempt, words: string[]) {
+function answerWrongly(
+  attempt: QuizAttempt,
+  words: string[],
+  optionsFor = providerFor(words)
+) {
   const position = currentPosition(attempt) as number;
   const wrong = attempt.options.find((word) => word !== words[position]);
   expect(wrong).toBeDefined();
-  return answerCurrentChallenge(attempt, words, wrong as string);
+  return answerCurrentChallenge(attempt, words, wrong as string, optionsFor);
 }
 
 describe('splitMnemonic', () => {
@@ -231,7 +254,7 @@ describe('buildChallengeOptions — TASK-226 decoys', () => {
 describe('startQuizAttempt', () => {
   it('opens on the first question with a full board and no mistakes', () => {
     for (let run = 0; run < 50; run++) {
-      const attempt = startQuizAttempt(LONG_WORDS);
+      const attempt = startQuizAttempt(LONG_WORDS, providerFor(LONG_WORDS));
       expect(attempt.positions).toHaveLength(VERIFICATION_WORD_COUNT);
       expect(attempt.currentIndex).toBe(0);
       expect(attempt.mistakes).toBe(0);
@@ -242,7 +265,7 @@ describe('startQuizAttempt', () => {
   });
 
   it('has no live question for an empty phrase', () => {
-    const attempt = startQuizAttempt([]);
+    const attempt = startQuizAttempt([], providerFor([]));
     expect(currentPosition(attempt)).toBeNull();
     expect(attempt.options).toEqual([]);
   });
@@ -250,26 +273,30 @@ describe('startQuizAttempt', () => {
 
 describe('answerCurrentChallenge — TASK-226 wrong picks really fail', () => {
   it('advances on a correct pick and verifies on the last one', () => {
-    let attempt = startQuizAttempt(LONG_WORDS);
+    const optionsFor = providerFor(LONG_WORDS);
+    let attempt = startQuizAttempt(LONG_WORDS, optionsFor);
 
-    const first = answerCorrectly(attempt, LONG_WORDS);
+    const first = answerCorrectly(attempt, LONG_WORDS, optionsFor);
     expect(first.status).toBe('advanced');
     attempt = (first as { attempt: QuizAttempt }).attempt;
     expect(attempt.currentIndex).toBe(1);
     expect(attempt.mistakes).toBe(0);
 
-    const second = answerCorrectly(attempt, LONG_WORDS);
+    const second = answerCorrectly(attempt, LONG_WORDS, optionsFor);
     expect(second.status).toBe('advanced');
     attempt = (second as { attempt: QuizAttempt }).attempt;
 
-    expect(answerCorrectly(attempt, LONG_WORDS).status).toBe('verified');
+    expect(answerCorrectly(attempt, LONG_WORDS, optionsFor).status).toBe(
+      'verified'
+    );
   });
 
-  it('counts a wrong pick, keeps the position, and re-rolls the board', () => {
-    const attempt = startQuizAttempt(LONG_WORDS);
+  it('counts a wrong pick and keeps the position, with the SAME option set', () => {
+    const optionsFor = providerFor(LONG_WORDS);
+    const attempt = startQuizAttempt(LONG_WORDS, optionsFor);
     const before = attempt.options;
 
-    const result = answerWrongly(attempt, LONG_WORDS);
+    const result = answerWrongly(attempt, LONG_WORDS, optionsFor);
     expect(result.status).toBe('retry');
     const next = (result as { attempt: QuizAttempt }).attempt;
 
@@ -279,38 +306,43 @@ describe('answerCurrentChallenge — TASK-226 wrong picks really fail', () => {
     // ...one mistake spent...
     expect(next.mistakes).toBe(1);
     expect(remainingMistakes(next)).toBe(MAX_MISTAKES - 1);
-    // ...and a freshly built board, so the previous set cannot be eliminated
-    // one chip at a time.
-    expect(next.options).toHaveLength(CHALLENGE_OPTION_COUNT);
+    // ...and the SAME set of chips. Rebuilding it would leak the answer by
+    // intersection (see the oracle suite below); the answer is still there, so
+    // this is never a dead end.
+    expect([...next.options].sort()).toEqual([...before].sort());
     expect(next.options).toContain(LONG_WORDS[currentPosition(next) as number]);
-    expect(next.options).not.toBe(before);
   });
 
   it('keeps correct progress when a later question is answered wrongly', () => {
     // A fat-finger must not throw away a correct run — that would punish the
     // legitimate user this challenge exists to protect.
-    let attempt = startQuizAttempt(LONG_WORDS);
-    attempt = (answerCorrectly(attempt, LONG_WORDS) as { attempt: QuizAttempt })
-      .attempt;
+    const optionsFor = providerFor(LONG_WORDS);
+    let attempt = startQuizAttempt(LONG_WORDS, optionsFor);
+    attempt = (
+      answerCorrectly(attempt, LONG_WORDS, optionsFor) as {
+        attempt: QuizAttempt;
+      }
+    ).attempt;
     expect(attempt.currentIndex).toBe(1);
 
-    const wrong = answerWrongly(attempt, LONG_WORDS);
+    const wrong = answerWrongly(attempt, LONG_WORDS, optionsFor);
     expect(wrong.status).toBe('retry');
     expect((wrong as { attempt: QuizAttempt }).attempt.currentIndex).toBe(1);
   });
 
   it('discards the whole attempt once the mistake budget is exhausted', () => {
-    let attempt = startQuizAttempt(LONG_WORDS);
+    const optionsFor = providerFor(LONG_WORDS);
+    let attempt = startQuizAttempt(LONG_WORDS, optionsFor);
 
     for (let mistake = 1; mistake <= MAX_MISTAKES; mistake++) {
-      const result = answerWrongly(attempt, LONG_WORDS);
+      const result = answerWrongly(attempt, LONG_WORDS, optionsFor);
       expect(result.status).toBe('retry');
       attempt = (result as { attempt: QuizAttempt }).attempt;
       expect(attempt.mistakes).toBe(mistake);
     }
     expect(remainingMistakes(attempt)).toBe(0);
 
-    const final = answerWrongly(attempt, LONG_WORDS);
+    const final = answerWrongly(attempt, LONG_WORDS, optionsFor);
     expect(final.status).toBe('reset');
     const fresh = (final as { attempt: QuizAttempt }).attempt;
     expect(fresh.mistakes).toBe(0);
@@ -320,18 +352,24 @@ describe('answerCurrentChallenge — TASK-226 wrong picks really fail', () => {
 
   it('cannot be passed by a word that is not on the board', () => {
     // No off-board path to a pass: anything not presented is a wrong answer.
-    const attempt = startQuizAttempt(LONG_WORDS);
+    const attempt = startQuizAttempt(LONG_WORDS, providerFor(LONG_WORDS));
     const result = answerCurrentChallenge(
       attempt,
       LONG_WORDS,
-      'zoo-not-a-chip'
+      'zoo-not-a-chip',
+      providerFor(LONG_WORDS)
     );
     expect(result.status).toBe('retry');
   });
 
   it('rebuilds instead of passing when there is no live question', () => {
-    const attempt = startQuizAttempt([]);
-    const result = answerCurrentChallenge(attempt, [], 'anything');
+    const attempt = startQuizAttempt([], providerFor([]));
+    const result = answerCurrentChallenge(
+      attempt,
+      [],
+      'anything',
+      providerFor([])
+    );
     expect(result.status).toBe('reset');
   });
 
@@ -339,13 +377,14 @@ describe('answerCurrentChallenge — TASK-226 wrong picks really fail', () => {
     // Exhaustive-ish: for every question index, a wrong pick at that point can
     // only ever produce retry/reset, never verified.
     for (let run = 0; run < 100; run++) {
-      let attempt = startQuizAttempt(LONG_WORDS);
+      const optionsFor = providerFor(LONG_WORDS);
+      let attempt = startQuizAttempt(LONG_WORDS, optionsFor);
       const wrongAt = run % VERIFICATION_WORD_COUNT;
       for (let question = 0; question < VERIFICATION_WORD_COUNT; question++) {
         const result =
           question === wrongAt
-            ? answerWrongly(attempt, LONG_WORDS)
-            : answerCorrectly(attempt, LONG_WORDS);
+            ? answerWrongly(attempt, LONG_WORDS, optionsFor)
+            : answerCorrectly(attempt, LONG_WORDS, optionsFor);
         if (question === wrongAt) {
           expect(result.status).not.toBe('verified');
           expect(result.status).not.toBe('advanced');
@@ -355,6 +394,71 @@ describe('answerCurrentChallenge — TASK-226 wrong picks really fail', () => {
         attempt = (result as { attempt: QuizAttempt }).attempt;
       }
     }
+  });
+});
+
+describe('createOptionProvider — the cross-board intersection oracle', () => {
+  it('returns the SAME set for a position, every time it is asked', () => {
+    // THE DEFECT THIS PINS: the first cut of this challenge rebuilt a fresh
+    // board on every retry. Only the answer is guaranteed to survive a rebuild —
+    // the four BIP-39 decoys are resampled from 2048 words and essentially never
+    // recur — so intersecting two boards for one position yields the answer.
+    // A user could answer wrong ON PURPOSE, intersect, and then answer
+    // correctly, inside the mistake budget, for all three questions.
+    for (let run = 0; run < 25; run++) {
+      const optionsFor = providerFor(LONG_WORDS);
+      for (let position = 0; position < LONG_WORDS.length; position++) {
+        const first = optionsFor(position);
+        for (let repeat = 0; repeat < 5; repeat++) {
+          expect(optionsFor(position)).toEqual(first);
+        }
+      }
+    }
+  });
+
+  it('gives a retry board that intersects the previous one in ALL its chips', () => {
+    // The observable form of the same property: an attacker who intersects the
+    // board before and after a wrong answer learns nothing, because the
+    // intersection is the whole board.
+    for (let run = 0; run < 50; run++) {
+      const optionsFor = providerFor(LONG_WORDS);
+      const attempt = startQuizAttempt(LONG_WORDS, optionsFor);
+      const before = new Set(attempt.options);
+
+      const result = answerWrongly(attempt, LONG_WORDS, optionsFor);
+      const after = (result as { attempt: QuizAttempt }).attempt.options;
+
+      const intersection = after.filter((word) => before.has(word));
+      expect(intersection).toHaveLength(CHALLENGE_OPTION_COUNT);
+    }
+  });
+
+  it('keeps a position stable across an attempt restart too', () => {
+    // The restart rebuilds POSITIONS, not boards. If it rebuilt boards, the same
+    // intersection attack would work across attempts instead of across retries.
+    const optionsFor = providerFor(LONG_WORDS);
+    const boards = LONG_WORDS.map((_, position) => optionsFor(position));
+
+    let attempt = startQuizAttempt(LONG_WORDS, optionsFor);
+    for (let mistake = 0; mistake <= MAX_MISTAKES; mistake++) {
+      attempt = (
+        answerWrongly(attempt, LONG_WORDS, optionsFor) as {
+          attempt: QuizAttempt;
+        }
+      ).attempt;
+    }
+
+    LONG_WORDS.forEach((_, position) => {
+      expect(optionsFor(position)).toEqual(boards[position]);
+    });
+  });
+
+  it('gives DIFFERENT phrases different boards', () => {
+    // The cache is per provider (i.e. per component mount), keyed by position
+    // only — it must never be shared across phrases.
+    const a = providerFor(LONG_WORDS)(4);
+    const b = providerFor(REPEATED_WORDS)(4);
+    expect(a).not.toEqual(b);
   });
 });
 
@@ -383,7 +487,8 @@ describe('DR-12 end-to-end: every repeated-word phrase stays answerable', () => 
           answerCurrentChallenge(
             attempt,
             REPEATED_WORDS,
-            REPEATED_WORDS[position]
+            REPEATED_WORDS[position],
+            providerFor(REPEATED_WORDS)
           ).status
         ).toBe('verified');
       }
@@ -398,10 +503,11 @@ describe('DR-12 end-to-end: every repeated-word phrase stays answerable', () => 
     for (let a = 0; a < words.length; a++) {
       for (let b = a + 1; b < words.length; b++) {
         for (let c = b + 1; c < words.length; c++) {
+          const optionsFor = providerFor(words);
           let attempt: QuizAttempt = {
             positions: [a, b, c],
             currentIndex: 0,
-            options: buildChallengeOptions(words, a),
+            options: optionsFor(a),
             mistakes: 0,
           };
 
@@ -411,7 +517,8 @@ describe('DR-12 end-to-end: every repeated-word phrase stays answerable', () => 
             const result = answerCurrentChallenge(
               attempt,
               words,
-              words[position]
+              words[position],
+              optionsFor
             );
             if (question < 2) {
               expect(result.status).toBe('advanced');
@@ -427,15 +534,21 @@ describe('DR-12 end-to-end: every repeated-word phrase stays answerable', () => 
 
   it('a repeated word is accepted at each of its positions, in one run', () => {
     // "abandon" sits at 0, 3 and 6 — ask all three in a single attempt.
+    const repeatedProvider = providerFor(REPEATED_WORDS);
     let attempt: QuizAttempt = {
       positions: [0, 3, 6],
       currentIndex: 0,
-      options: buildChallengeOptions(REPEATED_WORDS, 0),
+      options: repeatedProvider(0),
       mistakes: 0,
     };
     for (const expected of [0, 3, 6]) {
       expect(currentPosition(attempt)).toBe(expected);
-      const result = answerCurrentChallenge(attempt, REPEATED_WORDS, 'abandon');
+      const result = answerCurrentChallenge(
+        attempt,
+        REPEATED_WORDS,
+        'abandon',
+        repeatedProvider
+      );
       if (expected === 6) {
         expect(result.status).toBe('verified');
       } else {

--- a/src/components/wallet/__tests__/mnemonicQuiz.test.ts
+++ b/src/components/wallet/__tests__/mnemonicQuiz.test.ts
@@ -1,39 +1,94 @@
 /**
- * TASK-45 / DR-12 — regression tests for the recovery-phrase verification quiz.
+ * TASK-45 / DR-12 + TASK-226 — regression tests for the recovery-phrase
+ * verification challenge.
  *
- * The defect this pins: the quiz used to resolve a tapped word with
- * `mnemonicWords.indexOf(word)` (always the FIRST occurrence) and disable chips
- * by word VALUE. About 14% of 25-word Algorand phrases repeat a word, so when a
- * repeated word's LATER position was one of the verification targets the tap
- * resolved to a non-target position, no selection happened, and the user was
- * HARD-STUCK in onboarding with no way forward.
+ * Two defects are pinned here, and neither may come back:
  *
- * These tests deliberately use phrases with repeated words.
+ * 1. DR-12 — ONBOARDING LOCKOUT. The original quiz resolved a tapped word with
+ *    `mnemonicWords.indexOf(word)` (always the FIRST occurrence) and disabled
+ *    chips by word VALUE. About 14% of 25-word Algorand phrases repeat a word,
+ *    so when a repeated word's LATER position was a target the tap resolved to a
+ *    non-target position, nothing happened, and the user was HARD-STUCK in
+ *    onboarding with no way forward. The exhaustive suite at the bottom of this
+ *    file walks every position of a deliberately repeated-word phrase and proves
+ *    each one is answerable.
+ *
+ * 2. TASK-226 — PASSABLE WITHOUT THE PHRASE. Taps auto-routed to the slot they
+ *    belonged to (so a wrong tap was a silent no-op) and the chip bank held only
+ *    the phrase's own words, so the board could be filled by tapping at random.
+ *    The tests here pin that a wrong pick is a real, counted failure and that
+ *    decoys come from the wider BIP-39 wordlist.
  *
  * SECURITY NOTE: the phrases below are made-up word lists used purely as
  * position/value fixtures. They are not valid BIP-39/Algorand mnemonics and no
  * key material is derived from them anywhere in this file.
  */
 
+import { BIP39Utils } from '@/utils/bip39';
 import {
-  buildWordOptions,
-  clearWordSelection,
-  isVerificationComplete,
+  answerCurrentChallenge,
+  buildChallengeOptions,
+  CHALLENGE_OPTION_COUNT,
+  currentPosition,
+  MAX_MISTAKES,
+  PHRASE_DECOY_COUNT,
   pickVerificationPositions,
-  resolveVerificationTarget,
-  selectWordOption,
-  shuffleWordOptions,
+  remainingMistakes,
+  shuffle,
   splitMnemonic,
-  usedOptionIndices,
-  verifySelections,
+  startQuizAttempt,
   VERIFICATION_WORD_COUNT,
-  type WordSelections,
+  type QuizAttempt,
 } from '../mnemonicQuiz';
 
 // "abandon" appears at positions 0, 3 and 6 — the exact shape that used to lock
 // a user out.
 const REPEATED = 'abandon ability able abandon absent absorb abandon abstract';
 const REPEATED_WORDS = REPEATED.split(' ');
+
+/** A 25-word-shaped fixture of distinct BIP-39 words. */
+const LONG_WORDS = [
+  'abandon',
+  'ability',
+  'able',
+  'about',
+  'above',
+  'absent',
+  'absorb',
+  'abstract',
+  'absurd',
+  'abuse',
+  'access',
+  'accident',
+  'account',
+  'accuse',
+  'achieve',
+  'acid',
+  'acoustic',
+  'acquire',
+  'across',
+  'act',
+  'action',
+  'actor',
+  'actress',
+  'actual',
+  'adapt',
+];
+
+/** Answer the live question correctly; asserts the attempt is still coherent. */
+function answerCorrectly(attempt: QuizAttempt, words: string[]) {
+  const position = currentPosition(attempt);
+  expect(position).not.toBeNull();
+  return answerCurrentChallenge(attempt, words, words[position as number]);
+}
+
+/** Answer the live question with some chip that is NOT the right one. */
+function answerWrongly(attempt: QuizAttempt, words: string[]) {
+  const position = currentPosition(attempt) as number;
+  const wrong = attempt.options.find((word) => word !== words[position]);
+  expect(wrong).toBeDefined();
+  return answerCurrentChallenge(attempt, words, wrong as string);
+}
 
 describe('splitMnemonic', () => {
   it('collapses stray whitespace and trims', () => {
@@ -45,26 +100,14 @@ describe('splitMnemonic', () => {
   });
 });
 
-describe('buildWordOptions', () => {
-  it('carries the ORIGINAL position of every word, duplicates included', () => {
-    const options = buildWordOptions(REPEATED);
-    expect(options).toHaveLength(8);
-    expect(options.map((o) => o.index)).toEqual([0, 1, 2, 3, 4, 5, 6, 7]);
-    // Each occurrence of "abandon" is a distinct, independently addressable chip.
-    expect(
-      options.filter((o) => o.word === 'abandon').map((o) => o.index)
-    ).toEqual([0, 3, 6]);
-  });
-});
+describe('shuffle', () => {
+  it('preserves every element and does not mutate the input', () => {
+    const items = [...REPEATED_WORDS];
+    const snapshot = JSON.stringify(items);
+    const shuffled = shuffle(items);
 
-describe('shuffleWordOptions', () => {
-  it('preserves every (word, index) pair and does not mutate the input', () => {
-    const options = buildWordOptions(REPEATED);
-    const snapshot = JSON.stringify(options);
-    const shuffled = shuffleWordOptions(options);
-
-    expect(JSON.stringify(options)).toBe(snapshot);
-    expect([...shuffled].sort((a, b) => a.index - b.index)).toEqual(options);
+    expect(JSON.stringify(items)).toBe(snapshot);
+    expect([...shuffled].sort()).toEqual([...items].sort());
   });
 });
 
@@ -88,173 +131,316 @@ describe('pickVerificationPositions', () => {
   });
 });
 
-describe('resolveVerificationTarget — DR-12 duplicate words', () => {
-  it('resolves a LATER occurrence of a repeated word to its own position', () => {
-    // Target is position 6 — the THIRD "abandon". The old indexOf() logic
-    // resolved this tap to position 0, which is not a target, so the tap was a
-    // silent no-op and the user could never complete the quiz.
-    const target = resolveVerificationTarget(
-      { word: 'abandon', index: 6 },
-      [1, 4, 6],
-      {},
-      REPEATED_WORDS
-    );
-    expect(target).toBe(6);
+describe('buildChallengeOptions — TASK-226 decoys', () => {
+  it('always presents exactly one correct chip and no duplicates', () => {
+    for (let position = 0; position < LONG_WORDS.length; position++) {
+      for (let run = 0; run < 20; run++) {
+        const options = buildChallengeOptions(LONG_WORDS, position);
+        expect(options).toHaveLength(CHALLENGE_OPTION_COUNT);
+        expect(new Set(options).size).toBe(CHALLENGE_OPTION_COUNT);
+        expect(
+          options.filter((word) => word === LONG_WORDS[position])
+        ).toHaveLength(1);
+      }
+    }
   });
 
-  it('lets a non-target duplicate chip fill an equivalent empty target slot', () => {
-    // The user taps the chip at position 0; only position 6 is a target. Both
-    // chips read "abandon" and are visually indistinguishable, so the tap must
-    // still land rather than doing nothing.
-    const target = resolveVerificationTarget(
-      { word: 'abandon', index: 0 },
-      [1, 4, 6],
-      {},
-      REPEATED_WORDS
-    );
-    expect(target).toBe(6);
+  it('draws decoys the phrase does not contain (not just its own words)', () => {
+    // The whole point of TASK-226's decoy change: a bank of only the phrase's
+    // own words tells the user which words are real.
+    let sawForeignDecoy = false;
+    for (let run = 0; run < 50 && !sawForeignDecoy; run++) {
+      const options = buildChallengeOptions(LONG_WORDS, 4);
+      sawForeignDecoy = options.some((word) => !LONG_WORDS.includes(word));
+    }
+    expect(sawForeignDecoy).toBe(true);
   });
 
-  it('never reuses a chip that already filled a slot', () => {
-    const selections: WordSelections = {
-      6: { word: 'abandon', optionIndex: 6 },
-    };
-    expect(
-      resolveVerificationTarget(
-        { word: 'abandon', index: 6 },
-        [1, 4, 6],
-        selections,
-        REPEATED_WORDS
-      )
-    ).toBeNull();
+  it('draws every chip from the BIP-39 English wordlist', () => {
+    // Decoys must be presentationally indistinguishable from the answer: same
+    // lowercase BIP-39 vocabulary, rendered by the same chip.
+    for (let run = 0; run < 50; run++) {
+      const options = buildChallengeOptions(LONG_WORDS, run % 25);
+      options.forEach((word) => {
+        expect(BIP39Utils.isValidWord(word)).toBe(true);
+        expect(word).toBe(word.toLowerCase());
+      });
+    }
   });
 
-  it('returns null when no empty target slot expects this word', () => {
-    expect(
-      resolveVerificationTarget(
-        { word: 'absorb', index: 5 },
-        [1, 4, 6],
-        {},
-        REPEATED_WORDS
-      )
-    ).toBeNull();
-  });
-
-  it('fills a second target slot from the second duplicate chip', () => {
-    // Both position 0 and position 6 are targets and both hold "abandon".
-    const first = selectWordOption(
-      { word: 'abandon', index: 0 },
-      [0, 4, 6],
-      {},
-      REPEATED_WORDS
-    );
-    const second = selectWordOption(
-      { word: 'abandon', index: 6 },
-      [0, 4, 6],
-      first,
-      REPEATED_WORDS
-    );
-    expect(Object.keys(second).sort()).toEqual(['0', '6']);
-    expect(second[0].optionIndex).toBe(0);
-    expect(second[6].optionIndex).toBe(6);
-  });
-});
-
-describe('selectWordOption / clearWordSelection', () => {
-  it('is a no-op (same object) when the tap resolves to nothing', () => {
-    const selections: WordSelections = {};
-    expect(
-      selectWordOption(
-        { word: 'absorb', index: 5 },
-        [1, 4, 6],
-        selections,
-        REPEATED_WORDS
-      )
-    ).toBe(selections);
-  });
-
-  it('clearing a slot frees its chip for reuse', () => {
-    const filled = selectWordOption(
-      { word: 'abandon', index: 6 },
-      [1, 4, 6],
-      {},
-      REPEATED_WORDS
-    );
-    expect(usedOptionIndices(filled).has(6)).toBe(true);
-
-    const cleared = clearWordSelection(6, filled);
-    expect(usedOptionIndices(cleared).has(6)).toBe(false);
-    expect(
-      resolveVerificationTarget(
-        { word: 'abandon', index: 6 },
-        [1, 4, 6],
-        cleared,
-        REPEATED_WORDS
-      )
-    ).toBe(6);
-  });
-});
-
-describe('verifySelections', () => {
-  const targets = [1, 4, 6];
-
-  it('accepts a fully correct board containing a repeated word', () => {
-    let selections: WordSelections = {};
-    for (const index of targets) {
-      selections = selectWordOption(
-        { word: REPEATED_WORDS[index], index },
-        targets,
-        selections,
-        REPEATED_WORDS
+  it('mixes in some of the phrase’s own words as decoys', () => {
+    // Without these, the answer would be the only option belonging to the
+    // phrase and anyone who remembers the word SET could pass every question.
+    let sawPhraseDecoy = false;
+    for (let run = 0; run < 50 && !sawPhraseDecoy; run++) {
+      const options = buildChallengeOptions(LONG_WORDS, 4);
+      sawPhraseDecoy = options.some(
+        (word) => word !== LONG_WORDS[4] && LONG_WORDS.includes(word)
       );
     }
-    expect(isVerificationComplete(targets, selections)).toBe(true);
-    expect(verifySelections(targets, selections, REPEATED_WORDS)).toBe(true);
+    expect(sawPhraseDecoy).toBe(true);
   });
 
-  it('rejects an incomplete board', () => {
-    const selections = selectWordOption(
-      { word: REPEATED_WORDS[1], index: 1 },
-      targets,
-      {},
-      REPEATED_WORDS
+  it('keeps the number of phrase words on the board at its budget', () => {
+    // A board made mostly of the phrase's own words would show a shoulder-surfer
+    // the phrase's whole vocabulary; a board with none of them would let a
+    // set-memoriser pick "the familiar one". The budget is the answer plus
+    // PHRASE_DECOY_COUNT, and the only excess is the rare wordlist sample that
+    // happens to collide with the phrase (~0.05 per board for 25 words).
+    const runs = 500;
+    let total = 0;
+    for (let run = 0; run < runs; run++) {
+      const options = buildChallengeOptions(LONG_WORDS, 11);
+      total += options.filter((word) => LONG_WORDS.includes(word)).length;
+    }
+    const mean = total / runs;
+    expect(mean).toBeGreaterThanOrEqual(1 + PHRASE_DECOY_COUNT);
+    expect(mean).toBeLessThan(1 + PHRASE_DECOY_COUNT + 0.5);
+  });
+
+  it('puts the answer in a uniformly random slot', () => {
+    const counts = new Array(CHALLENGE_OPTION_COUNT).fill(0);
+    for (let run = 0; run < 2000; run++) {
+      const options = buildChallengeOptions(LONG_WORDS, 7);
+      counts[options.indexOf(LONG_WORDS[7])] += 1;
+    }
+    // Loose bound: no slot may be starved or dominant (uniform would be 250).
+    counts.forEach((count) => {
+      expect(count).toBeGreaterThan(120);
+      expect(count).toBeLessThan(400);
+    });
+  });
+
+  it('still fills the board when the rng is degenerate', () => {
+    const options = buildChallengeOptions(
+      LONG_WORDS,
+      3,
+      CHALLENGE_OPTION_COUNT,
+      () => 0
     );
-    expect(isVerificationComplete(targets, selections)).toBe(false);
-    expect(verifySelections(targets, selections, REPEATED_WORDS)).toBe(false);
+    expect(options).toHaveLength(CHALLENGE_OPTION_COUNT);
+    expect(new Set(options).size).toBe(CHALLENGE_OPTION_COUNT);
+    expect(options).toContain(LONG_WORDS[3]);
   });
 
-  it('rejects a board with a wrong word in a slot', () => {
-    const selections: WordSelections = {
-      1: { word: 'wrong', optionIndex: 99 },
-      4: { word: REPEATED_WORDS[4], optionIndex: 4 },
-      6: { word: REPEATED_WORDS[6], optionIndex: 6 },
-    };
-    expect(verifySelections(targets, selections, REPEATED_WORDS)).toBe(false);
+  it('returns nothing for a position that does not exist', () => {
+    expect(buildChallengeOptions(LONG_WORDS, 99)).toEqual([]);
   });
 });
 
-describe('DR-12 end-to-end: every repeated-word phrase stays completable', () => {
-  it('can always be finished, for every possible target triple', () => {
+describe('startQuizAttempt', () => {
+  it('opens on the first question with a full board and no mistakes', () => {
+    for (let run = 0; run < 50; run++) {
+      const attempt = startQuizAttempt(LONG_WORDS);
+      expect(attempt.positions).toHaveLength(VERIFICATION_WORD_COUNT);
+      expect(attempt.currentIndex).toBe(0);
+      expect(attempt.mistakes).toBe(0);
+      expect(attempt.options).toHaveLength(CHALLENGE_OPTION_COUNT);
+      expect(attempt.options).toContain(LONG_WORDS[attempt.positions[0]]);
+      expect(remainingMistakes(attempt)).toBe(MAX_MISTAKES);
+    }
+  });
+
+  it('has no live question for an empty phrase', () => {
+    const attempt = startQuizAttempt([]);
+    expect(currentPosition(attempt)).toBeNull();
+    expect(attempt.options).toEqual([]);
+  });
+});
+
+describe('answerCurrentChallenge — TASK-226 wrong picks really fail', () => {
+  it('advances on a correct pick and verifies on the last one', () => {
+    let attempt = startQuizAttempt(LONG_WORDS);
+
+    const first = answerCorrectly(attempt, LONG_WORDS);
+    expect(first.status).toBe('advanced');
+    attempt = (first as { attempt: QuizAttempt }).attempt;
+    expect(attempt.currentIndex).toBe(1);
+    expect(attempt.mistakes).toBe(0);
+
+    const second = answerCorrectly(attempt, LONG_WORDS);
+    expect(second.status).toBe('advanced');
+    attempt = (second as { attempt: QuizAttempt }).attempt;
+
+    expect(answerCorrectly(attempt, LONG_WORDS).status).toBe('verified');
+  });
+
+  it('counts a wrong pick, keeps the position, and re-rolls the board', () => {
+    const attempt = startQuizAttempt(LONG_WORDS);
+    const before = attempt.options;
+
+    const result = answerWrongly(attempt, LONG_WORDS);
+    expect(result.status).toBe('retry');
+    const next = (result as { attempt: QuizAttempt }).attempt;
+
+    // Same question...
+    expect(currentPosition(next)).toBe(currentPosition(attempt));
+    expect(next.currentIndex).toBe(attempt.currentIndex);
+    // ...one mistake spent...
+    expect(next.mistakes).toBe(1);
+    expect(remainingMistakes(next)).toBe(MAX_MISTAKES - 1);
+    // ...and a freshly built board, so the previous set cannot be eliminated
+    // one chip at a time.
+    expect(next.options).toHaveLength(CHALLENGE_OPTION_COUNT);
+    expect(next.options).toContain(LONG_WORDS[currentPosition(next) as number]);
+    expect(next.options).not.toBe(before);
+  });
+
+  it('keeps correct progress when a later question is answered wrongly', () => {
+    // A fat-finger must not throw away a correct run — that would punish the
+    // legitimate user this challenge exists to protect.
+    let attempt = startQuizAttempt(LONG_WORDS);
+    attempt = (answerCorrectly(attempt, LONG_WORDS) as { attempt: QuizAttempt })
+      .attempt;
+    expect(attempt.currentIndex).toBe(1);
+
+    const wrong = answerWrongly(attempt, LONG_WORDS);
+    expect(wrong.status).toBe('retry');
+    expect((wrong as { attempt: QuizAttempt }).attempt.currentIndex).toBe(1);
+  });
+
+  it('discards the whole attempt once the mistake budget is exhausted', () => {
+    let attempt = startQuizAttempt(LONG_WORDS);
+
+    for (let mistake = 1; mistake <= MAX_MISTAKES; mistake++) {
+      const result = answerWrongly(attempt, LONG_WORDS);
+      expect(result.status).toBe('retry');
+      attempt = (result as { attempt: QuizAttempt }).attempt;
+      expect(attempt.mistakes).toBe(mistake);
+    }
+    expect(remainingMistakes(attempt)).toBe(0);
+
+    const final = answerWrongly(attempt, LONG_WORDS);
+    expect(final.status).toBe('reset');
+    const fresh = (final as { attempt: QuizAttempt }).attempt;
+    expect(fresh.mistakes).toBe(0);
+    expect(fresh.currentIndex).toBe(0);
+    expect(fresh.options).toHaveLength(CHALLENGE_OPTION_COUNT);
+  });
+
+  it('cannot be passed by a word that is not on the board', () => {
+    // No off-board path to a pass: anything not presented is a wrong answer.
+    const attempt = startQuizAttempt(LONG_WORDS);
+    const result = answerCurrentChallenge(
+      attempt,
+      LONG_WORDS,
+      'zoo-not-a-chip'
+    );
+    expect(result.status).toBe('retry');
+  });
+
+  it('rebuilds instead of passing when there is no live question', () => {
+    const attempt = startQuizAttempt([]);
+    const result = answerCurrentChallenge(attempt, [], 'anything');
+    expect(result.status).toBe('reset');
+  });
+
+  it('never verifies a run that contains a wrong pick', () => {
+    // Exhaustive-ish: for every question index, a wrong pick at that point can
+    // only ever produce retry/reset, never verified.
+    for (let run = 0; run < 100; run++) {
+      let attempt = startQuizAttempt(LONG_WORDS);
+      const wrongAt = run % VERIFICATION_WORD_COUNT;
+      for (let question = 0; question < VERIFICATION_WORD_COUNT; question++) {
+        const result =
+          question === wrongAt
+            ? answerWrongly(attempt, LONG_WORDS)
+            : answerCorrectly(attempt, LONG_WORDS);
+        if (question === wrongAt) {
+          expect(result.status).not.toBe('verified');
+          expect(result.status).not.toBe('advanced');
+          break;
+        }
+        expect(result.status).toBe('advanced');
+        attempt = (result as { attempt: QuizAttempt }).attempt;
+      }
+    }
+  });
+});
+
+describe('DR-12 end-to-end: every repeated-word phrase stays answerable', () => {
+  it('builds an unambiguous, solvable board for EVERY position, duplicates included', () => {
+    for (let position = 0; position < REPEATED_WORDS.length; position++) {
+      for (let run = 0; run < 50; run++) {
+        const options = buildChallengeOptions(REPEATED_WORDS, position);
+        // Exactly one chip is right — a repeated word never yields two chips
+        // that are both "correct", which is the ambiguity DR-12 outlawed.
+        expect(
+          options.filter((word) => word === REPEATED_WORDS[position])
+        ).toHaveLength(1);
+        expect(new Set(options).size).toBe(options.length);
+
+        // And answering it is accepted, at EVERY one of the repeated word's
+        // positions — under the old value-indexed logic this silently did
+        // nothing and the user was hard-stuck in onboarding.
+        const attempt: QuizAttempt = {
+          positions: [position],
+          currentIndex: 0,
+          options,
+          mistakes: 0,
+        };
+        expect(
+          answerCurrentChallenge(
+            attempt,
+            REPEATED_WORDS,
+            REPEATED_WORDS[position]
+          ).status
+        ).toBe('verified');
+      }
+    }
+  });
+
+  it('can always be finished, for every possible question triple', () => {
     const words = REPEATED_WORDS;
-    // Exhaustively enumerate every 3-position target set for the repeated-word
-    // phrase. Under the old value-indexed logic many of these were unwinnable.
+    // Exhaustively enumerate every 3-position question set for the
+    // repeated-word phrase. Under the old value-indexed logic many of these
+    // were unwinnable.
     for (let a = 0; a < words.length; a++) {
       for (let b = a + 1; b < words.length; b++) {
         for (let c = b + 1; c < words.length; c++) {
-          const targets = [a, b, c];
-          let selections: WordSelections = {};
-          // Simulate the user tapping the chip at each target position.
-          for (const index of targets) {
-            selections = selectWordOption(
-              { word: words[index], index },
-              targets,
-              selections,
-              words
+          let attempt: QuizAttempt = {
+            positions: [a, b, c],
+            currentIndex: 0,
+            options: buildChallengeOptions(words, a),
+            mistakes: 0,
+          };
+
+          for (let question = 0; question < 3; question++) {
+            const position = currentPosition(attempt) as number;
+            expect(attempt.options).toContain(words[position]);
+            const result = answerCurrentChallenge(
+              attempt,
+              words,
+              words[position]
             );
+            if (question < 2) {
+              expect(result.status).toBe('advanced');
+              attempt = (result as { attempt: QuizAttempt }).attempt;
+            } else {
+              expect(result.status).toBe('verified');
+            }
           }
-          expect(isVerificationComplete(targets, selections)).toBe(true);
-          expect(verifySelections(targets, selections, words)).toBe(true);
         }
+      }
+    }
+  });
+
+  it('a repeated word is accepted at each of its positions, in one run', () => {
+    // "abandon" sits at 0, 3 and 6 — ask all three in a single attempt.
+    let attempt: QuizAttempt = {
+      positions: [0, 3, 6],
+      currentIndex: 0,
+      options: buildChallengeOptions(REPEATED_WORDS, 0),
+      mistakes: 0,
+    };
+    for (const expected of [0, 3, 6]) {
+      expect(currentPosition(attempt)).toBe(expected);
+      const result = answerCurrentChallenge(attempt, REPEATED_WORDS, 'abandon');
+      if (expected === 6) {
+        expect(result.status).toBe('verified');
+      } else {
+        expect(result.status).toBe('advanced');
+        attempt = (result as { attempt: QuizAttempt }).attempt;
       }
     }
   });

--- a/src/components/wallet/__tests__/mnemonicQuiz.test.ts
+++ b/src/components/wallet/__tests__/mnemonicQuiz.test.ts
@@ -435,7 +435,42 @@ describe('MAX_MISTAKES — the security lever', () => {
   });
 });
 
-describe('createOptionProvider — the cross-board intersection oracle', () => {
+describe('createOptionProvider — the option-set intersection oracle', () => {
+  it('derives the SAME board for a position across INDEPENDENT providers', () => {
+    // THE SECOND HALF OF THE DEFECT: memoising per component mount closed the
+    // oracle within a mount, but the failure path deliberately UNMOUNTS the
+    // challenge, so re-entering re-rolled every board. Someone could note the
+    // "which word is #7?" prompt, fail out, re-enter until #7 came round again,
+    // and intersect — an ORDER-recovery oracle, i.e. exactly what the challenge
+    // is meant to test. A board must be a pure function of the phrase, never of
+    // the mount.
+    for (let position = 0; position < LONG_WORDS.length; position++) {
+      const boards = Array.from({ length: 4 }, () =>
+        providerFor(LONG_WORDS)(position)
+      );
+      boards.forEach((board) => expect(board).toEqual(boards[0]));
+    }
+  });
+
+  it('derives the same board from an equal phrase built independently', () => {
+    // Determinism must come from the phrase's VALUE, not from array identity.
+    const copy = LONG_WORDS.join(' ').split(' ');
+    expect(copy).not.toBe(LONG_WORDS);
+    for (let position = 0; position < LONG_WORDS.length; position++) {
+      expect(providerFor(copy)(position)).toEqual(
+        providerFor(LONG_WORDS)(position)
+      );
+    }
+  });
+
+  it('gives different positions different boards', () => {
+    const optionsFor = providerFor(LONG_WORDS);
+    const seen = new Set(
+      LONG_WORDS.map((_, position) => optionsFor(position).join('|'))
+    );
+    expect(seen.size).toBe(LONG_WORDS.length);
+  });
+
   it('returns the SAME set for a position, every time it is asked', () => {
     // THE DEFECT THIS PINS: the first cut of this challenge rebuilt a fresh
     // board on every retry. Only the answer is guaranteed to survive a rebuild —
@@ -492,11 +527,17 @@ describe('createOptionProvider — the cross-board intersection oracle', () => {
   });
 
   it('gives DIFFERENT phrases different boards', () => {
-    // The cache is per provider (i.e. per component mount), keyed by position
-    // only — it must never be shared across phrases.
+    // The derivation is domain-separated per (phrase, position); a board must
+    // never carry over between phrases.
     const a = providerFor(LONG_WORDS)(4);
     const b = providerFor(REPEATED_WORDS)(4);
     expect(a).not.toEqual(b);
+
+    // A one-word edit must change the board, or the derivation would not really
+    // be a function of the phrase.
+    const edited = [...LONG_WORDS];
+    edited[20] = 'zebra';
+    expect(providerFor(edited)(4)).not.toEqual(a);
   });
 });
 

--- a/src/components/wallet/__tests__/mnemonicQuiz.test.ts
+++ b/src/components/wallet/__tests__/mnemonicQuiz.test.ts
@@ -397,6 +397,44 @@ describe('answerCurrentChallenge — TASK-226 wrong picks really fail', () => {
   });
 });
 
+describe('MAX_MISTAKES — the security lever', () => {
+  it('stays small enough that elimination does not make the challenge cheap', () => {
+    // Because a position's option set is stable, every tolerated mistake is a
+    // free elimination. Per-attempt pass probability is
+    // C(MAX_MISTAKES + 3, 3) / candidates ** 3, and the relevant guesser is not
+    // the blind one but someone who remembers the phrase's WORDS but not their
+    // ORDER — they can spot the ~4 phrase words on each board. At 3 tolerated
+    // mistakes that is 20/64 ≈ 31% per attempt; at 1 it is 4/64 ≈ 6%.
+    // Raising this constant re-opens that shortcut, so pin it.
+    expect(MAX_MISTAKES).toBeLessThanOrEqual(1);
+
+    const compositions = (budget: number) =>
+      ((budget + 3) * (budget + 2) * (budget + 1)) / 6;
+    const setMemoriserCandidates = 1 + PHRASE_DECOY_COUNT;
+    const perAttempt = compositions(MAX_MISTAKES) / setMemoriserCandidates ** 3;
+    expect(perAttempt).toBeLessThan(0.1);
+  });
+
+  it('still forgives a mistake — a legitimate user is never restarted for one slip', () => {
+    const optionsFor = providerFor(LONG_WORDS);
+    let attempt = startQuizAttempt(LONG_WORDS, optionsFor);
+
+    const slip = answerWrongly(attempt, LONG_WORDS, optionsFor);
+    expect(slip.status).toBe('retry');
+    attempt = (slip as { attempt: QuizAttempt }).attempt;
+
+    for (let question = 0; question < VERIFICATION_WORD_COUNT; question++) {
+      const result = answerCorrectly(attempt, LONG_WORDS, optionsFor);
+      if (question < VERIFICATION_WORD_COUNT - 1) {
+        expect(result.status).toBe('advanced');
+        attempt = (result as { attempt: QuizAttempt }).attempt;
+      } else {
+        expect(result.status).toBe('verified');
+      }
+    }
+  });
+});
+
 describe('createOptionProvider — the cross-board intersection oracle', () => {
   it('returns the SAME set for a position, every time it is asked', () => {
     // THE DEFECT THIS PINS: the first cut of this challenge rebuilt a fresh

--- a/src/components/wallet/mnemonicQuiz.ts
+++ b/src/components/wallet/mnemonicQuiz.ts
@@ -37,14 +37,13 @@
  *
  * The counter-risk — an observer separating real words from filler by noticing
  * that phrase words recur across boards while wordlist samples (1 in 2048) do
- * not — is bounded by scope: boards are memoised per component MOUNT
- * ({@link createOptionProvider}), an attempt only ever exposes
- * {@link VERIFICATION_WORD_COUNT} distinct boards, and the failure path unmounts
- * the challenge (onboarding returns to the phrase, post-hoc verification
- * leaves). So one mount leaks at most 3 boards' worth of draws, in which
- * recurrence is too rare to separate. Aggregating enough mounts to run that
- * frequency analysis costs many deliberate failures — and yields the phrase's
- * word SET, not its ORDER, which is what the challenge actually asks for.
+ * not — is bounded by determinism: a position's board is a pure function of the
+ * phrase ({@link createOptionProvider}), so repeat observations of the SAME
+ * question return the identical eight words and reveal nothing. Recurrence
+ * across DIFFERENT questions can still, over enough boards, hint at which words
+ * belong to the phrase — but that yields the phrase's word SET, never its ORDER,
+ * which is what the challenge actually asks for and what makes a phrase
+ * recoverable.
  *
  * Every option is a plain lowercase BIP-39 word rendered by the same chip
  * component, so decoys are presentationally indistinguishable from the answer,
@@ -107,6 +106,9 @@
  * is adequate for presentation ordering and decoy sampling — it is not used to
  * generate, derive, or protect key material.
  */
+
+import { sha256 } from '@noble/hashes/sha256';
+import { utf8ToBytes } from '@noble/hashes/utils';
 
 import { BIP39Utils } from '@/utils/bip39';
 
@@ -271,38 +273,94 @@ export function buildChallengeOptions(
  */
 export type OptionProvider = (position: number) => string[];
 
+/** Domain separator, so this digest can never be confused with anything else. */
+const BOARD_SEED_DOMAIN = 'voi-wallet/mnemonic-quiz/board/v1';
+
 /**
- * Build an option provider that memoises each position's board.
+ * sfc32 — a small, fast, well-distributed counter PRNG. Not cryptographic, and
+ * it does not need to be: it only decides which decoy words appear and in what
+ * order. Its ONLY job is to be reproducible.
+ */
+function sfc32(a: number, b: number, c: number, d: number): Rng {
+  return () => {
+    a >>>= 0;
+    b >>>= 0;
+    c >>>= 0;
+    d >>>= 0;
+    const t = (((a + b) | 0) + d) | 0;
+    d = (d + 1) | 0;
+    a = b ^ (b >>> 9);
+    b = (c + (c << 3)) | 0;
+    c = (c << 21) | (c >>> 11);
+    c = (c + t) | 0;
+    return (t >>> 0) / 4294967296;
+  };
+}
+
+/**
+ * A reproducible rng for one (phrase, position) board.
  *
- * ## Why this exists — the cross-board intersection oracle
+ * The digest is a ONE-WAY function of the phrase, computed in memory and thrown
+ * away with the rng. It is never stored, logged, transmitted, or used as key
+ * material — it is not a derivation, it just makes the decoy draw deterministic
+ * so the same position always yields the same board. Nothing about the phrase is
+ * recoverable from the board: the decoys are wordlist entries, and SHA-256 is
+ * preimage-resistant.
+ *
+ * The alternative — a per-mount random draw — is what made the board
+ * intersectable across remounts; see {@link createOptionProvider}.
+ */
+function createBoardRng(words: string[], position: number): Rng {
+  const digest = sha256(
+    utf8ToBytes(`${BOARD_SEED_DOMAIN}:${position}:${words.join(' ')}`)
+  );
+  const seed = (offset: number) =>
+    ((digest[offset] << 24) |
+      (digest[offset + 1] << 16) |
+      (digest[offset + 2] << 8) |
+      digest[offset + 3]) >>>
+    0;
+  return sfc32(seed(0), seed(4), seed(8), seed(12));
+}
+
+/**
+ * Build an option provider: the canonical board for each phrase position.
+ *
+ * ## Why this exists — the option-set intersection oracle
  *
  * The first cut of this challenge rebuilt a FRESH board every time a position
  * was re-asked, on the theory that a stable board could be eliminated one chip
- * at a time. That was backwards: the right answer is the one word GUARANTEED to
+ * at a time. That was backwards. The right answer is the one word GUARANTEED to
  * appear on every board for a position, while the decoys are resampled (the
  * BIP-39 ones from 2048 words, so they essentially never recur). Intersecting
- * two boards for the same position therefore yields the answer directly. An
- * attacker could deliberately answer wrong once, intersect, and then answer
- * correctly — inside the mistake budget, for all three questions.
+ * two boards for the same position therefore names the answer. An attacker could
+ * answer wrong on purpose, intersect, and then answer correctly.
  *
- * Memoising the set closes that channel completely: intersecting two
- * presentations returns the set itself, which is exactly what the user could
- * already see. Only the display ORDER is reshuffled between presentations, and a
- * uniform shuffle of an unchanged set carries no information.
+ * Memoising per component mount closed that within a mount but not across them:
+ * the failure path deliberately unmounts the challenge, so re-entering re-rolled
+ * every board, and a "which word is #7?" prompt observed across a handful of
+ * re-entries could be intersected just the same — an ORDER-recovery oracle,
+ * which is precisely what the challenge is supposed to test.
  *
- * Elimination within the mistake budget is then the residual. Drawing without
+ * So the board is DERIVED, not drawn: `sha256(domain : position : phrase)` seeds
+ * the decoy selection, making the set for a position a pure function of the
+ * phrase. Every observation of position 7 — this mount, the next one, next week
+ * — returns the identical eight words, so intersecting any number of them
+ * returns the set the user could already see, and frequency analysis has nothing
+ * to bite on. The Map is then only a cache; correctness comes from determinism.
+ * See {@link createBoardRng} for why hashing the phrase here is not a
+ * derivation of key material.
+ *
+ * Only the display ORDER is reshuffled between presentations, and a uniform
+ * shuffle of an unchanged set carries no information.
+ *
+ * Elimination within the mistake budget is the residual. Drawing without
  * replacement from a fixed set makes every guess worth exactly `1 / candidates`
  * no matter how many chips have already been ruled out, so spending a mistake
  * buys a guesser nothing per question — but it does buy them another guess, so
  * the budget itself is what has to be small. See {@link MAX_MISTAKES}.
- *
- * The cache lives as long as the caller holds the provider — one component
- * mount. It holds only words that are already on screen.
  */
-export function createOptionProvider(
-  words: string[],
-  rng: Rng = Math.random
-): OptionProvider {
+export function createOptionProvider(words: string[]): OptionProvider {
   const cache = new Map<number, string[]>();
   return (position: number) => {
     const cached = cache.get(position);
@@ -311,7 +369,7 @@ export function createOptionProvider(
       words,
       position,
       CHALLENGE_OPTION_COUNT,
-      rng
+      createBoardRng(words, position)
     );
     cache.set(position, options);
     return options;

--- a/src/components/wallet/mnemonicQuiz.ts
+++ b/src/components/wallet/mnemonicQuiz.ts
@@ -29,7 +29,22 @@
  *     never saw the display step.
  *
  * Mixing gives a shoulder-surfer no way to tell real words from decoys, while
- * still denying the "pick the familiar one" shortcut.
+ * still denying the "pick the familiar one" shortcut. Note that the answer chip
+ * is a real phrase word by necessity, so a correct pick reveals one (word,
+ * position) pair to anyone watching NO MATTER what the decoy policy is; the
+ * phrase decoys only remove the certainty an observer would otherwise have about
+ * the seven chips that were NOT picked.
+ *
+ * The counter-risk — an observer separating real words from filler by noticing
+ * that phrase words recur across boards while wordlist samples (1 in 2048) do
+ * not — is bounded by scope: boards are memoised per component MOUNT
+ * ({@link createOptionProvider}), an attempt only ever exposes
+ * {@link VERIFICATION_WORD_COUNT} distinct boards, and the failure path unmounts
+ * the challenge (onboarding returns to the phrase, post-hoc verification
+ * leaves). So one mount leaks at most 3 boards' worth of draws, in which
+ * recurrence is too rare to separate. Aggregating enough mounts to run that
+ * frequency analysis costs many deliberate failures — and yields the phrase's
+ * word SET, not its ORDER, which is what the challenge actually asks for.
  *
  * Every option is a plain lowercase BIP-39 word rendered by the same chip
  * component, so decoys are presentationally indistinguishable from the answer,
@@ -45,12 +60,30 @@
  * so a fat-finger does not throw away a correct run.
  *
  * After {@link MAX_MISTAKES} tolerated mistakes the next wrong pick discards the
- * whole attempt: brand-new positions, brand-new option sets, mistake counter
- * back to zero, and the host is told via `onFailed` so onboarding can send the
- * user back to re-read the phrase. There is deliberately NO permanent lockout —
- * a user holding a correct written phrase must always be able to pass — so the
- * bound on blind guessing is friction, not refusal. See MnemonicVerification for
- * the numbers.
+ * whole attempt: brand-new positions, mistake counter back to zero, and the host
+ * is told via `onFailed` so onboarding can send the user back to re-read the
+ * phrase.
+ *
+ * ## Attempts are NOT capped — a deliberate decision
+ *
+ * There is no permanent lockout, no persisted failure counter and no cooldown.
+ * A blind guesser can therefore keep starting new attempts, at ~2.9% each, and
+ * will eventually pass. That is accepted, for three reasons:
+ *
+ *   1. A user holding a correct written phrase must ALWAYS be able to pass. Any
+ *      hard cap risks locking a legitimate user out of the one signal that says
+ *      their funds are recoverable — a worse failure than a weak signal.
+ *   2. There is no third-party adversary. `backupVerified` authorises nothing;
+ *      it only silences a "you have not backed this up" warning. The only person
+ *      who benefits from faking it is the device owner, who is defeating their
+ *      own safety net, and who already has a one-tap "Skip for now".
+ *   3. Grinding is strictly more work than complying. ~34 attempts, each several
+ *      taps plus a bounce back to the phrase they are pretending to have copied.
+ *
+ * A cooldown would also not survive the failure path as designed: `onFailed`
+ * unmounts the challenge by design, so any in-memory counter resets, and making
+ * it stick would mean new persisted state on a security path. Flagged by Codex
+ * across two review rounds and knowingly retained.
  *
  * ## Duplicate words (DR-12) — still preserved
  *

--- a/src/components/wallet/mnemonicQuiz.ts
+++ b/src/components/wallet/mnemonicQuiz.ts
@@ -1,47 +1,118 @@
 /**
- * Pure helpers backing the recovery-phrase verification quiz (TASK-45, DR-12).
+ * Pure helpers backing the recovery-phrase verification challenge
+ * (TASK-45 / DR-12, strengthened by TASK-226).
  *
- * ## Why this exists
+ * ## The challenge model
  *
- * The quiz used to resolve a tapped word with `mnemonicWords.indexOf(word)`,
- * which always returns the FIRST occurrence, and disabled the option chips by
- * word VALUE. Roughly 14% of 25-word Algorand mnemonics repeat at least one
- * word, so if a repeated word's LATER position was one of the verification
- * targets the tap resolved to a position that wasn't a target, nothing was
- * selected, and the user was hard-stuck in onboarding with no way forward.
+ * One question at a time, and the question fixes the SLOT: "which word is #7?".
+ * The user picks from {@link CHALLENGE_OPTION_COUNT} chips, exactly one of which
+ * is the real word for that position. A wrong pick is a real failure.
  *
- * Everything here is therefore **position-indexed**: every option carries the
- * index it came from, selections record which option index filled which slot,
- * and chips are disabled by index rather than by value.
+ * This replaces the original auto-routing board, where a tapped chip was sent to
+ * whichever slot it belonged to. That made a wrong tap a silent no-op, and since
+ * the chip bank held only the phrase's own words, the quiz could be passed by
+ * tapping chips until the slots filled — without ever having written the phrase
+ * down (TASK-226).
+ *
+ * ## Decoys
+ *
+ * Wrong-answer chips are drawn from the BIP-39 English wordlist, and
+ * {@link PHRASE_DECOY_COUNT} of them are drawn from the phrase's OWN other
+ * words. That second part is deliberate and load-bearing in both directions:
+ *
+ *   - If every decoy were a random BIP-39 word, the real answer would be the
+ *     only option belonging to the phrase. Anyone who remembers the phrase's
+ *     word SET but not its order could pass every question by picking the
+ *     familiar word.
+ *   - If every decoy came from the phrase, the union of the option sets would
+ *     effectively display the phrase's whole word set to a shoulder-surfer who
+ *     never saw the display step.
+ *
+ * Mixing gives a shoulder-surfer no way to tell real words from decoys, while
+ * still denying the "pick the familiar one" shortcut.
+ *
+ * Every option is a plain lowercase BIP-39 word rendered by the same chip
+ * component, so decoys are presentationally indistinguishable from the answer,
+ * and the answer's slot in the option array is uniformly random.
+ *
+ * ## Retry policy
+ *
+ * A wrong pick costs a mistake and re-presents the SAME position with a FRESH
+ * option set — re-presenting the same set would let the user eliminate their way
+ * to the answer. Progress on already-answered positions is kept, so a fat-finger
+ * does not throw away a correct run.
+ *
+ * After {@link MAX_MISTAKES} tolerated mistakes the next wrong pick discards the
+ * whole attempt: brand-new positions, brand-new option sets, mistake counter
+ * back to zero, and the host is told via `onFailed` so onboarding can send the
+ * user back to re-read the phrase. There is deliberately NO permanent lockout —
+ * a user holding a correct written phrase must always be able to pass — so the
+ * bound on blind guessing is friction, not refusal. See MnemonicVerification for
+ * the numbers.
+ *
+ * ## Duplicate words (DR-12) — still preserved
+ *
+ * Roughly 14% of 25-word Algorand phrases repeat a word. The original quiz
+ * resolved a tapped word with `indexOf` (always the FIRST occurrence) and
+ * disabled chips by VALUE, so a repeated word's later position could be
+ * unanswerable and the user was hard-stuck in onboarding.
+ *
+ * The directed model removes that class of bug structurally: a question names a
+ * position, the answer is compared by value against the word AT that position,
+ * and {@link buildChallengeOptions} guarantees exactly one chip carries that
+ * value. A repeated word is therefore answerable at every one of its positions,
+ * and no two chips are ever ambiguous.
  *
  * ## Security note
  *
- * These helpers only ever reorder / compare words the user is already being
- * shown on the same screen. They never persist, log, or transmit anything.
- * `Math.random` is adequate for the presentation ordering here — it is not used
- * to generate, derive, or protect key material.
+ * These helpers only reorder / compare words the user is already being shown on
+ * the same screen. They never persist, log, or transmit anything. `Math.random`
+ * is adequate for presentation ordering and decoy sampling — it is not used to
+ * generate, derive, or protect key material.
  */
 
-/** A single tappable word chip, tied to its position in the phrase. */
-export interface WordOption {
-  /** The word as it appears in the phrase. */
-  word: string;
-  /** Zero-based position of this word in the original phrase. */
-  index: number;
-}
+import { BIP39Utils } from '@/utils/bip39';
 
-/** Which option chip filled a given verification slot. */
-export interface WordSelection {
-  word: string;
-  /** The `WordOption.index` that was consumed — used to disable that chip. */
-  optionIndex: number;
-}
-
-/** Slot position (zero-based) -> the selection that filled it. */
-export type WordSelections = Record<number, WordSelection>;
-
-/** Number of words the user is asked to confirm. */
+/** How many positions the user must confirm to pass. */
 export const VERIFICATION_WORD_COUNT = 3;
+
+/** Chips shown per question: 1 correct word + decoys. */
+export const CHALLENGE_OPTION_COUNT = 8;
+
+/** How many decoys are drawn from the phrase's own other words (see above). */
+export const PHRASE_DECOY_COUNT = 3;
+
+/**
+ * Wrong picks tolerated within one attempt. The NEXT wrong pick after this many
+ * discards the attempt and starts over with fresh positions.
+ */
+export const MAX_MISTAKES = 3;
+
+/** Source of randomness, injectable so tests can be deterministic. */
+export type Rng = () => number;
+
+/** One attempt at the challenge sequence. */
+export interface QuizAttempt {
+  /** Phrase positions to be asked, ascending. */
+  readonly positions: number[];
+  /** Index into {@link positions} of the question currently on screen. */
+  readonly currentIndex: number;
+  /** Chips for the current question, already shuffled. */
+  readonly options: string[];
+  /** Wrong picks so far in this attempt. */
+  readonly mistakes: number;
+}
+
+/** Outcome of answering the question currently on screen. */
+export type QuizAnswer =
+  /** Right, and that was the last question. */
+  | { status: 'verified' }
+  /** Right; move on to the next question. */
+  | { status: 'advanced'; attempt: QuizAttempt }
+  /** Wrong; same position, fresh options, mistake counted. */
+  | { status: 'retry'; attempt: QuizAttempt }
+  /** Wrong once too often; the attempt was discarded and rebuilt. */
+  | { status: 'reset'; attempt: QuizAttempt };
 
 /** Split a phrase into normalized words (collapses stray whitespace). */
 export function splitMnemonic(mnemonic: string): string[] {
@@ -49,21 +120,13 @@ export function splitMnemonic(mnemonic: string): string[] {
 }
 
 /**
- * Build the position-indexed option chips for a phrase, in phrase order.
- * Callers shuffle with {@link shuffleWordOptions}.
- */
-export function buildWordOptions(mnemonic: string): WordOption[] {
-  return splitMnemonic(mnemonic).map((word, index) => ({ word, index }));
-}
-
-/**
  * Unbiased Fisher-Yates shuffle returning a NEW array (the old
  * `sort(() => Math.random() - 0.5)` was both biased and comparator-unstable).
  */
-export function shuffleWordOptions(options: WordOption[]): WordOption[] {
-  const shuffled = [...options];
+export function shuffle<T>(items: T[], rng: Rng = Math.random): T[] {
+  const shuffled = [...items];
   for (let i = shuffled.length - 1; i > 0; i--) {
-    const j = Math.floor(Math.random() * (i + 1));
+    const j = Math.floor(rng() * (i + 1));
     [shuffled[i], shuffled[j]] = [shuffled[j], shuffled[i]];
   }
   return shuffled;
@@ -76,7 +139,8 @@ export function shuffleWordOptions(options: WordOption[]): WordOption[] {
  */
 export function pickVerificationPositions(
   total: number,
-  count: number = VERIFICATION_WORD_COUNT
+  count: number = VERIFICATION_WORD_COUNT,
+  rng: Rng = Math.random
 ): number[] {
   if (total <= 0) return [];
   if (total <= count) {
@@ -84,114 +148,163 @@ export function pickVerificationPositions(
   }
   const positions = new Set<number>();
   while (positions.size < count) {
-    positions.add(Math.floor(Math.random() * total));
+    positions.add(Math.floor(rng() * total));
   }
   return [...positions].sort((a, b) => a - b);
 }
 
-/** The set of option indices already consumed by a selection. */
-export function usedOptionIndices(selections: WordSelections): Set<number> {
-  return new Set(
-    Object.values(selections).map((selection) => selection.optionIndex)
-  );
-}
-
 /**
- * Decide which verification slot a tapped chip should fill.
+ * Build the chips for "which word is #position?".
  *
- * DR-12: resolution is by INDEX first. The value fallback exists purely so a
- * repeated word can be answered from *either* of its chips — without it, a user
- * facing a duplicate would have to guess which of two identical-looking chips
- * is the "live" one, and half the time the tap would do nothing.
- *
- * Returns `null` when the tap is a no-op (chip already used, or no matching
- * empty slot).
+ * Invariants (all pinned by tests):
+ *   - exactly one chip equals `words[position]`
+ *   - no duplicate chips, so no two chips are ever ambiguous (DR-12)
+ *   - decoys are BIP-39 words, a bounded number of them from the phrase itself
+ *   - order is uniformly shuffled
  */
-export function resolveVerificationTarget(
-  option: WordOption,
-  verificationWords: number[],
-  selections: WordSelections,
-  mnemonicWords: string[]
-): number | null {
-  // A chip may only ever be consumed once.
-  if (usedOptionIndices(selections).has(option.index)) {
-    return null;
-  }
+export function buildChallengeOptions(
+  words: string[],
+  position: number,
+  optionCount: number = CHALLENGE_OPTION_COUNT,
+  rng: Rng = Math.random
+): string[] {
+  const answer = words[position];
+  if (answer === undefined || optionCount <= 0) return [];
 
-  // Exact positional match — the common case, and the only one that can occur
-  // for a phrase with no repeated words.
-  if (
-    verificationWords.includes(option.index) &&
-    selections[option.index] === undefined
-  ) {
-    return option.index;
-  }
+  const chosen = new Set<string>([answer]);
 
-  // Duplicate-word fallback: fill the first still-empty target slot that
-  // expects this exact word.
-  const fallback = verificationWords.find(
-    (position) =>
-      selections[position] === undefined &&
-      mnemonicWords[position] === option.word
+  // Decoys from the phrase's own other words. Distinct values only, and never
+  // the answer itself — otherwise a repeated word would produce two chips that
+  // are both "correct", which is exactly the ambiguity DR-12 outlawed.
+  const phraseDecoyLimit = Math.min(optionCount, 1 + PHRASE_DECOY_COUNT);
+  const phrasePool = shuffle(
+    [...new Set(words)].filter((word) => word !== answer),
+    rng
   );
+  for (const word of phrasePool) {
+    if (chosen.size >= phraseDecoyLimit) break;
+    chosen.add(word);
+  }
 
-  return fallback === undefined ? null : fallback;
+  // Remainder from the wider BIP-39 wordlist. `Set` semantics mean a sample that
+  // collides with the answer or an existing decoy is simply skipped, so the
+  // "exactly one correct chip" invariant holds without a special case.
+  const listLength = BIP39Utils.getWordlistLength();
+  const maxSamples = optionCount * 64;
+  for (let i = 0; chosen.size < optionCount && i < maxSamples; i++) {
+    const word = BIP39Utils.getWordAtIndex(Math.floor(rng() * listLength));
+    if (word) chosen.add(word);
+  }
+
+  // Defensive top-up: guarantees termination with a full option set even if the
+  // injected rng is degenerate (e.g. a test stub that always returns 0).
+  for (let i = 0; chosen.size < optionCount && i < listLength; i++) {
+    const word = BIP39Utils.getWordAtIndex(i);
+    if (word) chosen.add(word);
+  }
+
+  return shuffle([...chosen], rng);
 }
 
-/** Apply a tap, returning a NEW selections object (or the same one on no-op). */
-export function selectWordOption(
-  option: WordOption,
-  verificationWords: number[],
-  selections: WordSelections,
-  mnemonicWords: string[]
-): WordSelections {
-  const target = resolveVerificationTarget(
-    option,
-    verificationWords,
-    selections,
-    mnemonicWords
+/** Start a fresh attempt: new positions, new options, no mistakes. */
+export function startQuizAttempt(
+  words: string[],
+  rng: Rng = Math.random
+): QuizAttempt {
+  const positions = pickVerificationPositions(
+    words.length,
+    VERIFICATION_WORD_COUNT,
+    rng
   );
-  if (target === null) return selections;
   return {
-    ...selections,
-    [target]: { word: option.word, optionIndex: option.index },
+    positions,
+    currentIndex: 0,
+    options:
+      positions.length > 0
+        ? buildChallengeOptions(
+            words,
+            positions[0],
+            CHALLENGE_OPTION_COUNT,
+            rng
+          )
+        : [],
+    mistakes: 0,
   };
 }
 
-/** Clear one slot, freeing the chip that filled it. */
-export function clearWordSelection(
-  position: number,
-  selections: WordSelections
-): WordSelections {
-  if (selections[position] === undefined) return selections;
-  const next = { ...selections };
-  delete next[position];
-  return next;
-}
-
-/** True once every target slot has a word in it. */
-export function isVerificationComplete(
-  verificationWords: number[],
-  selections: WordSelections
-): boolean {
-  return (
-    verificationWords.length > 0 &&
-    verificationWords.every((position) => selections[position] !== undefined)
-  );
+/** The phrase position currently being asked, or `null` if there is none. */
+export function currentPosition(attempt: QuizAttempt): number | null {
+  const position = attempt.positions[attempt.currentIndex];
+  return position === undefined ? null : position;
 }
 
 /**
- * True when every target slot holds the correct word. Compares by VALUE, which
- * is correct: a duplicate word answered from either of its chips is still the
- * right word for that position.
+ * Wrong picks still tolerated before the attempt is discarded. Zero means the
+ * next wrong pick restarts the challenge.
  */
-export function verifySelections(
-  verificationWords: number[],
-  selections: WordSelections,
-  mnemonicWords: string[]
-): boolean {
-  if (!isVerificationComplete(verificationWords, selections)) return false;
-  return verificationWords.every(
-    (position) => selections[position]?.word === mnemonicWords[position]
-  );
+export function remainingMistakes(attempt: QuizAttempt): number {
+  return Math.max(0, MAX_MISTAKES - attempt.mistakes);
+}
+
+/**
+ * Answer the question currently on screen.
+ *
+ * `picked` must be one of `attempt.options`; anything else is treated as a wrong
+ * answer rather than silently ignored, so there is no "off-board" path to a pass.
+ */
+export function answerCurrentChallenge(
+  attempt: QuizAttempt,
+  words: string[],
+  picked: string,
+  rng: Rng = Math.random
+): QuizAnswer {
+  const position = currentPosition(attempt);
+  if (position === null) {
+    // No question is live — never a pass; rebuild rather than dead-end.
+    return { status: 'reset', attempt: startQuizAttempt(words, rng) };
+  }
+
+  const isCorrect =
+    attempt.options.includes(picked) && picked === words[position];
+
+  if (isCorrect) {
+    const nextIndex = attempt.currentIndex + 1;
+    if (nextIndex >= attempt.positions.length) {
+      return { status: 'verified' };
+    }
+    return {
+      status: 'advanced',
+      attempt: {
+        ...attempt,
+        currentIndex: nextIndex,
+        options: buildChallengeOptions(
+          words,
+          attempt.positions[nextIndex],
+          CHALLENGE_OPTION_COUNT,
+          rng
+        ),
+      },
+    };
+  }
+
+  const mistakes = attempt.mistakes + 1;
+  if (mistakes > MAX_MISTAKES) {
+    return { status: 'reset', attempt: startQuizAttempt(words, rng) };
+  }
+
+  // Same position, FRESH options — re-presenting the same set would let the user
+  // eliminate their way to the answer.
+  return {
+    status: 'retry',
+    attempt: {
+      ...attempt,
+      mistakes,
+      options: buildChallengeOptions(
+        words,
+        position,
+        CHALLENGE_OPTION_COUNT,
+        rng
+      ),
+    },
+  };
 }

--- a/src/components/wallet/mnemonicQuiz.ts
+++ b/src/components/wallet/mnemonicQuiz.ts
@@ -77,8 +77,10 @@
  *      it only silences a "you have not backed this up" warning. The only person
  *      who benefits from faking it is the device owner, who is defeating their
  *      own safety net, and who already has a one-tap "Skip for now".
- *   3. Grinding is strictly more work than complying. ~34 attempts, each several
- *      taps plus a bounce back to the phrase they are pretending to have copied.
+ *   3. Grinding is strictly more work than complying. ~128 attempts blind, or
+ *      ~16 for someone who has memorised the words but not their order — each
+ *      several taps plus a bounce back to the phrase they are pretending to have
+ *      copied. See {@link MAX_MISTAKES} for the arithmetic.
  *
  * A cooldown would also not survive the failure path as designed: `onFailed`
  * unmounts the challenge by design, so any in-memory counter resets, and making
@@ -120,8 +122,27 @@ export const PHRASE_DECOY_COUNT = 3;
 /**
  * Wrong picks tolerated within one attempt. The NEXT wrong pick after this many
  * discards the attempt and starts over with fresh positions.
+ *
+ * This is the dominant security lever, so the value is not arbitrary. Because
+ * the option set for a position is stable (see {@link createOptionProvider}),
+ * every tolerated mistake is an elimination, and a guesser needs
+ * {@link VERIFICATION_WORD_COUNT} correct picks with at most this many failures
+ * anywhere in the run. Drawing without replacement makes each pick worth exactly
+ * `1 / candidates`, so the per-attempt pass probability is
+ * `C(MAX_MISTAKES + 3, 3) / candidates ** 3`:
+ *
+ * | tolerated | blind (8 candidates) | knows the word set (4 candidates) |
+ * | --------- | -------------------- | --------------------------------- |
+ * | 3         | 3.9%  (~26 attempts) | 31.3% (~3 attempts)               |
+ * | 1         | 0.78% (~128 attempts)| 6.3%  (~16 attempts)              |
+ *
+ * Three tolerated mistakes made the challenge cheap for someone who remembers
+ * the phrase's words but not their order — exactly the user it must stop, since
+ * word order is what makes a phrase recoverable. One tolerated mistake still
+ * forgives a fat-finger, and the penalty for a second is a restart, never a
+ * lockout.
  */
-export const MAX_MISTAKES = 3;
+export const MAX_MISTAKES = 1;
 
 /** Source of randomness, injectable so tests can be deterministic. */
 export type Rng = () => number;
@@ -269,11 +290,11 @@ export type OptionProvider = (position: number) => string[];
  * already see. Only the display ORDER is reshuffled between presentations, and a
  * uniform shuffle of an unchanged set carries no information.
  *
- * Elimination within the mistake budget is then the residual, and it is bounded
- * and cheap: drawing without replacement from a fixed set of
- * {@link CHALLENGE_OPTION_COUNT} makes every guess worth exactly
- * `1 / CHALLENGE_OPTION_COUNT` no matter how many chips have already been ruled
- * out, so a blind guesser gains nothing per question by spending mistakes.
+ * Elimination within the mistake budget is then the residual. Drawing without
+ * replacement from a fixed set makes every guess worth exactly `1 / candidates`
+ * no matter how many chips have already been ruled out, so spending a mistake
+ * buys a guesser nothing per question — but it does buy them another guess, so
+ * the budget itself is what has to be small. See {@link MAX_MISTAKES}.
  *
  * The cache lives as long as the caller holds the provider — one component
  * mount. It holds only words that are already on screen.

--- a/src/components/wallet/mnemonicQuiz.ts
+++ b/src/components/wallet/mnemonicQuiz.ts
@@ -37,10 +37,12 @@
  *
  * ## Retry policy
  *
- * A wrong pick costs a mistake and re-presents the SAME position with a FRESH
- * option set — re-presenting the same set would let the user eliminate their way
- * to the answer. Progress on already-answered positions is kept, so a fat-finger
- * does not throw away a correct run.
+ * A wrong pick costs a mistake and re-presents the SAME position with the SAME
+ * option set in a reshuffled order. The set is deliberately stable — see
+ * {@link createOptionProvider} for the cross-board intersection oracle that
+ * rebuilding it would open, and for why elimination inside the mistake budget
+ * gains a blind guesser nothing. Progress on already-answered positions is kept,
+ * so a fat-finger does not throw away a correct run.
  *
  * After {@link MAX_MISTAKES} tolerated mistakes the next wrong pick discards the
  * whole attempt: brand-new positions, brand-new option sets, mistake counter
@@ -206,9 +208,66 @@ export function buildChallengeOptions(
   return shuffle([...chosen], rng);
 }
 
-/** Start a fresh attempt: new positions, new options, no mistakes. */
+/**
+ * Returns the canonical option SET for a phrase position.
+ *
+ * Every presentation of a given position must draw from the SAME set — see
+ * {@link createOptionProvider} for why that is a security property and not an
+ * optimisation.
+ */
+export type OptionProvider = (position: number) => string[];
+
+/**
+ * Build an option provider that memoises each position's board.
+ *
+ * ## Why this exists — the cross-board intersection oracle
+ *
+ * The first cut of this challenge rebuilt a FRESH board every time a position
+ * was re-asked, on the theory that a stable board could be eliminated one chip
+ * at a time. That was backwards: the right answer is the one word GUARANTEED to
+ * appear on every board for a position, while the decoys are resampled (the
+ * BIP-39 ones from 2048 words, so they essentially never recur). Intersecting
+ * two boards for the same position therefore yields the answer directly. An
+ * attacker could deliberately answer wrong once, intersect, and then answer
+ * correctly — inside the mistake budget, for all three questions.
+ *
+ * Memoising the set closes that channel completely: intersecting two
+ * presentations returns the set itself, which is exactly what the user could
+ * already see. Only the display ORDER is reshuffled between presentations, and a
+ * uniform shuffle of an unchanged set carries no information.
+ *
+ * Elimination within the mistake budget is then the residual, and it is bounded
+ * and cheap: drawing without replacement from a fixed set of
+ * {@link CHALLENGE_OPTION_COUNT} makes every guess worth exactly
+ * `1 / CHALLENGE_OPTION_COUNT` no matter how many chips have already been ruled
+ * out, so a blind guesser gains nothing per question by spending mistakes.
+ *
+ * The cache lives as long as the caller holds the provider — one component
+ * mount. It holds only words that are already on screen.
+ */
+export function createOptionProvider(
+  words: string[],
+  rng: Rng = Math.random
+): OptionProvider {
+  const cache = new Map<number, string[]>();
+  return (position: number) => {
+    const cached = cache.get(position);
+    if (cached) return cached;
+    const options = buildChallengeOptions(
+      words,
+      position,
+      CHALLENGE_OPTION_COUNT,
+      rng
+    );
+    cache.set(position, options);
+    return options;
+  };
+}
+
+/** Start a fresh attempt: new positions, no mistakes. */
 export function startQuizAttempt(
   words: string[],
+  optionsFor: OptionProvider,
   rng: Rng = Math.random
 ): QuizAttempt {
   const positions = pickVerificationPositions(
@@ -219,15 +278,7 @@ export function startQuizAttempt(
   return {
     positions,
     currentIndex: 0,
-    options:
-      positions.length > 0
-        ? buildChallengeOptions(
-            words,
-            positions[0],
-            CHALLENGE_OPTION_COUNT,
-            rng
-          )
-        : [],
+    options: positions.length > 0 ? shuffle(optionsFor(positions[0]), rng) : [],
     mistakes: 0,
   };
 }
@@ -256,12 +307,16 @@ export function answerCurrentChallenge(
   attempt: QuizAttempt,
   words: string[],
   picked: string,
+  optionsFor: OptionProvider,
   rng: Rng = Math.random
 ): QuizAnswer {
   const position = currentPosition(attempt);
   if (position === null) {
     // No question is live — never a pass; rebuild rather than dead-end.
-    return { status: 'reset', attempt: startQuizAttempt(words, rng) };
+    return {
+      status: 'reset',
+      attempt: startQuizAttempt(words, optionsFor, rng),
+    };
   }
 
   const isCorrect =
@@ -277,34 +332,28 @@ export function answerCurrentChallenge(
       attempt: {
         ...attempt,
         currentIndex: nextIndex,
-        options: buildChallengeOptions(
-          words,
-          attempt.positions[nextIndex],
-          CHALLENGE_OPTION_COUNT,
-          rng
-        ),
+        options: shuffle(optionsFor(attempt.positions[nextIndex]), rng),
       },
     };
   }
 
   const mistakes = attempt.mistakes + 1;
   if (mistakes > MAX_MISTAKES) {
-    return { status: 'reset', attempt: startQuizAttempt(words, rng) };
+    return {
+      status: 'reset',
+      attempt: startQuizAttempt(words, optionsFor, rng),
+    };
   }
 
-  // Same position, FRESH options — re-presenting the same set would let the user
-  // eliminate their way to the answer.
+  // Same position, same SET, reshuffled order. The set must not be rebuilt: the
+  // answer is the only word guaranteed to survive a rebuild, so two boards for
+  // one position would intersect to it. See createOptionProvider.
   return {
     status: 'retry',
     attempt: {
       ...attempt,
       mistakes,
-      options: buildChallengeOptions(
-        words,
-        position,
-        CHALLENGE_OPTION_COUNT,
-        rng
-      ),
+      options: shuffle(optionsFor(position), rng),
     },
   };
 }

--- a/src/components/wallet/mnemonicQuiz.ts
+++ b/src/components/wallet/mnemonicQuiz.ts
@@ -66,7 +66,7 @@
  * ## Attempts are NOT capped — a deliberate decision
  *
  * There is no permanent lockout, no persisted failure counter and no cooldown.
- * A blind guesser can therefore keep starting new attempts, at ~2.9% each, and
+ * A blind guesser can therefore keep starting new attempts, at ~0.78% each, and
  * will eventually pass. That is accepted, for three reasons:
  *
  *   1. A user holding a correct written phrase must ALWAYS be able to pass. Any

--- a/src/screens/account/__tests__/CreateAccountScreen.test.tsx
+++ b/src/screens/account/__tests__/CreateAccountScreen.test.tsx
@@ -75,16 +75,9 @@ jest.mock('@/components/wallet/MnemonicDisplay', () => {
 
 import { Alert } from 'react-native';
 import CreateAccountScreen from '../CreateAccountScreen';
+import { completeQuiz } from '@/__tests__/fixtures/mnemonicQuiz';
 
-const QUIZ_TARGETS = [1, 4, 6];
-const PHRASE_LENGTH = MOCK_MNEMONIC.split(' ').length;
-
-function installDeterministicQuiz() {
-  const queue = QUIZ_TARGETS.map((pos) => pos / PHRASE_LENGTH);
-  jest
-    .spyOn(Math, 'random')
-    .mockImplementation(() => (queue.length > 0 ? queue.shift()! : 0));
-}
+const MOCK_WORDS = MOCK_MNEMONIC.split(' ');
 
 function pressAlertButton(label: string) {
   const spy = Alert.alert as unknown as jest.Mock;
@@ -102,7 +95,6 @@ function pressAlertButton(label: string) {
 
 beforeEach(() => {
   jest.spyOn(Alert, 'alert').mockImplementation(() => {});
-  installDeterministicQuiz();
 });
 
 afterEach(() => {
@@ -133,12 +125,7 @@ describe('CreateAccountScreen — backupVerified carrier (DR-11)', () => {
     const screen = renderAtBackupStep();
     fireEvent.press(screen.getByTestId('backup-continue'));
 
-    for (const index of QUIZ_TARGETS) {
-      fireEvent.press(
-        screen.getByTestId(`backup-verification-option-${index}`)
-      );
-    }
-    fireEvent.press(screen.getByTestId('backup-verification-verify'));
+    completeQuiz(screen, 'backup-verification', MOCK_WORDS);
 
     // Success is confirmed through an alert before the import runs.
     pressAlertButton('Continue');

--- a/src/screens/onboarding/CreateWalletScreen.tsx
+++ b/src/screens/onboarding/CreateWalletScreen.tsx
@@ -198,6 +198,10 @@ export default function CreateWalletScreen({ navigation }: Props) {
             <MnemonicVerification
               mnemonic={mnemonic}
               onVerified={() => goToSecuritySetup(true)}
+              // TASK-226: the challenge restarts itself after too many wrong
+              // answers; put the phrase back on screen so the user can actually
+              // write it down rather than grinding guesses against the board.
+              onFailed={() => setStep('display')}
               onSkip={handleSkipVerification}
               testIDPrefix="create-wallet-verification"
             />

--- a/src/screens/onboarding/__tests__/CreateWalletScreen.test.tsx
+++ b/src/screens/onboarding/__tests__/CreateWalletScreen.test.tsx
@@ -94,6 +94,11 @@ jest.mock('@/components/common/GlassButton', () => {
 
 import { Alert } from 'react-native';
 import CreateWalletScreen from '../CreateWalletScreen';
+import {
+  completeQuiz,
+  pressWrongQuizOption,
+} from '@/__tests__/fixtures/mnemonicQuiz';
+import { MAX_MISTAKES } from '@/components/wallet/mnemonicQuiz';
 
 type Listener = (event: {
   preventDefault: () => void;
@@ -134,21 +139,7 @@ function makeNavigation() {
   };
 }
 
-/**
- * Force the quiz onto a known target triple. `pickVerificationPositions` calls
- * `Math.floor(Math.random() * total)`, so feeding `pos / total` yields exactly
- * `pos`; the shuffle consumes whatever is left. The spy stays installed for the
- * whole test because the quiz only mounts after a press, well after render().
- */
-const QUIZ_TARGETS = [1, 4, 6];
-const PHRASE_LENGTH = MOCK_MNEMONIC.split(' ').length;
-
-function installDeterministicQuiz() {
-  const queue = QUIZ_TARGETS.map((pos) => pos / PHRASE_LENGTH);
-  jest
-    .spyOn(Math, 'random')
-    .mockImplementation(() => (queue.length > 0 ? queue.shift()! : 0));
-}
+const MOCK_WORDS = MOCK_MNEMONIC.split(' ');
 
 /** Press the button with the given text in the most recent Alert.alert call. */
 function pressAlertButton(label: string) {
@@ -167,7 +158,6 @@ function pressAlertButton(label: string) {
 
 beforeEach(() => {
   jest.spyOn(Alert, 'alert').mockImplementation(() => {});
-  installDeterministicQuiz();
 });
 
 afterEach(() => {
@@ -191,12 +181,9 @@ describe('CreateWalletScreen — verification carrier (DR-11)', () => {
     fireEvent.press(screen.getByTestId('saved-phrase-button'));
     expect(navigation.navigate).not.toHaveBeenCalled();
 
-    for (const index of QUIZ_TARGETS) {
-      fireEvent.press(
-        screen.getByTestId(`create-wallet-verification-option-${index}`)
-      );
-    }
-    fireEvent.press(screen.getByTestId('create-wallet-verification-verify'));
+    // Answer the directed challenge the way a user with a written copy would
+    // (TASK-226: there is no "fill any slot from any chip" board any more).
+    completeQuiz(screen, 'create-wallet-verification', MOCK_WORDS);
 
     expect(navigation.navigate).toHaveBeenCalledTimes(1);
     expect(navigation.navigate).toHaveBeenCalledWith('SecuritySetup', {
@@ -239,6 +226,37 @@ describe('CreateWalletScreen — verification carrier (DR-11)', () => {
     pressAlertButton('Cancel');
 
     expect(navigation.navigate).not.toHaveBeenCalled();
+  });
+
+  it('never navigates on wrong answers, and sends the user back to the phrase', () => {
+    // TASK-226: a wrong pick is a real failure. Exhausting the mistake budget
+    // returns the user to the phrase rather than letting them grind guesses,
+    // and nothing is ever marked verified along the way.
+    const navigation = makeNavigation();
+    const screen = render(
+      <CreateWalletScreen navigation={navigation as never} />
+    );
+
+    fireEvent.press(screen.getByTestId('saved-phrase-button'));
+    for (let mistake = 0; mistake <= MAX_MISTAKES; mistake++) {
+      pressWrongQuizOption(screen, 'create-wallet-verification', MOCK_WORDS);
+    }
+
+    expect(navigation.navigate).not.toHaveBeenCalled();
+    // Back on the phrase step, with the quiz gone.
+    expect(screen.queryByTestId('create-wallet-verification-root')).toBeNull();
+    expect(screen.getByTestId('mnemonic-display')).toHaveTextContent(
+      MOCK_MNEMONIC
+    );
+
+    // ...and the legitimate user can still get through afterwards.
+    fireEvent.press(screen.getByTestId('saved-phrase-button'));
+    completeQuiz(screen, 'create-wallet-verification', MOCK_WORDS);
+    expect(navigation.navigate).toHaveBeenCalledWith('SecuritySetup', {
+      mnemonic: MOCK_MNEMONIC,
+      source: 'create',
+      backupVerified: true,
+    });
   });
 });
 

--- a/src/screens/wallet/VerifyBackupScreen.tsx
+++ b/src/screens/wallet/VerifyBackupScreen.tsx
@@ -144,6 +144,20 @@ export default function VerifyBackupScreen() {
     }
   }, [markBackupVerified, navigation, target]);
 
+  // TASK-226: the challenge restarts itself after too many wrong answers. The
+  // onboarding hosts send the user back to the phrase at that point; this screen
+  // has no phrase step to return to, so it leaves instead. That is friction, not
+  // a lockout — the entry point is still there, and re-entering re-reads the
+  // phrase from the gated key store.
+  const handleFailed = useCallback(() => {
+    setMnemonic('');
+    Alert.alert(
+      'Too many incorrect answers',
+      'Check your written recovery phrase and try again from Settings.',
+      [{ text: 'OK', onPress: () => navigation.goBack() }]
+    );
+  }, [navigation]);
+
   return (
     <NFTBackground>
       <SafeAreaView style={styles.container} edges={['top', 'bottom']}>
@@ -178,6 +192,7 @@ export default function VerifyBackupScreen() {
             <MnemonicVerification
               mnemonic={mnemonic}
               onVerified={handleVerified}
+              onFailed={handleFailed}
               testIDPrefix="verify-backup"
             />
           )}

--- a/src/screens/wallet/__tests__/VerifyBackupScreen.test.tsx
+++ b/src/screens/wallet/__tests__/VerifyBackupScreen.test.tsx
@@ -12,7 +12,7 @@
  */
 
 import React from 'react';
-import { render, fireEvent, waitFor, act } from '@testing-library/react-native';
+import { render, waitFor, act } from '@testing-library/react-native';
 
 const MOCK_MNEMONIC =
   'abandon ability able abandon absent absorb abandon abstract';
@@ -79,16 +79,13 @@ jest.mock('@/components/common/UniversalHeader', () => {
 
 import { Alert } from 'react-native';
 import VerifyBackupScreen from '../VerifyBackupScreen';
+import {
+  completeQuiz,
+  pressWrongQuizOption,
+} from '@/__tests__/fixtures/mnemonicQuiz';
+import { MAX_MISTAKES } from '@/components/wallet/mnemonicQuiz';
 
-const QUIZ_TARGETS = [1, 4, 6];
-const PHRASE_LENGTH = MOCK_MNEMONIC.split(' ').length;
-
-function installDeterministicQuiz() {
-  const queue = QUIZ_TARGETS.map((pos) => pos / PHRASE_LENGTH);
-  jest
-    .spyOn(Math, 'random')
-    .mockImplementation(() => (queue.length > 0 ? queue.shift()! : 0));
-}
+const MOCK_WORDS = MOCK_MNEMONIC.split(' ');
 
 beforeEach(() => {
   mockAccounts = [
@@ -98,7 +95,6 @@ beforeEach(() => {
   mockActiveAccountId = 'acc-a';
   mockRouteParams = { accountAddress: 'ADDRESS_A' };
   jest.spyOn(Alert, 'alert').mockImplementation(() => {});
-  installDeterministicQuiz();
 });
 
 afterEach(() => {
@@ -122,10 +118,11 @@ describe('VerifyBackupScreen', () => {
   it('marks the account whose phrase was actually shown', async () => {
     const screen = await renderLoaded();
 
-    for (const index of QUIZ_TARGETS) {
-      fireEvent.press(screen.getByTestId(`verify-backup-option-${index}`));
-    }
-    fireEvent.press(screen.getByTestId('verify-backup-verify'));
+    completeQuiz(screen, 'verify-backup', MOCK_WORDS);
+    // Success kicks off an async store write which then clears the phrase from
+    // screen state, and the challenge rebuilds itself in response. Flush that
+    // continuation inside act() so the rebuild is not an unwrapped update.
+    await act(async () => {});
 
     await waitFor(() => expect(mockMarkBackupVerified).toHaveBeenCalled());
     expect(mockMarkBackupVerified).toHaveBeenCalledWith('acc-a');
@@ -149,10 +146,11 @@ describe('VerifyBackupScreen', () => {
     expect(mockGetMnemonic).toHaveBeenCalledTimes(1);
     expect(mockGetMnemonic).not.toHaveBeenCalledWith('ADDRESS_B');
 
-    for (const index of QUIZ_TARGETS) {
-      fireEvent.press(screen.getByTestId(`verify-backup-option-${index}`));
-    }
-    fireEvent.press(screen.getByTestId('verify-backup-verify'));
+    completeQuiz(screen, 'verify-backup', MOCK_WORDS);
+    // Success kicks off an async store write which then clears the phrase from
+    // screen state, and the challenge rebuilds itself in response. Flush that
+    // continuation inside act() so the rebuild is not an unwrapped update.
+    await act(async () => {});
 
     await waitFor(() => expect(mockMarkBackupVerified).toHaveBeenCalled());
     // Still account A — the one whose phrase is on screen.
@@ -210,10 +208,11 @@ describe('VerifyBackupScreen', () => {
     mockMarkBackupVerified.mockRejectedValueOnce(new Error('write failed'));
     const screen = await renderLoaded();
 
-    for (const index of QUIZ_TARGETS) {
-      fireEvent.press(screen.getByTestId(`verify-backup-option-${index}`));
-    }
-    fireEvent.press(screen.getByTestId('verify-backup-verify'));
+    completeQuiz(screen, 'verify-backup', MOCK_WORDS);
+    // Success kicks off an async store write which then clears the phrase from
+    // screen state, and the challenge rebuilds itself in response. Flush that
+    // continuation inside act() so the rebuild is not an unwrapped update.
+    await act(async () => {});
 
     await waitFor(() =>
       expect(Alert.alert).toHaveBeenCalledWith(
@@ -222,5 +221,26 @@ describe('VerifyBackupScreen', () => {
       )
     );
     expect(mockNavigation.goBack).not.toHaveBeenCalled();
+  });
+
+  it('never marks the account verified on wrong answers (TASK-226)', async () => {
+    const screen = await renderLoaded();
+
+    // Exhaust the mistake budget and then some — this used to be a silent no-op
+    // on an auto-routing board, so the account could be marked backed-up
+    // without the user ever knowing the phrase.
+    for (let mistake = 0; mistake <= MAX_MISTAKES + 2; mistake++) {
+      pressWrongQuizOption(screen, 'verify-backup', MOCK_WORDS);
+    }
+    expect(mockMarkBackupVerified).not.toHaveBeenCalled();
+
+    // A user who does know the phrase is still never locked out.
+    completeQuiz(screen, 'verify-backup', MOCK_WORDS);
+    // Success kicks off an async store write which then clears the phrase from
+    // screen state, and the challenge rebuilds itself in response. Flush that
+    // continuation inside act() so the rebuild is not an unwrapped update.
+    await act(async () => {});
+    await waitFor(() => expect(mockMarkBackupVerified).toHaveBeenCalled());
+    expect(mockMarkBackupVerified).toHaveBeenCalledWith('acc-a');
   });
 });

--- a/src/screens/wallet/__tests__/VerifyBackupScreen.test.tsx
+++ b/src/screens/wallet/__tests__/VerifyBackupScreen.test.tsx
@@ -226,21 +226,27 @@ describe('VerifyBackupScreen', () => {
   it('never marks the account verified on wrong answers (TASK-226)', async () => {
     const screen = await renderLoaded();
 
-    // Exhaust the mistake budget and then some — this used to be a silent no-op
-    // on an auto-routing board, so the account could be marked backed-up
-    // without the user ever knowing the phrase.
-    for (let mistake = 0; mistake <= MAX_MISTAKES + 2; mistake++) {
+    // Exhaust the mistake budget — this used to be a silent no-op on an
+    // auto-routing board, so the account could be marked backed-up without the
+    // user ever knowing the phrase.
+    for (let mistake = 0; mistake <= MAX_MISTAKES; mistake++) {
       pressWrongQuizOption(screen, 'verify-backup', MOCK_WORDS);
     }
-    expect(mockMarkBackupVerified).not.toHaveBeenCalled();
 
-    // A user who does know the phrase is still never locked out.
-    completeQuiz(screen, 'verify-backup', MOCK_WORDS);
-    // Success kicks off an async store write which then clears the phrase from
-    // screen state, and the challenge rebuilds itself in response. Flush that
-    // continuation inside act() so the rebuild is not an unwrapped update.
-    await act(async () => {});
-    await waitFor(() => expect(mockMarkBackupVerified).toHaveBeenCalled());
-    expect(mockMarkBackupVerified).toHaveBeenCalledWith('acc-a');
+    expect(mockMarkBackupVerified).not.toHaveBeenCalled();
+    // This screen has no phrase step to fall back to, so it bounces the user out
+    // rather than letting them grind attempts in place. Friction, not a lockout:
+    // the Settings entry point is still there and re-entering re-reads the
+    // phrase from the gated key store.
+    expect(Alert.alert).toHaveBeenCalledWith(
+      'Too many incorrect answers',
+      expect.any(String),
+      expect.any(Array)
+    );
+
+    const calls = (Alert.alert as unknown as jest.Mock).mock.calls;
+    const buttons = calls[calls.length - 1][2] as { onPress?: () => void }[];
+    act(() => buttons[0].onPress?.());
+    expect(mockNavigation.goBack).toHaveBeenCalled();
   });
 });


### PR DESCRIPTION
## Problem

The verification quiz shipped in TASK-45 (#149) was **passable without ever having written the phrase down**, so `backupVerified: true` was far weaker evidence than the fund-loss guarantee resting on it. Two properties combined:

1. **Taps auto-routed** — a tapped chip went to the slot it belonged to, so a wrong tap was a silent no-op rather than a wrong answer.
2. **The word bank held only the phrase's own words** — no decoys.

So the board could be filled by tapping chips at random.

## What this changes

A **directed challenge**: one question at a time, and the question fixes the slot.

- **"Which word is #7?"**, answered from 8 chips, exactly one correct.
- **Decoys from the BIP-39 English wordlist**, 3 of them from the phrase's own other words. Mixing is load-bearing in both directions: all-wordlist decoys would let anyone who remembers the phrase's word *set* pick the only familiar option; all-phrase decoys would show a shoulder-surfer the phrase's whole vocabulary. Every chip is a plain lowercase wordlist entry rendered by the same component, and the answer's slot is uniformly random.
- **A wrong pick is a real, counted failure.** It re-presents the same position with the same option set reshuffled, and keeps progress on already-answered questions so a fat-finger does not discard a correct run. A second wrong pick in one attempt discards the attempt and calls `onFailed`.
- **`onFailed` returns the user to the phrase** — onboarding and add-account go back to the display step; `VerifyBackupScreen` has no phrase step, so it alerts and leaves.
- **No permanent lockout.** A user holding a correct written phrase must always be able to pass, and "Skip for now" is unchanged (still available, still `backupVerified: false`).

The `KNOWN LIMITATION` block is gone; the modules now carry the threat model, the arithmetic, and the accepted residuals.

## Adversarial design — what was considered and how it was closed

Four Codex crypto-review rounds each found a genuine narrowing defect; the fifth returned CLEAN.

| Vector | Closure |
| --- | --- |
| **Brute force** | 8 options x 3 questions x 1 tolerated mistake gives ~0.78% per attempt (~128 attempts), each bouncing back through the phrase. |
| **Elimination within a board** | Drawing without replacement from a fixed set leaves every pick worth exactly `1 / candidates` however many chips were ruled out, so a mistake buys no per-question edge. The *budget* is the lever, hence `MAX_MISTAKES = 1` (below). |
| **Cross-board intersection** (round 1) | Rebuilding a fresh board per retry was backwards: the answer is the **only** word guaranteed to survive a rebuild, since wordlist decoys are resampled from 2048. Two boards for one position intersect to the answer. Fail on purpose, intersect, answer. |
| **Cross-remount intersection** (round 4) | Memoising per mount closed that within a mount, but the failure path *unmounts* by design, so re-entering re-rolled every board — an order-recovery oracle across re-entries. Boards are now **derived**: `sha256(domain : position : phrase)` seeds an sfc32 PRNG that selects the decoys, so a position's set is a pure function of the phrase and identical on every observation, forever. Intersecting any number of them returns the set the user could already see. |
| **Free elimination for a set-memoriser** (round 3) | With a stable board, someone who remembers the words but not the order narrows 8 to 4 and eliminates for free. At 3 tolerated mistakes that was 31% per attempt (~3 attempts). `MAX_MISTAKES` is now **1**: 6.3% (~16 attempts) for them, 0.78% (~128) blind. The constant is documented as the security lever and pinned by a test. |
| **Burst tapping** | Chips carry the board they were rendered from; a tap belonging to a superseded board is ignored, so several options cannot be tried for the cost of one mistake. Pinned by a test that fires every chip inside a single `act()`. |
| **Off-board answers** | Anything not presented is scored wrong, not ignored — there is no off-board path to a pass. |

### Tradeoff taken deliberately

**Attempts are not capped.** No lockout, no persisted counter, no cooldown. A hard cap risks blocking a legitimate user out of the one signal that says their funds are recoverable — a worse failure than a weak signal. `backupVerified` authorises nothing (it silences a warning banner), so the only person who gains by faking it is the device owner defeating their own safety net, and they already have a one-tap Skip. A cooldown would not survive the failure path either, since `onFailed` unmounts by design. Raised by Codex in rounds 1-2 and knowingly retained, with the reasoning written at the point of decision.

## DR-12 preserved — and now structural

The duplicate-word lockout (a repeated word's later position being unanswerable, hard-sticking users in onboarding) cannot recur: a question names a position, the answer is compared by value against the word *at* that position, and board construction guarantees exactly one chip carries that value, so no two chips are ever ambiguous. The exhaustive repeated-word regression is retained and extended — every position and every question triple of a deliberately repeated-word phrase, plus a wiring-level walk that mounts until all 8 positions of the fixture have been asked.

## DR-9

Unchanged. No new mnemonic navigation params, no persistence, no logging. Chips are addressed by their slot on screen, so no `testID` or key carries a phrase index. The board seed is a one-way digest held in memory and discarded with the rng — not a derivation of key material, never stored, logged or transmitted.

## Hosts

All three pick this up: `CreateWalletScreen` (first-wallet onboarding), `MnemonicBackupFlow` (add-account) and `VerifyBackupScreen`; the first two also wire `onFailed` back to the phrase.

## Gates

`npm run typecheck` 0 errors, `npm run lint` 0 errors, `npm test` **1503 passing / 95 suites** (baseline 1476/95). Rebased onto `main` after TASK-43 (#150).

Closes TASK-226.

https://claude.ai/code/session_01AL4EmUSYAiVXEstBgKqDmv
