### PR TITLE
chore(lint): scoped no-require-imports carve-outs + documented disables (TASK-234)

### DIFF
--- a/eslint.config.js
+++ b/eslint.config.js
@@ -46,6 +46,40 @@ module.exports = [
       'react-hooks/preserve-manual-memoization': 'warn',
       'react-hooks/purity': 'warn',
       'react-hooks/refs': 'warn',
+
+      // Unused-variable hygiene. eslint-config-expo/flat/utils/typescript.js
+      // already configures this rule as { vars:'all', args:'none',
+      // ignoreRestSiblings:true, caughtErrors:'all' }; ESLint replaces rule
+      // options wholesale rather than merging, so those four are repeated here
+      // verbatim and MUST stay in sync with the preset.
+      //
+      // Added: the `^_` escape-hatch patterns, as a FORWARD-LOOKING convention.
+      // They clear ZERO warnings today — the codebase currently has no
+      // `_`-prefixed unused variable, caught error, or destructured-array
+      // element (verified by regenerating lint-baseline.json: no-unused-vars is
+      // unchanged by this block). They exist so new code can opt a genuinely
+      // unused binding out of the rule — `catch (_e)`, `const [_unused, setX]`,
+      // `const _throwaway = …` — instead of accreting one-off inline disables.
+      //
+      // Deliberately NO `argsIgnorePattern`. The preset sets `args: 'none'`, so
+      // unused PARAMETERS are already invisible to the rule; an argsIgnorePattern
+      // would match nothing and clear 0 warnings, while giving the false
+      // impression that parameter hygiene is enforced. WARNING: anyone who later
+      // flips `args` to `'after-used'` to "tighten" this would unmask an entire
+      // unmeasured wave of unused-parameter warnings across every callback in the
+      // codebase — re-baseline first, do not treat it as a no-op tweak.
+      '@typescript-eslint/no-unused-vars': [
+        'warn',
+        {
+          vars: 'all',
+          args: 'none',
+          ignoreRestSiblings: true,
+          caughtErrors: 'all',
+          varsIgnorePattern: '^_',
+          caughtErrorsIgnorePattern: '^_',
+          destructuredArrayIgnorePattern: '^_',
+        },
+      ],
     },
   },
   {
@@ -69,6 +103,37 @@ module.exports = [
       'import/first': 'off',
       // Tests import default exports (services/stores) to jest.mock them.
       'import/no-named-as-default': 'off',
+      // Tests legitimately use require(): jest hoists jest.mock() factories above
+      // the import block and forbids them from closing over out-of-scope imports,
+      // so require() inside a factory is the only legal form; other specs stub or
+      // late-bind a module with require() to control load order. Turning the rule
+      // off here (rather than a `src/services/secure/**` carve-out) covers ALL of
+      // those — including every no-require-imports hit under
+      // src/services/secure/__tests__/, where the ONLY require sites live —
+      // without disarming the rule over production key/mnemonic/signing code,
+      // which has zero require sites of its own.
+      '@typescript-eslint/no-require-imports': 'off',
+    },
+  },
+  {
+    // Platform-adapter require()s (PLAN-12 DR-7). These three modules bridge the
+    // React Native app and the browser-extension build and pick an implementation
+    // at RUNTIME behind a platform guard —
+    // `isMobile() ? require('./mobile/X') : require('./extension/X')`. The two
+    // sides pull in mutually exclusive host deps (e.g. platform/mobile/
+    // secureStorage.ts imports expo-secure-store, while platform/extension/
+    // secureStorage.ts uses chrome.storage), so a static `import` of both would
+    // eagerly load a module that cannot resolve on the other platform. require()
+    // behind the guard is the intended pattern here, not debt — scope the rule
+    // off to exactly these files (polyfills.ts likewise late-requires its
+    // ponyfills so a native/global-present environment can skip them).
+    files: [
+      'src/platform/index.ts',
+      'src/platform/detection.ts',
+      'src/utils/polyfills.ts',
+    ],
+    rules: {
+      '@typescript-eslint/no-require-imports': 'off',
     },
   },
   {

--- a/lint-baseline.json
+++ b/lint-baseline.json
@@ -2,13 +2,12 @@
   "$comment": "Committed ESLint baseline for the `npm run lint` ratchet (PLAN-229 DR-2). Regenerate with `npm run lint:baseline`; verify with `npm run lint:baseline:check`. The `lint` script's --max-warnings MUST equal totals.warnings. Lower it in the same PR that clears the warnings. It never goes up.",
   "totals": {
     "errors": 0,
-    "warnings": 669,
+    "warnings": 619,
     "filesLinted": 431,
-    "filesWithFindings": 174
+    "filesWithFindings": 152
   },
   "rules": {
-    "@typescript-eslint/no-redeclare": 1,
-    "@typescript-eslint/no-require-imports": 68,
+    "@typescript-eslint/no-require-imports": 19,
     "@typescript-eslint/no-unused-vars": 306,
     "import/no-named-as-default": 41,
     "react-hooks/exhaustive-deps": 61,
@@ -21,9 +20,9 @@
   "files": {
     "src/components/UnifiedAuthModal.tsx": {
       "errors": 0,
-      "warnings": 5,
+      "warnings": 4,
       "rules": {
-        "@typescript-eslint/no-require-imports": 2,
+        "@typescript-eslint/no-require-imports": 1,
         "react-hooks/exhaustive-deps": 1,
         "react-hooks/immutability": 1,
         "react-hooks/set-state-in-effect": 1
@@ -186,9 +185,9 @@
     },
     "src/components/common/ThemedWebView.tsx": {
       "errors": 0,
-      "warnings": 6,
+      "warnings": 5,
       "rules": {
-        "@typescript-eslint/no-require-imports": 2,
+        "@typescript-eslint/no-require-imports": 1,
         "@typescript-eslint/no-unused-vars": 4
       }
     },
@@ -393,9 +392,8 @@
     },
     "src/contexts/AuthContext.tsx": {
       "errors": 0,
-      "warnings": 8,
+      "warnings": 7,
       "rules": {
-        "@typescript-eslint/no-require-imports": 1,
         "@typescript-eslint/no-unused-vars": 1,
         "react-hooks/exhaustive-deps": 1,
         "react-hooks/immutability": 3,
@@ -409,13 +407,6 @@
       "rules": {
         "react-hooks/exhaustive-deps": 1,
         "react-hooks/set-state-in-effect": 1
-      }
-    },
-    "src/hooks/__tests__/useSecureScreen.test.ts": {
-      "errors": 0,
-      "warnings": 3,
-      "rules": {
-        "@typescript-eslint/no-require-imports": 3
       }
     },
     "src/hooks/useThemedStyles.ts": {
@@ -433,33 +424,11 @@
         "react-hooks/exhaustive-deps": 1
       }
     },
-    "src/platform/detection.ts": {
-      "errors": 0,
-      "warnings": 1,
-      "rules": {
-        "@typescript-eslint/no-require-imports": 1
-      }
-    },
-    "src/platform/extension/chrome.d.ts": {
-      "errors": 0,
-      "warnings": 1,
-      "rules": {
-        "@typescript-eslint/no-redeclare": 1
-      }
-    },
     "src/platform/index.ts": {
       "errors": 0,
-      "warnings": 18,
+      "warnings": 2,
       "rules": {
-        "@typescript-eslint/no-require-imports": 16,
         "@typescript-eslint/no-unused-vars": 2
-      }
-    },
-    "src/platform/mobile/__tests__/secureStorageFailClosed.test.ts": {
-      "errors": 0,
-      "warnings": 1,
-      "rules": {
-        "@typescript-eslint/no-require-imports": 1
       }
     },
     "src/screens/account/AccountImportPreviewScreen.tsx": {
@@ -980,20 +949,6 @@
         "@typescript-eslint/no-unused-vars": 2
       }
     },
-    "src/services/backup/__tests__/createBackup.policy.test.ts": {
-      "errors": 0,
-      "warnings": 1,
-      "rules": {
-        "@typescript-eslint/no-require-imports": 1
-      }
-    },
-    "src/services/backup/__tests__/encryption.test.ts": {
-      "errors": 0,
-      "warnings": 1,
-      "rules": {
-        "@typescript-eslint/no-require-imports": 1
-      }
-    },
     "src/services/debug/logger.ts": {
       "errors": 0,
       "warnings": 3,
@@ -1007,13 +962,6 @@
       "rules": {
         "@typescript-eslint/no-require-imports": 1,
         "@typescript-eslint/no-unused-vars": 2
-      }
-    },
-    "src/services/ledger/__tests__/transport.test.ts": {
-      "errors": 0,
-      "warnings": 1,
-      "rules": {
-        "@typescript-eslint/no-require-imports": 1
       }
     },
     "src/services/ledger/simpleLedgerManager.ts": {
@@ -1071,90 +1019,6 @@
       "warnings": 11,
       "rules": {
         "@typescript-eslint/no-unused-vars": 11
-      }
-    },
-    "src/services/secure/__tests__/biometricConvenience.test.ts": {
-      "errors": 0,
-      "warnings": 1,
-      "rules": {
-        "@typescript-eslint/no-require-imports": 1
-      }
-    },
-    "src/services/secure/__tests__/biometricUnlock.test.ts": {
-      "errors": 0,
-      "warnings": 1,
-      "rules": {
-        "@typescript-eslint/no-require-imports": 1
-      }
-    },
-    "src/services/secure/__tests__/crossStoreResetHardening.test.ts": {
-      "errors": 0,
-      "warnings": 2,
-      "rules": {
-        "@typescript-eslint/no-require-imports": 2
-      }
-    },
-    "src/services/secure/__tests__/envelopeV2.test.ts": {
-      "errors": 0,
-      "warnings": 1,
-      "rules": {
-        "@typescript-eslint/no-require-imports": 1
-      }
-    },
-    "src/services/secure/__tests__/getPrivateKey.reader.test.ts": {
-      "errors": 0,
-      "warnings": 1,
-      "rules": {
-        "@typescript-eslint/no-require-imports": 1
-      }
-    },
-    "src/services/secure/__tests__/getPrivateKey.vault.test.ts": {
-      "errors": 0,
-      "warnings": 1,
-      "rules": {
-        "@typescript-eslint/no-require-imports": 1
-      }
-    },
-    "src/services/secure/__tests__/hasPinStrict.test.ts": {
-      "errors": 0,
-      "warnings": 1,
-      "rules": {
-        "@typescript-eslint/no-require-imports": 1
-      }
-    },
-    "src/services/secure/__tests__/keyWriterChangePin.test.ts": {
-      "errors": 0,
-      "warnings": 1,
-      "rules": {
-        "@typescript-eslint/no-require-imports": 1
-      }
-    },
-    "src/services/secure/__tests__/migrationEngine.test.ts": {
-      "errors": 0,
-      "warnings": 1,
-      "rules": {
-        "@typescript-eslint/no-require-imports": 1
-      }
-    },
-    "src/services/secure/__tests__/passphrase.test.ts": {
-      "errors": 0,
-      "warnings": 3,
-      "rules": {
-        "@typescript-eslint/no-require-imports": 3
-      }
-    },
-    "src/services/secure/__tests__/pinThrottle.test.ts": {
-      "errors": 0,
-      "warnings": 1,
-      "rules": {
-        "@typescript-eslint/no-require-imports": 1
-      }
-    },
-    "src/services/secure/__tests__/reconcilePrimitives.test.ts": {
-      "errors": 0,
-      "warnings": 1,
-      "rules": {
-        "@typescript-eslint/no-require-imports": 1
       }
     },
     "src/services/secure/keyManager.ts": {
@@ -1260,9 +1124,9 @@
     },
     "src/services/walletconnect/index.ts": {
       "errors": 0,
-      "warnings": 6,
+      "warnings": 5,
       "rules": {
-        "@typescript-eslint/no-require-imports": 2,
+        "@typescript-eslint/no-require-imports": 1,
         "@typescript-eslint/no-unused-vars": 4
       }
     },
@@ -1295,13 +1159,6 @@
         "@typescript-eslint/no-unused-vars": 2
       }
     },
