### PR TITLE
refactor(alert): hoist Alert require shims to static imports (TASK-233)

### DIFF
--- a/lint-baseline.json
+++ b/lint-baseline.json
@@ -2,12 +2,12 @@
   "$comment": "Committed ESLint baseline for the `npm run lint` ratchet (PLAN-229 DR-2). Regenerate with `npm run lint:baseline`; verify with `npm run lint:baseline:check`. The `lint` script's --max-warnings MUST equal totals.warnings. Lower it in the same PR that clears the warnings. It never goes up.",
   "totals": {
     "errors": 0,
-    "warnings": 619,
+    "warnings": 606,
     "filesLinted": 431,
-    "filesWithFindings": 152
+    "filesWithFindings": 150
   },
   "rules": {
-    "@typescript-eslint/no-require-imports": 19,
+    "@typescript-eslint/no-require-imports": 6,
     "@typescript-eslint/no-unused-vars": 306,
     "import/no-named-as-default": 41,
     "react-hooks/exhaustive-deps": 61,
@@ -20,9 +20,8 @@
   "files": {
     "src/components/UnifiedAuthModal.tsx": {
       "errors": 0,
-      "warnings": 4,
+      "warnings": 3,
       "rules": {
-        "@typescript-eslint/no-require-imports": 1,
         "react-hooks/exhaustive-deps": 1,
         "react-hooks/immutability": 1,
         "react-hooks/set-state-in-effect": 1
@@ -185,9 +184,8 @@
     },
     "src/components/common/ThemedWebView.tsx": {
       "errors": 0,
-      "warnings": 5,
+      "warnings": 4,
       "rules": {
-        "@typescript-eslint/no-require-imports": 1,
         "@typescript-eslint/no-unused-vars": 4
       }
     },
@@ -382,9 +380,8 @@
     },
     "src/components/walletconnect/QRScanner.tsx": {
       "errors": 0,
-      "warnings": 7,
+      "warnings": 6,
       "rules": {
-        "@typescript-eslint/no-require-imports": 1,
         "@typescript-eslint/no-unused-vars": 4,
         "react-hooks/immutability": 1,
         "react-hooks/set-state-in-effect": 1
@@ -440,9 +437,8 @@
     },
     "src/screens/account/AddWatchAccountScreen.tsx": {
       "errors": 0,
-      "warnings": 2,
+      "warnings": 1,
       "rules": {
-        "@typescript-eslint/no-require-imports": 1,
         "@typescript-eslint/no-unused-vars": 1
       }
     },
@@ -480,25 +476,16 @@
     },
     "src/screens/auth/LockScreen.tsx": {
       "errors": 0,
-      "warnings": 3,
+      "warnings": 2,
       "rules": {
-        "@typescript-eslint/no-require-imports": 1,
         "react-hooks/exhaustive-deps": 1,
         "react-hooks/immutability": 1
       }
     },
-    "src/screens/auth/SecureStorageUnavailableScreen.tsx": {
-      "errors": 0,
-      "warnings": 1,
-      "rules": {
-        "@typescript-eslint/no-require-imports": 1
-      }
-    },
     "src/screens/onboarding/CreateWalletScreen.tsx": {
       "errors": 0,
-      "warnings": 3,
+      "warnings": 2,
       "rules": {
-        "@typescript-eslint/no-require-imports": 1,
         "@typescript-eslint/no-unused-vars": 1,
         "react-hooks/set-state-in-effect": 1
       }
@@ -525,13 +512,6 @@
         "@typescript-eslint/no-unused-vars": 1
       }
     },
-    "src/screens/remoteSigner/ExportAccountsScreen.tsx": {
-      "errors": 0,
-      "warnings": 1,
-      "rules": {
-        "@typescript-eslint/no-require-imports": 1
-      }
-    },
     "src/screens/remoteSigner/ImportFromOnlineWalletScreen.tsx": {
       "errors": 0,
       "warnings": 3,
@@ -543,26 +523,23 @@
     },
     "src/screens/remoteSigner/ImportRemoteSignerScreen.tsx": {
       "errors": 0,
-      "warnings": 3,
+      "warnings": 2,
       "rules": {
-        "@typescript-eslint/no-require-imports": 1,
         "@typescript-eslint/no-unused-vars": 2
       }
     },
     "src/screens/remoteSigner/RemoteSignerSettingsScreen.tsx": {
       "errors": 0,
-      "warnings": 6,
+      "warnings": 5,
       "rules": {
-        "@typescript-eslint/no-require-imports": 1,
         "@typescript-eslint/no-unused-vars": 4,
         "react-hooks/set-state-in-effect": 1
       }
     },
     "src/screens/remoteSigner/SignRequestScannerScreen.tsx": {
       "errors": 0,
-      "warnings": 9,
+      "warnings": 8,
       "rules": {
-        "@typescript-eslint/no-require-imports": 1,
         "@typescript-eslint/no-unused-vars": 5,
         "react-hooks/exhaustive-deps": 1,
         "react-hooks/immutability": 1,
@@ -571,18 +548,16 @@
     },
     "src/screens/remoteSigner/SignatureDisplayScreen.tsx": {
       "errors": 0,
-      "warnings": 3,
+      "warnings": 2,
       "rules": {
-        "@typescript-eslint/no-require-imports": 1,
         "@typescript-eslint/no-unused-vars": 1,
         "react-hooks/set-state-in-effect": 1
       }
     },
     "src/screens/remoteSigner/TransactionReviewScreen.tsx": {
       "errors": 0,
-      "warnings": 3,
+      "warnings": 2,
       "rules": {
-        "@typescript-eslint/no-require-imports": 1,
         "@typescript-eslint/no-unused-vars": 2
       }
     },

--- a/package.json
+++ b/package.json
@@ -7,7 +7,7 @@
     "android": "expo run:android",
     "ios": "expo run:ios",
     "web": "expo start --web",
-    "lint": "eslint src/ --max-warnings 619",
+    "lint": "eslint src/ --max-warnings 606",
     "lint:fix": "eslint src/ --fix",
     "lint:baseline": "node scripts/lint-baseline.mjs --write",
     "lint:baseline:check": "node scripts/lint-baseline.mjs --check",

--- a/src/components/UnifiedAuthModal.tsx
+++ b/src/components/UnifiedAuthModal.tsx
@@ -1,5 +1,6 @@
 import React, { useState, useEffect } from 'react';
 import {
+  Alert,
   Modal,
   View,
   Text,
@@ -29,7 +30,6 @@ const showAlert = (
     window.alert(`${title}\n\n${message}`);
     buttons?.[0]?.onPress?.();
   } else {
-    const { Alert } = require('react-native');
     Alert.alert(title, message, buttons);
   }
 };

--- a/src/components/common/ThemedWebView.tsx
+++ b/src/components/common/ThemedWebView.tsx
@@ -6,7 +6,7 @@ import React, {
   useMemo,
   useCallback,
 } from 'react';
-import { View, Text, StyleSheet, Platform, Linking } from 'react-native';
+import { Alert, View, Text, StyleSheet, Platform, Linking } from 'react-native';
 import { Ionicons } from '@expo/vector-icons';
 import { useTheme } from '@/contexts/ThemeContext';
 import { useSafeAreaInsets } from 'react-native-safe-area-context';
@@ -26,7 +26,6 @@ const showAlert = (title: string, message: string) => {
   if (Platform.OS === 'web') {
     window.alert(`${title}\n\n${message}`);
   } else {
-    const { Alert } = require('react-native');
     Alert.alert(title, message, [{ text: 'OK' }]);
   }
 };

--- a/src/components/walletconnect/QRScanner.tsx
+++ b/src/components/walletconnect/QRScanner.tsx
@@ -1,5 +1,6 @@
 import React, { useState, useEffect, useRef, useCallback } from 'react';
 import {
+  Alert,
   View,
   Text,
   StyleSheet,
@@ -33,7 +34,11 @@ import { CameraView, Camera } from 'expo-camera';
 const showAlert = (
   title: string,
   message: string,
-  buttons?: { text: string; onPress?: () => void; style?: string }[]
+  buttons?: {
+    text: string;
+    onPress?: () => void;
+    style?: 'default' | 'cancel' | 'destructive';
+  }[]
 ) => {
   if (Platform.OS === 'web') {
     if (buttons && buttons.length > 1) {
@@ -51,7 +56,6 @@ const showAlert = (
       buttons?.[0]?.onPress?.();
     }
   } else {
-    const { Alert } = require('react-native');
     Alert.alert(title, message, buttons);
   }
 };

--- a/src/screens/account/AddWatchAccountScreen.tsx
+++ b/src/screens/account/AddWatchAccountScreen.tsx
@@ -1,5 +1,6 @@
 import React, { useCallback, useState } from 'react';
 import {
+  Alert,
   View,
   Text,
   StyleSheet,
@@ -66,7 +67,6 @@ export default function AddWatchAccountScreen() {
       window.alert(`${title}\n\n${message}`);
       buttons?.[0]?.onPress?.();
     } else {
-      const { Alert } = require('react-native');
       Alert.alert(title, message, buttons);
     }
   };

--- a/src/screens/auth/LockScreen.tsx
+++ b/src/screens/auth/LockScreen.tsx
@@ -1,5 +1,6 @@
 import React, { useState, useEffect, useCallback } from 'react';
 import {
+  Alert,
   View,
   Text,
   StyleSheet,
@@ -24,7 +25,11 @@ import { SECURITY_CONFIG, SECURITY_MESSAGES } from '@/config/security';
 const showAlert = (
   title: string,
   message: string,
-  buttons?: { text: string; onPress?: () => void; style?: string }[]
+  buttons?: {
+    text: string;
+    onPress?: () => void;
+    style?: 'default' | 'cancel' | 'destructive';
+  }[]
 ) => {
   if (Platform.OS === 'web') {
     if (buttons && buttons.length > 1) {
@@ -40,7 +45,6 @@ const showAlert = (
       buttons?.[0]?.onPress?.();
     }
   } else {
-    const { Alert } = require('react-native');
     Alert.alert(title, message, buttons);
   }
 };

--- a/src/screens/auth/SecureStorageUnavailableScreen.tsx
+++ b/src/screens/auth/SecureStorageUnavailableScreen.tsx
@@ -1,5 +1,6 @@
 import React, { useEffect, useRef, useState } from 'react';
 import {
+  Alert,
   View,
   Text,
   StyleSheet,
@@ -21,7 +22,11 @@ import { MultiAccountWalletService } from '@/services/wallet';
 const showAlert = (
   title: string,
   message: string,
-  buttons?: { text: string; onPress?: () => void; style?: string }[]
+  buttons?: {
+    text: string;
+    onPress?: () => void;
+    style?: 'default' | 'cancel' | 'destructive';
+  }[]
 ) => {
   if (Platform.OS === 'web') {
     if (buttons && buttons.length > 1) {
@@ -37,7 +42,6 @@ const showAlert = (
       buttons?.[0]?.onPress?.();
     }
   } else {
-    const { Alert } = require('react-native');
     Alert.alert(title, message, buttons);
   }
 };

--- a/src/screens/onboarding/CreateWalletScreen.tsx
+++ b/src/screens/onboarding/CreateWalletScreen.tsx
@@ -1,5 +1,5 @@
 import React, { useCallback, useEffect, useRef, useState } from 'react';
-import { View, Text, StyleSheet, Platform } from 'react-native';
+import { Alert, View, Text, StyleSheet, Platform } from 'react-native';
 import { SafeAreaView } from 'react-native-safe-area-context';
 import { Ionicons } from '@expo/vector-icons';
 import { StackNavigationProp } from '@react-navigation/stack';
@@ -45,7 +45,11 @@ export default function CreateWalletScreen({ navigation }: Props) {
   const showAlert = (
     title: string,
     message: string,
-    buttons?: { text: string; onPress?: () => void; style?: string }[]
+    buttons?: {
+      text: string;
+      onPress?: () => void;
+      style?: 'default' | 'cancel' | 'destructive';
+    }[]
   ) => {
     if (Platform.OS === 'web') {
       if (buttons && buttons.length > 1) {
@@ -63,7 +67,6 @@ export default function CreateWalletScreen({ navigation }: Props) {
         buttons?.[0]?.onPress?.();
       }
     } else {
-      const { Alert } = require('react-native');
       Alert.alert(title, message, buttons);
     }
   };
@@ -129,8 +132,6 @@ export default function CreateWalletScreen({ navigation }: Props) {
       }
       return;
     }
-    // eslint-disable-next-line @typescript-eslint/no-require-imports
-    const { Alert } = require('react-native');
     Alert.alert(title, message, [
       { text: 'Cancel', style: 'cancel' },
       { text: 'Go Back', style: 'destructive', onPress: onConfirm },

--- a/src/screens/remoteSigner/ExportAccountsScreen.tsx
+++ b/src/screens/remoteSigner/ExportAccountsScreen.tsx
@@ -8,6 +8,7 @@
 
 import React, { useState, useMemo } from 'react';
 import {
+  Alert,
   View,
   Text,
   StyleSheet,
@@ -200,7 +201,6 @@ export default function ExportAccountsScreen() {
     if (Platform.OS === 'web') {
       window.alert(`${title}\n\n${message}`);
     } else {
-      const { Alert } = require('react-native');
       Alert.alert(title, message);
     }
   };

--- a/src/screens/remoteSigner/ImportRemoteSignerScreen.tsx
+++ b/src/screens/remoteSigner/ImportRemoteSignerScreen.tsx
@@ -7,6 +7,7 @@
 
 import React, { useState, useRef } from 'react';
 import {
+  Alert,
   View,
   Text,
   StyleSheet,
@@ -43,7 +44,11 @@ type VerifiedStatus = 'v2-verified' | 'v1-unsigned';
 const showAlert = (
   title: string,
   message: string,
-  buttons?: { text: string; onPress?: () => void; style?: string }[]
+  buttons?: {
+    text: string;
+    onPress?: () => void;
+    style?: 'default' | 'cancel' | 'destructive';
+  }[]
 ) => {
   if (Platform.OS === 'web') {
     if (buttons && buttons.length > 1) {
@@ -61,7 +66,6 @@ const showAlert = (
       buttons?.[0]?.onPress?.();
     }
   } else {
-    const { Alert } = require('react-native');
     Alert.alert(title, message, buttons);
   }
 };

--- a/src/screens/remoteSigner/RemoteSignerSettingsScreen.tsx
+++ b/src/screens/remoteSigner/RemoteSignerSettingsScreen.tsx
@@ -9,6 +9,7 @@
 
 import React, { useState, useEffect } from 'react';
 import {
+  Alert,
   View,
   Text,
   StyleSheet,
@@ -48,7 +49,11 @@ import { TransferToAirgapFlow } from '@/components/remoteSigner/TransferToAirgap
 const showAlert = (
   title: string,
   message: string,
-  buttons?: { text: string; onPress?: () => void; style?: string }[]
+  buttons?: {
+    text: string;
+    onPress?: () => void;
+    style?: 'default' | 'cancel' | 'destructive';
+  }[]
 ) => {
   if (Platform.OS === 'web') {
     if (buttons && buttons.length > 1) {
@@ -66,7 +71,6 @@ const showAlert = (
       buttons?.[0]?.onPress?.();
     }
   } else {
-    const { Alert } = require('react-native');
     Alert.alert(title, message, buttons);
   }
 };

--- a/src/screens/remoteSigner/SignRequestScannerScreen.tsx
+++ b/src/screens/remoteSigner/SignRequestScannerScreen.tsx
@@ -7,6 +7,7 @@
 
 import React, { useState, useEffect, useRef, useCallback } from 'react';
 import {
+  Alert,
   View,
   Text,
   StyleSheet,
@@ -40,7 +41,11 @@ const { width } = Dimensions.get('window');
 const showAlert = (
   title: string,
   message: string,
-  buttons?: { text: string; onPress?: () => void; style?: string }[]
+  buttons?: {
+    text: string;
+    onPress?: () => void;
+    style?: 'default' | 'cancel' | 'destructive';
+  }[]
 ) => {
   if (Platform.OS === 'web') {
     if (buttons && buttons.length > 1) {
@@ -58,7 +63,6 @@ const showAlert = (
       buttons?.[0]?.onPress?.();
     }
   } else {
-    const { Alert } = require('react-native');
     Alert.alert(title, message, buttons);
   }
 };

--- a/src/screens/remoteSigner/SignatureDisplayScreen.tsx
+++ b/src/screens/remoteSigner/SignatureDisplayScreen.tsx
@@ -8,6 +8,7 @@
 
 import React, { useState, useEffect, useMemo } from 'react';
 import {
+  Alert,
   View,
   Text,
   StyleSheet,
@@ -39,7 +40,11 @@ import algosdk from 'algosdk';
 const showAlert = (
   title: string,
   message: string,
-  buttons?: { text: string; onPress?: () => void; style?: string }[]
+  buttons?: {
+    text: string;
+    onPress?: () => void;
+    style?: 'default' | 'cancel' | 'destructive';
+  }[]
 ) => {
   if (Platform.OS === 'web') {
     if (buttons && buttons.length > 1) {
@@ -57,7 +62,6 @@ const showAlert = (
       buttons?.[0]?.onPress?.();
     }
   } else {
-    const { Alert } = require('react-native');
     Alert.alert(title, message, buttons);
   }
 };

--- a/src/screens/remoteSigner/TransactionReviewScreen.tsx
+++ b/src/screens/remoteSigner/TransactionReviewScreen.tsx
@@ -7,6 +7,7 @@
 
 import React, { useState, useMemo, useCallback } from 'react';
 import {
+  Alert,
   View,
   Text,
   StyleSheet,
@@ -41,7 +42,11 @@ import { formatVoiBalance } from '@/utils/bigint';
 const showAlert = (
   title: string,
   message: string,
-  buttons?: { text: string; onPress?: () => void; style?: string }[]
+  buttons?: {
+    text: string;
+    onPress?: () => void;
+    style?: 'default' | 'cancel' | 'destructive';
+  }[]
 ) => {
   if (Platform.OS === 'web') {
     if (buttons && buttons.length > 1) {
@@ -59,7 +64,6 @@ const showAlert = (
       buttons?.[0]?.onPress?.();
     }
   } else {
-    const { Alert } = require('react-native');
     Alert.alert(title, message, buttons);
   }
 };


### PR DESCRIPTION
## What

Hoists the cross-platform `showAlert` helpers' native-branch `const { Alert } = require('react-native')` shims to static named imports.

**Sites hoisted: 14 statements across 13 files** (CreateWalletScreen had two — `:66` and `:133`). Each file already had a static `… from 'react-native'` import; `Alert` was added to that existing specifier list and the require line deleted. One inline `no-require-imports` disable that was attached to the `:133` Alert require in CreateWalletScreen was removed with it.

Files: `UnifiedAuthModal`, `ThemedWebView`, `QRScanner`, `AddWatchAccountScreen`, `LockScreen`, `SecureStorageUnavailableScreen`, `CreateWalletScreen` (×2), and 6 remoteSigner screens (`RemoteSignerSettings`, `ExportAccounts`, `SignatureDisplay`, `TransactionReview`, `ImportRemoteSigner`, `SignRequestScanner`).

No `Platform.OS` branching was altered — only the require line inside each `else` (native) branch was removed.

## rnw Alert export confirmed

Safe because react-native-web ships an `Alert` export: `node_modules/react-native-web/dist/exports/Alert` exists (verified before starting). A static named import of a nonexistent export would silently yield `undefined` under Metro CJS interop, which no static gate catches — hence the device check below.

## Necessary type-only fix (deviation from "import/require lines only")

The `require()` shim returned `any`, which masked a latent type looseness: each local `showAlert` typed its button `style` as `string`. With `Alert` now statically typed, `tsc` (a required gate) flags this in 9 files. The button `style` field was narrowed to the real `AlertButton` union `'default' | 'cancel' | 'destructive'`. This is **type-only and runtime-neutral** — every existing caller already passes those literals (`'cancel'`/`'destructive'`). Without it the hoist does not typecheck.

## Ratchet (DR-9, regenerated — not hand-computed)

- `--max-warnings` 619 → **606** (`npm run lint:baseline` authoritative total; `lint-baseline.json` re-committed).
- `@typescript-eslint/no-require-imports`: 19 → **6** (**delta 13**). The 14 hoisted statements cleared 13 warnings; the 14th (CreateWalletScreen `:133`) was already suppressed by an inline disable, so removing it + its disable is net-zero on the count.
- **No other rule moved** (only `warnings` 619→606 and `filesWithFindings` 152→150 changed in the summary).
- `npm run lint:baseline:check` passes.

## Left untouched (TASK-234, PR #154)

The `react-native-webview` module require in `ThemedWebView` and the `expo-local-authentication` require in `UnifiedAuthModal`, plus both their `no-require-imports` disables — these are NOT Alert requires. Re-grep confirmed only the Alert requires were removed.

## Gates

- `npm run typecheck` — clean (0)
- `npm run lint` — exit 0 at `--max-warnings 606`
- `npm test -- --ci` — 95 suites / 1503 tests green
- `npm run lint:baseline:check` — passes
- Codex review — **CLEAN**

## Device check (batched, NOT a merge gate — per HT-218)

Because a silently-`undefined` `Alert` fails only at call time, a pre-release device pass should trigger one alert on `SignRequestScannerScreen` and one on `CreateWalletScreen` to confirm the native dialog still appears. This is batched pre-release, not a merge gate.

https://claude.ai/code/session_01AL4EmUSYAiVXEstBgKqDmv