### PR TITLE
refactor(lint): remove dead imports and catch bindings (TASK-232)

### DIFF
--- a/lint-baseline.json
+++ b/lint-baseline.json
@@ -2,14 +2,14 @@
   "$comment": "Committed ESLint baseline for the `npm run lint` ratchet (PLAN-229 DR-2). Regenerate with `npm run lint:baseline`; verify with `npm run lint:baseline:check`. The `lint` script's --max-warnings MUST equal totals.warnings. Lower it in the same PR that clears the warnings. It never goes up.",
   "totals": {
     "errors": 0,
-    "warnings": 606,
+    "warnings": 410,
     "filesLinted": 431,
-    "filesWithFindings": 150
+    "filesWithFindings": 126
   },
   "rules": {
     "@typescript-eslint/no-require-imports": 6,
-    "@typescript-eslint/no-unused-vars": 306,
-    "import/no-named-as-default": 41,
+    "@typescript-eslint/no-unused-vars": 114,
+    "import/no-named-as-default": 37,
     "react-hooks/exhaustive-deps": 61,
     "react-hooks/immutability": 98,
     "react-hooks/preserve-manual-memoization": 25,
@@ -46,18 +46,11 @@
         "react-hooks/set-state-in-effect": 1
       }
     },
-    "src/components/account/AccountImportItem.tsx": {
-      "errors": 0,
-      "warnings": 1,
-      "rules": {
-        "@typescript-eslint/no-unused-vars": 1
-      }
-    },
     "src/components/account/AccountListItem.tsx": {
       "errors": 0,
-      "warnings": 6,
+      "warnings": 2,
       "rules": {
-        "@typescript-eslint/no-unused-vars": 6
+        "@typescript-eslint/no-unused-vars": 2
       }
     },
     "src/components/account/AccountRecipientModal.tsx": {
@@ -69,16 +62,16 @@
     },
     "src/components/account/AccountSelector.tsx": {
       "errors": 0,
-      "warnings": 2,
+      "warnings": 1,
       "rules": {
-        "@typescript-eslint/no-unused-vars": 2
+        "@typescript-eslint/no-unused-vars": 1
       }
     },
     "src/components/account/AddAccountModal.tsx": {
       "errors": 0,
-      "warnings": 5,
+      "warnings": 4,
       "rules": {
-        "@typescript-eslint/no-unused-vars": 4,
+        "@typescript-eslint/no-unused-vars": 3,
         "react-hooks/exhaustive-deps": 1
       }
     },
@@ -98,17 +91,15 @@
     },
     "src/components/assets/AssetOptInModal.tsx": {
       "errors": 0,
-      "warnings": 2,
+      "warnings": 1,
       "rules": {
-        "@typescript-eslint/no-unused-vars": 1,
         "react-hooks/set-state-in-effect": 1
       }
     },
     "src/components/assets/MultiNetworkAssetItem.tsx": {
       "errors": 0,
-      "warnings": 2,
+      "warnings": 1,
       "rules": {
-        "@typescript-eslint/no-unused-vars": 1,
         "react-hooks/set-state-in-effect": 1
       }
     },
@@ -128,18 +119,11 @@
         "react-hooks/set-state-in-effect": 1
       }
     },
-    "src/components/common/AnimatedNumber.tsx": {
-      "errors": 0,
-      "warnings": 2,
-      "rules": {
-        "@typescript-eslint/no-unused-vars": 2
-      }
-    },
     "src/components/common/BlurredContainer.tsx": {
       "errors": 0,
-      "warnings": 2,
+      "warnings": 1,
       "rules": {
-        "@typescript-eslint/no-unused-vars": 2
+        "@typescript-eslint/no-unused-vars": 1
       }
     },
     "src/components/common/GlassButton.tsx": {
@@ -151,25 +135,24 @@
     },
     "src/components/common/GlassCard.tsx": {
       "errors": 0,
-      "warnings": 5,
+      "warnings": 4,
       "rules": {
-        "@typescript-eslint/no-unused-vars": 1,
         "react-hooks/immutability": 4
       }
     },
     "src/components/common/GlassInput.tsx": {
       "errors": 0,
-      "warnings": 8,
+      "warnings": 6,
       "rules": {
-        "@typescript-eslint/no-unused-vars": 4,
+        "@typescript-eslint/no-unused-vars": 2,
         "react-hooks/immutability": 4
       }
     },
     "src/components/common/NFTBackground.tsx": {
       "errors": 0,
-      "warnings": 3,
+      "warnings": 2,
       "rules": {
-        "@typescript-eslint/no-unused-vars": 3
+        "@typescript-eslint/no-unused-vars": 2
       }
     },
     "src/components/common/NFTThemeSelector.tsx": {
@@ -184,24 +167,22 @@
     },
     "src/components/common/ThemedWebView.tsx": {
       "errors": 0,
-      "warnings": 4,
+      "warnings": 1,
       "rules": {
-        "@typescript-eslint/no-unused-vars": 4
+        "@typescript-eslint/no-unused-vars": 1
       }
     },
     "src/components/common/UniversalHeader.tsx": {
       "errors": 0,
-      "warnings": 5,
+      "warnings": 2,
       "rules": {
-        "@typescript-eslint/no-unused-vars": 3,
         "react-hooks/immutability": 2
       }
     },
     "src/components/debug/DebugLogsModal.tsx": {
       "errors": 0,
-      "warnings": 3,
+      "warnings": 1,
       "rules": {
-        "@typescript-eslint/no-unused-vars": 2,
         "react-hooks/set-state-in-effect": 1
       }
     },
@@ -238,17 +219,16 @@
     },
     "src/components/navigation/FABRadialMenu.tsx": {
       "errors": 0,
-      "warnings": 10,
+      "warnings": 6,
       "rules": {
-        "@typescript-eslint/no-unused-vars": 4,
         "react-hooks/immutability": 6
       }
     },
     "src/components/network/NetworkIndicator.tsx": {
       "errors": 0,
-      "warnings": 3,
+      "warnings": 2,
       "rules": {
-        "@typescript-eslint/no-unused-vars": 3
+        "@typescript-eslint/no-unused-vars": 2
       }
     },
     "src/components/network/NetworkSwitcher.tsx": {
@@ -277,17 +257,15 @@
     },
     "src/components/remoteSigner/AnimatedQRCode.tsx": {
       "errors": 0,
-      "warnings": 2,
+      "warnings": 1,
       "rules": {
-        "@typescript-eslint/no-unused-vars": 1,
         "react-hooks/set-state-in-effect": 1
       }
     },
     "src/components/remoteSigner/AnimatedQRScanner.tsx": {
       "errors": 0,
-      "warnings": 2,
+      "warnings": 1,
       "rules": {
-        "@typescript-eslint/no-unused-vars": 1,
         "react-hooks/set-state-in-effect": 1
       }
     },
@@ -308,13 +286,6 @@
         "react-hooks/purity": 1
       }
     },
-    "src/components/social/MessageBubble.tsx": {
-      "errors": 0,
-      "warnings": 1,
-      "rules": {
-        "@typescript-eslint/no-unused-vars": 1
-      }
-    },
     "src/components/social/MessageInput.tsx": {
       "errors": 0,
       "warnings": 1,
@@ -324,9 +295,9 @@
     },
     "src/components/swap/RouteDetailModal.tsx": {
       "errors": 0,
-      "warnings": 7,
+      "warnings": 5,
       "rules": {
-        "@typescript-eslint/no-unused-vars": 4,
+        "@typescript-eslint/no-unused-vars": 2,
         "react-hooks/exhaustive-deps": 1,
         "react-hooks/immutability": 1,
         "react-hooks/set-state-in-effect": 1
@@ -364,13 +335,6 @@
         "@typescript-eslint/no-unused-vars": 1
       }
     },
-    "src/components/wallet/MnemonicBackupFlow.tsx": {
-      "errors": 0,
-      "warnings": 1,
-      "rules": {
-        "@typescript-eslint/no-unused-vars": 1
-      }
-    },
     "src/components/walletconnect/DAppInfo.tsx": {
       "errors": 0,
       "warnings": 1,
@@ -380,9 +344,9 @@
     },
     "src/components/walletconnect/QRScanner.tsx": {
       "errors": 0,
-      "warnings": 6,
+      "warnings": 5,
       "rules": {
-        "@typescript-eslint/no-unused-vars": 4,
+        "@typescript-eslint/no-unused-vars": 3,
         "react-hooks/immutability": 1,
         "react-hooks/set-state-in-effect": 1
       }
@@ -406,26 +370,12 @@
         "react-hooks/set-state-in-effect": 1
       }
     },
-    "src/hooks/useThemedStyles.ts": {
-      "errors": 0,
-      "warnings": 2,
-      "rules": {
-        "@typescript-eslint/no-unused-vars": 2
-      }
-    },
     "src/navigation/AppNavigator.tsx": {
       "errors": 0,
-      "warnings": 7,
+      "warnings": 3,
       "rules": {
-        "@typescript-eslint/no-unused-vars": 6,
+        "@typescript-eslint/no-unused-vars": 2,
         "react-hooks/exhaustive-deps": 1
-      }
-    },
-    "src/platform/index.ts": {
-      "errors": 0,
-      "warnings": 2,
-      "rules": {
-        "@typescript-eslint/no-unused-vars": 2
       }
     },
     "src/screens/account/AccountImportPreviewScreen.tsx": {
@@ -436,13 +386,6 @@
       }
     },
     "src/screens/account/AddWatchAccountScreen.tsx": {
-      "errors": 0,
-      "warnings": 1,
-      "rules": {
-        "@typescript-eslint/no-unused-vars": 1
-      }
-    },
-    "src/screens/account/CreateAccountScreen.tsx": {
       "errors": 0,
       "warnings": 1,
       "rules": {
@@ -484,9 +427,8 @@
     },
     "src/screens/onboarding/CreateWalletScreen.tsx": {
       "errors": 0,
-      "warnings": 2,
+      "warnings": 1,
       "rules": {
-        "@typescript-eslint/no-unused-vars": 1,
         "react-hooks/set-state-in-effect": 1
       }
     },
@@ -499,9 +441,8 @@
     },
     "src/screens/onboarding/SecuritySetupScreen.tsx": {
       "errors": 0,
-      "warnings": 2,
+      "warnings": 1,
       "rules": {
-        "@typescript-eslint/no-unused-vars": 1,
         "react-hooks/immutability": 1
       }
     },
@@ -514,33 +455,24 @@
     },
     "src/screens/remoteSigner/ImportFromOnlineWalletScreen.tsx": {
       "errors": 0,
-      "warnings": 3,
+      "warnings": 2,
       "rules": {
-        "@typescript-eslint/no-unused-vars": 1,
         "react-hooks/exhaustive-deps": 1,
         "react-hooks/set-state-in-effect": 1
       }
     },
