### PR TITLE
refactor(walletconnect): hoist crypto-js + remove stale requires (TASK-235)

### DIFF
--- a/lint-baseline.json
+++ b/lint-baseline.json
@@ -2,12 +2,11 @@
   "$comment": "Committed ESLint baseline for the `npm run lint` ratchet (PLAN-229 DR-2). Regenerate with `npm run lint:baseline`; verify with `npm run lint:baseline:check`. The `lint` script's --max-warnings MUST equal totals.warnings. Lower it in the same PR that clears the warnings. It never goes up.",
   "totals": {
     "errors": 0,
-    "warnings": 410,
-    "filesLinted": 431,
+    "warnings": 404,
+    "filesLinted": 432,
     "filesWithFindings": 126
   },
   "rules": {
-    "@typescript-eslint/no-require-imports": 6,
     "@typescript-eslint/no-unused-vars": 114,
     "import/no-named-as-default": 37,
     "react-hooks/exhaustive-deps": 61,
@@ -838,9 +837,8 @@
     },
     "src/services/deeplink/index.ts": {
       "errors": 0,
-      "warnings": 3,
+      "warnings": 2,
       "rules": {
-        "@typescript-eslint/no-require-imports": 1,
         "@typescript-eslint/no-unused-vars": 2
       }
     },
@@ -945,9 +943,8 @@
     },
     "src/services/walletconnect/index.ts": {
       "errors": 0,
-      "warnings": 3,
+      "warnings": 2,
       "rules": {
-        "@typescript-eslint/no-require-imports": 1,
         "@typescript-eslint/no-unused-vars": 2
       }
     },
@@ -960,9 +957,8 @@
     },
     "src/services/walletconnect/v1/crypto.ts": {
       "errors": 0,
-      "warnings": 5,
+      "warnings": 2,
       "rules": {
-        "@typescript-eslint/no-require-imports": 3,
         "@typescript-eslint/no-unused-vars": 2
       }
     },
@@ -1004,9 +1000,8 @@
     },
     "src/utils/animations.ts": {
       "errors": 0,
-      "warnings": 29,
+      "warnings": 28,
       "rules": {
-        "@typescript-eslint/no-require-imports": 1,
         "react-hooks/immutability": 28
       }
     }

--- a/package.json
+++ b/package.json
@@ -7,7 +7,7 @@
     "android": "expo run:android",
     "ios": "expo run:ios",
     "web": "expo start --web",
-    "lint": "eslint src/ --max-warnings 410",
+    "lint": "eslint src/ --max-warnings 404",
     "lint:fix": "eslint src/ --fix",
     "lint:baseline": "node scripts/lint-baseline.mjs --write",
     "lint:baseline:check": "node scripts/lint-baseline.mjs --check",

--- a/src/services/deeplink/index.ts
+++ b/src/services/deeplink/index.ts
@@ -1,5 +1,5 @@
 import { Alert, Platform, Linking } from 'react-native';