-    "src/store/__tests__/remoteSignerStore.test.ts": {
-      "errors": 0,
-      "warnings": 1,
-      "rules": {
-        "@typescript-eslint/no-require-imports": 1
-      }
-    },
     "src/store/claimableStore.ts": {
       "errors": 0,
       "warnings": 2,
@@ -1331,13 +1188,6 @@
       "rules": {
         "@typescript-eslint/no-unused-vars": 4,
         "import/no-named-as-default": 1
-      }
-    },
-    "src/utils/__tests__/splashController.test.ts": {
-      "errors": 0,
-      "warnings": 1,
-      "rules": {
-        "@typescript-eslint/no-require-imports": 1
       }
     },
     "src/utils/accountQRParser.ts": {
@@ -1374,13 +1224,6 @@
       "warnings": 2,
       "rules": {
         "@typescript-eslint/no-unused-vars": 2
-      }
-    },
-    "src/utils/polyfills.ts": {
-      "errors": 0,
-      "warnings": 4,
-      "rules": {
-        "@typescript-eslint/no-require-imports": 4
       }
     }
   }

--- a/package.json
+++ b/package.json
@@ -7,7 +7,7 @@
     "android": "expo run:android",
     "ios": "expo run:ios",
     "web": "expo start --web",
-    "lint": "eslint src/ --max-warnings 669",
+    "lint": "eslint src/ --max-warnings 619",
     "lint:fix": "eslint src/ --fix",
     "lint:baseline": "node scripts/lint-baseline.mjs --write",
     "lint:baseline:check": "node scripts/lint-baseline.mjs --check",