-    "src/screens/remoteSigner/ImportRemoteSignerScreen.tsx": {
-      "errors": 0,
-      "warnings": 2,
-      "rules": {
-        "@typescript-eslint/no-unused-vars": 2
-      }
-    },
     "src/screens/remoteSigner/RemoteSignerSettingsScreen.tsx": {
       "errors": 0,
-      "warnings": 5,
+      "warnings": 1,
       "rules": {
-        "@typescript-eslint/no-unused-vars": 4,
         "react-hooks/set-state-in-effect": 1
       }
     },
     "src/screens/remoteSigner/SignRequestScannerScreen.tsx": {
       "errors": 0,
-      "warnings": 8,
+      "warnings": 6,
       "rules": {
-        "@typescript-eslint/no-unused-vars": 5,
+        "@typescript-eslint/no-unused-vars": 3,
         "react-hooks/exhaustive-deps": 1,
         "react-hooks/immutability": 1,
         "react-hooks/set-state-in-effect": 1
@@ -563,24 +495,17 @@
     },
     "src/screens/settings/AboutScreen.tsx": {
       "errors": 0,
-      "warnings": 2,
+      "warnings": 1,
       "rules": {
-        "@typescript-eslint/no-unused-vars": 2
+        "@typescript-eslint/no-unused-vars": 1
       }
     },
     "src/screens/settings/BackupWalletScreen.tsx": {
       "errors": 0,
-      "warnings": 4,
+      "warnings": 2,
       "rules": {
-        "@typescript-eslint/no-unused-vars": 3,
+        "@typescript-eslint/no-unused-vars": 1,
         "react-hooks/exhaustive-deps": 1
-      }
-    },
-    "src/screens/settings/ChangePinScreen.tsx": {
-      "errors": 0,
-      "warnings": 1,
-      "rules": {
-        "@typescript-eslint/no-unused-vars": 1
       }
     },
     "src/screens/settings/NotificationSettingsScreen.tsx": {
@@ -595,9 +520,9 @@
     },
     "src/screens/settings/RestoreWalletScreen.tsx": {
       "errors": 0,
-      "warnings": 4,
+      "warnings": 3,
       "rules": {
-        "@typescript-eslint/no-unused-vars": 4
+        "@typescript-eslint/no-unused-vars": 3
       }
     },
     "src/screens/settings/SecuritySettingsScreen.tsx": {
@@ -617,9 +542,9 @@
     },
     "src/screens/settings/ShowRecoveryPhraseScreen.tsx": {
       "errors": 0,
-      "warnings": 3,
+      "warnings": 2,
       "rules": {
-        "@typescript-eslint/no-unused-vars": 2,
+        "@typescript-eslint/no-unused-vars": 1,
         "react-hooks/set-state-in-effect": 1
       }
     },
@@ -678,69 +603,59 @@
         "react-hooks/set-state-in-effect": 1
       }
     },
-    "src/screens/transaction/AppCallConfirmScreen.tsx": {
-      "errors": 0,
-      "warnings": 2,
-      "rules": {
-        "@typescript-eslint/no-unused-vars": 2
-      }
-    },
     "src/screens/transaction/KeyregConfirmScreen.tsx": {
       "errors": 0,
-      "warnings": 4,
+      "warnings": 1,
       "rules": {
-        "@typescript-eslint/no-unused-vars": 4
+        "@typescript-eslint/no-unused-vars": 1
       }
     },
     "src/screens/wallet/AccountInfoScreen.tsx": {
       "errors": 0,
-      "warnings": 9,
+      "warnings": 8,
       "rules": {
-        "@typescript-eslint/no-unused-vars": 6,
+        "@typescript-eslint/no-unused-vars": 5,
         "import/no-named-as-default": 1,
         "react-hooks/set-state-in-effect": 2
       }
     },
     "src/screens/wallet/AccountSearchScreen.tsx": {
       "errors": 0,
-      "warnings": 3,
+      "warnings": 2,
       "rules": {
-        "@typescript-eslint/no-unused-vars": 1,
         "react-hooks/exhaustive-deps": 1,
         "react-hooks/set-state-in-effect": 1
       }
     },
     "src/screens/wallet/AssetDetailScreen.tsx": {
       "errors": 0,
-      "warnings": 6,
+      "warnings": 5,
       "rules": {
-        "@typescript-eslint/no-unused-vars": 3,
+        "@typescript-eslint/no-unused-vars": 2,
         "react-hooks/exhaustive-deps": 1,
         "react-hooks/set-state-in-effect": 2
       }
     },
     "src/screens/wallet/BuyScreen.tsx": {
       "errors": 0,
-      "warnings": 4,
+      "warnings": 1,
       "rules": {
-        "@typescript-eslint/no-unused-vars": 4
+        "@typescript-eslint/no-unused-vars": 1
       }
     },
     "src/screens/wallet/ClaimAllConfirmationScreen.tsx": {
       "errors": 0,
-      "warnings": 8,
+      "warnings": 3,
       "rules": {
-        "@typescript-eslint/no-unused-vars": 4,
-        "import/no-named-as-default": 2,
+        "import/no-named-as-default": 1,
         "react-hooks/set-state-in-effect": 2
       }
     },
     "src/screens/wallet/ClaimTokenScreen.tsx": {
       "errors": 0,
-      "warnings": 10,
+      "warnings": 3,
       "rules": {
-        "@typescript-eslint/no-unused-vars": 6,
-        "import/no-named-as-default": 2,
+        "import/no-named-as-default": 1,
         "react-hooks/set-state-in-effect": 2
       }
     },