-import { NavigationContainerRef } from '@react-navigation/native';
+import { NavigationContainerRef, StackActions } from '@react-navigation/native';
 import { WalletConnectService } from '@/services/walletconnect';
 import {
   parseWalletConnectUri,
@@ -1176,7 +1176,6 @@ export class DeepLinkService {
       // Use type assertion to handle React Navigation's complex generic types
       if (options?.replace) {
         // Use StackActions.replace to replace current screen in stack
-        const { StackActions } = require('@react-navigation/native');
         this.navigationRef.dispatch(
           StackActions.replace(route.screen, route.params)
         );

--- a/src/services/walletconnect/__tests__/utils.test.ts
+++ b/src/services/walletconnect/__tests__/utils.test.ts
@@ -23,6 +23,7 @@ import {
   formatSessionExpiry,
   truncateAddress,
   sanitizeMetadata,
+  normalizeV1Metadata,
   getNetworkByChainId,
   getChainDataByChainId,
   getNetworkNameByChainId,
@@ -883,6 +884,58 @@ describe('sanitizeMetadata', () => {
     });
     expect(out.icons).toEqual([]);
     expect(out.name).toBe('X');
+  });
+});
+
+// ===========================================================================
+// normalizeV1Metadata
+// ===========================================================================
+
+describe('normalizeV1Metadata', () => {
+  const fallback = {
+    name: 'Fallback dApp',
+    description: 'fallback description',
+    url: 'https://fallback.example',
+    icons: ['https://fallback.example/icon.png'],
+  };
+
+  it('returns the fallback verbatim when metadata is null', () => {
+    expect(normalizeV1Metadata(null, fallback)).toBe(fallback);
+  });
+
+  it('preserves all fields when the description is a non-null string', () => {
+    const meta = {
+      name: 'Real dApp',
+      description: 'a real description',
+      url: 'https://dapp.example',
+      icons: ['https://dapp.example/icon.png'],
+    };
+    expect(normalizeV1Metadata(meta, fallback)).toEqual(meta);
+  });
+
+  it('coerces a null description to an empty string (not the fallback)', () => {
+    const meta = {
+      name: 'No-desc dApp',
+      description: null,
+      url: 'https://dapp.example',
+      icons: [],
+    };
+    expect(normalizeV1Metadata(meta, fallback)).toEqual({
+      name: 'No-desc dApp',
+      description: '',
+      url: 'https://dapp.example',
+      icons: [],
+    });
+  });
+
+  it('preserves an empty-string description without substituting a fallback', () => {
+    const meta = {
+      name: 'Empty-desc dApp',
+      description: '',
+      url: 'https://dapp.example',
+      icons: [],
+    };
+    expect(normalizeV1Metadata(meta, fallback).description).toBe('');
   });
 });
 