--- a/src/__tests__/babel-console-strip.test.ts
+++ b/src/__tests__/babel-console-strip.test.ts
@@ -8,7 +8,6 @@ import * as path from 'path';
 
 // @babel/core is available transitively via babel-preset-expo. Use require so
 // the test still resolves it if the ESM import shape ever changes.
-// eslint-disable-next-line @typescript-eslint/no-require-imports
 const babel = require('@babel/core');
 
 const CONFIG_FILE = path.resolve(__dirname, '..', '..', 'babel.config.js');

--- a/src/components/UnifiedAuthModal.tsx
+++ b/src/components/UnifiedAuthModal.tsx
@@ -209,6 +209,7 @@ export default function UnifiedAuthModal({
     }
 
     try {
+      // eslint-disable-next-line @typescript-eslint/no-require-imports -- platform-guarded: expo-local-authentication is native-only and this branch is unreachable on web (the function returns earlier there); require() keeps it out of the web bundle.
       const LocalAuthentication = require('expo-local-authentication');
       const hasHardware = await LocalAuthentication.hasHardwareAsync();
       const isEnrolled = await LocalAuthentication.isEnrolledAsync();

--- a/src/components/common/ThemedWebView.tsx
+++ b/src/components/common/ThemedWebView.tsx
@@ -15,6 +15,7 @@ import { useSafeAreaInsets } from 'react-native-safe-area-context';
 let WebView: any = null;
 let WebViewProps: any = {};
 if (Platform.OS !== 'web') {
+  // eslint-disable-next-line @typescript-eslint/no-require-imports -- platform-guarded (Platform.OS !== 'web'): react-native-webview has no web build, so a static import would break the web bundle. require() defers the load to native only.
   const webviewModule = require('react-native-webview');
   WebView = webviewModule.WebView;
   WebViewProps = webviewModule.WebViewProps;

--- a/src/components/common/__tests__/GlassButton.a11y.test.tsx
+++ b/src/components/common/__tests__/GlassButton.a11y.test.tsx
@@ -15,7 +15,6 @@ import { render } from '@testing-library/react-native';
 import { GlassButton } from '../GlassButton';
 
 jest.mock('@/contexts/ThemeContext', () => ({
-  // eslint-disable-next-line @typescript-eslint/no-require-imports
   useTheme: () => ({ theme: require('@/constants/themes').lightTheme }),
 }));
 

--- a/src/components/common/__tests__/GlassCard.a11y.test.tsx
+++ b/src/components/common/__tests__/GlassCard.a11y.test.tsx
@@ -16,7 +16,6 @@ import { render } from '@testing-library/react-native';
 import { GlassCard } from '../GlassCard';
 
 jest.mock('@/contexts/ThemeContext', () => ({
-  // eslint-disable-next-line @typescript-eslint/no-require-imports
   useTheme: () => ({ theme: require('@/constants/themes').lightTheme }),
 }));
 

--- a/src/components/common/__tests__/OfflineBanner.test.tsx
+++ b/src/components/common/__tests__/OfflineBanner.test.tsx
@@ -44,7 +44,6 @@ jest.mock('@/platform', () => ({
 }));
 
 jest.mock('@/contexts/ThemeContext', () => ({
-  // eslint-disable-next-line @typescript-eslint/no-require-imports
   useTheme: () => ({ theme: require('@/constants/themes').lightTheme }),
 }));
 

--- a/src/components/common/__tests__/UniversalHeader.a11y.test.tsx
+++ b/src/components/common/__tests__/UniversalHeader.a11y.test.tsx
@@ -12,7 +12,6 @@ import { render } from '@testing-library/react-native';
 import UniversalHeader from '../UniversalHeader';
 
 jest.mock('@/contexts/ThemeContext', () => ({
-  // eslint-disable-next-line @typescript-eslint/no-require-imports
   useTheme: () => ({ theme: require('@/constants/themes').lightTheme }),
 }));
 

--- a/src/components/common/__tests__/decorativeLayers.a11y.test.tsx
+++ b/src/components/common/__tests__/decorativeLayers.a11y.test.tsx
@@ -29,7 +29,6 @@ jest.mock('@/contexts/ThemeContext', () => ({
 const mockThemeValue = jest.fn(() => mockTheme);
 
 jest.mock('expo-image', () => ({
-  // eslint-disable-next-line @typescript-eslint/no-require-imports
   Image: require('react-native').View,
 }));
 

--- a/src/components/update/__tests__/UpdateBanner.a11y.test.tsx
+++ b/src/components/update/__tests__/UpdateBanner.a11y.test.tsx
@@ -14,7 +14,6 @@ import { render } from '@testing-library/react-native';
 import UpdateBanner from '../UpdateBanner';
 
 jest.mock('@/contexts/ThemeContext', () => ({
-  // eslint-disable-next-line @typescript-eslint/no-require-imports
   useTheme: () => ({ theme: require('@/constants/themes').lightTheme }),
 }));
 

--- a/src/components/wallet/__tests__/MnemonicVerification.test.tsx
+++ b/src/components/wallet/__tests__/MnemonicVerification.test.tsx
@@ -35,7 +35,6 @@ import {
 } from '@/__tests__/fixtures/mnemonicQuiz';
 
 jest.mock('@/contexts/ThemeContext', () => ({
-  // eslint-disable-next-line @typescript-eslint/no-require-imports
   useTheme: () => ({ theme: require('@/constants/themes').lightTheme }),
 }));
 

--- a/src/config/__tests__/metroInlineRequires.test.ts
+++ b/src/config/__tests__/metroInlineRequires.test.ts
@@ -10,7 +10,6 @@ import { resolve } from 'path';
 
 // Plain-CJS module shared with metro.config.js. require() keeps tsc from needing
 // a declaration file for the root config module.
-// eslint-disable-next-line @typescript-eslint/no-require-imports
 const inlineRequiresConfig = require('../../../metro.inlineRequires') as {
   NON_INLINED_REQUIRES: string[];
   METRO_BASE_NON_INLINED: string[];

--- a/src/contexts/AuthContext.tsx
+++ b/src/contexts/AuthContext.tsx
@@ -31,6 +31,7 @@ const checkBiometricAvailability = async (): Promise<{
     return { hasHardware: false, isEnrolled: false };
   }
   try {
+    // eslint-disable-next-line @typescript-eslint/no-require-imports -- platform-guarded (Platform.OS === 'web' returns above): expo-local-authentication is native-only; require() keeps it out of the web bundle.
     const LocalAuthentication = require('expo-local-authentication');
     // hasHardwareAsync and isEnrolledAsync are independent native reads — run
     // them concurrently (F-03) instead of serially. A rejection in either still

--- a/src/platform/__tests__/connectivity.test.ts
+++ b/src/platform/__tests__/connectivity.test.ts
@@ -191,7 +191,6 @@ describe('MobileConnectivityAdapter', () => {
   });
 
   const loadAdapter = () => {
-    // eslint-disable-next-line @typescript-eslint/no-require-imports
     const { MobileConnectivityAdapter } = require('../mobile/connectivity');
     return new MobileConnectivityAdapter();
   };

--- a/src/platform/extension/__tests__/storageFailClosed.test.ts
+++ b/src/platform/extension/__tests__/storageFailClosed.test.ts
@@ -28,7 +28,6 @@ let currentLastError: { message: string } | undefined;
   },
 };
 
-// eslint-disable-next-line @typescript-eslint/no-require-imports
 const { ExtensionStorageAdapter } = require('../storage');
 
 describe('ExtensionStorageAdapter.getItem — failure vs absence (TASK-213)', () => {

--- a/src/platform/extension/chrome.d.ts
+++ b/src/platform/extension/chrome.d.ts
@@ -111,5 +111,5 @@ declare namespace chrome {
 }
 
 // Make chrome available globally.
-// eslint-disable-next-line no-var -- ambient global: `declare var` is the correct idiom for a runtime-provided global (as in lib.dom.d.ts); let/const would change the declaration semantics.
+// eslint-disable-next-line no-var, @typescript-eslint/no-redeclare -- ambient global: `declare var` is the correct idiom for a runtime-provided global (as in lib.dom.d.ts); let/const would change the declaration semantics. no-redeclare fires because this `var` merges with the `declare namespace chrome` at :6 — a legal TS var+namespace merge that the rule's `ignoreDeclarationMerge` option does NOT whitelist (it covers interface/namespace/class/function/enum, not var). Not a bug: `tsc --noEmit --skipLibCheck` on this file exits 0. Suppress rather than delete the declaration.
 declare var chrome: typeof chrome;

--- a/src/screens/account/__tests__/CreateAccountScreen.test.tsx
+++ b/src/screens/account/__tests__/CreateAccountScreen.test.tsx
@@ -50,7 +50,6 @@ jest.mock('@react-navigation/native', () => ({
 jest.mock('@/hooks/useSecureScreen', () => ({ useSecureScreen: () => {} }));
 
 jest.mock('@/contexts/ThemeContext', () => ({
-  // eslint-disable-next-line @typescript-eslint/no-require-imports
   useTheme: () => ({ theme: require('@/constants/themes').lightTheme }),
 }));
 
@@ -63,7 +62,6 @@ jest.mock(
 );
 
 jest.mock('@/components/wallet/MnemonicDisplay', () => {
-  // eslint-disable-next-line @typescript-eslint/no-require-imports
   const { Text } = require('react-native');
   return {
     __esModule: true,

--- a/src/screens/onboarding/__tests__/CreateWalletScreen.test.tsx
+++ b/src/screens/onboarding/__tests__/CreateWalletScreen.test.tsx
@@ -30,7 +30,6 @@ jest.mock('@/services/wallet', () => ({
 }));
 
 jest.mock('@/contexts/ThemeContext', () => ({
-  // eslint-disable-next-line @typescript-eslint/no-require-imports
   useTheme: () => ({ theme: require('@/constants/themes').lightTheme }),
 }));
 
@@ -45,13 +44,11 @@ jest.mock(
 );
 
 jest.mock('@/components/common/NFTBackground', () => {
-  // eslint-disable-next-line @typescript-eslint/no-require-imports
   const { View } = require('react-native');
   return { NFTBackground: ({ children }: never) => <View>{children}</View> };
 });
 
 jest.mock('@/components/common/UniversalHeader', () => {
-  // eslint-disable-next-line @typescript-eslint/no-require-imports
   const { Text, TouchableOpacity } = require('react-native');
   return {
     __esModule: true,
@@ -64,7 +61,6 @@ jest.mock('@/components/common/UniversalHeader', () => {
 });
 
 jest.mock('@/components/wallet/MnemonicDisplay', () => {
-  // eslint-disable-next-line @typescript-eslint/no-require-imports
   const { Text } = require('react-native');
   return {
     __esModule: true,
@@ -75,7 +71,6 @@ jest.mock('@/components/wallet/MnemonicDisplay', () => {
 });
 
 jest.mock('@/components/common/GlassButton', () => {
-  // eslint-disable-next-line @typescript-eslint/no-require-imports
   const { Text, TouchableOpacity } = require('react-native');
   return {
     GlassButton: ({

--- a/src/screens/wallet/__tests__/TransactionHistoryScreen.errorState.test.tsx
+++ b/src/screens/wallet/__tests__/TransactionHistoryScreen.errorState.test.tsx
@@ -45,7 +45,6 @@ jest.mock('@/contexts/AuthContext', () => ({
 }));
 
 jest.mock('@/contexts/ThemeContext', () => ({
-  // eslint-disable-next-line @typescript-eslint/no-require-imports
   useTheme: () => ({ theme: require('@/constants/themes').lightTheme }),
 }));
 
@@ -71,7 +70,6 @@ jest.mock('@/components/common/NFTBackground', () => ({
 }));
 
 jest.mock('@/components/common/BlurredContainer', () => {
-  // eslint-disable-next-line @typescript-eslint/no-require-imports
   const { View } = require('react-native');
   return {
     BlurredContainer: ({ children }: { children: React.ReactNode }) => (
@@ -81,7 +79,6 @@ jest.mock('@/components/common/BlurredContainer', () => {
 });
 
 jest.mock('@/components/transaction/TransactionListItem', () => {
-  // eslint-disable-next-line @typescript-eslint/no-require-imports
   const { Text } = require('react-native');
   return {
     __esModule: true,

--- a/src/screens/wallet/__tests__/VerifyBackupScreen.test.tsx
+++ b/src/screens/wallet/__tests__/VerifyBackupScreen.test.tsx
@@ -53,7 +53,6 @@ jest.mock('@react-navigation/native', () => ({
 jest.mock('@/hooks/useSecureScreen', () => ({ useSecureScreen: () => {} }));
 
 jest.mock('@/contexts/ThemeContext', () => ({
-  // eslint-disable-next-line @typescript-eslint/no-require-imports
   useTheme: () => ({ theme: require('@/constants/themes').lightTheme }),
 }));
 
@@ -66,13 +65,11 @@ jest.mock(
 );
 
 jest.mock('@/components/common/NFTBackground', () => {
-  // eslint-disable-next-line @typescript-eslint/no-require-imports
   const { View } = require('react-native');
   return { NFTBackground: ({ children }: never) => <View>{children}</View> };
 });
 
 jest.mock('@/components/common/UniversalHeader', () => {
-  // eslint-disable-next-line @typescript-eslint/no-require-imports
   const { View } = require('react-native');
   return { __esModule: true, default: () => <View /> };
 });

--- a/src/services/transactions/__tests__/construction.test.ts
+++ b/src/services/transactions/__tests__/construction.test.ts
@@ -68,7 +68,6 @@ jest.mock('@/services/mimir', () => ({
 // library's official jest mock so the graph loads. None of the constructors
 // under test touch storage.
 jest.mock('@react-native-async-storage/async-storage', () =>
-  // eslint-disable-next-line @typescript-eslint/no-require-imports -- require is required inside a hoisted jest.mock factory
   require('@react-native-async-storage/async-storage/jest/async-storage-mock')
 );
 

--- a/src/services/walletconnect/index.ts
+++ b/src/services/walletconnect/index.ts
@@ -215,6 +215,7 @@ export class WalletConnectService extends EventEmitter {
 
       // Set up call_request listener on DeepLinkService
       // This ensures navigation works the same way as during initial URI connection
+      // eslint-disable-next-line @typescript-eslint/no-require-imports -- breaks a REAL require cycle: @/services/deeplink imports this module, so a static import here would form a load-time circular dependency. (Contrast :463, whose "avoid circular dependencies" note is stale — WalletConnectV1Client is already statically imported at line 36.)
       const DeepLinkService = require('@/services/deeplink').DeepLinkService;
       const deepLinkService = DeepLinkService.getInstance();
 


### PR DESCRIPTION
Wave 1 of PLAN-229 (ESLint burndown). **Config + comment lines only — no executable source changed.** Verified: every `.ts`/`.tsx` line change is a comment or blank line (`git diff -w` shows only comment additions/removals + config).

## Ratchet — regenerated, not hand-computed (DR-9)

| Rule | Before | After | Δ | vs. estimate |
| --- | --- | --- | --- | --- |
| `@typescript-eslint/no-require-imports` | 68 | **19** | −49 | estimate said 22; actual is 19 |
| `@typescript-eslint/no-redeclare` | 1 | **0** | −1 | matched (1→0) |
| every other rule | — | — | 0 | byte-identical |
| **total** | **669** | **619** | **−50** | — |

`no-unused-vars` stays **306** — proving the new `^_` patterns clear **0 warnings today**, exactly as documented.

- `lint-baseline.json` regenerated; `package.json` `--max-warnings` **669 → 619** in this same PR.
- `npm run lint:baseline:check` passes (pin matches artifact).

## Changes

**ESLint config (`eslint.config.js`):**
- `@typescript-eslint/no-require-imports: 'off'` added to the **existing** test-file block (jest.mock-factory requires + late-bind stubs). This covers **every** secure-storage `no-require-imports` hit — all of which live under `src/services/secure/__tests__/` — **without** disarming the rule over production key/mnemonic/signing source, which has zero require sites of its own. (A `src/services/secure/**` carve-out would have been wrong.)
- New carve-out block scoped to exactly the three PLAN-12 DR-7 platform-adapter files (`src/platform/index.ts`, `src/platform/detection.ts`, `src/utils/polyfills.ts`) — genuinely platform-guarded `isMobile() ? require('./mobile/X') : require('./extension/X')`; the two sides pull mutually exclusive host deps (expo-secure-store vs chrome.storage).
- Forward-looking `^_` patterns added to `no-unused-vars`: `varsIgnorePattern`, `caughtErrorsIgnorePattern`, `destructuredArrayIgnorePattern`. Comment documents that they clear 0 today, that `argsIgnorePattern` would clear 0 (the expo preset sets `args:'none'`, so params are invisible), and warns that flipping `args` to `'after-used'` would unmask an unmeasured wave.

**Documented inline `-- reason` disables:**
- `common/ThemedWebView.tsx:18`, `UnifiedAuthModal.tsx:212`, `AuthContext.tsx:34` — platform-guarded native-only requires (`expo-local-authentication` / `react-native-webview` have no web build).
- `services/walletconnect/index.ts:218` — the **real** deeplink require cycle (`@/services/deeplink` imports this module). `:463` is left flagged: its "avoid circular dependencies" note is stale — `WalletConnectV1Client` is already statically imported at line 36.
- `platform/extension/chrome.d.ts:115` — `@typescript-eslint/no-redeclare` added to the existing `no-var` disable (legal `var`+`namespace` merge that `ignoreDeclarationMerge` does not whitelist). **Declaration kept, not deleted.**

**Test-file cleanup (comment-only):** turning `no-require-imports` off for test files orphaned 25 existing inline directives (ESLint flat-config reports unused disable directives as warnings — verified). Those now-dead comment lines were removed from 16 test files so the ratchet stays honest and **only** `no-require-imports` and `no-redeclare` move. The underlying `require()` calls are untouched.

## Gates
- `npm run typecheck` — clean
- `npm run lint` — exit 0 at the new 619 ceiling
- `npm test -- --ci` — 95 suites / 1503 tests green
- `npm run lint:baseline:check` — passes
- Scratch-file check confirmed the `^_` patterns are wired: `catch (_e)` / `const [_a, setA]` produce no warning, while `catch (ee)` / `const [aa, …]` warn with `must match /^_/u`.
- Codex review: **CLEAN**.

https://claude.ai/code/session_01AL4EmUSYAiVXEstBgKqDmv