@@ -769,9 +684,9 @@
     },
     "src/screens/wallet/HomeScreen.tsx": {
       "errors": 0,
-      "warnings": 23,
+      "warnings": 15,
       "rules": {
-        "@typescript-eslint/no-unused-vars": 14,
+        "@typescript-eslint/no-unused-vars": 6,
         "import/no-named-as-default": 1,
         "react-hooks/exhaustive-deps": 2,
         "react-hooks/immutability": 3,
@@ -787,9 +702,9 @@
     },
     "src/screens/wallet/NFTScreen.tsx": {
       "errors": 0,
-      "warnings": 15,
+      "warnings": 9,
       "rules": {
-        "@typescript-eslint/no-unused-vars": 7,
+        "@typescript-eslint/no-unused-vars": 1,
         "react-hooks/exhaustive-deps": 3,
         "react-hooks/immutability": 2,
         "react-hooks/preserve-manual-memoization": 2,
@@ -798,16 +713,16 @@
     },
     "src/screens/wallet/ReceiveScreen.tsx": {
       "errors": 0,
-      "warnings": 5,
+      "warnings": 2,
       "rules": {
-        "@typescript-eslint/no-unused-vars": 5
+        "@typescript-eslint/no-unused-vars": 2
       }
     },
     "src/screens/wallet/RekeyAccountScreen.tsx": {
       "errors": 0,
-      "warnings": 9,
+      "warnings": 6,
       "rules": {
-        "@typescript-eslint/no-unused-vars": 4,
+        "@typescript-eslint/no-unused-vars": 1,
         "import/no-named-as-default": 1,
         "react-hooks/exhaustive-deps": 2,
         "react-hooks/set-state-in-effect": 2
@@ -815,10 +730,10 @@
     },
     "src/screens/wallet/SendScreen.tsx": {
       "errors": 0,
-      "warnings": 33,
+      "warnings": 26,
       "rules": {
-        "@typescript-eslint/no-unused-vars": 18,
-        "import/no-named-as-default": 2,
+        "@typescript-eslint/no-unused-vars": 12,
+        "import/no-named-as-default": 1,
         "react-hooks/exhaustive-deps": 8,
         "react-hooks/immutability": 1,
         "react-hooks/set-state-in-effect": 4
@@ -826,9 +741,8 @@
     },
     "src/screens/wallet/SwapScreen.tsx": {
       "errors": 0,
-      "warnings": 14,
+      "warnings": 10,
       "rules": {
-        "@typescript-eslint/no-unused-vars": 4,
         "react-hooks/exhaustive-deps": 2,
         "react-hooks/immutability": 3,
         "react-hooks/refs": 4,
@@ -837,10 +751,10 @@
     },
     "src/screens/wallet/TransactionConfirmationScreen.tsx": {
       "errors": 0,
-      "warnings": 13,
+      "warnings": 7,
       "rules": {
-        "@typescript-eslint/no-unused-vars": 7,
-        "import/no-named-as-default": 2,
+        "@typescript-eslint/no-unused-vars": 2,
+        "import/no-named-as-default": 1,
         "react-hooks/exhaustive-deps": 2,
         "react-hooks/immutability": 2
       }
@@ -863,9 +777,8 @@
     },
     "src/screens/wallet/UniversalTransactionSigningScreen.tsx": {
       "errors": 0,
-      "warnings": 3,
+      "warnings": 2,
       "rules": {
-        "@typescript-eslint/no-unused-vars": 1,
         "react-hooks/exhaustive-deps": 1,
         "react-hooks/immutability": 1
       }
@@ -879,9 +792,8 @@
     },
     "src/screens/walletconnect/SessionProposalScreen.tsx": {
       "errors": 0,
-      "warnings": 3,
+      "warnings": 1,
       "rules": {
-        "@typescript-eslint/no-unused-vars": 2,
         "react-hooks/immutability": 1
       }
     },
@@ -896,9 +808,9 @@
     },
     "src/screens/walletconnect/TransactionRequestScreen.tsx": {
       "errors": 0,
-      "warnings": 13,
+      "warnings": 9,
       "rules": {
-        "@typescript-eslint/no-unused-vars": 9,
+        "@typescript-eslint/no-unused-vars": 5,
         "react-hooks/exhaustive-deps": 2,
         "react-hooks/immutability": 2
       }
@@ -919,16 +831,9 @@
     },
     "src/services/auth/transactionAuthController.ts": {
       "errors": 0,
-      "warnings": 2,
+      "warnings": 1,
       "rules": {
-        "@typescript-eslint/no-unused-vars": 2
-      }
-    },
-    "src/services/debug/logger.ts": {
-      "errors": 0,
-      "warnings": 3,
-      "rules": {
-        "@typescript-eslint/no-unused-vars": 3
+        "@typescript-eslint/no-unused-vars": 1
       }
     },
     "src/services/deeplink/index.ts": {
@@ -939,21 +844,7 @@
         "@typescript-eslint/no-unused-vars": 2
       }
     },
-    "src/services/ledger/simpleLedgerManager.ts": {
-      "errors": 0,
-      "warnings": 4,
-      "rules": {
-        "@typescript-eslint/no-unused-vars": 4
-      }
-    },
     "src/services/ledger/simpleLedgerSigner.ts": {
-      "errors": 0,
-      "warnings": 3,
-      "rules": {
-        "@typescript-eslint/no-unused-vars": 3
-      }
-    },
-    "src/services/messaging/index.ts": {
       "errors": 0,
       "warnings": 1,
       "rules": {
@@ -962,17 +853,9 @@
     },
     "src/services/network/index.ts": {
       "errors": 0,
-      "warnings": 7,
+      "warnings": 3,
       "rules": {
-        "@typescript-eslint/no-unused-vars": 4,
         "import/no-named-as-default": 3
-      }
-    },
-    "src/services/nft.ts": {
-      "errors": 0,
-      "warnings": 1,
-      "rules": {
-        "@typescript-eslint/no-unused-vars": 1
       }
     },
     "src/services/remoteSigner/animatedQR.ts": {
@@ -980,20 +863,6 @@
       "warnings": 1,
       "rules": {
         "@typescript-eslint/no-unused-vars": 1
-      }
-    },
-    "src/services/remoteSigner/signingRouter.ts": {
-      "errors": 0,
-      "warnings": 1,
-      "rules": {
-        "@typescript-eslint/no-unused-vars": 1
-      }
-    },
-    "src/services/secure/AccountSecureStorage.ts": {
-      "errors": 0,
-      "warnings": 11,
-      "rules": {
-        "@typescript-eslint/no-unused-vars": 11
       }
     },
     "src/services/secure/keyManager.ts": {
@@ -1005,17 +874,9 @@
     },
     "src/services/secure/simplifiedKeyManager.ts": {
       "errors": 0,
-      "warnings": 3,
-      "rules": {
-        "@typescript-eslint/no-unused-vars": 1,
-        "import/no-named-as-default": 2
-      }
-    },
-    "src/services/secure/transactionManager.ts": {
-      "errors": 0,
       "warnings": 2,
       "rules": {
-        "@typescript-eslint/no-unused-vars": 2
+        "import/no-named-as-default": 2
       }
     },
     "src/services/swap/index.ts": {
@@ -1023,20 +884,6 @@
       "warnings": 1,
       "rules": {
         "import/no-named-as-default": 1
-      }
-    },
-    "src/services/swap/types.ts": {
-      "errors": 0,
-      "warnings": 1,
-      "rules": {
-        "@typescript-eslint/no-unused-vars": 1
-      }
-    },
-    "src/services/theme/themeGenerator.ts": {
-      "errors": 0,
-      "warnings": 3,
-      "rules": {
-        "@typescript-eslint/no-unused-vars": 3
       }
     },
     "src/services/token-mapping/index.ts": {
@@ -1063,17 +910,16 @@
     },
     "src/services/transactions/index.ts": {
       "errors": 0,
-      "warnings": 7,
+      "warnings": 1,
       "rules": {
-        "@typescript-eslint/no-unused-vars": 6,
         "import/no-named-as-default": 1
       }
     },
     "src/services/transactions/unifiedSigner.ts": {
       "errors": 0,
-      "warnings": 7,
+      "warnings": 3,
       "rules": {
-        "@typescript-eslint/no-unused-vars": 7
+        "@typescript-eslint/no-unused-vars": 3
       }
     },
     "src/services/wallet/index.ts": {
@@ -1099,31 +945,17 @@
     },
     "src/services/walletconnect/index.ts": {
       "errors": 0,
-      "warnings": 5,
+      "warnings": 3,
       "rules": {
         "@typescript-eslint/no-require-imports": 1,
-        "@typescript-eslint/no-unused-vars": 4
-      }
-    },
-    "src/services/walletconnect/types.ts": {
-      "errors": 0,
-      "warnings": 2,
-      "rules": {
         "@typescript-eslint/no-unused-vars": 2
       }
     },
     "src/services/walletconnect/utils.ts": {
       "errors": 0,
-      "warnings": 6,
+      "warnings": 1,
       "rules": {
-        "@typescript-eslint/no-unused-vars": 6
-      }
-    },
-    "src/services/walletconnect/v1/client.ts": {
-      "errors": 0,
-      "warnings": 2,
-      "rules": {
-        "@typescript-eslint/no-unused-vars": 2
+        "@typescript-eslint/no-unused-vars": 1
       }
     },
     "src/services/walletconnect/v1/crypto.ts": {
@@ -1143,33 +975,24 @@
     },
     "src/store/friendsStore.ts": {
       "errors": 0,
-      "warnings": 3,
-      "rules": {
-        "@typescript-eslint/no-unused-vars": 2,
-        "import/no-named-as-default": 1
-      }
-    },
-    "src/store/messagesStore.ts": {
-      "errors": 0,
       "warnings": 2,
       "rules": {
         "@typescript-eslint/no-unused-vars": 1,
         "import/no-named-as-default": 1
       }
     },
-    "src/store/walletStore.ts": {
+    "src/store/messagesStore.ts": {
       "errors": 0,
-      "warnings": 5,
+      "warnings": 1,
       "rules": {
-        "@typescript-eslint/no-unused-vars": 4,
         "import/no-named-as-default": 1
       }
     },
-    "src/utils/accountQRParser.ts": {
+    "src/store/walletStore.ts": {
       "errors": 0,
-      "warnings": 2,
+      "warnings": 1,
       "rules": {
-        "@typescript-eslint/no-unused-vars": 2
+        "import/no-named-as-default": 1
       }
     },
     "src/utils/address.ts": {
@@ -1185,20 +1008,6 @@
       "rules": {
         "@typescript-eslint/no-require-imports": 1,
         "react-hooks/immutability": 28
-      }
-    },
-    "src/utils/assetImages.ts": {
-      "errors": 0,
-      "warnings": 1,
-      "rules": {
-        "@typescript-eslint/no-unused-vars": 1
-      }
-    },
-    "src/utils/formatting.ts": {
-      "errors": 0,
-      "warnings": 2,
-      "rules": {
-        "@typescript-eslint/no-unused-vars": 2
       }
     }
   }

--- a/package.json
+++ b/package.json
@@ -7,7 +7,7 @@
     "android": "expo run:android",
     "ios": "expo run:ios",
     "web": "expo start --web",
-    "lint": "eslint src/ --max-warnings 606",
+    "lint": "eslint src/ --max-warnings 410",
     "lint:fix": "eslint src/ --fix",
     "lint:baseline": "node scripts/lint-baseline.mjs --write",
     "lint:baseline:check": "node scripts/lint-baseline.mjs --check",

--- a/src/components/account/AccountImportItem.tsx
+++ b/src/components/account/AccountImportItem.tsx
@@ -1,12 +1,5 @@
 import React, { useState } from 'react';
-import {
-  View,
-  Text,
-  StyleSheet,
-  TextInput,
-  TouchableOpacity,
-  Switch,
-} from 'react-native';
+import { View, Text, StyleSheet, TextInput, Switch } from 'react-native';
 import { Ionicons } from '@expo/vector-icons';
 import { ScannedAccount } from '@/utils/accountQRParser';
 import AccountAvatar from '@/components/account/AccountAvatar';

--- a/src/components/account/AccountListItem.tsx
+++ b/src/components/account/AccountListItem.tsx
@@ -1,4 +1,4 @@
-import React, { useEffect, useMemo } from 'react';
+import React from 'react';
 import { View, Text, TouchableOpacity, StyleSheet, Alert } from 'react-native';
 import { Ionicons } from '@expo/vector-icons';
 import { useThemedStyles, useThemeColors } from '@/hooks/useThemedStyles';
@@ -9,14 +9,9 @@ import {
   AccountType,
   RekeyedAccountMetadata,
 } from '@/types/wallet';
-import {
-  useWalletStore,
-  useAccountBalance,
-  useAccountEnvoiName,
-} from '@/store/walletStore';
+import { useWalletStore, useAccountBalance } from '@/store/walletStore';
 import AccountAvatar from './AccountAvatar';
 import { formatNativeBalance } from '@/utils/bigint';
-import { formatAddressSync } from '@/utils/address';
 import { useCurrentNetworkConfig } from '@/store/networkStore';
 
 interface AccountListItemProps {

--- a/src/components/account/AccountSelector.tsx
+++ b/src/components/account/AccountSelector.tsx
@@ -8,11 +8,7 @@ import {
 } from '@/store/walletStore';
 import { useCurrentNetworkConfig } from '@/store/networkStore';
 import AccountAvatar from './AccountAvatar';
-import {
-  formatVoiBalance,
-  formatNativeBalance,
-  getCurrencySymbol,
-} from '@/utils/bigint';
+import { formatVoiBalance, getCurrencySymbol } from '@/utils/bigint';
 import { useThemedStyles } from '@/hooks/useThemedStyles';
 import { useTheme } from '@/contexts/ThemeContext';
 import { Theme } from '@/constants/themes';

--- a/src/components/account/AddAccountModal.tsx
+++ b/src/components/account/AddAccountModal.tsx
@@ -10,7 +10,6 @@ import {
 } from '@gorhom/bottom-sheet';
 import { BottomSheetDefaultBackdropProps } from '@gorhom/bottom-sheet/lib/typescript/components/bottomSheetBackdrop/types';
 import { useWalletStore } from '@/store/walletStore';
-import { AccountType } from '@/types/wallet';
 
 interface AddAccountModalProps {
   isVisible: boolean;

--- a/src/components/assets/AssetOptInModal.tsx
+++ b/src/components/assets/AssetOptInModal.tsx
@@ -24,10 +24,7 @@ import { Theme } from '@/constants/themes';
 import KeyboardAwareScrollView from '@/components/common/KeyboardAwareScrollView';
 import { useSafeAreaInsets } from 'react-native-safe-area-context';
 import { NetworkId } from '@/types/network';
-import {
-  getNetworkConfig,
-  NETWORK_CONFIGURATIONS,
-} from '@/services/network/config';
+import { NETWORK_CONFIGURATIONS } from '@/services/network/config';
 
 interface AssetInfo {
   assetId: number;

--- a/src/components/assets/MultiNetworkAssetItem.tsx
+++ b/src/components/assets/MultiNetworkAssetItem.tsx
@@ -3,7 +3,7 @@ import { View, Text, TouchableOpacity, StyleSheet } from 'react-native';
 import { Image } from 'expo-image';
 import { Ionicons } from '@expo/vector-icons';
 import { MappedAsset } from '@/services/token-mapping/types';
-import { formatAssetBalance, formatNativeBalance } from '@/utils/bigint';
+import { formatAssetBalance } from '@/utils/bigint';
 import { formatCurrency } from '@/utils/formatting';
 import { getNetworkConfig } from '@/services/network/config';
 import { useThemedStyles } from '@/hooks/useThemedStyles';

--- a/src/components/common/AnimatedNumber.tsx
+++ b/src/components/common/AnimatedNumber.tsx
@@ -18,11 +18,9 @@ import Animated, {
   useAnimatedStyle,
   withTiming,
   useDerivedValue,
-  useAnimatedProps,
   runOnJS,
 } from 'react-native-reanimated';
 import { useTheme } from '@/contexts/ThemeContext';
-import { timingConfigs } from '@/utils/animations';
 
 interface AnimatedNumberProps {
   /** The number value to display */

--- a/src/components/common/BlurredContainer.tsx
+++ b/src/components/common/BlurredContainer.tsx
@@ -1,5 +1,5 @@
 import React, { useMemo } from 'react';
-import { View, StyleSheet, Platform, ViewStyle } from 'react-native';
+import { View, StyleSheet, ViewStyle } from 'react-native';
 import { LinearGradient } from 'expo-linear-gradient';
 import { useTheme } from '@/contexts/ThemeContext';
 import { SafeBlurView } from './SafeBlurView';

--- a/src/components/common/GlassCard.tsx
+++ b/src/components/common/GlassCard.tsx
@@ -10,7 +10,6 @@ import React, { useMemo, useCallback } from 'react';
 import {
   View,
   StyleSheet,
-  Platform,
   Pressable,
   ViewStyle,
   StyleProp,

--- a/src/components/common/GlassInput.tsx
+++ b/src/components/common/GlassInput.tsx
@@ -22,13 +22,12 @@ import Animated, {
   useAnimatedStyle,
   useSharedValue,
   withSpring,
-  withTiming,
   interpolate,
   interpolateColor,
 } from 'react-native-reanimated';
 import { useTheme } from '@/contexts/ThemeContext';
 import { SafeBlurView } from './SafeBlurView';
-import { springConfigs, timingConfigs } from '@/utils/animations';
+import { springConfigs } from '@/utils/animations';
 
 export type InputSize = 'sm' | 'md' | 'lg';
 

--- a/src/components/common/NFTBackground.tsx
+++ b/src/components/common/NFTBackground.tsx
@@ -1,5 +1,5 @@
 import React, { useMemo } from 'react';
-import { View, StyleSheet, Dimensions, Platform } from 'react-native';
+import { View, StyleSheet, Dimensions } from 'react-native';
 import { Image } from 'expo-image';
 import { LinearGradient } from 'expo-linear-gradient';
 import { useTheme } from '@/contexts/ThemeContext';

--- a/src/components/common/ThemedWebView.tsx
+++ b/src/components/common/ThemedWebView.tsx
@@ -166,7 +166,7 @@ const ThemedWebView = forwardRef<ThemedWebViewRef, ThemedWebViewProps>(
         if (Platform.OS === 'web') {
           try {
             iframeRef.current?.contentWindow?.history.back();
-          } catch (e) {
+          } catch {
             // Cross-origin restrictions may prevent this
           }
         } else {
@@ -177,7 +177,7 @@ const ThemedWebView = forwardRef<ThemedWebViewRef, ThemedWebViewProps>(
         if (Platform.OS === 'web') {
           try {
             iframeRef.current?.contentWindow?.history.forward();
-          } catch (e) {
+          } catch {
             // Cross-origin restrictions may prevent this
           }
         } else {
@@ -188,7 +188,7 @@ const ThemedWebView = forwardRef<ThemedWebViewRef, ThemedWebViewProps>(
         if (Platform.OS === 'web') {
           try {
             (iframeRef.current?.contentWindow as any)?.eval(script);
-          } catch (e) {
+          } catch {
             // Cross-origin restrictions may prevent this
             console.warn(
               'Cannot inject JavaScript into iframe due to cross-origin restrictions'

--- a/src/components/common/UniversalHeader.tsx
+++ b/src/components/common/UniversalHeader.tsx
@@ -1,19 +1,18 @@
 import React, { useCallback, useMemo } from 'react';
-import { View, Text, StyleSheet, Pressable, Platform } from 'react-native';
+import { View, Text, StyleSheet, Pressable } from 'react-native';
 import { LinearGradient } from 'expo-linear-gradient';
 import { Ionicons } from '@expo/vector-icons';
 import Animated, {
   useAnimatedStyle,
   useSharedValue,
   withSpring,
-  withTiming,
 } from 'react-native-reanimated';
 import AccountSelector from '../account/AccountSelector';
 import { useThemedStyles, useThemeColors } from '@/hooks/useThemedStyles';
 import { Theme } from '@/constants/themes';
 import { useTheme } from '@/contexts/ThemeContext';
 import { SafeBlurView } from './SafeBlurView';
-import { springConfigs, timingConfigs } from '@/utils/animations';
+import { springConfigs } from '@/utils/animations';
 
 interface UniversalHeaderProps {
   title: string;

--- a/src/components/debug/DebugLogsModal.tsx
+++ b/src/components/debug/DebugLogsModal.tsx
@@ -9,7 +9,6 @@ import {
   Share,
   Alert,
   SafeAreaView,
-  Dimensions,
   Platform,
   StatusBar,
 } from 'react-native';
@@ -66,7 +65,7 @@ export const DebugLogsModal: React.FC<DebugLogsModalProps> = ({
         message: logText,
         title: 'Ledger Debug Logs',
       });
-    } catch (error) {
+    } catch {
       Alert.alert('Error', 'Failed to share logs');
     }
   };

--- a/src/components/navigation/FABRadialMenu.tsx
+++ b/src/components/navigation/FABRadialMenu.tsx
@@ -16,14 +16,11 @@ import {
   TouchableWithoutFeedback,
   TouchableOpacity,
   Text,
-  Dimensions,
 } from 'react-native';
 import Animated, {
   useSharedValue,
   useAnimatedStyle,
   withSpring,
-  withTiming,
-  withDelay,
   interpolate,
   runOnJS,
   type SharedValue,
@@ -31,7 +28,7 @@ import Animated, {
 import { Ionicons } from '@expo/vector-icons';
 import { useNavigation } from '@react-navigation/native';
 import { useTheme } from '@/contexts/ThemeContext';
-import { springConfigs, timingConfigs } from '@/utils/animations';
+import { springConfigs } from '@/utils/animations';
 import { GlassCard } from '@/components/common/GlassCard';
 import { useActiveAccount } from '@/store/walletStore';
 import { useTotalUnreadCount } from '@/store/messagesStore';

--- a/src/components/network/NetworkIndicator.tsx
+++ b/src/components/network/NetworkIndicator.tsx
@@ -1,6 +1,5 @@
 import React from 'react';
 import { View, Text, StyleSheet, TouchableOpacity } from 'react-native';
-import { NetworkId } from '@/types/network';
 import { getNetworkConfig } from '@/services/network/config';
 import {
   useCurrentNetwork,

--- a/src/components/remoteSigner/AnimatedQRCode.tsx
+++ b/src/components/remoteSigner/AnimatedQRCode.tsx
@@ -14,7 +14,6 @@ import {
   AnimatedQRService,
   AnimatedQREncodeResult,
 } from '@/services/remoteSigner/animatedQR';
-import { REMOTE_SIGNER_CONSTANTS } from '@/types/remoteSigner';
 
 interface AnimatedQRCodeProps {
   /** The data to encode in the QR code(s) */

--- a/src/components/remoteSigner/AnimatedQRScanner.tsx
+++ b/src/components/remoteSigner/AnimatedQRScanner.tsx
@@ -12,7 +12,6 @@ import {
   StyleSheet,
   TouchableOpacity,
   Dimensions,
-  Platform,
 } from 'react-native';
 import { CameraView, useCameraPermissions } from 'expo-camera';
 import { useFocusEffect } from '@react-navigation/native';

--- a/src/components/social/MessageBubble.tsx
+++ b/src/components/social/MessageBubble.tsx
@@ -15,11 +15,7 @@ import { useThemedStyles } from '@/hooks/useThemedStyles';
 import { Theme } from '@/constants/themes';
 import { useTheme } from '@/contexts/ThemeContext';
 import { useCurrentNetworkConfig } from '@/store/networkStore';
-import {
-  Message,
-  MessageStatus,
-  MESSAGE_FEE_MICRO,
-} from '@/services/messaging/types';
+import { Message, MESSAGE_FEE_MICRO } from '@/services/messaging/types';
 
 interface MessageBubbleProps {
   message: Message;

--- a/src/components/swap/RouteDetailModal.tsx
+++ b/src/components/swap/RouteDetailModal.tsx
@@ -23,10 +23,8 @@ import {
   SwapToken,
   UnifiedRoute,
   UnifiedRoutePool,
-  UnifiedRouteHop,
 } from '../../services/swap/types';
 import { SwapService } from '../../services/swap';
-import { NetworkId } from '../../types/network';
 import { useNetworkStore } from '../../store/networkStore';
 import { useThemedStyles, useThemeColors } from '@/hooks/useThemedStyles';
 import { getTokenImageSource } from '../../utils/tokenImages';

--- a/src/components/wallet/MnemonicBackupFlow.tsx
+++ b/src/components/wallet/MnemonicBackupFlow.tsx
@@ -145,7 +145,7 @@ export default function MnemonicBackupFlow({
             () => setHasCopied(false),
             3000
           );
-        } catch (error) {
+        } catch {
           Alert.alert('Error', 'Failed to copy to clipboard');
         }
       });

--- a/src/components/walletconnect/QRScanner.tsx
+++ b/src/components/walletconnect/QRScanner.tsx
@@ -18,10 +18,7 @@ import {
   getArc0090UriType,
   isLegacyVoiUri,
 } from '@/utils/arc0090Uri';
-import {
-  parseArc0300AccountImportUri,
-  Arc0300AccountImportResult,
-} from '@/utils/arc0300';
+import { parseArc0300AccountImportUri } from '@/utils/arc0300';
 import algosdk from 'algosdk';
 import { useTheme } from '@/contexts/ThemeContext';
 import { useThemedStyles } from '@/hooks/useThemedStyles';

--- a/src/hooks/useThemedStyles.ts
+++ b/src/hooks/useThemedStyles.ts
@@ -1,7 +1,7 @@
 import { useMemo } from 'react';
 import { StyleSheet, ViewStyle, TextStyle } from 'react-native';
 import { useTheme } from '../contexts/ThemeContext';
-import { Theme, GlassEffect, TypographyStyle } from '../constants/themes';
+import { Theme, GlassEffect } from '../constants/themes';
 
 export const useThemedStyles = <T extends StyleSheet.NamedStyles<T>>(
   styleFactory: (theme: Theme) => T
@@ -11,7 +11,7 @@ export const useThemedStyles = <T extends StyleSheet.NamedStyles<T>>(
   return useMemo(() => {
     try {
       return styleFactory(theme);
-    } catch (error) {
+    } catch {
       console.warn(
         'useThemedStyles: Error creating styles, using empty styles'
       );

--- a/src/navigation/AppNavigator.tsx
+++ b/src/navigation/AppNavigator.tsx
@@ -1,9 +1,7 @@
-import React, { useEffect, useRef, useCallback, Suspense } from 'react';
+import React, { useEffect, useRef, Suspense } from 'react';
 import {
   NavigationContainer,
   StackActions,
-  useFocusEffect,
-  useNavigation,
   NavigatorScreenParams,
 } from '@react-navigation/native';
 import { createBottomTabNavigator } from '@react-navigation/bottom-tabs';
@@ -89,7 +87,6 @@ import { SerializableClaimableItem } from '@/types/claimable';
 import { NFTBackground } from '@/components/common/NFTBackground';
 import { TransactionRequestQueue } from '@/services/walletconnect/TransactionRequestQueue';
 import { FABRadialMenu } from '@/components/navigation/FABRadialMenu';
-import { useUpdates } from 'expo-updates';
 import { useUpdateStore } from '@/store/updateStore';
 
 // Import TransactionHistoryScreen directly to avoid async-require issues in EAS builds

--- a/src/platform/index.ts
+++ b/src/platform/index.ts
@@ -14,7 +14,7 @@
  * ```
  */
 
-import { isMobile, isExtension, getCachedPlatform } from './detection';
+import { isMobile } from './detection';
 import type {
   CryptoAdapter,
   SecureStorageAdapter,

--- a/src/screens/account/CreateAccountScreen.tsx
+++ b/src/screens/account/CreateAccountScreen.tsx
@@ -73,7 +73,7 @@ export default function CreateAccountScreen() {
       const wallet = WalletService.generateWallet();
       setMnemonic(wallet.mnemonic);
       setStep('backup');
-    } catch (error) {
+    } catch {
       Alert.alert('Error', 'Failed to generate wallet');
     }
   };

--- a/src/screens/onboarding/CreateWalletScreen.tsx
+++ b/src/screens/onboarding/CreateWalletScreen.tsx
@@ -76,7 +76,7 @@ export default function CreateWalletScreen({ navigation }: Props) {
     try {
       const wallet = WalletService.generateWallet();
       setMnemonic(wallet.mnemonic);
-    } catch (error) {
+    } catch {
       showAlert('Error', 'Failed to generate wallet');
     }
   }, []);

--- a/src/screens/onboarding/SecuritySetupScreen.tsx
+++ b/src/screens/onboarding/SecuritySetupScreen.tsx
@@ -14,7 +14,6 @@ import {
   AddWatchAccountRequest,
 } from '@/types/wallet';
 import {
-  ScannedAccount,
   getAccountSecret,
   clearAccountSecret,
   clearAccountSecrets,

--- a/src/screens/remoteSigner/ImportFromOnlineWalletScreen.tsx
+++ b/src/screens/remoteSigner/ImportFromOnlineWalletScreen.tsx
@@ -20,7 +20,6 @@ import {
   TouchableOpacity,
   ActivityIndicator,
   ScrollView,
-  Alert,
 } from 'react-native';
 import { SafeAreaView } from 'react-native-safe-area-context';
 import { useNavigation } from '@react-navigation/native';

--- a/src/screens/remoteSigner/ImportRemoteSignerScreen.tsx
+++ b/src/screens/remoteSigner/ImportRemoteSignerScreen.tsx
@@ -189,7 +189,7 @@ export default function ImportRemoteSignerScreen() {
       if (text) {
         handleSingleFrame(text.trim());
       }
-    } catch (error) {
+    } catch {
       showAlert('Error', 'Failed to read from clipboard');
     }
   };
@@ -231,7 +231,7 @@ export default function ImportRemoteSignerScreen() {
         image.src = e.target?.result as string;
       };
       reader.readAsDataURL(file);
-    } catch (error) {
+    } catch {
       showAlert('Error', 'Failed to process the image file.');
     }
   };

--- a/src/screens/remoteSigner/RemoteSignerSettingsScreen.tsx
+++ b/src/screens/remoteSigner/RemoteSignerSettingsScreen.tsx
@@ -36,11 +36,7 @@ import {
 } from '@/store/remoteSignerStore';
 import { useAccounts, useWalletStore } from '@/store/walletStore';
 import { AppMode } from '@/types/remoteSigner';
-import {
-  AccountType,
-  StandardAccountMetadata,
-  AccountMetadata,
-} from '@/types/wallet';
+import { AccountType, StandardAccountMetadata } from '@/types/wallet';
 import * as Updates from 'expo-updates';
 import AccountListModal from '@/components/account/AccountListModal';
 import { TransferToAirgapFlow } from '@/components/remoteSigner/TransferToAirgapFlow';
@@ -158,7 +154,7 @@ export default function RemoteSignerSettingsScreen() {
               } else {
                 await Updates.reloadAsync();
               }
-            } catch (error) {
+            } catch {
               showAlert('Error', 'Failed to switch mode. Please try again.');
               setIsModeSwitching(false);
             }
@@ -189,7 +185,7 @@ export default function RemoteSignerSettingsScreen() {
       } else {
         await Updates.reloadAsync();
       }
-    } catch (error) {
+    } catch {
       showAlert('Error', 'Failed to set up signer mode. Please try again.');
       setIsModeSwitching(false);
     }
@@ -205,7 +201,7 @@ export default function RemoteSignerSettingsScreen() {
       await updateSignerDeviceName(deviceName.trim());
       setIsEditingName(false);
       showAlert('Success', 'Device name updated');
-    } catch (error) {
+    } catch {
       showAlert('Error', 'Failed to update device name');
     }
   };

--- a/src/screens/remoteSigner/SignRequestScannerScreen.tsx
+++ b/src/screens/remoteSigner/SignRequestScannerScreen.tsx
@@ -204,7 +204,7 @@ export default function SignRequestScannerScreen() {
       if (text) {
         processQRData(text.trim());
       }
-    } catch (error) {
+    } catch {
       showAlert('Error', 'Failed to read from clipboard');
     }
   };
@@ -246,7 +246,7 @@ export default function SignRequestScannerScreen() {
         image.src = e.target?.result as string;
       };
       reader.readAsDataURL(file);
-    } catch (error) {
+    } catch {
       showAlert('Error', 'Failed to process the image file.');
     }
   };

--- a/src/screens/settings/AboutScreen.tsx
+++ b/src/screens/settings/AboutScreen.tsx
@@ -61,7 +61,7 @@ export default function AboutScreen() {
       } else {
         Alert.alert('Error', `Cannot open ${label}`);
       }
-    } catch (error) {
+    } catch {
       Alert.alert('Error', `Failed to open ${label}`);
     }
   };

--- a/src/screens/settings/BackupWalletScreen.tsx
+++ b/src/screens/settings/BackupWalletScreen.tsx
@@ -151,7 +151,7 @@ export default function BackupWalletScreen() {
       try {
         await BackupService.shareBackup(backupResult.fileUri);
         setBackupSaved(true);
-      } catch (err) {
+      } catch {
         Alert.alert(
           'Save Failed',
           'Could not save the backup file. Please try again.'
@@ -165,7 +165,7 @@ export default function BackupWalletScreen() {
     try {
       await BackupService.shareBackup(backupResult.fileUri);
       setBackupSaved(true);
-    } catch (err) {
+    } catch {
       Alert.alert(
         'Share Failed',
         'Could not share the backup file. Please try again.'

--- a/src/screens/settings/ChangePinScreen.tsx
+++ b/src/screens/settings/ChangePinScreen.tsx
@@ -177,7 +177,7 @@ export default function ChangePinScreen() {
             );
           }
         }
-      } catch (error) {
+      } catch {
         Alert.alert('Error', 'Failed to verify. Please try again.');
         setCurrentPin('');
       } finally {

--- a/src/screens/settings/RestoreWalletScreen.tsx
+++ b/src/screens/settings/RestoreWalletScreen.tsx
@@ -99,7 +99,7 @@ export default function RestoreWalletScreen() {
 
       // Show password modal to decrypt and validate
       setShowPasswordModal(true);
-    } catch (err) {
+    } catch {
       Alert.alert('Error', 'Failed to select file. Please try again.', [
         { text: 'OK' },
       ]);

--- a/src/screens/settings/ShowRecoveryPhraseScreen.tsx
+++ b/src/screens/settings/ShowRecoveryPhraseScreen.tsx
@@ -154,7 +154,7 @@ export default function ShowRecoveryPhraseScreen() {
 
           // Reset the copied state after 3 seconds
           timeoutRef.current = setTimeout(() => setHasCopied(false), 3000);
-        } catch (error) {
+        } catch {
           Alert.alert('Error', 'Failed to copy to clipboard');
         }
       });

--- a/src/screens/transaction/AppCallConfirmScreen.tsx
+++ b/src/screens/transaction/AppCallConfirmScreen.tsx
@@ -108,7 +108,7 @@ export default function AppCallConfirmScreen() {
             return new Uint8Array(Buffer.from(arg));
           }
         });
-      } catch (err) {
+      } catch {
         Alert.alert('Invalid Arguments', 'Failed to decode app arguments.');
         return;
       }
@@ -122,7 +122,7 @@ export default function AppCallConfirmScreen() {
           appIndex: params.appId,
           name: decodeBase64Url(box),
         }));
-      } catch (err) {
+      } catch {
         Alert.alert(
           'Invalid Box References',
           'Failed to decode box references.'

--- a/src/screens/transaction/KeyregConfirmScreen.tsx
+++ b/src/screens/transaction/KeyregConfirmScreen.tsx
@@ -6,7 +6,6 @@ import {
   TouchableOpacity,
   ScrollView,
   Alert,
-  ActivityIndicator,
 } from 'react-native';
 import { SafeAreaView } from 'react-native-safe-area-context';
 import { useNavigation, useRoute, RouteProp } from '@react-navigation/native';
@@ -17,10 +16,7 @@ import { Theme } from '@/constants/themes';
 import { GlassCard } from '@/components/common/GlassCard';
 import UniversalHeader from '@/components/common/UniversalHeader';
 import UnifiedTransactionAuthModal from '@/components/UnifiedTransactionAuthModal';
-import {
-  useTransactionAuthController,
-  TransactionAuthController,
-} from '@/services/auth/transactionAuthController';
+import { useTransactionAuthController } from '@/services/auth/transactionAuthController';
 import { UnifiedTransactionRequest } from '@/services/transactions/unifiedSigner';
 import { formatAddress } from '@/utils/address';
 import { useWalletStore, useActiveAccount } from '@/store/walletStore';
@@ -94,7 +90,7 @@ export default function KeyregConfirmScreen() {
       if (params.sprfkey) {
         stateProofKey = decodeBase64Url(params.sprfkey);
       }
-    } catch (err) {
+    } catch {
       Alert.alert('Invalid Keys', 'Failed to decode participation keys.');
       return;
     }

--- a/src/screens/wallet/AccountInfoScreen.tsx
+++ b/src/screens/wallet/AccountInfoScreen.tsx
@@ -9,7 +9,6 @@ import {
   Dimensions,
   TouchableOpacity,
   Alert,
-  Linking,
 } from 'react-native';
 import { useNavigation, RouteProp, useRoute } from '@react-navigation/native';
 import { NativeStackNavigationProp } from '@react-navigation/native-stack';

--- a/src/screens/wallet/AccountSearchScreen.tsx
+++ b/src/screens/wallet/AccountSearchScreen.tsx
@@ -20,7 +20,7 @@ import algosdk from 'algosdk';
 import { WalletStackParamList } from '@/navigation/AppNavigator';
 import { useThemedStyles } from '@/hooks/useThemedStyles';
 import { Theme } from '@/constants/themes';
-import { EnvoiService, EnvoiNameInfo } from '@/services/envoi';
+import { EnvoiService } from '@/services/envoi';
 import { formatAddress } from '@/utils/address';
 import AccountAvatar from '@/components/account/AccountAvatar';
 import { useFriendsStore } from '@/store/friendsStore';

--- a/src/screens/wallet/AssetDetailScreen.tsx
+++ b/src/screens/wallet/AssetDetailScreen.tsx
@@ -7,7 +7,6 @@ import {
   FlatList,
   TouchableOpacity,
   Alert,
-  ActivityIndicator,
 } from 'react-native';
 import { Image } from 'expo-image';
 import { SafeAreaView } from 'react-native-safe-area-context';

--- a/src/screens/wallet/BuyScreen.tsx
+++ b/src/screens/wallet/BuyScreen.tsx
@@ -5,15 +5,7 @@ import React, {
   useCallback,
   useEffect,
 } from 'react';
-import {
-  View,
-  Text,
-  StyleSheet,
-  Alert,
-  Linking,
-  Platform,
-  RefreshControl,
-} from 'react-native';
+import { View, Text, StyleSheet, RefreshControl } from 'react-native';
 import { SafeAreaView } from 'react-native-safe-area-context';
 import ThemedWebView, {
   ThemedWebViewRef,

--- a/src/screens/wallet/ClaimAllConfirmationScreen.tsx
+++ b/src/screens/wallet/ClaimAllConfirmationScreen.tsx
@@ -37,15 +37,12 @@ import { GlassCard } from '@/components/common/GlassCard';
 import { GlassButton } from '@/components/common/GlassButton';
 import KeyboardAwareScrollView from '@/components/common/KeyboardAwareScrollView';
 import { useActiveAccount } from '@/store/walletStore';
-import {
-  ClaimableItem,
-  fromSerializableClaimableItem,
-} from '@/types/claimable';
+import { fromSerializableClaimableItem } from '@/types/claimable';
 import {
   Arc200TransactionService,
   Arc200ClaimParams,
 } from '@/services/transactions/arc200';
-import VoiNetworkService, { NetworkService } from '@/services/network';
+import { NetworkService } from '@/services/network';
 import EnvoiService, { EnvoiSearchResult } from '@/services/envoi';
 import { normalizeAssetImageUrl } from '@/utils/assetImages';
 import { toErrorAlert } from '@/utils/errorMapping';
@@ -164,7 +161,7 @@ export default function ClaimAllConfirmationScreen() {
           setNameResolutionError('Invalid address');
           setRecipientAddress('');
         }
-      } catch (error) {
+      } catch {
         setNameResolutionError('Failed to resolve address');
         setRecipientAddress('');
       } finally {
@@ -286,7 +283,7 @@ export default function ClaimAllConfirmationScreen() {
             CLAIM_NETWORK_ID
           );
           setEstimatedFee(costEstimate.total);
-        } catch (error) {
+        } catch {
           setEstimatedFee(1000 * items.length);
         }
         return;

--- a/src/screens/wallet/ClaimTokenScreen.tsx
+++ b/src/screens/wallet/ClaimTokenScreen.tsx
@@ -15,7 +15,6 @@ import {
   Alert,
   ActivityIndicator,
   Switch,
-  ScrollView,
 } from 'react-native';
 import { Image } from 'expo-image';
 import { SafeAreaView } from 'react-native-safe-area-context';
@@ -38,12 +37,9 @@ import { GlassButton } from '@/components/common/GlassButton';
 import KeyboardAwareScrollView from '@/components/common/KeyboardAwareScrollView';
 import AccountRecipientModal from '@/components/account/AccountRecipientModal';
 import { useActiveAccount } from '@/store/walletStore';
-import {
-  ClaimableItem,
-  fromSerializableClaimableItem,
-} from '@/types/claimable';
+import { fromSerializableClaimableItem } from '@/types/claimable';
 import { Arc200TransactionService } from '@/services/transactions/arc200';
-import VoiNetworkService, { NetworkService } from '@/services/network';
+import { NetworkService } from '@/services/network';
 import EnvoiService, { EnvoiSearchResult } from '@/services/envoi';
 import { normalizeAssetImageUrl } from '@/utils/assetImages';
 import {
@@ -54,10 +50,7 @@ import {
 import { NetworkId } from '@/types/network';
 import { useCurrentNetworkConfig } from '@/store/networkStore';
 import { registerNavigationCallbacks } from '@/services/navigation/callbackRegistry';
-import type {
-  WalletStackParamList,
-  RootStackParamList,
-} from '@/navigation/AppNavigator';
+import type { WalletStackParamList } from '@/navigation/AppNavigator';
 
 // Claimable tokens are always on Voi network
 const CLAIM_NETWORK_ID = NetworkId.VOI_MAINNET;
@@ -164,7 +157,7 @@ export default function ClaimTokenScreen() {
           setNameResolutionError('Invalid address');
           setRecipientAddress('');
         }
-      } catch (error) {
+      } catch {
         setNameResolutionError('Failed to resolve address');
         setRecipientAddress('');
       } finally {
@@ -286,7 +279,7 @@ export default function ClaimTokenScreen() {
             CLAIM_NETWORK_ID
           );
           setEstimatedFee(costEstimate.total);
-        } catch (error) {
+        } catch {
           setEstimatedFee(1000);
         }
         return;

--- a/src/screens/wallet/HomeScreen.tsx
+++ b/src/screens/wallet/HomeScreen.tsx
@@ -29,11 +29,7 @@ import Animated, {
   withTiming,
   Easing,
 } from 'react-native-reanimated';
-import {
-  TransactionInfo,
-  AssetBalance,
-  needsBackupVerification,
-} from '@/types/wallet';
+import { AssetBalance, needsBackupVerification } from '@/types/wallet';
 import { useAuth } from '@/contexts/AuthContext';
 import {
   useActiveAccount,
@@ -45,16 +41,13 @@ import {
   useIsMultiNetworkView,
   useMultiNetworkBalance,
   useAssetNetworkFilter,
-  useAssetFilterSettings,
 } from '@/store/walletStore';
 import VoiNetworkService, { NetworkStatus } from '@/services/network';
-import { formatNativeBalance, formatAssetBalance } from '@/utils/bigint';
+import { formatNativeBalance } from '@/utils/bigint';
 import { formatCurrency } from '@/utils/formatting';
-import { formatAddressSync } from '@/utils/address';
-import { useCurrentNetworkConfig, useNetworkStore } from '@/store/networkStore';
+import { useCurrentNetworkConfig } from '@/store/networkStore';
 import { getNetworkConfig } from '@/services/network/config';
 import { NetworkId } from '@/types/network';
-import AccountSelector from '@/components/account/AccountSelector';
 import AccountListModal from '@/components/account/AccountListModal';
 import UniversalHeader from '@/components/common/UniversalHeader';
 import AddAccountModal from '@/components/account/AddAccountModal';
@@ -71,10 +64,9 @@ import type { AssetFilterSettings } from '@/components/assets/AssetFilterModal';
 import { MappedAsset } from '@/services/token-mapping/types';
 import { GlassCard } from '@/components/common/GlassCard';
 import { GlassButton } from '@/components/common/GlassButton';
-import { BlurredContainer } from '@/components/common/BlurredContainer';
 import { NFTBackground } from '@/components/common/NFTBackground';
 import { useTheme } from '@/contexts/ThemeContext';
-import { springConfigs, getStaggerDelay } from '@/utils/animations';
+import { springConfigs } from '@/utils/animations';
 import ClaimableBanner from '@/components/claimable/ClaimableBanner';
 import {
   useClaimableStore,

--- a/src/screens/wallet/NFTScreen.tsx
+++ b/src/screens/wallet/NFTScreen.tsx
@@ -21,12 +21,7 @@ import type {
   MainTabParamList,
   RootStackParamList,
 } from '@/navigation/AppNavigator';
-import Animated, {
-  useAnimatedStyle,
-  useSharedValue,
-  withSpring,
-  withTiming,
-} from 'react-native-reanimated';
+import Animated from 'react-native-reanimated';
 import { useActiveAccount } from '@/store/walletStore';
 import { NFTService } from '@/services/nft';
 import { ARC72Collection, NFTToken } from '@/types/nft';
@@ -40,8 +35,6 @@ import { useTheme } from '@/contexts/ThemeContext';
 import { NetworkId } from '@/types/network';
 import { NFTBackground } from '@/components/common/NFTBackground';
 import { GlassCard } from '@/components/common/GlassCard';
-import { BlurredContainer } from '@/components/common/BlurredContainer';
-import { springConfigs } from '@/utils/animations';
 
 const AnimatedPressable = Animated.createAnimatedComponent(Pressable);
 

--- a/src/screens/wallet/ReceiveScreen.tsx
+++ b/src/screens/wallet/ReceiveScreen.tsx
@@ -1,9 +1,8 @@
-import React, { useState, useEffect } from 'react';
+import React, { useState } from 'react';
 import {
   View,
   Text,
   StyleSheet,
-  TouchableOpacity,
   Alert,
   Share,
   ActivityIndicator,
@@ -31,7 +30,6 @@ import { Theme } from '@/constants/themes';
 import { useTheme } from '@/contexts/ThemeContext';
 import { useActiveAccount, useActiveAccountBalance } from '@/store/walletStore';
 import { formatVoiBalance } from '@/utils/bigint';
-import AccountSelector from '@/components/account/AccountSelector';
 import AccountListModal from '@/components/account/AccountListModal';
 import AddAccountModal from '@/components/account/AddAccountModal';
 import UniversalHeader from '@/components/common/UniversalHeader';

--- a/src/screens/wallet/RekeyAccountScreen.tsx
+++ b/src/screens/wallet/RekeyAccountScreen.tsx
@@ -18,7 +18,6 @@ import {
   AccountMetadata,
   AccountType,
   StandardAccountMetadata,
-  RekeyedAccountMetadata,
   LedgerAccountMetadata,
   RemoteSignerAccountMetadata,
   LedgerSigningInfo,
@@ -36,11 +35,8 @@ import RekeyToLedger from '@/components/ledger/RekeyToLedger';
 import AirgapVerificationFlow from '@/components/rekey/AirgapVerificationFlow';
 import { useTheme } from '@/contexts/ThemeContext';
 import { NetworkId } from '@/types/network';
-import {
-  getNetworkConfig,
-  NETWORK_CONFIGURATIONS,
-} from '@/services/network/config';
-import { NetworkService, RekeyInfo } from '@/services/network';
+import { NETWORK_CONFIGURATIONS } from '@/services/network/config';
+import { NetworkService } from '@/services/network';
 
 type RekeyAccountScreenRouteProp = RouteProp<
   SettingsStackParamList,

--- a/src/screens/wallet/SendScreen.tsx
+++ b/src/screens/wallet/SendScreen.tsx
@@ -1,4 +1,4 @@
-import React, { useState, useEffect, useCallback, useMemo } from 'react';
+import React, { useState, useEffect, useMemo } from 'react';
 import algosdk from 'algosdk';
 import {
   View,
@@ -6,7 +6,6 @@ import {
   StyleSheet,
   TextInput,
   TouchableOpacity,
-  Pressable,
   Alert,
   ActivityIndicator,
   ScrollView,
@@ -26,12 +25,11 @@ import { useThemedStyles, useThemeColors } from '@/hooks/useThemedStyles';
 import { Theme } from '@/constants/themes';
 import { useTheme } from '@/contexts/ThemeContext';
 import { TransactionService } from '@/services/transactions';
-import VoiNetworkService, { NetworkService } from '@/services/network';
+import { NetworkService } from '@/services/network';
 import tokenMappingService from '@/services/token-mapping';
 import type { TokenMapping } from '@/services/token-mapping/types';
 import {
   useActiveAccount,
-  useActiveAccountBalance,
   useWalletStore,
   useMultiNetworkBalance,
 } from '@/store/walletStore';
@@ -62,7 +60,6 @@ import {
 import { isAlgorandPaymentUri, parseAlgorandUri } from '@/utils/algorandUri';
 import { toErrorAlert } from '@/utils/errorMapping';
 import EnvoiService, { EnvoiSearchResult } from '@/services/envoi';
-import AccountSelector from '@/components/account/AccountSelector';
 import AccountListModal from '@/components/account/AccountListModal';
 import AddAccountModal from '@/components/account/AddAccountModal';
 import AccountRecipientModal from '@/components/account/AccountRecipientModal';
@@ -71,7 +68,6 @@ import KeyboardAwareScrollView from '@/components/common/KeyboardAwareScrollView
 import { SecureKeyManager } from '@/services/secure/keyManager';
 import NetworkAssetSelector from '@/components/send/NetworkAssetSelector';
 import { NFTBackground } from '@/components/common/NFTBackground';
-import { GlassCard } from '@/components/common/GlassCard';
 import { GlassButton } from '@/components/common/GlassButton';
 import { BlurredContainer } from '@/components/common/BlurredContainer';
 

--- a/src/screens/wallet/SwapScreen.tsx
+++ b/src/screens/wallet/SwapScreen.tsx
@@ -11,8 +11,6 @@ import {
   TextInput,
   TouchableOpacity,
   Alert,
-  ActivityIndicator,
-  ScrollView,
   Linking,
   BackHandler,
   Animated,
@@ -47,7 +45,6 @@ import { SwapService, SwapToken, UnifiedSwapQuote } from '@/services/swap';
 import { NetworkId } from '@/types/network';
 import tokenMappingService from '@/services/token-mapping';
 import { NetworkService } from '@/services/network';
-import algosdk from 'algosdk';
 import { getTokenImageSource } from '@/utils/tokenImages';
 import { getUserFacingMessage, toErrorAlert } from '@/utils/errorMapping';
 import {
@@ -642,7 +639,7 @@ export default function SwapScreen() {
       } else {
         Alert.alert('Error', 'Cannot open this URL');
       }
-    } catch (error) {
+    } catch {
       Alert.alert('Error', 'Failed to open URL');
     }
   };

--- a/src/screens/wallet/TransactionConfirmationScreen.tsx
+++ b/src/screens/wallet/TransactionConfirmationScreen.tsx
@@ -1,10 +1,9 @@
-import React, { useState, useEffect, useCallback } from 'react';
+import React, { useState, useEffect } from 'react';
 import {
   View,
   Text,
   StyleSheet,
   TouchableOpacity,
-  ActivityIndicator,
   ScrollView,
   Alert,
 } from 'react-native';
@@ -15,14 +14,8 @@ import { formatAddress } from '@/utils/address';
 import EnvoiService, { EnvoiNameInfo } from '@/services/envoi';
 import UnifiedTransactionAuthModal from '@/components/UnifiedTransactionAuthModal';
 import TransactionVerification from '@/components/ledger/TransactionVerification';
-import {
-  useTransactionAuthController,
-  TransactionAuthController,
-} from '@/services/auth/transactionAuthController';
-import {
-  unifiedSigner,
-  UnifiedTransactionRequest,
-} from '@/services/transactions/unifiedSigner';
+import { useTransactionAuthController } from '@/services/auth/transactionAuthController';
+import { UnifiedTransactionRequest } from '@/services/transactions/unifiedSigner';
 import UniversalHeader from '@/components/common/UniversalHeader';
 import { WalletStackParamList } from '@/navigation/AppNavigator';
 import { AccountMetadata } from '@/types/wallet';
@@ -37,7 +30,7 @@ import EnvoiProfileCard from '@/components/envoi/EnvoiProfileCard';
 import { useThemedStyles } from '@/hooks/useThemedStyles';
 import { Theme } from '@/constants/themes';
 import tokenMappingService from '@/services/token-mapping';
-import VoiNetworkService, { NetworkService } from '@/services/network';
+import { NetworkService } from '@/services/network';
 import { useMultiNetworkBalance } from '@/store/walletStore';
 
 type TransactionConfirmationScreenRouteProp = RouteProp<

--- a/src/screens/wallet/UniversalTransactionSigningScreen.tsx
+++ b/src/screens/wallet/UniversalTransactionSigningScreen.tsx
@@ -27,7 +27,6 @@ import {
 import { useTheme } from '@/contexts/ThemeContext';
 import { useThemedStyles } from '@/hooks/useThemedStyles';
 import { Theme } from '@/constants/themes';
-import { NetworkId } from '@/types/network';
 import TransactionDangerBanner from '@/components/transaction/TransactionDangerBanner';
 import {
   detectTransactionDangers,

--- a/src/screens/walletconnect/SessionProposalScreen.tsx
+++ b/src/screens/walletconnect/SessionProposalScreen.tsx
@@ -22,17 +22,11 @@ import {
   VOI_CHAIN_DATA,
   ALGORAND_MAINNET_CHAIN_DATA,
 } from '@/services/walletconnect';
-import {
-  WalletConnectV1Client,
-  DEFAULT_CHAIN_ID,
-} from '@/services/walletconnect/v1';
+import { WalletConnectV1Client } from '@/services/walletconnect/v1';
 import { MultiAccountWalletService } from '@/services/wallet';
 import { AccountMetadata } from '@/types/wallet';
 import UniversalHeader from '@/components/common/UniversalHeader';
-import {
-  getSignableAccounts,
-  truncateAddress,
-} from '@/services/walletconnect/utils';
+import { getSignableAccounts } from '@/services/walletconnect/utils';
 import AccountSelectionItem from '@/components/walletconnect/AccountSelectionItem';
 import { useTheme } from '@/contexts/ThemeContext';
 import { useThemedStyles } from '@/hooks/useThemedStyles';

--- a/src/screens/walletconnect/TransactionRequestScreen.tsx
+++ b/src/screens/walletconnect/TransactionRequestScreen.tsx
@@ -6,7 +6,6 @@ import {
   ScrollView,
   TouchableOpacity,
   Alert,
-  ActivityIndicator,
 } from 'react-native';
 import { SafeAreaView } from 'react-native-safe-area-context';
 import { StackNavigationProp } from '@react-navigation/stack';
@@ -18,16 +17,10 @@ import Toast from 'react-native-toast-message';
 import { RootStackParamList } from '@/navigation/AppNavigator';
 import {
   WalletConnectService,
-  WalletConnectRequestEvent,
   WalletTransaction,
 } from '@/services/walletconnect';
 import { MultiAccountWalletService } from '@/services/wallet';
-import {
-  AccountMetadata,
-  AccountType,
-  LedgerAccountMetadata,
-  WalletAccount,
-} from '@/types/wallet';
+import { AccountMetadata, WalletAccount } from '@/types/wallet';
 import UniversalHeader from '@/components/common/UniversalHeader';
 import UnifiedTransactionAuthModal from '@/components/UnifiedTransactionAuthModal';
 import { useTransactionAuthController } from '@/services/auth/transactionAuthController';

--- a/src/services/auth/transactionAuthController.ts
+++ b/src/services/auth/transactionAuthController.ts
@@ -624,7 +624,7 @@ export class TransactionAuthController {
           isLedgerFlow = true;
           this.ledgerSigningInfo = ledgerInfo;
         }
-      } catch (ledgerError) {
+      } catch {
         // Ledger info not available, continue with regular flow
       }
 

--- a/src/services/debug/logger.ts
+++ b/src/services/debug/logger.ts
@@ -77,7 +77,7 @@ class DebugLogger {
       this.listeners.forEach((listener) => {
         try {
           listener(this.logs);
-        } catch (error) {
+        } catch {
           // Don't let listener errors break logging
         }
       });
@@ -93,7 +93,7 @@ class DebugLogger {
     this.listeners.forEach((listener) => {
       try {
         listener(this.logs);
-      } catch (error) {
+      } catch {
         // Don't let listener errors break logging
       }
     });
@@ -124,7 +124,7 @@ class DebugLogger {
     this.listeners.forEach((listener) => {
       try {
         listener(this.logs);
-      } catch (error) {
+      } catch {
         // Don't let listener errors break logging
       }
     });

--- a/src/services/ledger/simpleLedgerManager.ts
+++ b/src/services/ledger/simpleLedgerManager.ts
@@ -1,15 +1,11 @@
 import { Platform, PermissionsAndroid } from 'react-native';
-import type { Permission, PermissionStatus } from 'react-native';
+import type { Permission } from 'react-native';
 import TransportBLE from '@ledgerhq/react-native-hw-transport-ble';
 import TransportHID from '@ledgerhq/react-native-hid';
 import Transport from '@ledgerhq/hw-transport';
-import type { Device as BleDevice } from 'react-native-ble-plx';
 import type { DeviceModelId } from '@ledgerhq/devices';
 
-import {
-  LedgerDeviceNotConnectedError,
-  LedgerAccountError,
-} from '@/types/wallet';
+import { LedgerDeviceNotConnectedError } from '@/types/wallet';
 
 export interface SimpleLedgerDevice {
   id: string;
@@ -119,7 +115,7 @@ export class SimpleLedgerManager {
     if (this.connectionPromise) {
       try {
         return await this.connectionPromise;
-      } catch (error) {
+      } catch {
         // Continue with new connection attempt
       }
     }

--- a/src/services/ledger/simpleLedgerSigner.ts
+++ b/src/services/ledger/simpleLedgerSigner.ts
@@ -1,4 +1,4 @@
-import algosdk, { Transaction } from 'algosdk';
+import { Transaction } from 'algosdk';
 import { ledgerAlgorandService } from './algorand';
 import { simpleLedgerManager } from './simpleLedgerManager';
 import {
@@ -187,7 +187,7 @@ export class SimpleLedgerSigner {
       if (!transport) return false;
 
       return await simpleLedgerManager.verifyDeviceReady();
-    } catch (error) {
+    } catch {
       return false;
     }
   }

--- a/src/services/messaging/index.ts
+++ b/src/services/messaging/index.ts
@@ -24,7 +24,6 @@ import {
   SendMessageRequest,
   SendMessageResult,
   MESSAGE_FEE_MICRO,
-  EncryptedMessagePayloadV2,
   MessagingKeyPair,
 } from './types';
 import {

--- a/src/services/network/index.ts
+++ b/src/services/network/index.ts
@@ -10,14 +10,9 @@ import {
   NetworkConfiguration,
   NetworkStatus,
   NetworkError,
-  NetworkUnavailableError,
 } from '@/types/network';
-import {
-  getNetworkConfig,
-  DEFAULT_NETWORK_ID,
-  isFeatureAvailable,
-} from './config';
-import { MimirApiService, MimirAsset, Arc200Transfer } from '@/services/mimir';
+import { getNetworkConfig, DEFAULT_NETWORK_ID } from './config';
+import { MimirApiService, MimirAsset } from '@/services/mimir';
 import VoiPriceService from '@/services/price';
 import AlgorandPriceService from '@/services/algorand-price';
 import EnvoiService from '@/services/envoi';
@@ -233,7 +228,7 @@ export class NetworkService {
       NetworkService.activeNetworkId = networkId;
 
       console.log(`Switched to network: ${newConfig.name} (${networkId})`);
-    } catch (error) {
+    } catch {
       // Restore previous network configuration on failure
       this.currentNetworkId = previousNetworkId;
       this.config = getNetworkConfig(previousNetworkId);

--- a/src/services/nft.ts
+++ b/src/services/nft.ts
@@ -6,7 +6,6 @@ import {
   NFTMetadata,
   NFTCollectionsIndexerResponse,
   NFTCollectionsResponse,
-  ARC72Collection,
 } from '@/types/nft';
 import { NFT_CONSTANTS, NFT_ERROR_MESSAGES } from '@/constants/nft';
 

--- a/src/services/remoteSigner/signingRouter.ts
+++ b/src/services/remoteSigner/signingRouter.ts
@@ -13,7 +13,6 @@ import {
 } from '@/types/wallet';
 import { RemoteSignerService } from './index';
 import { RemoteSignerRequest } from '@/types/remoteSigner';
-import { NetworkService } from '@/services/network';
 
 /**
  * Result of checking if an account needs remote signing

--- a/src/services/secure/AccountSecureStorage.ts
+++ b/src/services/secure/AccountSecureStorage.ts
@@ -1599,7 +1599,7 @@ export class AccountSecureStorage {
             secretPayloadRaw = await secureStorage.getItem(
               this.secretKey(accountId)
             );
-          } catch (error) {
+          } catch {
             throw new AuthenticationRequiredError(
               'Failed to access private key with PIN'
             );
@@ -1650,7 +1650,7 @@ export class AccountSecureStorage {
             secretPayloadRaw = await secureStorage.getItem(
               this.secretKey(accountId)
             );
-          } catch (error) {
+          } catch {
             throw new AccountRetrievalError('Failed to retrieve account data');
           }
         }
@@ -2614,7 +2614,7 @@ export class AccountSecureStorage {
         // throttle's job to special-case.
         await this.saveThrottle(updated);
         return false;
-      } catch (error) {
+      } catch {
         console.warn('PIN verification failed');
         return false;
       }
@@ -2883,7 +2883,7 @@ export class AccountSecureStorage {
     try {
       const storedData = await this.getStoredPinData();
       return Boolean(storedData);
-    } catch (error) {
+    } catch {
       return false;
     }
   }
@@ -3347,7 +3347,7 @@ export class AccountSecureStorage {
       await secureStorage
         .deleteItem(this.BIOMETRIC_ENABLED_KEY)
         .catch(() => {});
-    } catch (error) {
+    } catch {
       throw new AccountStorageError('Failed to store biometric setting');
     }
   }
@@ -3366,7 +3366,7 @@ export class AccountSecureStorage {
         }
       }
       return enabled === 'true';
-    } catch (error) {
+    } catch {
       return false;
     }
   }
@@ -3484,7 +3484,7 @@ export class AccountSecureStorage {
     try {
       await storage.setItem(this.PIN_TIMEOUT_KEY, String(timeoutMinutes));
       await secureStorage.deleteItem(this.PIN_TIMEOUT_KEY).catch(() => {});
-    } catch (error) {
+    } catch {
       throw new AccountStorageError('Failed to store PIN timeout setting');
     }
   }
@@ -3510,7 +3510,7 @@ export class AccountSecureStorage {
 
       const timeoutNumber = Number(timeout);
       return isNaN(timeoutNumber) ? 5 : timeoutNumber;
-    } catch (error) {
+    } catch {
       return 5; // Default fallback
     }
   }
@@ -3575,7 +3575,7 @@ export class AccountSecureStorage {
       await secureStorage.setItem(this.SALT_KEY, salt);
       await storage.removeItem(this.SALT_KEY).catch(() => {});
       return salt;
-    } catch (error) {
+    } catch {
       throw new AccountStorageError('Failed to generate or retrieve salt');
     }
   }
@@ -3680,7 +3680,7 @@ export class AccountSecureStorage {
       // Clear any temporary crypto variables by overwriting with zeros
       // Note: JavaScript strings are immutable, but this signals intent
       console.log('Cleared sensitive data from memory');
-    } catch (error) {
+    } catch {
       // Don't log detailed error to prevent information leakage
       console.warn('Failed to clear sensitive data');
     }
@@ -3759,7 +3759,7 @@ export class AccountSecureStorage {
           await secureStorage.deleteItem(this.PIN_THROTTLE_KEY).catch(() => {});
           this.throttleMirror = null;
         });
-      } catch (error) {
+      } catch {
         throw new AccountStorageError('Failed to clear all secure storage');
       }
     });

--- a/src/services/secure/simplifiedKeyManager.ts
+++ b/src/services/secure/simplifiedKeyManager.ts
@@ -5,7 +5,6 @@ import {
   RekeyedAccountMetadata,
   LedgerAccountMetadata,
   LedgerSigningInfo,
-  LedgerDeviceNotConnectedError,
   LedgerAccountError,
 } from '@/types/wallet';
 import RekeyManager from '@/services/wallet/rekeyManager';

--- a/src/services/secure/transactionManager.ts
+++ b/src/services/secure/transactionManager.ts
@@ -1,8 +1,6 @@
 import {
   TransactionService,
   TransactionParams,
-  UnsignedTransaction,
-  UnsignedTransactionGroup,
   SignProgressCallbacks,
 } from '@/services/transactions';
 import { WalletAccount } from '@/types/wallet';

--- a/src/services/swap/types.ts
+++ b/src/services/swap/types.ts
@@ -3,8 +3,6 @@
  * Network-agnostic interfaces for swap operations across multiple DEX providers
  */
 
-import { NetworkId } from '@/types/network';
-
 /**
  * Unified token representation for swap operations
  */

--- a/src/services/theme/themeGenerator.ts
+++ b/src/services/theme/themeGenerator.ts
@@ -1,9 +1,4 @@
-import {
-  Theme,
-  GlassEffect,
-  ShadowStyle,
-  TypographyStyle,
-} from '@/constants/themes';
+import { Theme } from '@/constants/themes';
 import { ExtractedColors, ColorPalette } from './colorExtraction';
 
 /**

--- a/src/services/transactions/index.ts
+++ b/src/services/transactions/index.ts
@@ -10,10 +10,8 @@ import {
 } from '@/types/wallet';
 import { isSoftwareAuthError } from '@/services/secure/authErrors';
 import {
-  toBigIntSafeNumber,
   compareBigIntSafe,
   compareBigInt,
-  addBigIntSafe,
   subtractBigIntSafe,
 } from '@/utils/bigint';
 import { SECURITY_CONFIG, SECURITY_MESSAGES } from '@/config/security';
@@ -864,7 +862,7 @@ export class TransactionService {
               'Insufficient VOI balance for ARC-200 transfer fees and MBR'
             );
           }
-        } catch (error) {
+        } catch {
           errors.push('Failed to estimate ARC-200 transfer cost');
         }
       } else if (assetType === 'arc72') {
@@ -903,7 +901,7 @@ export class TransactionService {
               );
             }
           }
-        } catch (error) {
+        } catch {
           errors.push('Failed to estimate ARC-72 transfer cost');
         }
       } else if (assetType === 'asa') {
@@ -1393,7 +1391,7 @@ export class TransactionService {
                 'Ledger device for the target account is not available. Connect it before rekeying.'
               );
             }
-          } catch (error) {
+          } catch {
             errors.push(
               'Unable to verify Ledger device availability for the target account.'
             );
@@ -1455,7 +1453,7 @@ export class TransactionService {
                 'Ledger device for the controlling account is not available. Connect it before rekeying.'
               );
             }
-          } catch (error) {
+          } catch {
             errors.push(
               'Unable to verify Ledger device availability for the controlling account.'
             );

--- a/src/services/transactions/unifiedSigner.ts
+++ b/src/services/transactions/unifiedSigner.ts
@@ -1,10 +1,5 @@
 import algosdk from 'algosdk';
-import {
-  TransactionService,
-  TransactionParams,
-  UnsignedTransaction,
-  UnsignedTransactionGroup,
-} from '@/services/transactions';
+import { TransactionService, TransactionParams } from '@/services/transactions';
 import {
   WalletConnectService,
   WalletTransaction,
@@ -401,7 +396,7 @@ export class UnifiedTransactionSigner {
               } else {
                 txn = algosdk.decodeUnsignedTransaction(txnBytes);
               }
-            } catch (decodeError) {
+            } catch {
               // Transaction is already signed (logic sig, etc.) - pass through as-is
               signedTxns.push(wtxn.txn);
               callbacks?.onLedgerSigned?.({ index: i + 1, total });
@@ -480,7 +475,7 @@ export class UnifiedTransactionSigner {
                 } else {
                   txn = algosdk.decodeUnsignedTransaction(txnBytes);
                 }
-              } catch (decodeError) {
+              } catch {
                 // Transaction is already signed (logic sig, etc.) - pass through as-is
                 return wtxn.txn;
               }

--- a/src/services/walletconnect/index.ts
+++ b/src/services/walletconnect/index.ts
@@ -1,4 +1,4 @@
-import { SignClientTypes, SessionTypes } from '@walletconnect/types';
+import { SignClientTypes } from '@walletconnect/types';
 import { getSdkError, buildApprovedNamespaces } from '@walletconnect/utils';
 import { EventEmitter } from 'events';
 import algosdk from 'algosdk';
@@ -14,7 +14,6 @@ import {
   WalletConnectSession,
   SessionProposal,
   WalletTransaction,
-  WalletConnectEventListener,
   WalletConnectRequestEvent,
 } from './types';
 import {

--- a/src/services/walletconnect/types.ts
+++ b/src/services/walletconnect/types.ts
@@ -1,8 +1,4 @@
-import {
-  SessionTypes,
-  SignClientTypes,
-  ProposalTypes,
-} from '@walletconnect/types';
+import { ProposalTypes } from '@walletconnect/types';
 
 export interface WalletConnectMetadata {
   name: string;

--- a/src/services/walletconnect/utils.ts
+++ b/src/services/walletconnect/utils.ts
@@ -54,7 +54,7 @@ export function parseWalletConnectUri(uri: string): {
     }
 
     return { topic, version, params };
-  } catch (error) {
+  } catch {
     return {};
   }
 }
@@ -85,7 +85,7 @@ export function detectWalletConnectVersion(uri: string): 1 | 2 | null {
     if (parsed.params?.['relay-protocol'] || parsed.params?.symKey) return 2;
 
     return null;
-  } catch (error) {
+  } catch {
     return null;
   }
 }
@@ -140,7 +140,7 @@ export function parseWalletConnectRequestUri(uri: string): {
     const sessionTopic = params.get('sessionTopic') || undefined;
     const requestId = requestIdStr ? Number(requestIdStr) : undefined;
     return { requestId, sessionTopic };
-  } catch (e) {
+  } catch {
     return {};
   }
 }
@@ -229,7 +229,7 @@ export function validateAlgorandTransaction(txn: WalletTransaction): boolean {
     }
 
     return true;
-  } catch (error) {
+  } catch {
     return false;
   }
 }
@@ -279,7 +279,7 @@ export function getTransactionSigningInfo(
     // This is a simplified extraction - in practice you'd use algosdk to decode
     // For now, assume the sender is provided via authAddr or signers
     senderAddress = transaction.authAddr || transaction.signers?.[0] || '';
-  } catch (error) {
+  } catch {
     return { canSign: false, isRekeyed: false };
   }
 

--- a/src/services/walletconnect/v1/client.ts
+++ b/src/services/walletconnect/v1/client.ts
@@ -9,10 +9,8 @@ import {
   WalletConnectV1SessionConfig,
   WalletConnectV1SessionData,
   WalletConnectV1SessionRequest,
-  WalletConnectV1Request,
   WalletConnectV1Event,
   AlgoSignTxnRequest,
-  WalletConnectV1PeerMeta,
   WalletConnectV1StoredSession,
 } from './types';
 import { WalletConnectV1WebSocket } from './websocket';

--- a/src/store/friendsStore.ts
+++ b/src/store/friendsStore.ts
@@ -3,7 +3,6 @@ import { subscribeWithSelector } from 'zustand/middleware';
 import AsyncStorage from '@react-native-async-storage/async-storage';
 import {
   Friend,
-  FriendTransaction,
   FriendAlreadyExistsError,
   FriendNotFoundError,
   InvalidEnvoiNameError,

--- a/src/store/messagesStore.ts
+++ b/src/store/messagesStore.ts
@@ -18,7 +18,6 @@ import {
   Message,
   MessageThread,
   MessageStatus,
-  MessagingKeyPair,
 } from '@/services/messaging/types';
 import MessagingService from '@/services/messaging';
 import { computeSyncCursor } from '@/services/messaging/syncCursor';

--- a/src/store/walletStore.ts
+++ b/src/store/walletStore.ts
@@ -19,18 +19,14 @@ import {
   AccountBalance,
   AssetParams,
   TransactionInfo,
-  AccountNotFoundError,
-  AccountExistsError,
 } from '../types/wallet';
 import { MultiAccountWalletService } from '../services/wallet';
 import rekeyManager from '@/services/wallet/rekeyManager';
-import { NetworkService, VoiNetworkService } from '../services/network';
+import { NetworkService } from '../services/network';
 import { NetworkId } from '../types/network';
 import EnvoiService, { EnvoiNameInfo } from '../services/envoi';
 import { MimirApiService, Arc200TokenMetadata } from '../services/mimir';
-import tokenMappingService, {
-  TokenMappingService,
-} from '../services/token-mapping';
+import tokenMappingService from '../services/token-mapping';
 import { MultiNetworkBalanceService } from '../services/network/multi-network';
 import {
   TokenMapping,

--- a/src/utils/accountQRParser.ts
+++ b/src/utils/accountQRParser.ts
@@ -1,4 +1,3 @@
-import algosdk from 'algosdk';
 import { MultiAccountWalletService } from '@/services/wallet';
 import {
   parseArc0300AccountImportUri,
@@ -476,7 +475,7 @@ export class AccountQRParser {
           address = walletAccount.address;
           type = 'standard';
           isValid = true;
-        } catch (error) {
+        } catch {
           errorMessage = 'Invalid private key';
         }
       } else if (accountData.address) {

--- a/src/utils/assetImages.ts
+++ b/src/utils/assetImages.ts
@@ -97,7 +97,7 @@ export const normalizeAssetImageUrl = (
       parsed.hash = '';
       return parsed.toString();
     }
-  } catch (error) {
+  } catch {
     // Ignore invalid URLs and fall through to undefined
   }
 

--- a/src/utils/formatting.ts
+++ b/src/utils/formatting.ts
@@ -207,7 +207,7 @@ export const formatNumber = (
     }
 
     return formatted;
-  } catch (error) {
+  } catch {
     // Fallback to basic formatting
     return value.toFixed(decimalPlaces);
   }
@@ -271,7 +271,7 @@ export const formatCurrency = (
     }
 
     return formatter.format(value);
-  } catch (error) {
+  } catch {
     // Fallback formatting
     const formatted = value.toFixed(2);
     return showCurrencySymbol ? `$${formatted}` : formatted;


### PR DESCRIPTION
## TASK-232 — Remove dead imports and catch bindings (PLAN-229 W1, final task)

Purely mechanical sweep of two `@typescript-eslint/no-unused-vars` sub-classes. **Two edit types only**, computed from the *current* lint output (not the plan's stale 133/62 counts, which were measured four merges ago):

1. **Dead imports** — deleted the unused import specifier; deleted the whole `import` statement when it emptied.
2. **Catch bindings** — rewrote `} catch (error) {` → `} catch {` (optional catch binding; Hermes-supported, 136 existing precedents in `src/`). **No statement inside any catch body was modified.**

### Numbers

| Metric | Before | After | Delta |
| --- | --- | --- | --- |
| `no-unused-vars` | 306 | 114 | **−192** (130 import bindings + 62 catch bindings) |
| `import/no-named-as-default` | 41 | 37 | −4 (removal cascade) |
| **Total lint warnings** | **606** | **410** | **−196** |

- **Files changed: 82** (80 source files + `package.json` + `lint-baseline.json`).
- Cleared in **2 lint passes** — pass 1 (130 imports + 62 catch) exposed 9 newly-unused imports via cascade; pass 2 cleared 7 of them (the other 2 are DR-5 carve-outs, see below).

### Ratchet (DR-9)

- `lint-baseline.json` regenerated (`npm run lint:baseline`) — authoritative total **410**.
- `package.json` `--max-warnings` lowered **606 → 410** in this same PR.
- `npm run lint:baseline:check` passes.

### Mechanical-diff proof

```
git diff -U0 -- src/ | grep '^+' | grep -v '^+++' | grep -vE '^\+\s*(import|\}|\)|catch|$)'
```
→ **empty**. Every added source line is an import statement/continuation, a closing brace/paren, `catch`, or blank. (The only non-conforming added lines in the full diff are the ratchet artifacts: the `"warnings"` counts in `lint-baseline.json` and the `--max-warnings 410` line in `package.json` — both intended.)

### DR-5 carve-outs preserved — do NOT "finish the job"

These are intentionally left flagged; each is evidence for an unresolved decision owned by another task:

1. **`src/services/walletconnect/index.ts`** — `detectRequestedChains` / `areRequiredChainsSupported` imports. Evidence for the unwired chain-support guard (TASK-240). Left untouched (2 surviving warnings). Note: their sibling dead imports in the same file (`SessionTypes`, `WalletConnectEventListener`) *were* in scope and removed, which shifted these from lines 26-27 to 25-26.
2. **`src/screens/walletconnect/TransactionRequestScreen.tsx`** — `setParsedTransactions` / `setDecodedTransactions` unused setters. Evidence for the empty review-panel defect (TASK-240). These are unused setters, not imports, so out of scope by classification anyway.
3. **`src/platform/index.ts:17`** — removed only `isExtension` and `getCachedPlatform`; **kept `isMobile`** (8 live call sites at lines 48/64/80/96/112/128/144/164 — the mobile-vs-extension adapter selector).

Also left untouched (frozen setters owned by W3): `SendScreen.tsx` `setAccountBalance` (TASK-239), `RekeyAccountScreen.tsx` `setIsProcessing` (TASK-252), and `walletconnect/utils.ts` `txnBytes` (TASK-240).

Out of scope (TASK-236 / W2 and W3): all dead local vars, handlers, and state — left exactly as-is. The 114 remaining `no-unused-vars` = ~107 dead handlers/state (TASK-236) + the 7 DR-9 deliberate survivors.

### Gates

- `npx tsc --noEmit` → **0**
- `npm test -- --ci` → **95 suites / 1503 tests, all green**
- `npm run lint` → **0** (410 warnings at the new 410 ceiling)
- `npm run lint:baseline:check` → **passes**

### Codex review

**CLEAN** — confirmed every source change is an import-specifier/statement removal or a catch-binding removal (no catch body, no local touched); DR-5 carve-outs intact; `isMobile` + all 8 call sites intact; no side-effect-only import removed; no load-bearing module dropped; AccountSecureStorage security-relevant catch bodies unchanged. (Its only note was that `package.json`/`lint-baseline.json` are additional change categories — the intended DR-9 ratchet artifacts.)

https://claude.ai/code/session_01AL4EmUSYAiVXEstBgKqDmv