--- a/src/services/walletconnect/index.ts
+++ b/src/services/walletconnect/index.ts
@@ -25,6 +25,7 @@ import {
   detectRequestedChains,
   areRequiredChainsSupported,
   truncateAddress,
+  normalizeV1Metadata,
 } from './utils';
 import {
   DEFAULT_NAMESPACES,
@@ -459,8 +460,6 @@ export class WalletConnectService extends EventEmitter {
 
   private getV1Sessions(): WalletConnectSession[] {
     try {
-      // Dynamically import v1 client to avoid circular dependencies
-      const { WalletConnectV1Client } = require('@/services/walletconnect/v1');
       const v1Client = WalletConnectV1Client.getInstance();
       const v1SessionData = v1Client.getSessionData();
 
@@ -468,15 +467,20 @@ export class WalletConnectService extends EventEmitter {
         return [];
       }
 
+      // v1 peer/client metadata permits a null description, but the display
+      // session type requires a string; `normalizeV1Metadata` coerces null ->
+      // '' at the boundary (and returns the fallback when metadata is absent).
+      // This null-safety gap was previously masked by the removed
+      // `require('@/services/walletconnect/v1')` resolving to `any`.
       // Convert v1 session format to v2 session format for display
       const v1Session: WalletConnectSession = {
         topic: v1SessionData.handshakeTopic,
-        peerMetadata: v1SessionData.peerMeta || {
+        peerMetadata: normalizeV1Metadata(v1SessionData.peerMeta, {
           name: 'Unknown dApp',
           description: '',
           url: '',
           icons: [],
-        },
+        }),
         namespaces: {
           algorand: {
             accounts: v1SessionData.accounts.map(
@@ -492,7 +496,7 @@ export class WalletConnectService extends EventEmitter {
         controller: v1SessionData.clientId,
         self: {
           publicKey: v1SessionData.clientId,
-          metadata: v1SessionData.clientMeta || {
+          metadata: normalizeV1Metadata(v1SessionData.clientMeta, {
             name: 'Voi Wallet',
             description: 'Mobile wallet for Voi Network',
             url: 'https://getvoi.app',
@@ -500,16 +504,16 @@ export class WalletConnectService extends EventEmitter {
               'https://getvoi.app/android-chrome-192x192.png',
               'https://getvoi.app/android-chrome-512x512.png',
             ],
-          },
+          }),
         },
         peer: {
           publicKey: v1SessionData.peerId,
-          metadata: v1SessionData.peerMeta || {
+          metadata: normalizeV1Metadata(v1SessionData.peerMeta, {
             name: 'Unknown dApp',
             description: '',
             url: '',
             icons: [],
-          },
+          }),
         },
       };
 

--- a/src/services/walletconnect/utils.ts
+++ b/src/services/walletconnect/utils.ts
@@ -3,8 +3,10 @@ import { isValidAddress } from 'algosdk';
 import {
   WalletTransaction,
   WalletConnectSession,
+  WalletConnectMetadata,
   SessionProposal,
 } from './types';
+import type { WalletConnectV1PeerMeta } from './v1/types';
 import {
   AccountType,
   AccountMetadata,
@@ -412,6 +414,20 @@ export function sanitizeMetadata(metadata: any) {
     url: metadata?.url || '',
     icons: Array.isArray(metadata?.icons) ? metadata.icons : [],
   };
+}
+
+/**
+ * Normalize WalletConnect v1 peer/client metadata to the display
+ * `WalletConnectMetadata` shape. v1 metadata permits a `null` description, but
+ * the display type requires a string, so a null description is coerced to ''.
+ * When the v1 metadata is absent (`null`), the caller-provided fallback is
+ * returned unchanged. All other fields are preserved verbatim.
+ */
+export function normalizeV1Metadata(
+  meta: WalletConnectV1PeerMeta | null,
+  fallback: WalletConnectMetadata
+): WalletConnectMetadata {
+  return meta ? { ...meta, description: meta.description ?? '' } : fallback;
 }
 
 /**

--- a/src/services/walletconnect/v1/__tests__/crypto.vectors.test.ts
+++ b/src/services/walletconnect/v1/__tests__/crypto.vectors.test.ts
@@ -1,0 +1,151 @@
+/**
+ * Fixed-vector regression tests for the WalletConnect v1 session crypto path
+ * (AES-256-CBC + HMAC-SHA256, `../crypto.ts`).
+ *
+ * These lock the EXACT byte output of the crypto primitives. The expected hex
+ * literals below were CAPTURED from the pre-hoist implementation (three
+ * per-function `require('crypto-js')` sites) on the parent commit and are
+ * hardcoded here verbatim — they are NOT recomputed from the implementation.
+ * The require->static-import hoist (TASK-235) must leave every one of these
+ * bytes unchanged; if any literal below no longer matches, the hoist altered
+ * crypto output and must be reverted.
+ *
+ * `encryptMessage` -> `aesEncrypt` + `computeHMAC` (payload.data / payload.hmac).
+ * `decryptMessage` -> `computeHMAC` (verify) + `aesDecrypt` (round-trip).
+ * A fixed IV is injected by mocking expo-crypto so encryption is deterministic.
+ */
+
+// 16-byte deterministic IV (hex a0a1..af) injected via the expo-crypto mock so
+// `generateIV()` is reproducible and encrypt output is a fixed vector.
+const FIXED_IV_BYTES = [
+  0xa0, 0xa1, 0xa2, 0xa3, 0xa4, 0xa5, 0xa6, 0xa7, 0xa8, 0xa9, 0xaa, 0xab, 0xac,
+  0xad, 0xae, 0xaf,
+];
+const FIXED_IV_HEX = 'a0a1a2a3a4a5a6a7a8a9aaabacadaeaf';
+
+jest.mock('expo-crypto', () => ({
+  getRandomBytesAsync: jest.fn(
+    async (n: number) => new Uint8Array(FIXED_IV_BYTES.slice(0, n))
+  ),
+}));
+
+import { encryptMessage, decryptMessage } from '../crypto';
+
+const KEY_A =
+  '000102030405060708090a0b0c0d0e0f101112131415161718191a1b1c1d1e1f';
+const KEY_B =
+  'fedcba9876543210fedcba9876543210fedcba9876543210fedcba9876543210';
+
+interface Vector {
+  name: string;
+  key: string;
+  message: string;
+  data: string; // expected AES-256-CBC ciphertext (hex)
+  hmac: string; // expected HMAC-SHA256 over (ciphertext || iv) (hex)
+}
+
+// Captured verbatim from the pre-hoist implementation. IV is FIXED_IV_HEX for all.
+const VECTORS: Vector[] = [
+  {
+    name: 'KEY_A / wc_sessionUpdate JSON-RPC',
+    key: KEY_A,
+    message: '{"id":1,"jsonrpc":"2.0","method":"wc_sessionUpdate"}',
+    data: '5c504a3a30ffbf5b1cfe5426789ee9238806b2c5257b0dd51c4aa7bf7f388cd517973ac8f5fb9517ad1aa7646e4155394803c6eb85a25c2fc93b081a963f3cdc',
+    hmac: '80edcac6193a4dce8be4cc14e64192e64f6fd09d52a955d1119583e5f195bcf8',
+  },
+  {
+    name: 'KEY_A / short "hello world" (partial-block padding)',
+    key: KEY_A,
+    message: 'hello world',
+    data: 'dbe615888cba8369bc71d49b9cb64d92',
+    hmac: 'cd73759e1d9e19cfeef584b178c1556a8bd9a6808c567d882e11b812b065e336',
+  },
+  {
+    name: 'KEY_A / empty string (full padding block)',
+    key: KEY_A,
+    message: '',
+    data: '600d07a3b9b2c4e4082153d6d1707aa6',
+    hmac: '63985e44e18457af5cce55b50ea003303b224ef53322115300c3cb987177c61b',
+  },
+  {
+    name: 'KEY_A / exactly 16 bytes (extra full padding block)',
+    key: KEY_A,
+    message: '0123456789abcdef',
+    data: 'ce1cf3a4e3b87b139ba3cff10ace35b606d96b2e184bf22b73d31ba4be14d8c9',
+    hmac: 'f806e4dfc7a5c33e14666f0bbc16d2cd01c520b4366f169a15359168b371e39a',
+  },
+  {
+    name: 'KEY_B / wc_sessionUpdate JSON-RPC',
+    key: KEY_B,
+    message: '{"id":1,"jsonrpc":"2.0","method":"wc_sessionUpdate"}',
+    data: '91eb83f19a702bee84fc006306037e972d207a6dca1f36351db0b1eeb58b666b3fb4b03f6f4737cdd3c13f3602a28b24a72b27f3c0cc7f0f8ccc548248f10816',
+    hmac: '8e42f45522451adbb6cf5cc79202a734132f5a6ff84af25e84811028cde88bed',
+  },
+  {
+    name: 'KEY_B / short "hello world"',
+    key: KEY_B,
+    message: 'hello world',
+    data: '1a547ce2dee52bcf3e8bccf4d2aa33bd',
+    hmac: 'd39087e54c9e7e5f1c510d16447b0045545adfcbdb9ca84e48e750cfc20e1ca4',
+  },
+  {
+    name: 'KEY_B / empty string',
+    key: KEY_B,
+    message: '',
+    data: '129b478891f7e3ed8fbacc734badd003',
+    hmac: 'e5a2d44dca8613f310243e1e884839f0eacfe2c10ffc93c5171d9c1ae0804398',
+  },
+  {
+    name: 'KEY_B / exactly 16 bytes',
+    key: KEY_B,
+    message: '0123456789abcdef',
+    data: 'af4511fef07832843d7549254d47d0c77a5254f587b63354e12c5f33e31f5131',
+    hmac: '41ec14e19c32f984519a178fc54b089d8ca18140e55762f0b3f9a5b1cf784c89',
+  },
+];
+
+describe('WalletConnect v1 crypto — fixed vectors (byte-identical lock)', () => {
+  describe('encryptMessage produces the exact captured ciphertext + HMAC', () => {
+    it.each(VECTORS)(
+      'encrypts $name to the fixed vector',
+      async ({ key, message, data, hmac }) => {
+        const payload = await encryptMessage(message, key);
+        expect(payload).toEqual({ data, hmac, iv: FIXED_IV_HEX });
+      }
+    );
+  });
+
+  describe('decryptMessage recovers the plaintext (HMAC verify + AES decrypt)', () => {
+    it.each(VECTORS)(
+      'decrypts $name back to the original message',
+      async ({ key, message, data, hmac }) => {
+        const plaintext = await decryptMessage(
+          { data, hmac, iv: FIXED_IV_HEX },
+          key
+        );
+        expect(plaintext).toBe(message);
+      }
+    );
+  });
+
+  describe('encrypt -> decrypt round-trips to the original message', () => {
+    it.each(VECTORS)('round-trips $name', async ({ key, message }) => {
+      const payload = await encryptMessage(message, key);
+      const plaintext = await decryptMessage(payload, key);
+      expect(plaintext).toBe(message);
+    });
+  });
+
+  it('rejects a payload whose ciphertext was tampered (HMAC verify still enforced)', async () => {
+    const { key, hmac } = VECTORS[0];
+    // Flip the first byte of the ciphertext; HMAC no longer matches.
+    const tampered = {
+      data: 'ff' + VECTORS[0].data.slice(2),
+      hmac,
+      iv: FIXED_IV_HEX,
+    };
+    await expect(decryptMessage(tampered, key)).rejects.toThrow(
+      /HMAC verification failed/
+    );
+  });
+});

--- a/src/services/walletconnect/v1/crypto.ts
+++ b/src/services/walletconnect/v1/crypto.ts
@@ -3,6 +3,7 @@
  * Uses AES-256-CBC with HMAC-SHA256 for message security
  */
 
+import CryptoJS from 'crypto-js';
 import * as Crypto from 'expo-crypto';
 import { WalletConnectV1EncryptedPayload } from './types';
 
@@ -79,8 +80,6 @@ async function generateIV(): Promise<Uint8Array> {
  * WalletConnect v1 uses proper HMAC, not simple hash(key + data)
  */
 function computeHMAC(key: Uint8Array, data: Uint8Array): Uint8Array {
-  const CryptoJS = require('crypto-js');
-
   // Convert Uint8Arrays to hex strings first, then to WordArrays
   // This ensures proper byte representation
   const keyHex = uint8ArrayToHex(key);
@@ -105,8 +104,6 @@ async function aesEncrypt(
   key: Uint8Array,
   iv: Uint8Array
 ): Promise<Uint8Array> {
-  const CryptoJS = require('crypto-js');
-
   // Convert to WordArray format using hex encoding (consistent with decrypt)
   const keyHex = uint8ArrayToHex(key);
   const ivHex = uint8ArrayToHex(iv);
@@ -143,8 +140,6 @@ async function aesDecrypt(
   key: Uint8Array,
   iv: Uint8Array
 ): Promise<Uint8Array> {
-  const CryptoJS = require('crypto-js');
-
   // Convert to WordArray format using hex encoding (same as HMAC)
   const keyHex = uint8ArrayToHex(key);
   const ivHex = uint8ArrayToHex(iv);

--- a/src/utils/animations.ts
+++ b/src/utils/animations.ts
@@ -320,16 +320,6 @@ export const interpolations = {
 };
 
 /**
- * Utility to create a delayed animation
- */
-export function withDelay<T>(delay: number, animation: T): T {
-  // Note: react-native-reanimated has its own withDelay, but this wrapper
-  // provides consistent typing
-  const { withDelay: reanimatedWithDelay } = require('react-native-reanimated');
-  return reanimatedWithDelay(delay, animation);
-}
-
-/**
  * Simple fade in hook - auto-triggers on mount
  */
 export function useFadeIn(delay: number = 0, duration: number = 300) {


### PR DESCRIPTION
## TASK-235 — Wave 2 of PLAN-229 (no-require-imports burndown, high-stakes / load-order-sensitive sites)

Four stale/foot-gun `require()` sites in or adjacent to security- and navigation-critical code, plus the ratchet.

### Subtask 1 — WC v1 session crypto hoist (`services/walletconnect/v1/crypto.ts`)
Hoisted the three per-function `require('crypto-js')` sites (in `computeHMAC`, `aesEncrypt`, `aesDecrypt`) to a single static `import CryptoJS from 'crypto-js'`. This is a **require→static-import HOIST only** — the crypto algorithm, keys, IV handling, padding, and byte logic are byte-for-byte unchanged.

- The default-import form is already the established pattern in this repo's other crypto paths (`services/secure/envelopeV2.ts`, `services/secure/AccountSecureStorage.ts`, `services/backup/encryption.ts`). `esModuleInterop`/`allowSyntheticDefaultImports` are on and `@types/crypto-js` is present, so the default import exposes the identical `.HmacSHA256` / `.AES` / `.enc` / `.mode` / `.pad` / `.lib.CipherParams` members the requires used.
- **Fixed-vector test (byte-identical confirmed):** new `v1/__tests__/crypto.vectors.test.ts` captures the EXACT pre-hoist AES-256-CBC ciphertext + HMAC-SHA256 output for 8 fixed (key, IV, message) vectors — the expected hex values are **hardcoded literals captured on the parent commit, not recomputed from the impl**. They passed on the parent commit and **still pass identically post-hoist** (25 assertions: exact-ciphertext, exact-HMAC, decrypt, round-trip, and a tamper-rejection case). No byte changed.

### Subtask 2 — stale require + misleading comment (`services/walletconnect/index.ts`)
Deleted the `getV1Sessions` `require('@/services/walletconnect/v1')` and its stale `// avoid circular dependencies` comment. `WalletConnectV1Client` is **already statically imported** (line 35, used at 127/424), so there is no cycle and **module load timing is unchanged** — the eager import already existed. The genuine deeplink-cycle require (elsewhere in this file, disabled with an eslint comment) was **not** touched.

- De-`any`-ing `v1Client` (a bare `require()` returns `any`) surfaced a **latent null-safety gap** the `any` was masking: v1 peer/client metadata `description` is `string | null`, but the display `WalletConnectMetadata` type requires a string. Handled per PLAN-229 DR-3 (fold the latent defect into the PR that touches the line) with a small, unit-tested `normalizeV1Metadata` helper (sibling to `sanitizeMetadata`) that coerces a null description to `''`, preserving every other field and the existing fallback objects verbatim. 4 new unit tests in `utils.test.ts`.

### Subtask 3 — StackActions type-only → runtime import (`services/deeplink/index.ts`)
Folded `StackActions` into the existing line-2 `@react-navigation/native` import (previously **type-only**, importing only `NavigationContainerRef`) and dropped the lazy `require`. **Load-order checked:** `@react-navigation/native` is a leaf third-party package that cannot import app code (grep confirms no app imports), runtime imports from it are already a normal top-level pattern across the app's screens, `StackActions` was already resolved at runtime from the identical specifier, and typecheck confirms it is a valid export. Converting the elided import to a runtime one is safe.

### Subtask 4 — dead `withDelay` wrapper deletion (`utils/animations.ts`)
Deleted the exported `withDelay` wrapper (whose body called `require('react-native-reanimated')`) entirely. **Zero consumers confirmed** — `grep -rn withDelay src/` now returns no hits at all (the reanimated-direct usage the ticket referenced is no longer present). Nothing else in this known decoy file was touched.

### Ratchet (DR-9)
- `no-require-imports`: **6 → 0** (3 crypto-js + walletconnect:463 + deeplink:1179 + the withDelay wrapper). The rule is now entirely gone from the per-rule breakdown.
- Total warnings: **410 → 404**. `lint-baseline.json` regenerated and `package.json` `--max-warnings` lowered to 404 in this same commit; `npm run lint:baseline:check` passes.

### Gates
- `npm run typecheck` — clean
- `npm run lint` — exit 0 at ceiling 404
- `npm test -- --ci` — **96 suites / 1532 tests** green (95/1503 baseline + 25 new crypto-vector assertions + 4 new metadata-helper tests)
- `npm run lint:baseline:check` — passes

### Codex (crypto-focused) — CLEAN
Verified via babel transform that the static default import compiles to the same CommonJS module object; HMAC/AES calls, keys, IV generation, padding and byte handling unchanged; fixed vectors use hardcoded (not impl-derived) expected values; metadata coercion only converts null→''; other edits mechanical.

### Device checks (NOT a merge gate — batched pre-release per HT-218)
- A live WalletConnect v1 session connect + one signed `call_request`.
- A deep link exercising the `options.replace` branch of `navigateToRoute`.

https://claude.ai/code/session_01AL4EmUSYAiVXEstBgKqDmv