### PR TITLE
refactor(screens): delete dead handlers, memos, state, constants (TASK-236)

### DIFF
--- a/lint-baseline.json
+++ b/lint-baseline.json
@@ -2,19 +2,19 @@
   "$comment": "Committed ESLint baseline for the `npm run lint` ratchet (PLAN-229 DR-2). Regenerate with `npm run lint:baseline`; verify with `npm run lint:baseline:check`. The `lint` script's --max-warnings MUST equal totals.warnings. Lower it in the same PR that clears the warnings. It never goes up.",
   "totals": {
     "errors": 0,
-    "warnings": 404,
+    "warnings": 297,
     "filesLinted": 432,
-    "filesWithFindings": 126
+    "filesWithFindings": 98
   },
   "rules": {
-    "@typescript-eslint/no-unused-vars": 114,
+    "@typescript-eslint/no-unused-vars": 9,
     "import/no-named-as-default": 37,
     "react-hooks/exhaustive-deps": 61,
-    "react-hooks/immutability": 98,
+    "react-hooks/immutability": 97,
     "react-hooks/preserve-manual-memoization": 25,
     "react-hooks/purity": 5,
     "react-hooks/refs": 7,
-    "react-hooks/set-state-in-effect": 57
+    "react-hooks/set-state-in-effect": 56
   },
   "files": {
     "src/components/UnifiedAuthModal.tsx": {
@@ -37,19 +37,11 @@
     },
     "src/components/account/AccountAvatar.tsx": {
       "errors": 0,
-      "warnings": 4,
+      "warnings": 3,
       "rules": {
-        "@typescript-eslint/no-unused-vars": 1,
         "import/no-named-as-default": 1,
         "react-hooks/exhaustive-deps": 1,
         "react-hooks/set-state-in-effect": 1
-      }
-    },
-    "src/components/account/AccountListItem.tsx": {
-      "errors": 0,
-      "warnings": 2,
-      "rules": {
-        "@typescript-eslint/no-unused-vars": 2
       }
     },
     "src/components/account/AccountRecipientModal.tsx": {
@@ -59,18 +51,10 @@
         "react-hooks/exhaustive-deps": 1
       }
     },
-    "src/components/account/AccountSelector.tsx": {
+    "src/components/account/AddAccountModal.tsx": {
       "errors": 0,
       "warnings": 1,
       "rules": {
-        "@typescript-eslint/no-unused-vars": 1
-      }
-    },
-    "src/components/account/AddAccountModal.tsx": {
-      "errors": 0,
-      "warnings": 4,
-      "rules": {
-        "@typescript-eslint/no-unused-vars": 3,
         "react-hooks/exhaustive-deps": 1
       }
     },
@@ -118,13 +102,6 @@
         "react-hooks/set-state-in-effect": 1
       }
     },
-    "src/components/common/BlurredContainer.tsx": {
-      "errors": 0,
-      "warnings": 1,
-      "rules": {
-        "@typescript-eslint/no-unused-vars": 1
-      }
-    },
     "src/components/common/GlassButton.tsx": {
       "errors": 0,
       "warnings": 4,
@@ -141,34 +118,18 @@
     },
     "src/components/common/GlassInput.tsx": {
       "errors": 0,
-      "warnings": 6,
+      "warnings": 4,
       "rules": {
-        "@typescript-eslint/no-unused-vars": 2,
         "react-hooks/immutability": 4
-      }
-    },
-    "src/components/common/NFTBackground.tsx": {
-      "errors": 0,
-      "warnings": 2,
-      "rules": {
-        "@typescript-eslint/no-unused-vars": 2
       }
     },
     "src/components/common/NFTThemeSelector.tsx": {
       "errors": 0,
-      "warnings": 6,
+      "warnings": 5,
       "rules": {
-        "@typescript-eslint/no-unused-vars": 1,
         "react-hooks/exhaustive-deps": 2,
         "react-hooks/immutability": 1,
         "react-hooks/set-state-in-effect": 2
-      }
-    },
-    "src/components/common/ThemedWebView.tsx": {
-      "errors": 0,
-      "warnings": 1,
-      "rules": {
-        "@typescript-eslint/no-unused-vars": 1
       }
     },
     "src/components/common/UniversalHeader.tsx": {
@@ -185,18 +146,10 @@
         "react-hooks/set-state-in-effect": 1
       }
     },
-    "src/components/envoi/EnvoiProfileCard.tsx": {
-      "errors": 0,
-      "warnings": 1,
-      "rules": {
-        "@typescript-eslint/no-unused-vars": 1
-      }
-    },
     "src/components/ledger/ConnectionModal.tsx": {
       "errors": 0,
-      "warnings": 3,
+      "warnings": 2,
       "rules": {
-        "@typescript-eslint/no-unused-vars": 1,
         "import/no-named-as-default": 1,
         "react-hooks/set-state-in-effect": 1
       }
@@ -221,13 +174,6 @@
       "warnings": 6,
       "rules": {
         "react-hooks/immutability": 6
-      }
-    },
-    "src/components/network/NetworkIndicator.tsx": {
-      "errors": 0,
-      "warnings": 2,
-      "rules": {
-        "@typescript-eslint/no-unused-vars": 2
       }
     },
     "src/components/network/NetworkSwitcher.tsx": {
@@ -285,18 +231,10 @@
         "react-hooks/purity": 1
       }
     },
-    "src/components/social/MessageInput.tsx": {
-      "errors": 0,
-      "warnings": 1,
-      "rules": {
-        "@typescript-eslint/no-unused-vars": 1
-      }
-    },
     "src/components/swap/RouteDetailModal.tsx": {
       "errors": 0,
-      "warnings": 5,
+      "warnings": 3,
       "rules": {
-        "@typescript-eslint/no-unused-vars": 2,
         "react-hooks/exhaustive-deps": 1,
         "react-hooks/immutability": 1,
         "react-hooks/set-state-in-effect": 1
@@ -321,40 +259,23 @@
     },
     "src/components/transaction/TransactionAddressDisplay.tsx": {
       "errors": 0,
-      "warnings": 2,
+      "warnings": 1,
       "rules": {
-        "@typescript-eslint/no-unused-vars": 1,
         "import/no-named-as-default": 1
-      }
-    },
-    "src/components/transaction/TransactionListItem.tsx": {
-      "errors": 0,
-      "warnings": 1,
-      "rules": {
-        "@typescript-eslint/no-unused-vars": 1
-      }
-    },
-    "src/components/walletconnect/DAppInfo.tsx": {
-      "errors": 0,
-      "warnings": 1,
-      "rules": {
-        "@typescript-eslint/no-unused-vars": 1
       }
     },
     "src/components/walletconnect/QRScanner.tsx": {
       "errors": 0,
-      "warnings": 5,
+      "warnings": 2,
       "rules": {
-        "@typescript-eslint/no-unused-vars": 3,
         "react-hooks/immutability": 1,
         "react-hooks/set-state-in-effect": 1
       }
     },
     "src/contexts/AuthContext.tsx": {
       "errors": 0,
-      "warnings": 7,
+      "warnings": 6,
       "rules": {
-        "@typescript-eslint/no-unused-vars": 1,
         "react-hooks/exhaustive-deps": 1,
         "react-hooks/immutability": 3,
         "react-hooks/purity": 1,
@@ -371,24 +292,9 @@
     },
     "src/navigation/AppNavigator.tsx": {
       "errors": 0,
-      "warnings": 3,
+      "warnings": 1,
       "rules": {
-        "@typescript-eslint/no-unused-vars": 2,
         "react-hooks/exhaustive-deps": 1
-      }
-    },
-    "src/screens/account/AccountImportPreviewScreen.tsx": {
-      "errors": 0,
-      "warnings": 1,
-      "rules": {
-        "@typescript-eslint/no-unused-vars": 1
-      }
-    },
-    "src/screens/account/AddWatchAccountScreen.tsx": {
-      "errors": 0,
-      "warnings": 1,
-      "rules": {
-        "@typescript-eslint/no-unused-vars": 1
       }
     },
     "src/screens/account/LedgerAccountImportScreen.tsx": {
@@ -401,9 +307,8 @@
     },
     "src/screens/account/MnemonicImportScreen.tsx": {
       "errors": 0,
-      "warnings": 3,
+      "warnings": 2,
       "rules": {
-        "@typescript-eslint/no-unused-vars": 1,
         "react-hooks/exhaustive-deps": 1,
         "react-hooks/preserve-manual-memoization": 1
       }
@@ -445,13 +350,6 @@
         "react-hooks/immutability": 1
       }
     },
-    "src/screens/remoteSigner/AirgapHomeScreen.tsx": {
-      "errors": 0,
-      "warnings": 1,
-      "rules": {
-        "@typescript-eslint/no-unused-vars": 1
-      }
-    },
     "src/screens/remoteSigner/ImportFromOnlineWalletScreen.tsx": {
       "errors": 0,
       "warnings": 2,
@@ -469,59 +367,33 @@
     },
     "src/screens/remoteSigner/SignRequestScannerScreen.tsx": {
       "errors": 0,
-      "warnings": 6,
+      "warnings": 2,
       "rules": {
-        "@typescript-eslint/no-unused-vars": 3,
         "react-hooks/exhaustive-deps": 1,
-        "react-hooks/immutability": 1,
-        "react-hooks/set-state-in-effect": 1
+        "react-hooks/immutability": 1
       }
     },
     "src/screens/remoteSigner/SignatureDisplayScreen.tsx": {
       "errors": 0,
-      "warnings": 2,
-      "rules": {
-        "@typescript-eslint/no-unused-vars": 1,
-        "react-hooks/set-state-in-effect": 1
-      }
-    },
-    "src/screens/remoteSigner/TransactionReviewScreen.tsx": {
-      "errors": 0,
-      "warnings": 2,
-      "rules": {
-        "@typescript-eslint/no-unused-vars": 2
-      }
-    },
-    "src/screens/settings/AboutScreen.tsx": {
-      "errors": 0,
       "warnings": 1,
       "rules": {
-        "@typescript-eslint/no-unused-vars": 1
+        "react-hooks/set-state-in-effect": 1
       }
     },
     "src/screens/settings/BackupWalletScreen.tsx": {
       "errors": 0,
-      "warnings": 2,
+      "warnings": 1,
       "rules": {
-        "@typescript-eslint/no-unused-vars": 1,
         "react-hooks/exhaustive-deps": 1
       }
     },
     "src/screens/settings/NotificationSettingsScreen.tsx": {
       "errors": 0,
-      "warnings": 5,
+      "warnings": 4,
       "rules": {
-        "@typescript-eslint/no-unused-vars": 1,
         "react-hooks/exhaustive-deps": 1,
         "react-hooks/immutability": 1,
         "react-hooks/set-state-in-effect": 2
-      }
-    },
-    "src/screens/settings/RestoreWalletScreen.tsx": {
-      "errors": 0,
-      "warnings": 3,
-      "rules": {
-        "@typescript-eslint/no-unused-vars": 3
       }
     },
     "src/screens/settings/SecuritySettingsScreen.tsx": {
@@ -533,10 +405,9 @@
     },
     "src/screens/settings/SettingsScreen.tsx": {
       "errors": 0,
-      "warnings": 8,
+      "warnings": 2,
       "rules": {
-        "@typescript-eslint/no-unused-vars": 5,
-        "react-hooks/immutability": 3
+        "react-hooks/immutability": 2
       }
     },
     "src/screens/settings/ShowRecoveryPhraseScreen.tsx": {
@@ -567,18 +438,16 @@
     },
     "src/screens/social/FriendProfileScreen.tsx": {
       "errors": 0,
-      "warnings": 4,
+      "warnings": 3,
       "rules": {
-        "@typescript-eslint/no-unused-vars": 1,
         "react-hooks/preserve-manual-memoization": 2,
         "react-hooks/set-state-in-effect": 1
       }
     },
     "src/screens/social/MessagesInboxScreen.tsx": {
       "errors": 0,
-      "warnings": 5,
+      "warnings": 4,
       "rules": {
-        "@typescript-eslint/no-unused-vars": 1,
         "react-hooks/preserve-manual-memoization": 3,
         "react-hooks/purity": 1
       }
@@ -592,9 +461,8 @@
     },
     "src/screens/social/NewMessageScreen.tsx": {
       "errors": 0,
-      "warnings": 6,
+      "warnings": 5,
       "rules": {
-        "@typescript-eslint/no-unused-vars": 1,
         "import/no-named-as-default": 1,
         "react-hooks/exhaustive-deps": 1,
         "react-hooks/immutability": 1,
@@ -602,18 +470,10 @@
         "react-hooks/set-state-in-effect": 1
       }
     },
-    "src/screens/transaction/KeyregConfirmScreen.tsx": {
-      "errors": 0,
-      "warnings": 1,
-      "rules": {
-        "@typescript-eslint/no-unused-vars": 1
-      }
-    },
     "src/screens/wallet/AccountInfoScreen.tsx": {
       "errors": 0,
-      "warnings": 8,
+      "warnings": 3,
       "rules": {
-        "@typescript-eslint/no-unused-vars": 5,
         "import/no-named-as-default": 1,
         "react-hooks/set-state-in-effect": 2
       }
@@ -628,18 +488,10 @@
     },
     "src/screens/wallet/AssetDetailScreen.tsx": {
       "errors": 0,
-      "warnings": 5,
+      "warnings": 3,
       "rules": {
-        "@typescript-eslint/no-unused-vars": 2,
         "react-hooks/exhaustive-deps": 1,
         "react-hooks/set-state-in-effect": 2
-      }
-    },
-    "src/screens/wallet/BuyScreen.tsx": {
-      "errors": 0,
-      "warnings": 1,
-      "rules": {
-        "@typescript-eslint/no-unused-vars": 1
       }
     },
     "src/screens/wallet/ClaimAllConfirmationScreen.tsx": {
@@ -683,9 +535,8 @@
     },
     "src/screens/wallet/HomeScreen.tsx": {
       "errors": 0,
-      "warnings": 15,
+      "warnings": 9,
       "rules": {
-        "@typescript-eslint/no-unused-vars": 6,
         "import/no-named-as-default": 1,
         "react-hooks/exhaustive-deps": 2,
         "react-hooks/immutability": 3,
@@ -701,20 +552,12 @@
     },
     "src/screens/wallet/NFTScreen.tsx": {
       "errors": 0,
-      "warnings": 9,
+      "warnings": 8,
       "rules": {
-        "@typescript-eslint/no-unused-vars": 1,
         "react-hooks/exhaustive-deps": 3,
         "react-hooks/immutability": 2,
         "react-hooks/preserve-manual-memoization": 2,
         "react-hooks/set-state-in-effect": 1
-      }
-    },
-    "src/screens/wallet/ReceiveScreen.tsx": {
-      "errors": 0,
-      "warnings": 2,
-      "rules": {
-        "@typescript-eslint/no-unused-vars": 2
       }
     },
     "src/screens/wallet/RekeyAccountScreen.tsx": {
@@ -729,9 +572,9 @@
     },
     "src/screens/wallet/SendScreen.tsx": {
       "errors": 0,
-      "warnings": 26,
+      "warnings": 15,
       "rules": {
-        "@typescript-eslint/no-unused-vars": 12,
+        "@typescript-eslint/no-unused-vars": 1,
         "import/no-named-as-default": 1,
         "react-hooks/exhaustive-deps": 8,
         "react-hooks/immutability": 1,
@@ -750,9 +593,8 @@
     },
     "src/screens/wallet/TransactionConfirmationScreen.tsx": {
       "errors": 0,
-      "warnings": 7,
+      "warnings": 5,
       "rules": {
-        "@typescript-eslint/no-unused-vars": 2,
         "import/no-named-as-default": 1,
         "react-hooks/exhaustive-deps": 2,
         "react-hooks/immutability": 2
@@ -807,46 +649,11 @@
     },
     "src/screens/walletconnect/TransactionRequestScreen.tsx": {
       "errors": 0,
-      "warnings": 9,
+      "warnings": 6,
       "rules": {
-        "@typescript-eslint/no-unused-vars": 5,
+        "@typescript-eslint/no-unused-vars": 2,
         "react-hooks/exhaustive-deps": 2,
         "react-hooks/immutability": 2
-      }
-    },
-    "src/services/auth-account-discovery/index.ts": {
-      "errors": 0,
-      "warnings": 1,
-      "rules": {
-        "@typescript-eslint/no-unused-vars": 1
-      }
-    },
-    "src/services/auth/simpleLedgerAuthController.ts": {
-      "errors": 0,
-      "warnings": 1,
-      "rules": {
-        "@typescript-eslint/no-unused-vars": 1
-      }
-    },
-    "src/services/auth/transactionAuthController.ts": {
-      "errors": 0,
-      "warnings": 1,
-      "rules": {
-        "@typescript-eslint/no-unused-vars": 1
-      }
-    },
-    "src/services/deeplink/index.ts": {
-      "errors": 0,
-      "warnings": 2,
-      "rules": {
-        "@typescript-eslint/no-unused-vars": 2
-      }
-    },
-    "src/services/ledger/simpleLedgerSigner.ts": {
-      "errors": 0,
-      "warnings": 1,
-      "rules": {
-        "@typescript-eslint/no-unused-vars": 1
       }
     },
     "src/services/network/index.ts": {
@@ -854,13 +661,6 @@
       "warnings": 3,
       "rules": {
         "import/no-named-as-default": 3
-      }
-    },
-    "src/services/remoteSigner/animatedQR.ts": {
-      "errors": 0,
-      "warnings": 1,
-      "rules": {
-        "@typescript-eslint/no-unused-vars": 1
       }
     },
     "src/services/secure/keyManager.ts": {
@@ -884,13 +684,6 @@
         "import/no-named-as-default": 1
       }
     },
-    "src/services/token-mapping/index.ts": {
-      "errors": 0,
-      "warnings": 3,
-      "rules": {
-        "@typescript-eslint/no-unused-vars": 3
-      }
-    },
     "src/services/transactions/arc200.ts": {
       "errors": 0,
       "warnings": 2,
@@ -900,9 +693,8 @@
     },
     "src/services/transactions/arc72.ts": {
       "errors": 0,
-      "warnings": 3,
+      "warnings": 2,
       "rules": {
-        "@typescript-eslint/no-unused-vars": 1,
         "import/no-named-as-default": 2
       }
     },
@@ -911,13 +703,6 @@
       "warnings": 1,
       "rules": {
         "import/no-named-as-default": 1
-      }
-    },
-    "src/services/transactions/unifiedSigner.ts": {
-      "errors": 0,
-      "warnings": 3,
-      "rules": {
-        "@typescript-eslint/no-unused-vars": 3
       }
     },
     "src/services/wallet/index.ts": {
@@ -955,13 +740,6 @@
         "@typescript-eslint/no-unused-vars": 1
       }
     },
-    "src/services/walletconnect/v1/crypto.ts": {
-      "errors": 0,
-      "warnings": 2,
-      "rules": {
-        "@typescript-eslint/no-unused-vars": 2
-      }
-    },
     "src/store/claimableStore.ts": {
       "errors": 0,
       "warnings": 2,
@@ -971,9 +749,8 @@
     },
     "src/store/friendsStore.ts": {
       "errors": 0,
-      "warnings": 2,
+      "warnings": 1,
       "rules": {
-        "@typescript-eslint/no-unused-vars": 1,
         "import/no-named-as-default": 1
       }
     },

--- a/package.json
+++ b/package.json
@@ -7,7 +7,7 @@
     "android": "expo run:android",
     "ios": "expo run:ios",
     "web": "expo start --web",
-    "lint": "eslint src/ --max-warnings 404",
+    "lint": "eslint src/ --max-warnings 297",
     "lint:fix": "eslint src/ --fix",
     "lint:baseline": "node scripts/lint-baseline.mjs --write",
     "lint:baseline:check": "node scripts/lint-baseline.mjs --check",

--- a/src/components/account/AccountAvatar.tsx
+++ b/src/components/account/AccountAvatar.tsx
@@ -149,7 +149,6 @@ export default function AccountAvatar({
   const themeColors = useThemeColors();
   const [envoiAvatarUrl, setEnvoiAvatarUrl] = useState<string | null>(null);
   const [avatarError, setAvatarError] = useState<boolean>(false);
-  const [isLoading, setIsLoading] = useState<boolean>(false);
 
   const safeAddress = address || 'default';
   const colors = generateColors(safeAddress);
@@ -170,7 +169,6 @@ export default function AccountAvatar({
     if (account?.avatarUrl) {
       initialUrl = account.avatarUrl;
       setEnvoiAvatarUrl(account.avatarUrl);
-      setIsLoading(false);
       setAvatarError(false);
       avatarUrlCache.set(address, account.avatarUrl);
     }
@@ -190,14 +188,12 @@ export default function AccountAvatar({
     if (persistedAvatar && persistedAvatar !== initialUrl) {
       initialUrl = persistedAvatar;
       setEnvoiAvatarUrl(persistedAvatar);
-      setIsLoading(false);
       setAvatarError(false);
       avatarUrlCache.set(address, persistedAvatar);
     } else if (avatarUrlCache.has(address)) {
       const cachedUrl = avatarUrlCache.get(address);
       initialUrl = cachedUrl || null;
       setEnvoiAvatarUrl(initialUrl);
-      setIsLoading(false);
       if (cachedUrl) {
         setAvatarError(false);
       }
@@ -206,7 +202,6 @@ export default function AccountAvatar({
     // Register callback for this instance
     const updateCallback = (url: string | null) => {
       setEnvoiAvatarUrl(url);
-      setIsLoading(false);
       if (url) {
         setAvatarError(false);
       }
@@ -225,7 +220,6 @@ export default function AccountAvatar({
 
     // Check if already loading
     if (avatarLoadingState.get(address)) {
-      setIsLoading(true);
       return () => {
         avatarCallbacks.get(address)?.delete(updateCallback);
       };
@@ -233,7 +227,6 @@ export default function AccountAvatar({
 
     // Start loading
     avatarLoadingState.set(address, true);
-    setIsLoading(true);
 
     const loadEnvoiAvatar = async () => {
       try {

--- a/src/components/account/AccountListItem.tsx
+++ b/src/components/account/AccountListItem.tsx
@@ -45,7 +45,6 @@ export default function AccountListItem({
   // Extract values without destructuring to avoid infinite loops
   const centralizedBalance = accountBalanceData.balance;
   const isBalanceLoading = accountBalanceData.isLoading;
-  const reloadAccountBalance = accountBalanceData.reload;
 
   // Don't load individual balances - the modal will batch load all balances
   // This prevents each item from triggering separate state updates
@@ -109,27 +108,6 @@ export default function AccountListItem({
     }
   };
 
-  const getRekeyStatusIcon = (account: AccountMetadata) => {
-    if (account.type !== AccountType.REKEYED) {
-      return null;
-    }
-
-    const rekeyedAccount = account as RekeyedAccountMetadata;
-    if (rekeyedAccount.canSign) {
-      return {
-        name: 'key' as const,
-        color: colors.success, // We have signing authority
-        tooltip: 'Rekeyed account - you have signing authority',
-      };
-    } else {
-      return {
-        name: 'lock-closed' as const,
-        color: colors.warning, // We do not have signing authority
-        tooltip: 'Rekeyed account - you do not have signing authority',
-      };
-    }
-  };
-
   const handleSelect = async () => {
     try {
       if (!isActive) {
@@ -176,7 +154,6 @@ export default function AccountListItem({
   };
 
   const typeLabel = getAccountTypeLabel(account);
-  const rekeyIcon = getRekeyStatusIcon(account);
 
   return (
     <TouchableOpacity

--- a/src/components/account/AccountSelector.tsx
+++ b/src/components/account/AccountSelector.tsx
@@ -1,11 +1,7 @@
 import React from 'react';
 import { View, Text, TouchableOpacity, StyleSheet } from 'react-native';
 import { Ionicons } from '@expo/vector-icons';
-import {
-  useActiveAccount,
-  useAccounts,
-  useActiveAccountBalance,
-} from '@/store/walletStore';
+import { useActiveAccount, useActiveAccountBalance } from '@/store/walletStore';
 import { useCurrentNetworkConfig } from '@/store/networkStore';
 import AccountAvatar from './AccountAvatar';
 import { formatVoiBalance, getCurrencySymbol } from '@/utils/bigint';
@@ -34,7 +30,6 @@ export default function AccountSelector({
   const { theme } = useTheme();
   const colors = createColors(theme);
   const activeAccount = useActiveAccount();
-  const allAccounts = useAccounts();
   const { balance: centralizedBalance, isLoading: isBalanceLoading } =
     useActiveAccountBalance();
   const currentNetworkConfig = useCurrentNetworkConfig();
@@ -68,8 +63,6 @@ export default function AccountSelector({
     }
     return formatVoiBalance(amount);
   };
-
-  const hasMultipleAccounts = allAccounts.length > 1;
 
   return (
     <TouchableOpacity

--- a/src/components/account/AddAccountModal.tsx
+++ b/src/components/account/AddAccountModal.tsx
@@ -9,7 +9,6 @@ import {
   BottomSheetView,
 } from '@gorhom/bottom-sheet';
 import { BottomSheetDefaultBackdropProps } from '@gorhom/bottom-sheet/lib/typescript/components/bottomSheetBackdrop/types';
-import { useWalletStore } from '@/store/walletStore';
 
 interface AddAccountModalProps {
   isVisible: boolean;
@@ -34,9 +33,6 @@ export default function AddAccountModal({
   airgapMode = false,
 }: AddAccountModalProps) {
   const bottomSheetRef = useRef<BottomSheetModal>(null);
-  const createAccount = useWalletStore((state) => state.createAccount);
-  const importAccount = useWalletStore((state) => state.importAccount);
-  const addWatchAccount = useWalletStore((state) => state.addWatchAccount);
 
   // Handle sheet changes
   const handleSheetChanges = useCallback(

--- a/src/components/common/BlurredContainer.tsx
+++ b/src/components/common/BlurredContainer.tsx
@@ -107,7 +107,6 @@ export const BlurredContainer: React.FC<BlurredContainerProps> = ({
       alignSelf,
       flexWrap,
       gap,
-      ...rest
     } = styleObj;
     return {
       flexDirection,

--- a/src/components/common/GlassInput.tsx
+++ b/src/components/common/GlassInput.tsx
@@ -5,7 +5,7 @@
  * and optional floating labels. Works seamlessly with NFT background theming.
  */
 
-import React, { useMemo, useCallback, useState, useRef } from 'react';
+import React, { useMemo, useCallback, useRef } from 'react';
 import {
   View,
   TextInput,
@@ -62,7 +62,6 @@ interface GlassInputProps extends Omit<TextInputProps, 'style'> {
 
 const AnimatedView = Animated.View;
 const AnimatedText = Animated.Text;
-const AnimatedTextInput = Animated.createAnimatedComponent(TextInput);
 
 export const GlassInput: React.FC<GlassInputProps> = ({
   size = 'md',
@@ -90,7 +89,6 @@ export const GlassInput: React.FC<GlassInputProps> = ({
   const inputRef = useRef<TextInput>(null);
 
   // State
-  const [isFocused, setIsFocused] = useState(false);
 
   // Animation values
   const focusProgress = useSharedValue(0);
@@ -132,7 +130,6 @@ export const GlassInput: React.FC<GlassInputProps> = ({
   // Handle focus
   const handleFocus = useCallback(
     (e: any) => {
-      setIsFocused(true);
       focusProgress.value = withSpring(1, springConfigs.snappy);
       if (floatingLabel) {
         labelProgress.value = withSpring(1, springConfigs.smooth);
@@ -145,7 +142,6 @@ export const GlassInput: React.FC<GlassInputProps> = ({
   // Handle blur
   const handleBlur = useCallback(
     (e: any) => {
-      setIsFocused(false);
       focusProgress.value = withSpring(0, springConfigs.snappy);
       if (floatingLabel && !value) {
         labelProgress.value = withSpring(0, springConfigs.smooth);
@@ -160,13 +156,6 @@ export const GlassInput: React.FC<GlassInputProps> = ({
     onChangeText?.('');
     inputRef.current?.focus();
   }, [onChangeText]);
-
-  // Border color based on state
-  const getBorderColor = useCallback(() => {
-    if (error) return theme.colors.error;
-    if (isFocused) return theme.colors.primary;
-    return theme.colors.glassBorder;
-  }, [error, isFocused, theme.colors]);
 
   // Animated container style
   const animatedContainerStyle = useAnimatedStyle(() => {

--- a/src/components/common/NFTBackground.tsx
+++ b/src/components/common/NFTBackground.tsx
@@ -1,10 +1,8 @@
 import React, { useMemo } from 'react';
-import { View, StyleSheet, Dimensions } from 'react-native';
+import { View, StyleSheet } from 'react-native';
 import { Image } from 'expo-image';
 import { LinearGradient } from 'expo-linear-gradient';
 import { useTheme } from '@/contexts/ThemeContext';
-
-const { width: SCREEN_WIDTH, height: SCREEN_HEIGHT } = Dimensions.get('window');
 
 interface NFTBackgroundProps {
   children: React.ReactNode;

--- a/src/components/common/NFTThemeSelector.tsx
+++ b/src/components/common/NFTThemeSelector.tsx
@@ -34,7 +34,7 @@ export default function NFTThemeSelector({
 }: NFTThemeSelectorProps) {
   const insets = useSafeAreaInsets();
   const styles = useMemo(() => createStyles(theme, insets), [theme, insets]);
-  const { setNFTTheme, nftThemeData } = useTheme();
+  const { setNFTTheme } = useTheme();
   const activeAccount = useActiveAccount();
 
   // State management
@@ -204,14 +204,6 @@ export default function NFTThemeSelector({
     } finally {
       setProcessingNFT(null);
     }
-  };
-
-  const isNFTSelected = (nft: NFTToken): boolean => {
-    if (!nftThemeData) return false;
-    return (
-      nftThemeData.contractId === nft.contractId &&
-      nftThemeData.tokenId === nft.tokenId
-    );
   };
 
   const handleLoadMore = () => {

--- a/src/components/common/ThemedWebView.tsx
+++ b/src/components/common/ThemedWebView.tsx
@@ -13,12 +13,10 @@ import { useSafeAreaInsets } from 'react-native-safe-area-context';
 
 // Conditionally import WebView - it doesn't work on web
 let WebView: any = null;
-let WebViewProps: any = {};
 if (Platform.OS !== 'web') {
   // eslint-disable-next-line @typescript-eslint/no-require-imports -- platform-guarded (Platform.OS !== 'web'): react-native-webview has no web build, so a static import would break the web bundle. require() defers the load to native only.
   const webviewModule = require('react-native-webview');
   WebView = webviewModule.WebView;
-  WebViewProps = webviewModule.WebViewProps;
 }
 
 // Cross-platform alert helper

--- a/src/components/envoi/EnvoiProfileCard.tsx
+++ b/src/components/envoi/EnvoiProfileCard.tsx
@@ -16,7 +16,6 @@ import { useThemedStyles, useThemeColors } from '@/hooks/useThemedStyles';
 import { Theme } from '@/constants/themes';
 import AccountAvatar from '@/components/account/AccountAvatar';
 import { GlassCard } from '@/components/common/GlassCard';
-import { useTheme } from '@/contexts/ThemeContext';
 
 interface EnvoiProfileCardProps {
   address: string;
@@ -210,7 +209,6 @@ export default function EnvoiProfileCard({
 }: EnvoiProfileCardProps) {
   const styles = useThemedStyles(createStyles);
   const themeColors = useThemeColors();
-  const { theme } = useTheme();
   const displayName = envoiProfile?.name || name;
   const bio = envoiProfile?.bio;
   const socialLinks = envoiProfile?.socialLinks;

--- a/src/components/ledger/ConnectionModal.tsx
+++ b/src/components/ledger/ConnectionModal.tsx
@@ -10,7 +10,6 @@ import {
 
 import DeviceDiscovery from './DeviceDiscovery';
 import { DebugLogsModal } from '@/components/debug/DebugLogsModal';
-import { useTheme } from '@/contexts/ThemeContext';
 import { useThemedStyles, useThemeColors } from '@/hooks/useThemedStyles';
 import { Theme } from '@/constants/themes';
 import {
@@ -41,7 +40,6 @@ const LedgerConnectionModal: React.FC<LedgerConnectionModalProps> = ({
   title = 'Connect Ledger Device',
   description = 'Select your Ledger device to pair with Voi Wallet. Make sure the device is unlocked and the Algorand app is open.',
 }) => {
-  const { theme } = useTheme();
   const colors = useThemeColors();
   const styles = useThemedStyles(createStyles);
 

--- a/src/components/network/NetworkIndicator.tsx
+++ b/src/components/network/NetworkIndicator.tsx
@@ -2,12 +2,10 @@ import React from 'react';
 import { View, Text, StyleSheet, TouchableOpacity } from 'react-native';
 import { getNetworkConfig } from '@/services/network/config';
 import {
-  useCurrentNetwork,
   useCurrentNetworkConfig,
   useAvailableNetworks,
 } from '@/store/networkStore';
 import { useIsMultiNetworkView } from '@/store/walletStore';
-import { useTheme } from '@/contexts/ThemeContext';
 import { useThemedStyles } from '@/hooks/useThemedStyles';
 import { Theme } from '@/constants/themes';
 
@@ -24,11 +22,9 @@ export default function NetworkIndicator({
   size = 'medium',
   viewMode,
 }: NetworkIndicatorProps) {
-  const currentNetwork = useCurrentNetwork();
   const networkConfig = useCurrentNetworkConfig();
   const availableNetworks = useAvailableNetworks();
   const isMultiNetworkView = useIsMultiNetworkView();
-  const { theme } = useTheme();
   const styles = useThemedStyles(createStyles);
 
   // Use prop override or global state

--- a/src/components/social/MessageInput.tsx
+++ b/src/components/social/MessageInput.tsx
@@ -216,8 +216,6 @@ const EMOJI_CATEGORIES = [
   },
 ];
 
-const RECENT_EMOJIS_KEY = '@recent_emojis';
-
 interface MessageInputProps {
   onSend: (content: string) => Promise<void>;
   isSending: boolean;

--- a/src/components/swap/RouteDetailModal.tsx
+++ b/src/components/swap/RouteDetailModal.tsx
@@ -24,7 +24,6 @@ import {
   UnifiedRoute,
   UnifiedRoutePool,
 } from '../../services/swap/types';
-import { SwapService } from '../../services/swap';
 import { useNetworkStore } from '../../store/networkStore';
 import { useThemedStyles, useThemeColors } from '@/hooks/useThemedStyles';
 import { getTokenImageSource } from '../../utils/tokenImages';
@@ -63,9 +62,6 @@ export const RouteDetailModal: React.FC<RouteDetailModalProps> = ({
   const [routeSteps, setRouteSteps] = useState<RouteStep[]>([]);
   const [loading, setLoading] = useState(true);
   const [slideAnim] = useState(new Animated.Value(0));
-  const [intermediateTokens, setIntermediateTokens] = useState<
-    Map<string, SwapToken>
-  >(new Map());
 
   useEffect(() => {
     if (visible) {
@@ -100,28 +96,6 @@ export const RouteDetailModal: React.FC<RouteDetailModalProps> = ({
       }
 
       let steps: RouteStep[] = [];
-      const tokenMap = new Map<string, SwapToken>();
-      const provider = SwapService.getProvider(currentNetwork);
-
-      // Fetch intermediate tokens for multi-hop routes
-      // In UnifiedRoute, hops may have inputToken/outputToken as SwapToken | null
-      if (
-        route.type === 'multi-hop' &&
-        route.hops &&
-        Array.isArray(route.hops)
-      ) {
-        // Collect intermediate tokens from hops that have them
-        for (const hop of route.hops) {
-          if (hop.inputToken) {
-            tokenMap.set(String(hop.inputToken.id), hop.inputToken);
-          }
-          if (hop.outputToken) {
-            tokenMap.set(String(hop.outputToken.id), hop.outputToken);
-          }
-        }
-      }
-
-      setIntermediateTokens(tokenMap);
 
       // Handle direct routes with pools array
       if (

--- a/src/components/transaction/TransactionAddressDisplay.tsx
+++ b/src/components/transaction/TransactionAddressDisplay.tsx
@@ -21,7 +21,6 @@ export default function TransactionAddressDisplay({
   showDirection = true,
 }: TransactionAddressDisplayProps) {
   const [nameInfo, setNameInfo] = useState<EnvoiNameInfo | null>(null);
-  const [isLoading, setIsLoading] = useState(false);
 
   useEffect(() => {
     let mounted = true;
@@ -30,7 +29,6 @@ export default function TransactionAddressDisplay({
       if (!address) return;
 
       try {
-        setIsLoading(true);
         const envoiService = EnvoiService.getInstance();
         const result = await envoiService.getName(address);
 
@@ -41,10 +39,6 @@ export default function TransactionAddressDisplay({
         console.warn('Failed to load Envoi name:', error);
         if (mounted) {
           setNameInfo(null);
-        }
-      } finally {
-        if (mounted) {
-          setIsLoading(false);
         }
       }
     };

--- a/src/components/transaction/TransactionListItem.tsx
+++ b/src/components/transaction/TransactionListItem.tsx
@@ -167,17 +167,6 @@ const TransactionListItem = React.memo(
       return 'confirmed';
     };
 
-    const getStatusColor = (status: string) => {
-      switch (status) {
-        case 'pending':
-          return 'warning';
-        case 'failed':
-          return 'error';
-        default:
-          return isOutgoing ? 'error' : 'success';
-      }
-    };
-
     const renderAssetIcon = () => {
       // For native token, use network-specific image
       if (
@@ -251,7 +240,6 @@ const TransactionListItem = React.memo(
     };
 
     const status = getTransactionStatus();
-    const statusColor = getStatusColor(status);
 
     const containerStyle = [
       styles.container,

--- a/src/components/walletconnect/DAppInfo.tsx
+++ b/src/components/walletconnect/DAppInfo.tsx
@@ -2,7 +2,6 @@ import React from 'react';
 import { View, Text, StyleSheet } from 'react-native';
 import { Image } from 'expo-image';
 import { WalletConnectMetadata } from '@/services/walletconnect/types';
-import { useTheme } from '@/contexts/ThemeContext';
 import { useThemedStyles } from '@/hooks/useThemedStyles';
 import { Theme } from '@/constants/themes';
 
@@ -19,7 +18,6 @@ export default function DAppInfo({
 }: Props) {
   const iconSize = compact ? 32 : 48;
   const nameSize = compact ? 14 : 16;
-  const { theme } = useTheme();
   const styles = useThemedStyles(createStyles);
 
   return (

--- a/src/components/walletconnect/QRScanner.tsx
+++ b/src/components/walletconnect/QRScanner.tsx
@@ -5,7 +5,6 @@ import {
   Text,
   StyleSheet,
   TouchableOpacity,
-  Dimensions,
   Platform,
   ActivityIndicator,
 } from 'react-native';
@@ -62,15 +61,12 @@ interface Props {
   onSuccess?: (uri: string) => void;
 }
 
-const { width, height } = Dimensions.get('window');
-
 export default function QRScanner({ onClose, onSuccess }: Props) {
   const [hasPermission, setHasPermission] = useState<boolean | null>(null);
   const [scanned, setScanned] = useState(false);
   const [isProcessing, setIsProcessing] = useState(false);
   const [isCapturing, setIsCapturing] = useState(false);
   const fileInputRef = useRef<HTMLInputElement>(null);
-  const canvasRef = useRef<HTMLCanvasElement>(null);
   const { theme } = useTheme();
   const styles = useThemedStyles(createStyles);
 

--- a/src/contexts/AuthContext.tsx
+++ b/src/contexts/AuthContext.tsx
@@ -100,7 +100,6 @@ export interface AuthContextType {
 
 const AuthContext = createContext<AuthContextType | undefined>(undefined);
 
-const DEFAULT_SESSION_TIMEOUT = 5 * 60 * 1000; // 5 minutes default
 const ACTIVITY_CHECK_INTERVAL = 30 * 1000; // 30 seconds
 const BACKGROUND_GRACE_PERIOD = 60 * 1000; // 60 seconds
 

--- a/src/navigation/AppNavigator.tsx
+++ b/src/navigation/AppNavigator.tsx
@@ -855,7 +855,6 @@ function MainTabNavigator() {
   const isSignerMode = appMode === 'signer';
 
   // Extract theme values to stable variables to avoid context issues in callbacks
-  const primaryColor = theme.colors.primary;
   const tabIconActive = theme.colors.tabIconActive;
   const tabIconInactive = theme.colors.tabIconInactive;
   // Use solid background when no NFT background, semi-transparent when NFT is enabled
@@ -1362,9 +1361,6 @@ export default function AppNavigator() {
   const navigationRef = useRef<any>(null);
   const initializationRef = useRef<boolean>(false);
   const { initializeNetwork } = useNetworkStore();
-
-  // Disable URL-based linking for Chrome extensions to prevent "file couldn't be accessed" errors
-  const isExtension = Platform.OS === 'web' && detectPlatform() === 'extension';
 
   // For extensions, don't use any linking config - this completely disables URL-based navigation
   // which prevents full page reloads when switching tabs

--- a/src/screens/account/AccountImportPreviewScreen.tsx
+++ b/src/screens/account/AccountImportPreviewScreen.tsx
@@ -54,7 +54,7 @@ export default function AccountImportPreviewScreen({
   navigation,
   route,
 }: Props) {
-  const { accounts: initialAccounts, source } = route.params;
+  const { accounts: initialAccounts } = route.params;
   const { theme } = useTheme();
 
   const [accounts, setAccounts] = useState<ScannedAccount[]>(initialAccounts);

--- a/src/screens/account/AddWatchAccountScreen.tsx
+++ b/src/screens/account/AddWatchAccountScreen.tsx
@@ -40,11 +40,6 @@ type AddWatchAccountScreenRouteProp = RouteProp<
   'AddWatchAccount'
 >;
 
-interface Props {
-  navigation: AddWatchAccountScreenNavigationProp;
-  route: AddWatchAccountScreenRouteProp;
-}
-
 export default function AddWatchAccountScreen() {
   const { theme } = useTheme();
   const styles = useThemedStyles(createStyles);

--- a/src/screens/account/MnemonicImportScreen.tsx
+++ b/src/screens/account/MnemonicImportScreen.tsx
@@ -324,24 +324,6 @@ export default function MnemonicImportScreen({ navigation, route }: Props) {
     accountLabel,
   ]);
 
-  const handleClear = useCallback(() => {
-    Alert.alert(
-      'Clear All Words',
-      'Are you sure you want to clear all entered words?',
-      [
-        { text: 'Cancel', style: 'cancel' },
-        {
-          text: 'Clear',
-          style: 'destructive',
-          onPress: () => {
-            clearImportState();
-            inputRefs.current[0]?.focus();
-          },
-        },
-      ]
-    );
-  }, [clearImportState]);
-
   const renderWordInput = useCallback(
     ({ item: index }: { item: number }) => {
       const word = words[index];

--- a/src/screens/remoteSigner/AirgapHomeScreen.tsx
+++ b/src/screens/remoteSigner/AirgapHomeScreen.tsx
@@ -36,7 +36,6 @@ import Animated, {
 } from 'react-native-reanimated';
 import { useThemedStyles, useThemeColors } from '@/hooks/useThemedStyles';
 import { Theme } from '@/constants/themes';
-import { useTheme } from '@/contexts/ThemeContext';
 import { GlassCard } from '@/components/common/GlassCard';
 import { GlassButton } from '@/components/common/GlassButton';
 import { NFTBackground } from '@/components/common/NFTBackground';
@@ -62,7 +61,6 @@ export default function AirgapHomeScreen() {
   const navigation = useNavigation<NavigationProp>();
   const styles = useThemedStyles(createStyles);
   const colors = useThemeColors();
-  const { theme } = useTheme();
 
   // State
   const [isAccountListVisible, setIsAccountListVisible] = useState(false);

--- a/src/screens/remoteSigner/SignRequestScannerScreen.tsx
+++ b/src/screens/remoteSigner/SignRequestScannerScreen.tsx
@@ -24,10 +24,7 @@ import jsQR from 'jsqr';
 import { useThemedStyles } from '@/hooks/useThemedStyles';
 import { useTheme } from '@/contexts/ThemeContext';
 import { Theme } from '@/constants/themes';
-import {
-  useRemoteSignerStore,
-  useSignerConfig,
-} from '@/store/remoteSignerStore';
+import { useRemoteSignerStore } from '@/store/remoteSignerStore';
 import { useWalletStore } from '@/store/walletStore';
 import { RemoteSignerService } from '@/services/remoteSigner';
 import { isRemoteSignerRequest } from '@/types/remoteSigner';
@@ -72,7 +69,6 @@ export default function SignRequestScannerScreen() {
   const styles = useThemedStyles(createStyles);
   const navigation = useNavigation<any>();
 
-  const signerConfig = useSignerConfig();
   const accounts = useWalletStore((state) => state.wallet?.accounts ?? []);
   const validateRequest = useRemoteSignerStore(
     (state) => state.validateRequest
@@ -81,8 +77,6 @@ export default function SignRequestScannerScreen() {
     (state) => state.setPendingRequest
   );
 
-  const [hasPermission, setHasPermission] = useState<boolean | null>(null);
-  const [scanned, setScanned] = useState(false);
   const [isProcessing, setIsProcessing] = useState(false);
 
   const fileInputRef = useRef<HTMLInputElement>(null);
@@ -98,18 +92,14 @@ export default function SignRequestScannerScreen() {
   useEffect(() => {
     if (Platform.OS !== 'web') {
       requestCameraPermission();
-    } else {
-      setHasPermission(true);
     }
   }, []);
 
   const requestCameraPermission = async () => {
     try {
-      const { status } = await Camera.requestCameraPermissionsAsync();
-      setHasPermission(status === 'granted');
+      await Camera.requestCameraPermissionsAsync();
     } catch (error) {
       console.error('Camera permission error:', error);
-      setHasPermission(false);
     }
   };
 
@@ -128,7 +118,6 @@ export default function SignRequestScannerScreen() {
             'Invalid QR Code',
             'This QR code is not a transaction signing request.'
           );
-          setScanned(false);
           setIsProcessing(false);
           return;
         }
@@ -140,7 +129,6 @@ export default function SignRequestScannerScreen() {
             'Invalid Request',
             validation.error || 'Request validation failed'
           );
-          setScanned(false);
           setIsProcessing(false);
           return;
         }
@@ -159,7 +147,6 @@ export default function SignRequestScannerScreen() {
             'Missing Keys',
             `This device does not have the signing keys for:\n${missingSigners.slice(0, 3).join('\n')}${missingSigners.length > 3 ? `\n...and ${missingSigners.length - 3} more` : ''}`
           );
-          setScanned(false);
           setIsProcessing(false);
           return;
         }
@@ -175,7 +162,6 @@ export default function SignRequestScannerScreen() {
           'Invalid QR Code',
           'Could not read the QR code. Make sure you are scanning a transaction signing request.'
         );
-        setScanned(false);
       } finally {
         setIsProcessing(false);
       }
@@ -187,15 +173,6 @@ export default function SignRequestScannerScreen() {
       setPendingRequest,
       navigation,
     ]
-  );
-
-  const handleBarCodeScanned = useCallback(
-    ({ data }: { data: string }) => {
-      if (scanned || isProcessing) return;
-      setScanned(true);
-      processQRData(data);
-    },
-    [scanned, isProcessing, processQRData]
   );
 
   const handlePasteFromClipboard = async () => {
@@ -304,7 +281,6 @@ export default function SignRequestScannerScreen() {
   const handleAnimatedScan = useCallback(
     (data: string) => {
       if (isProcessing) return;
-      setScanned(true);
       processQRData(data);
     },
     [isProcessing, processQRData]

--- a/src/screens/remoteSigner/SignatureDisplayScreen.tsx
+++ b/src/screens/remoteSigner/SignatureDisplayScreen.tsx
@@ -8,7 +8,6 @@
 
 import React, { useState, useEffect, useMemo } from 'react';
 import {
-  Alert,
   View,
   Text,
   StyleSheet,
@@ -35,36 +34,6 @@ import {
 import { AccountType, AccountMetadata } from '@/types/wallet';
 import { AnimatedQRCode } from '@/components/remoteSigner';
 import algosdk from 'algosdk';
-
-// Cross-platform alert helper
-const showAlert = (
-  title: string,
-  message: string,
-  buttons?: {
-    text: string;
-    onPress?: () => void;
-    style?: 'default' | 'cancel' | 'destructive';
-  }[]
-) => {
-  if (Platform.OS === 'web') {
-    if (buttons && buttons.length > 1) {
-      const confirmed = window.confirm(`${title}\n\n${message}`);
-      if (confirmed) {
-        const confirmButton =
-          buttons.find((b) => b.style !== 'cancel') || buttons[0];
-        confirmButton?.onPress?.();
-      } else {
-        const cancelButton = buttons.find((b) => b.style === 'cancel');
-        cancelButton?.onPress?.();
-      }
-    } else {
-      window.alert(`${title}\n\n${message}`);
-      buttons?.[0]?.onPress?.();
-    }
-  } else {
-    Alert.alert(title, message, buttons);
-  }
-};
 
 type RouteParams = {
   SignatureDisplay: {

--- a/src/screens/remoteSigner/TransactionReviewScreen.tsx
+++ b/src/screens/remoteSigner/TransactionReviewScreen.tsx
@@ -107,11 +107,7 @@ export default function TransactionReviewScreen() {
   const setPendingRequest = useRemoteSignerStore(
     (state) => state.setPendingRequest
   );
-  const markRequestProcessed = useRemoteSignerStore(
-    (state) => state.markRequestProcessed
-  );
-
-  const [currentTxnIndex, setCurrentTxnIndex] = useState(0);
+  const [currentTxnIndex] = useState(0);
   const [showFullDetails, setShowFullDetails] = useState(false);
   const [isSigning, setIsSigning] = useState(false);
   const [showAuthModal, setShowAuthModal] = useState(false);

--- a/src/screens/settings/AboutScreen.tsx
+++ b/src/screens/settings/AboutScreen.tsx
@@ -11,7 +11,6 @@ import {
 } from 'react-native';
 import { Image } from 'expo-image';
 import { SafeAreaView } from 'react-native-safe-area-context';
-import { useNavigation } from '@react-navigation/native';
 import { Ionicons } from '@expo/vector-icons';
 import Constants from 'expo-constants';
 import * as Updates from 'expo-updates';
@@ -36,7 +35,6 @@ const getUpdateInfo = () => {
 };
 
 export default function AboutScreen() {
-  const navigation = useNavigation();
   const styles = useThemedStyles(createStyles);
   const colors = useThemeColors();
   const updateInfo = getUpdateInfo();

--- a/src/screens/settings/BackupWalletScreen.tsx
+++ b/src/screens/settings/BackupWalletScreen.tsx
@@ -12,7 +12,6 @@ import * as FileSystem from 'expo-file-system/legacy';
 import { SafeAreaView } from 'react-native-safe-area-context';
 import { useNavigation } from '@react-navigation/native';
 import { Ionicons } from '@expo/vector-icons';
-import { useTheme } from '@/contexts/ThemeContext';
 import { useThemedStyles, useThemeColors } from '@/hooks/useThemedStyles';
 import { Theme } from '@/constants/themes';
 import { GlassCard } from '@/components/common/GlassCard';
@@ -29,7 +28,6 @@ import {
 
 export default function BackupWalletScreen() {
   const navigation = useNavigation();
-  const { theme } = useTheme();
   const styles = useThemedStyles(createStyles);
   const colors = useThemeColors();
   const accounts = useAccounts();

--- a/src/screens/settings/NotificationSettingsScreen.tsx
+++ b/src/screens/settings/NotificationSettingsScreen.tsx
@@ -17,7 +17,6 @@ import {
 } from 'react-native';
 import { SafeAreaView } from 'react-native-safe-area-context';
 import { useNavigation } from '@react-navigation/native';
-import Slider from '@react-native-community/slider';
 import { Ionicons } from '@expo/vector-icons';
 import { useTheme } from '@/contexts/ThemeContext';
 import { useThemedStyles, useThemeColors } from '@/hooks/useThemedStyles';
@@ -116,114 +115,6 @@ function SettingToggle({
     </View>
   );
 }
-
-interface SliderSettingProps {
-  icon: keyof typeof Ionicons.glyphMap;
-  label: string;
-  description?: string;
-  value: number;
-  onValueChange: (value: number) => void;
-  minimumValue: number;
-  maximumValue: number;
-  step?: number;
-  formatValue: (value: number) => string;
-  disabled?: boolean;
-}
-
-function SliderSetting({
-  icon,
-  label,
-  description,
-  value,
-  onValueChange,
-  minimumValue,
-  maximumValue,
-  step = 1,
-  formatValue,
-  disabled = false,
-}: SliderSettingProps) {
-  const { theme } = useTheme();
-  const themeColors = useThemeColors();
-
-  return (
-    <View
-      style={{
-        paddingVertical: theme.spacing.md,
-        paddingHorizontal: theme.spacing.md,
-        borderBottomWidth: 1,
-        borderBottomColor: theme.colors.glassBorder,
-        opacity: disabled ? 0.5 : 1,
-      }}
-    >
-      <View
-        style={{
-          flexDirection: 'row',
-          alignItems: 'center',
-          marginBottom: theme.spacing.sm,
-        }}
-      >
-        <View
-          style={{
-            width: 32,
-            height: 32,
-            borderRadius: theme.borderRadius.sm,
-            backgroundColor: `${theme.colors.primary}15`,
-            alignItems: 'center',
-            justifyContent: 'center',
-            marginRight: theme.spacing.md,
-          }}
-        >
-          <Ionicons name={icon} size={18} color={theme.colors.primary} />
-        </View>
-        <View style={{ flex: 1 }}>
-          <Text
-            style={{
-              fontSize: theme.typography.body.fontSize,
-              fontWeight: '600',
-              color: themeColors.text,
-            }}
-          >
-            {label}
-          </Text>
-          {description && (
-            <Text
-              style={{
-                fontSize: theme.typography.caption.fontSize,
-                color: themeColors.textMuted,
-                marginTop: 2,
-              }}
-            >
-              {description}
-            </Text>
-          )}
-        </View>
-        <Text
-          style={{
-            fontSize: theme.typography.body.fontSize,
-            color: themeColors.textMuted,
-            minWidth: 60,
-            textAlign: 'right',
-          }}
-        >
-          {formatValue(value)}
-        </Text>
-      </View>
-      <Slider
-        style={{ width: '100%', height: 40 }}
-        minimumValue={minimumValue}
-        maximumValue={maximumValue}
-        step={step}
-        value={value}
-        onValueChange={onValueChange}
-        disabled={disabled}
-        minimumTrackTintColor={theme.colors.primary}
-        maximumTrackTintColor={theme.colors.glassBorder}
-        thumbTintColor={theme.colors.primary}
-      />
-    </View>
-  );
-}
-
 interface NumberInputSettingProps {
   icon: keyof typeof Ionicons.glyphMap;
   label: string;

--- a/src/screens/settings/RestoreWalletScreen.tsx
+++ b/src/screens/settings/RestoreWalletScreen.tsx
@@ -8,11 +8,7 @@ import {
   ScrollView,
 } from 'react-native';
 import { SafeAreaView } from 'react-native-safe-area-context';
-import {
-  useNavigation,
-  useRoute,
-  CommonActions,
-} from '@react-navigation/native';
+import { useNavigation, CommonActions } from '@react-navigation/native';
 import { Ionicons } from '@expo/vector-icons';
 import * as DocumentPicker from 'expo-document-picker';
 import { useTheme } from '@/contexts/ThemeContext';
@@ -29,15 +25,9 @@ import {
   BackupError,
 } from '@/services/backup';
 
-interface RouteParams {
-  isOnboarding?: boolean;
-}
-
 export default function RestoreWalletScreen() {
   const navigation = useNavigation();
-  const route = useRoute();
-  const { isOnboarding } = (route.params as RouteParams) || {};
-  const { theme, reloadTheme } = useTheme();
+  const { reloadTheme } = useTheme();
   const styles = useThemedStyles(createStyles);
   const colors = useThemeColors();
 
@@ -54,7 +44,6 @@ export default function RestoreWalletScreen() {
   const [password, setPassword] = useState('');
   const [error, setError] = useState<string | undefined>();
   const [isValidating, setIsValidating] = useState(false);
-  const [isRestoring, setIsRestoring] = useState(false);
 
   // Set up progress callback
   useEffect(() => {
@@ -146,7 +135,6 @@ export default function RestoreWalletScreen() {
 
     setShowConfirmationModal(false);
     setShowProgressModal(true);
-    setIsRestoring(true);
 
     try {
       const result = await BackupService.restoreBackup(
@@ -201,7 +189,6 @@ export default function RestoreWalletScreen() {
           : 'Failed to restore backup. Please try again.';
       Alert.alert('Restore Failed', message, [{ text: 'OK' }]);
     } finally {
-      setIsRestoring(false);
       setPassword('');
     }
   }, [selectedFile, password, navigation, reloadTheme]);

--- a/src/screens/settings/SettingsScreen.tsx
+++ b/src/screens/settings/SettingsScreen.tsx
@@ -1,4 +1,4 @@
-import React, { useState, useEffect, useCallback } from 'react';
+import React, { useState, useCallback } from 'react';
 import {
   View,
   Text,
@@ -24,7 +24,6 @@ import {
   useWalletStore,
   useWalletSettings,
 } from '@/store/walletStore';
-import { useAuth } from '@/contexts/AuthContext';
 import UniversalHeader from '@/components/common/UniversalHeader';
 import AccountListModal from '@/components/account/AccountListModal';
 import AddAccountModal from '@/components/account/AddAccountModal';
@@ -34,13 +33,9 @@ import LocaleSwitcher from '@/components/common/LocaleSwitcher';
 import NFTThemeSelector from '@/components/common/NFTThemeSelector';
 import { formatAddress } from '@/utils/address';
 import { AccountMetadata, AccountType } from '@/types/wallet';
-import {
-  useCurrentNetworkConfig,
-  useIsCurrentNetworkHealthy,
-} from '@/store/networkStore';
+import { useIsCurrentNetworkHealthy } from '@/store/networkStore';
 import NetworkSwitcher from '@/components/network/NetworkSwitcher';
 import NetworkIndicator from '@/components/network/NetworkIndicator';
-import * as LocalAuthentication from 'expo-local-authentication';
 import { useTheme } from '@/contexts/ThemeContext';
 import { useThemedStyles, useThemeColors } from '@/hooks/useThemedStyles';
 import { Theme, ThemeMode } from '@/constants/themes';
@@ -246,8 +241,6 @@ export default function SettingsScreen() {
     (state) => state.updateWalletSettings
   );
   const walletSettings = useWalletSettings();
-  const { authState, enableBiometrics } = useAuth();
-  const currentNetworkConfig = useCurrentNetworkConfig();
   const isNetworkHealthy = useIsCurrentNetworkHealthy();
   const {
     theme,
@@ -266,8 +259,6 @@ export default function SettingsScreen() {
   const [accountToRename, setAccountToRename] =
     useState<AccountMetadata | null>(null);
   const [isRenamingAccount, setIsRenamingAccount] = useState(false);
-  const [isBiometricAvailable, setIsBiometricAvailable] = useState(false);
-  const [isTogglingBiometric, setIsTogglingBiometric] = useState(false);
   const [isNetworkSwitcherVisible, setIsNetworkSwitcherVisible] =
     useState(false);
   const [isLocaleModalVisible, setIsLocaleModalVisible] = useState(false);
@@ -292,21 +283,6 @@ export default function SettingsScreen() {
 
   const getAccountDisplayName = (account: AccountMetadata) =>
     account.label?.trim() || formatAddress(account.address);
-
-  useEffect(() => {
-    checkBiometricAvailability();
-  }, []);
-
-  const checkBiometricAvailability = async () => {
-    try {
-      const hasHardware = await LocalAuthentication.hasHardwareAsync();
-      const isEnrolled = await LocalAuthentication.isEnrolledAsync();
-      setIsBiometricAvailable(hasHardware && isEnrolled);
-    } catch (error) {
-      console.warn('Failed to check biometric availability:', error);
-      setIsBiometricAvailable(false);
-    }
-  };
 
   const handleAccountSelectorPress = () => {
     setIsAccountModalVisible(true);
@@ -419,42 +395,8 @@ export default function SettingsScreen() {
     );
   };
 
-  const handleChangePin = () => {
-    navigation.navigate('ChangePin');
-  };
-
   const handleSecuritySettings = () => {
     navigation.navigate('SecuritySettings');
-  };
-
-  const handleBiometricToggle = async (enabled: boolean) => {
-    if (!isBiometricAvailable) {
-      Alert.alert(
-        'Biometric Authentication Unavailable',
-        'Biometric authentication is not available on this device or no biometric data is enrolled. Please set up biometric authentication in your device settings.'
-      );
-      return;
-    }
-
-    setIsTogglingBiometric(true);
-
-    try {
-      await enableBiometrics(enabled);
-
-      const message = enabled
-        ? 'Biometric authentication has been enabled'
-        : 'Biometric authentication has been disabled';
-
-      Alert.alert('Success', message);
-    } catch (error) {
-      const errorMessage =
-        error instanceof Error
-          ? error.message
-          : 'Failed to update biometric setting';
-      Alert.alert('Error', errorMessage);
-    } finally {
-      setIsTogglingBiometric(false);
-    }
   };
 
   const handleWalletConnectSessions = () => {

--- a/src/screens/social/FriendProfileScreen.tsx
+++ b/src/screens/social/FriendProfileScreen.tsx
@@ -35,28 +35,6 @@ import { useTheme } from '@/contexts/ThemeContext';
 import { GlassButton } from '@/components/common/GlassButton';
 import { useIsMessagingEnabled } from '@/store/experimentalStore';
 
-const formatRelativeTime = (timestamp?: number): string => {
-  if (!timestamp) return 'No recent activity';
-
-  const diff = Date.now() - timestamp;
-  if (diff < 60_000) return 'Just now';
-
-  const minutes = Math.floor(diff / 60_000);
-  if (minutes < 60) return `${minutes}m ago`;
-
-  const hours = Math.floor(minutes / 60);
-  if (hours < 24) return `${hours}h ago`;
-
-  const days = Math.floor(hours / 24);
-  if (days < 7) return `${days}d ago`;
-
-  const weeks = Math.floor(days / 7);
-  if (weeks < 4) return `${weeks}w ago`;
-
-  const months = Math.floor(days / 30);
-  return `${months}mo ago`;
-};
-
 const formatDate = (timestamp?: number): string => {
   if (!timestamp) return 'Unknown';
   return new Date(timestamp).toLocaleString();

--- a/src/screens/social/MessagesInboxScreen.tsx
+++ b/src/screens/social/MessagesInboxScreen.tsx
@@ -72,7 +72,6 @@ export default function MessagesInboxScreen() {
   const {
     initialize,
     isInitialized,
-    isLoading,
     isKeyRegistered,
     checkKeyRegistration,
     fetchAllThreads,

--- a/src/screens/social/NewMessageScreen.tsx
+++ b/src/screens/social/NewMessageScreen.tsx
@@ -62,7 +62,7 @@ export default function NewMessageScreen() {
 
   const activeAccount = useActiveAccount();
   const allAccounts = useAccounts();
-  const { isKeyRegistered, checkKeyRegistration } = useMessagesStore();
+  const { checkKeyRegistration } = useMessagesStore();
   const friends = useFriendsStore((state) => state.friends);
   const friendsInitialize = useFriendsStore((state) => state.initialize);
   const friendsIsInitialized = useFriendsStore((state) => state.isInitialized);

--- a/src/screens/transaction/KeyregConfirmScreen.tsx
+++ b/src/screens/transaction/KeyregConfirmScreen.tsx
@@ -19,7 +19,7 @@ import UnifiedTransactionAuthModal from '@/components/UnifiedTransactionAuthModa
 import { useTransactionAuthController } from '@/services/auth/transactionAuthController';
 import { UnifiedTransactionRequest } from '@/services/transactions/unifiedSigner';
 import { formatAddress } from '@/utils/address';
-import { useWalletStore, useActiveAccount } from '@/store/walletStore';
+import { useWalletStore } from '@/store/walletStore';
 import { NetworkId } from '@/types/network';
 import { WalletAccount } from '@/types/wallet';
 import { getNetworkConfig } from '@/services/network/config';
@@ -44,7 +44,6 @@ export default function KeyregConfirmScreen() {
   const colors = useThemeColors();
 
   const { wallet } = useWalletStore();
-  const activeAccount = useActiveAccount();
   const authController = useTransactionAuthController();
 
   const [showAuthModal, setShowAuthModal] = useState(false);

--- a/src/screens/wallet/AccountInfoScreen.tsx
+++ b/src/screens/wallet/AccountInfoScreen.tsx
@@ -8,13 +8,11 @@ import {
   ActivityIndicator,
   Dimensions,
   TouchableOpacity,
-  Alert,
 } from 'react-native';
 import { useNavigation, RouteProp, useRoute } from '@react-navigation/native';
 import { NativeStackNavigationProp } from '@react-navigation/native-stack';
 import { Ionicons } from '@expo/vector-icons';
 import { SafeAreaView } from 'react-native-safe-area-context';
-import * as Clipboard from 'expo-clipboard';
 import { PieChart } from 'react-native-chart-kit';
 import { WalletStackParamList } from '@/navigation/AppNavigator';
 import { useThemedStyles } from '@/hooks/useThemedStyles';
@@ -69,7 +67,6 @@ export default function AccountInfoScreen() {
   const [refreshing, setRefreshing] = useState(false);
   const [voiAccountInfo, setVoiAccountInfo] = useState<any>(null);
   const [algoAccountInfo, setAlgoAccountInfo] = useState<any>(null);
-  const [isLoadingAccountInfo, setIsLoadingAccountInfo] = useState(true);
   const [accountAge, setAccountAge] = useState<string>('Loading...');
   const route = useRoute<AccountInfoScreenRouteProp>();
   const navigation =
@@ -201,8 +198,6 @@ export default function AccountInfoScreen() {
   const loadAccountInfo = useCallback(async () => {
     if (!displayAddress) return;
 
-    setIsLoadingAccountInfo(true);
-
     // Load account info from both networks
     const loadVoi = async () => {
       try {
@@ -248,7 +243,6 @@ export default function AccountInfoScreen() {
     };
 
     await Promise.allSettled([loadVoi(), loadAlgo()]);
-    setIsLoadingAccountInfo(false);
   }, [displayAddress]);
 
   // Calculate total USD value for a mapped asset
@@ -364,8 +358,6 @@ export default function AccountInfoScreen() {
     // Voi Network
     const voiAmount =
       multiNetworkBalance.perNetworkAmounts[NetworkId.VOI_MAINNET];
-    const voiPrice =
-      multiNetworkBalance.perNetworkPrices[NetworkId.VOI_MAINNET];
     if (voiAmount !== undefined) {
       // Calculate value ONLY from balances on this specific network
       let voiValue = 0;
@@ -402,8 +394,6 @@ export default function AccountInfoScreen() {
     // Algorand Network
     const algoAmount =
       multiNetworkBalance.perNetworkAmounts[NetworkId.ALGORAND_MAINNET];
-    const algoPrice =
-      multiNetworkBalance.perNetworkPrices[NetworkId.ALGORAND_MAINNET];
     if (algoAmount !== undefined) {
       // Calculate value ONLY from balances on this specific network
       let algoValue = 0;
@@ -439,18 +429,6 @@ export default function AccountInfoScreen() {
 
     return stats;
   }, [multiNetworkBalance]);
-
-  const copyAddressToClipboard = async () => {
-    if (displayAddress) {
-      try {
-        await Clipboard.setStringAsync(displayAddress);
-        Alert.alert('Copied', 'Address copied to clipboard');
-      } catch (error) {
-        console.error('Failed to copy address:', error);
-        Alert.alert('Error', 'Failed to copy address');
-      }
-    }
-  };
 
   const navigateToMyAccount = () => {
     navigation.navigate('AccountInfo', {});
@@ -542,7 +520,6 @@ export default function AccountInfoScreen() {
     ? multiNetworkBalance.assets.length
     : 0;
   const networksActive = multiNetworkBalance?.sourceNetworks.length || 0;
-  const totalMinBalance = multiNetworkBalance?.minBalance || 0n;
 
   if (!displayAddress) {
     return (

--- a/src/screens/wallet/AssetDetailScreen.tsx
+++ b/src/screens/wallet/AssetDetailScreen.tsx
@@ -75,7 +75,6 @@ export default function AssetDetailScreen() {
   const [showAuthModal, setShowAuthModal] = useState(false);
   const [optingOut, setOptingOut] = useState(false);
   const [isSwappable, setIsSwappable] = useState(false);
-  const [checkingSwappable, setCheckingSwappable] = useState(true);
   const loadMoreInFlightRef = React.useRef(false);
   const route = useRoute();
   const navigation = useNavigation<StackNavigationProp<any>>();
@@ -266,7 +265,6 @@ export default function AssetDetailScreen() {
   // Check if token is swappable (VOI via SnowballSwap, Algorand via Deflex)
   useEffect(() => {
     const checkSwappable = async () => {
-      setCheckingSwappable(true);
       try {
         const effectiveNetworkId =
           (networkId as NetworkId) || NetworkId.VOI_MAINNET;
@@ -291,8 +289,6 @@ export default function AssetDetailScreen() {
       } catch (error) {
         console.error('Error checking token swappability:', error);
         setIsSwappable(false);
-      } finally {
-        setCheckingSwappable(false);
       }
     };
 
@@ -604,10 +600,6 @@ export default function AssetDetailScreen() {
 
   const formatTimestamp = (timestamp: number) => {
     return new Date(timestamp).toLocaleDateString();
-  };
-
-  const formatAddress = (address: string) => {
-    return `${address.slice(0, 6)}...${address.slice(-6)}`;
   };
 
   const formatBalance = (amount: number | bigint) => {

--- a/src/screens/wallet/BuyScreen.tsx
+++ b/src/screens/wallet/BuyScreen.tsx
@@ -11,14 +11,13 @@ import ThemedWebView, {
   ThemedWebViewRef,
 } from '@/components/common/ThemedWebView';
 import { Ionicons } from '@expo/vector-icons';
-import { useNavigation, useRoute } from '@react-navigation/native';
+import { useRoute } from '@react-navigation/native';
 import { useWalletStore, useActiveAccount } from '@/store/walletStore';
 import UniversalHeader from '@/components/common/UniversalHeader';
 import AccountListModal from '@/components/account/AccountListModal';
 import { useTheme } from '@/contexts/ThemeContext';
 
 export default function BuyScreen() {
-  const navigation = useNavigation();
   const route = useRoute();
   const reloadTimestamp = (route.params as { reload?: number } | undefined)
     ?.reload;

--- a/src/screens/wallet/HomeScreen.tsx
+++ b/src/screens/wallet/HomeScreen.tsx
@@ -33,20 +33,16 @@ import { AssetBalance, needsBackupVerification } from '@/types/wallet';
 import { useAuth } from '@/contexts/AuthContext';
 import {
   useActiveAccount,
-  useAccounts,
   useWalletStore,
   useActiveAccountBalance,
   useAccountEnvoiName,
-  useViewMode,
   useIsMultiNetworkView,
   useMultiNetworkBalance,
   useAssetNetworkFilter,
 } from '@/store/walletStore';
 import VoiNetworkService, { NetworkStatus } from '@/services/network';
-import { formatNativeBalance } from '@/utils/bigint';
 import { formatCurrency } from '@/utils/formatting';
 import { useCurrentNetworkConfig } from '@/store/networkStore';
-import { getNetworkConfig } from '@/services/network/config';
 import { NetworkId } from '@/types/network';
 import AccountListModal from '@/components/account/AccountListModal';
 import UniversalHeader from '@/components/common/UniversalHeader';
@@ -82,8 +78,6 @@ import { useAppMode, useRemoteSignerStore } from '@/store/remoteSignerStore';
 import { ErrorStateView } from '@/components/common/ErrorStateView';
 import { toErrorAlert } from '@/utils/errorMapping';
 import { useConnectivity } from '@/hooks/useConnectivity';
-
-const AnimatedPressable = Animated.createAnimatedComponent(Pressable);
 
 export default function HomeScreen() {
   // `networkStatus` used to be written twice and read nowhere (TASK-40 / R-03).
@@ -220,7 +214,6 @@ export default function HomeScreen() {
   }, []);
 
   const initialize = useWalletStore((state) => state.initialize);
-  const wallet = useWalletStore((state) => state.wallet);
   // Wallet-store hydration flag (F-48, TASK-182). This is the SAME signal the
   // splash readiness owner (AppStack) gates on, so the "Loading wallet..."
   // placeholder and the splash hide stay in lockstep. Once the store is
@@ -233,7 +226,6 @@ export default function HomeScreen() {
   const loadAccountTransactions = useWalletStore(
     (state) => state.loadAccountTransactions
   );
-  const allAccounts = useAccounts();
   const {
     balance: accountBalance,
     isLoading: isBalanceLoading,
@@ -251,7 +243,6 @@ export default function HomeScreen() {
   const loadEnvoiName = useWalletStore((state) => state.loadEnvoiName);
 
   // Multi-network view mode
-  const viewMode = useViewMode();
   const isMultiNetworkView = useIsMultiNetworkView();
   const assetNetworkFilter = useAssetNetworkFilter();
   const {
@@ -1150,10 +1141,6 @@ export default function HomeScreen() {
     return `${address.slice(0, 6)}...${address.slice(-6)}`;
   };
 
-  const formatBalance = (amount: number | bigint) => {
-    return formatNativeBalance(amount, currentNetworkConfig.nativeToken);
-  };
-
   const calculateTotalUsdValue = React.useMemo(() => {
     if (isMultiNetworkView && multiNetworkBalance) {
       // Multi-network calculation - ALWAYS show combined total regardless of filter
@@ -1283,88 +1270,6 @@ export default function HomeScreen() {
   const algorandNetworkUsdValue = React.useMemo(() => {
     return calculateNetworkUsdValue(NetworkId.ALGORAND_MAINNET);
   }, [calculateNetworkUsdValue]);
-
-  const calculateNativeTokenEquivalent = React.useMemo(() => {
-    if (isMultiNetworkView && multiNetworkBalance) {
-      // Multi-network: Show breakdown by network, filtered by assetNetworkFilter
-      const parts: string[] = [];
-
-      // Determine which networks to include based on filter
-      const shouldIncludeNetwork = (networkId: NetworkId) => {
-        if (assetNetworkFilter === 'all') return true;
-        if (assetNetworkFilter === 'voi')
-          return networkId === NetworkId.VOI_MAINNET;
-        if (assetNetworkFilter === 'algorand')
-          return networkId === NetworkId.ALGORAND_MAINNET;
-        return true;
-      };
-
-      Object.entries(multiNetworkBalance.perNetworkAmounts).forEach(
-        ([networkId, amount]) => {
-          // Skip if this network is filtered out
-          if (!shouldIncludeNetwork(networkId as NetworkId)) {
-            return;
-          }
-
-          const config = getNetworkConfig(networkId as NetworkId);
-          const amountNum =
-            typeof amount === 'bigint' ? Number(amount) : amount;
-          const formatted = formatNativeBalance(amountNum, config.nativeToken);
-          parts.push(`${formatted} ${config.nativeToken}`);
-        }
-      );
-
-      return parts.length > 0
-        ? parts.join(' + ')
-        : formatNativeBalance(0, 'VOI');
-    }
-
-    // Single-network calculation (existing logic)
-    const nativePrice = accountBalance?.voiPrice || accountBalance?.algoPrice;
-    if (!nativePrice)
-      return formatNativeBalance(0, currentNetworkConfig.nativeToken);
-
-    // Get total USD value without formatting
-    let totalUsdValue = 0;
-
-    // Add native token value
-    if (nativePrice && accountBalance.amount) {
-      const amount =
-        typeof accountBalance.amount === 'bigint'
-          ? Number(accountBalance.amount)
-          : accountBalance.amount;
-      const nativeValue = amount / 1_000_000; // Convert micro-units to whole units
-      totalUsdValue += nativeValue * nativePrice;
-    }
-
-    // Add asset values
-    if (accountBalance.assets) {
-      accountBalance.assets.forEach((asset) => {
-        if (asset.usdValue && asset.amount) {
-          const unitPrice = parseFloat(asset.usdValue);
-          const amount =
-            typeof asset.amount === 'bigint'
-              ? Number(asset.amount)
-              : asset.amount;
-          const normalizedBalance = amount / 10 ** asset.decimals;
-          totalUsdValue += normalizedBalance * unitPrice;
-        }
-      });
-    }
-
-    const nativeTokenEquivalent = totalUsdValue / nativePrice;
-    // Convert to micro-units for formatting
-    return formatNativeBalance(
-      nativeTokenEquivalent * 1_000_000,
-      currentNetworkConfig.nativeToken
-    );
-  }, [
-    isMultiNetworkView,
-    multiNetworkBalance,
-    assetNetworkFilter,
-    accountBalance,
-    currentNetworkConfig,
-  ]);
 
   // Show the placeholder only while the wallet store has NOT yet hydrated its
   // cached balances. Once `isWalletInitialized` is true the cached balances are

--- a/src/screens/wallet/NFTScreen.tsx
+++ b/src/screens/wallet/NFTScreen.tsx
@@ -21,7 +21,6 @@ import type {
   MainTabParamList,
   RootStackParamList,
 } from '@/navigation/AppNavigator';
-import Animated from 'react-native-reanimated';
 import { useActiveAccount } from '@/store/walletStore';
 import { NFTService } from '@/services/nft';
 import { ARC72Collection, NFTToken } from '@/types/nft';
@@ -35,8 +34,6 @@ import { useTheme } from '@/contexts/ThemeContext';
 import { NetworkId } from '@/types/network';
 import { NFTBackground } from '@/components/common/NFTBackground';
 import { GlassCard } from '@/components/common/GlassCard';
-
-const AnimatedPressable = Animated.createAnimatedComponent(Pressable);
 
 type TabType = 'my-nfts' | 'browse-collections';
 type ViewMode = 'my-nfts' | 'browse-collections' | 'collection-tokens';

--- a/src/screens/wallet/ReceiveScreen.tsx
+++ b/src/screens/wallet/ReceiveScreen.tsx
@@ -64,7 +64,6 @@ export default function ReceiveScreen() {
   const route = useRoute();
   const routeParams = route.params as ReceiveScreenRouteParams | undefined;
   const contextAssetName = routeParams?.assetName;
-  const contextAssetId = routeParams?.assetId;
 
   const activeAccount = useActiveAccount();
   const activeAccountBalance = useActiveAccountBalance();
@@ -72,7 +71,6 @@ export default function ReceiveScreen() {
   // Extract values without destructuring to avoid infinite loops
   const accountBalance = activeAccountBalance.balance;
   const isLoading = activeAccountBalance.isLoading;
-  const reloadBalance = activeAccountBalance.reload;
 
   // Removed problematic useEffect that was causing infinite balance reloading
 

--- a/src/screens/wallet/SendScreen.tsx
+++ b/src/screens/wallet/SendScreen.tsx
@@ -28,11 +28,7 @@ import { TransactionService } from '@/services/transactions';
 import { NetworkService } from '@/services/network';
 import tokenMappingService from '@/services/token-mapping';
 import type { TokenMapping } from '@/services/token-mapping/types';
-import {
-  useActiveAccount,
-  useWalletStore,
-  useMultiNetworkBalance,
-} from '@/store/walletStore';
+import { useActiveAccount, useMultiNetworkBalance } from '@/store/walletStore';
 import {
   formatNativeBalance,
   formatAssetBalance,
@@ -132,8 +128,6 @@ export default function SendScreen() {
   const [isSearchingNames, setIsSearchingNames] = useState(false);
   const [selectedAssetId, setSelectedAssetId] = useState<number | null>(null);
   const [showAssetSelector, setShowAssetSelector] = useState(false);
-  const [qrScannerVisible, setQrScannerVisible] = useState(false);
-  const [canSignFromActive, setCanSignFromActive] = useState(false);
   const [hasLedgerSigner, setHasLedgerSigner] = useState(false);
 
   const contextAssetName = routeParams?.assetName;
@@ -202,17 +196,8 @@ export default function SendScreen() {
     }
   }, [hasNoContext, selectedAssetId]);
 
-  // Handle network change
-  const handleNetworkChange = (networkId: NetworkId) => {
-    setSelectedNetworkId(networkId);
-    setAmount(''); // Clear amount when network changes
-    setEstimatedFee(0);
-  };
-
   // Track if note is non-modifiable (xnote from ARC-0090)
   const [isNoteReadOnly, setIsNoteReadOnly] = useState(false);
-  // Track if fee was specified in URI
-  const [uriFee, setUriFee] = useState<number | null>(null);
 
   // Pre-fill form fields from payment request parameters
   useEffect(() => {
@@ -295,7 +280,6 @@ export default function SendScreen() {
         const feeInMicrounits = parseInt(routeParams.fee);
         if (feeInMicrounits >= 1000) {
           // Minimum fee is 1000 microunits
-          setUriFee(feeInMicrounits);
           setEstimatedFee(feeInMicrounits);
         }
       }
@@ -306,9 +290,6 @@ export default function SendScreen() {
   }, [routeParams]);
 
   const activeAccount = useActiveAccount();
-  const refreshAllBalances = useWalletStore(
-    (state) => state.refreshAllBalances
-  );
 
   // State for all available versions of this asset across networks
   const [assetOptions, setAssetOptions] = useState<
@@ -324,7 +305,6 @@ export default function SendScreen() {
       imageUrl?: string;
     }[]
   >([]);
-  const [isLoadingOptions, setIsLoadingOptions] = useState(false);
 
   // Selected asset state
   const [selectedAsset, setSelectedAsset] = useState<{
@@ -334,7 +314,6 @@ export default function SendScreen() {
 
   // Balance for the selected asset
   const [accountBalance, setAccountBalance] = useState<any>(null);
-  const [isLoading, setIsLoading] = useState(false);
 
   const { balance: multiNetworkBalance } = useMultiNetworkBalance(
     activeAccount?.id || ''
@@ -467,15 +446,9 @@ export default function SendScreen() {
 
     const fetchAssetOptions = async () => {
       if (!activeAccount) {
-        // Clear the spinner even though we build no options: a superseded
-        // (now-cancelled) earlier run may have left it on, and its guarded
-        // finally won't clear it. Clearing is always safe — only *overwriting
-        // options* must stay behind the cancelled guard.
-        setIsLoadingOptions(false);
         return;
       }
 
-      setIsLoadingOptions(true);
       try {
         // Same mappings the narrowing memo used (see relevantMappedAssets), so
         // the mapping lookup below stays consistent with the pre-narrowed slice.
@@ -682,10 +655,6 @@ export default function SendScreen() {
         }
       } catch (error) {
         console.error('Failed to fetch asset options:', error);
-      } finally {
-        // Only the current run should clear the spinner; a superseded run
-        // clearing it would race the fresher run that's still loading.
-        if (!cancelled) setIsLoadingOptions(false);
       }
     };
 
@@ -751,7 +720,6 @@ export default function SendScreen() {
       try {
         if (!activeAccount) {
           if (!isCancelled) {
-            setCanSignFromActive(false);
             setHasLedgerSigner(false);
           }
           return;
@@ -761,7 +729,6 @@ export default function SendScreen() {
           activeAccount.address
         );
         if (isCancelled) return;
-        setCanSignFromActive(Boolean(info?.canSign));
 
         // Probe for a Ledger signer via id, then signing address, then the account address
         let ledgerFound = false;
@@ -802,7 +769,6 @@ export default function SendScreen() {
         }
       } catch {
         if (!isCancelled) {
-          setCanSignFromActive(false);
           setHasLedgerSigner(false);
         }
       }
@@ -902,27 +868,6 @@ export default function SendScreen() {
 
     const asset = getCurrentAsset();
     return asset?.decimals || 0;
-  };
-
-  const getAssetName = () => {
-    // Use selectedAsset if available
-    const option = getCurrentAssetOption();
-    if (option) {
-      return option.name;
-    }
-
-    // Fallback to legacy logic
-    if (effectiveAssetId === 0 || !effectiveAssetId) {
-      return selectedNetworkConfig.nativeToken;
-    }
-
-    const asset = getCurrentAsset();
-    return (
-      asset?.name ||
-      asset?.symbol ||
-      contextAssetName ||
-      `Asset ${effectiveAssetId}`
-    );
   };
 
   const convertAmountToBaseUnits = (amount: string): bigint => {
@@ -1514,14 +1459,6 @@ export default function SendScreen() {
     } finally {
       setIsSending(false);
     }
-  };
-
-  const resetForm = async () => {
-    setRecipientAddress('');
-    setAmount('');
-    setNote('');
-    setEstimatedFee(0);
-    // Balance will auto-refresh via the useEffect watching selectedNetworkId
   };
 
   const formatBalance = (amount: number | bigint) => {

--- a/src/screens/wallet/TransactionConfirmationScreen.tsx
+++ b/src/screens/wallet/TransactionConfirmationScreen.tsx
@@ -89,7 +89,6 @@ export default function TransactionConfirmationScreen() {
   const [showAuthModal, setShowAuthModal] = useState(false);
   const [currentRequest, setCurrentRequest] =
     useState<UnifiedTransactionRequest | null>(null);
-  const [isSending, setIsSending] = useState(false);
   const [fallbackImageUrl, setFallbackImageUrl] = useState<string | undefined>(
     undefined
   );

--- a/src/screens/walletconnect/TransactionRequestScreen.tsx
+++ b/src/screens/walletconnect/TransactionRequestScreen.tsx
@@ -74,7 +74,6 @@ export default function TransactionRequestScreen({ navigation, route }: Props) {
   const { requestEvent } = route.params;
   const version = (route.params as any)?.version as number | undefined;
   const autoRetry = (route.params as any)?.autoRetry as boolean | undefined;
-  const [isLoading, setIsLoading] = useState(false);
   const { theme } = useTheme();
   const styles = useThemedStyles(createStyles);
   const [showAuthModal, setShowAuthModal] = useState(false);
@@ -89,7 +88,6 @@ export default function TransactionRequestScreen({ navigation, route }: Props) {
   >([]);
   const [selectedAccount, setSelectedAccount] =
     useState<AccountMetadata | null>(null);
-  const [accounts, setAccounts] = useState<AccountMetadata[]>([]);
   const [networkName, setNetworkName] = useState<string>('Unknown Network');
   const [networkCurrency, setNetworkCurrency] = useState<string>('TOKEN');
   const [dangerAcknowledged, setDangerAcknowledged] = useState(false);
@@ -136,7 +134,6 @@ export default function TransactionRequestScreen({ navigation, route }: Props) {
     try {
       // Load accounts
       const allAccounts = await MultiAccountWalletService.getAllAccounts();
-      setAccounts(allAccounts);
 
       const eventParams = (requestEvent as any).params;
       if (!eventParams) {

--- a/src/services/auth-account-discovery/index.ts
+++ b/src/services/auth-account-discovery/index.ts
@@ -134,7 +134,6 @@ export class AuthAccountDiscoveryService {
   ): Promise<NetworkAuthAccount[]> {
     const networkService = NetworkService.getInstance(networkId);
     const indexerClient = networkService.getIndexerClient();
-    const networkConfig = getNetworkConfig(networkId);
     const networkName = getNetworkDisplayName(networkId);
 
     const allAuthAccounts: NetworkAuthAccount[] = [];

--- a/src/services/auth/simpleLedgerAuthController.ts
+++ b/src/services/auth/simpleLedgerAuthController.ts
@@ -294,8 +294,6 @@ export class SimpleLedgerAuthController {
    * Handle Ledger manager state changes
    */
   private handleLedgerStateChange(stateChange: LedgerStateChange): void {
-    const deviceConnected =
-      stateChange.state === 'ready' || stateChange.state === 'signing';
     const deviceName = stateChange.device?.name;
 
     // Map ledger manager states to our simplified states

--- a/src/services/auth/transactionAuthController.ts
+++ b/src/services/auth/transactionAuthController.ts
@@ -1746,10 +1746,7 @@ export class TransactionAuthController {
       };
 
       // Execute the signing
-      const result = await this.unifiedSigner.signTransaction(
-        this.currentRequest,
-        callbacks
-      );
+      await this.unifiedSigner.signTransaction(this.currentRequest, callbacks);
     } catch (error) {
       this.isSigningInProgress = false;
       const message = this.sanitizeLedgerError(error);

--- a/src/services/deeplink/index.ts
+++ b/src/services/deeplink/index.ts
@@ -6,7 +6,6 @@ import {
   isWalletConnectUri,
   isWalletConnectPairingUri,
   isWalletConnectRequestUri,
-  parseWalletConnectRequestUri,
   isVoiUri,
   detectWalletConnectVersion,
   parseWalletConnectV1Uri,
@@ -544,10 +543,8 @@ export class DeepLinkService {
     try {
       // Determine URI type (pairing vs. request)
       if (isWalletConnectRequestUri(url)) {
-        // This is a request deep link used to wake the app; do not call pair()
-        const { requestId, sessionTopic } = parseWalletConnectRequestUri(url);
-
-        // Let the pending session_request event drive navigation
+        // This is a request deep link used to wake the app; do not call pair().
+        // Let the pending session_request event drive navigation.
         return true;
       }
 

--- a/src/services/ledger/simpleLedgerSigner.ts
+++ b/src/services/ledger/simpleLedgerSigner.ts
@@ -53,7 +53,7 @@ export class SimpleLedgerSigner {
   ): Promise<SimpleLedgerSigningResult> {
     try {
       // Ensure device is connected and ready
-      const transport = await this.ensureDeviceReady(callbacks);
+      await this.ensureDeviceReady(callbacks);
 
       callbacks?.onSigningStarted?.();
       simpleLedgerManager.setSigningInProgress(true);

--- a/src/services/remoteSigner/animatedQR.ts
+++ b/src/services/remoteSigner/animatedQR.ts
@@ -60,11 +60,6 @@ export interface AnimatedQRDecodeState {
 }
 
 /**
- * UR type identifier for our remote signer payloads
- */
-const UR_TYPE = 'bytes';
-
-/**
  * Animated QR Code Service
  *
  * Provides encoding and decoding of large payloads using fountain codes

--- a/src/services/token-mapping/index.ts
+++ b/src/services/token-mapping/index.ts
@@ -91,10 +91,8 @@ function convertAramidMappingsToTokenMappings(): TokenMapping[] {
   }
 
   // Process ARC200 token mappings from VOI_ARC200_TOKEN_MAPPINGS
-  for (const [chainId, chainData] of Object.entries(
-    VOI_ARC200_TOKEN_MAPPINGS
-  )) {
-    for (const [tokenId, tokenData] of Object.entries(chainData.tokens)) {
+  for (const chainData of Object.values(VOI_ARC200_TOKEN_MAPPINGS)) {
+    for (const tokenData of Object.values(chainData.tokens)) {
       // Only process tokens that have an arc200TokenId
       if ('arc200TokenId' in tokenData && tokenData.arc200TokenId) {
         // Find the corresponding mapping group for this token
@@ -153,92 +151,6 @@ function convertAramidMappingsToTokenMappings(): TokenMapping[] {
  * Converted token mappings from ARAMID_TOKEN_MAPPINGS
  */
 const CONVERTED_TOKEN_MAPPINGS = convertAramidMappingsToTokenMappings();
-
-/**
- * Mock token mappings for development
- * TODO: Replace with actual API data once endpoint is available
- */
-const MOCK_TOKEN_MAPPINGS: TokenMapping[] = [
-  {
-    mappingId: 'algo',
-    name: 'ALGO',
-    tokens: [
-      {
-        networkId: NetworkId.ALGORAND_MAINNET,
-        assetId: 0,
-        symbol: 'ALGO',
-        decimals: 6,
-      },
-      {
-        networkId: NetworkId.VOI_MAINNET,
-        assetId: 302189,
-        symbol: 'aALGO',
-        decimals: 6,
-      },
-      {
-        networkId: NetworkId.VOI_MAINNET,
-        assetId: 413153,
-        symbol: 'aALGO',
-        decimals: 6,
-      },
-    ],
-    verified: true,
-    metadata: {
-      description:
-        'Algorand native token and its bridged equivalent on Voi Network',
-    },
-  },
-  {
-    mappingId: 'voi',
-    name: 'VOI',
-    tokens: [
-      {
-        networkId: NetworkId.VOI_MAINNET,
-        assetId: 0,
-        symbol: 'VOI',
-        decimals: 6,
-      },
-      {
-        networkId: NetworkId.ALGORAND_MAINNET,
-        assetId: 2320775407,
-        symbol: 'aVOI',
-        decimals: 6,
-      },
-    ],
-    verified: true,
-    metadata: {
-      description: 'VOI native token and its bridged equivalent on Algorand',
-    },
-  },
-  {
-    mappingId: 'usdc',
-    name: 'USDC',
-    tokens: [
-      {
-        networkId: NetworkId.VOI_MAINNET,
-        assetId: 302190,
-        symbol: 'aUSDC',
-        decimals: 6,
-      },
-      {
-        networkId: NetworkId.VOI_MAINNET,
-        assetId: 395614,
-        symbol: 'aUSDC',
-        decimals: 6,
-      },
-      {
-        networkId: NetworkId.ALGORAND_MAINNET,
-        assetId: 31566704,
-        symbol: 'USDC',
-        decimals: 6,
-      },
-    ],
-    verified: true,
-    metadata: {
-      description: 'USDC stablecoin across networks',
-    },
-  },
-];
 
 console.log(
   `[TokenMappingService] CONVERTED_TOKEN_MAPPINGS defined with ${CONVERTED_TOKEN_MAPPINGS.length} mappings:`,

--- a/src/services/transactions/arc72.ts
+++ b/src/services/transactions/arc72.ts
@@ -237,9 +237,6 @@ export class Arc72TransactionService {
       // Simulate the transaction to get box references
       const algodClient = networkService.getAlgodClient();
 
-      // Create the simulation request using the correct algosdk format
-      const encodedTxn = algosdk.encodeUnsignedTransaction(simulationTxn);
-
       // Create a mock signed transaction with a 64-byte signature
       const mockSignedTxn = new algosdk.SignedTransaction({
         txn: simulationTxn,

--- a/src/services/transactions/unifiedSigner.ts
+++ b/src/services/transactions/unifiedSigner.ts
@@ -1,9 +1,6 @@
 import algosdk from 'algosdk';
 import { TransactionService, TransactionParams } from '@/services/transactions';
-import {
-  WalletConnectService,
-  WalletTransaction,
-} from '@/services/walletconnect';
+import { WalletTransaction } from '@/services/walletconnect';
 import {
   WalletAccount,
   AccountMetadata,
@@ -351,8 +348,6 @@ export class UnifiedTransactionSigner {
     }
 
     try {
-      // Use WalletConnect service but with unified progress tracking
-      const wcService = WalletConnectService.getInstance();
       const total = request.walletConnectParams.transactions.length;
 
       // Track signing progress for each transaction
@@ -443,8 +438,6 @@ export class UnifiedTransactionSigner {
             signedTxns.push(Buffer.from(signedTxnBlob).toString('base64'));
             callbacks?.onLedgerSigned?.({ index: i + 1, total });
           } catch (error) {
-            const errorObj =
-              error instanceof Error ? error : new Error(String(error));
             const sanitizedError = this.sanitizeBLEError(error);
             callbacks?.onLedgerRejected?.({
               index: i + 1,
@@ -516,8 +509,6 @@ export class UnifiedTransactionSigner {
 
               return Buffer.from(signedTxnBlob).toString('base64');
             } catch (error) {
-              const errorObj =
-                error instanceof Error ? error : new Error(String(error));
               const sanitizedError = this.sanitizeBLEError(error);
               callbacks?.onLedgerRejected?.({
                 index: i + 1,

--- a/src/services/walletconnect/v1/crypto.ts
+++ b/src/services/walletconnect/v1/crypto.ts
@@ -44,29 +44,6 @@ function uint8ArrayToString(bytes: Uint8Array): string {
 }
 
 /**
- * Convert base64 to Uint8Array
- */
-function base64ToUint8Array(base64: string): Uint8Array {
-  const binaryString = atob(base64);
-  const bytes = new Uint8Array(binaryString.length);
-  for (let i = 0; i < binaryString.length; i++) {
-    bytes[i] = binaryString.charCodeAt(i);
-  }
-  return bytes;
-}
-
-/**
- * Convert Uint8Array to base64
- */
-function uint8ArrayToBase64(bytes: Uint8Array): string {
-  let binaryString = '';
-  for (let i = 0; i < bytes.length; i++) {
-    binaryString += String.fromCharCode(bytes[i]);
-  }
-  return btoa(binaryString);
-}
-
-/**
  * Generate random IV (Initialization Vector) for AES
  */
 async function generateIV(): Promise<Uint8Array> {

--- a/src/store/friendsStore.ts
+++ b/src/store/friendsStore.ts
@@ -12,11 +12,9 @@ import EnvoiService from '@/services/envoi';
 
 const STORAGE_KEYS = {
   FRIENDS_LIST: '@friends/list',
-  PROFILES_CACHE: '@friends/profiles_cache',
 } as const;
 
 const MAX_FRIENDS = 500;
-const PROFILE_CACHE_TTL = 60 * 60 * 1000; // 1 hour
 
 interface FriendsState {
   // State


### PR DESCRIPTION
## Wave 2 dead-code sweep (TASK-236 / PLAN-229)

Deletes ~107 confirmed-dead unused bindings — dead handlers, unrendered memos, unused-VALUE `useState` tuples, orphaned store subscriptions, module constants, and dead helpers — across 56 source files. Pure deletion: `tsc` clean, tests green, Codex CLEAN.

### no-unused-vars: 114 → 9

**Note the number is 9, not the 7 in the DR-9 ledger.** Two additional warnings survive on purpose, both owned by the **W3 "Secret hygiene"** task, which the plan explicitly keeps *out* of this bulk dead-code PR "so they get their own eyes" (security review). The enumerated DR-9 ledger of 7 undercounts them — the same class of omission DR-9 was corrected for twice before. Deleting them here would (a) violate DR-5, and (b) for `mnemonicWords`, perform a coordinated 3-site removal of a **second live copy of the 25-word recovery phrase** in secret-lifetime-critical code without the mandated review.

### The 9 surviving no-unused-vars are LIVE warnings (NOT disabled) — do not "finish the job"

| Site | Binding | Owner |
| --- | --- | --- |
| `services/walletconnect/index.ts` | `detectRequestedChains` | TASK-240 (DR-5: unwired chain guard) |
| `services/walletconnect/index.ts` | `areRequiredChainsSupported` | TASK-240 (DR-5) |
| `screens/walletconnect/TransactionRequestScreen.tsx` | `setParsedTransactions` | TASK-240 (DR-5: empty review panel) |
| `screens/walletconnect/TransactionRequestScreen.tsx` | `setDecodedTransactions` | TASK-240 (DR-5) |
| `services/walletconnect/utils.ts` | `txnBytes` | TASK-240 (DR-5) |
| `screens/wallet/SendScreen.tsx` | `setAccountBalance` | TASK-239 (frozen setter = MBR bug) |
| `screens/wallet/RekeyAccountScreen.tsx` | `setIsProcessing` | TASK-252 (frozen setter = inert rekey guards) |
| `screens/settings/ShowRecoveryPhraseScreen.tsx` | `mnemonicWords` | **W3 Secret-hygiene** (2nd recovery-phrase copy) |
| `services/wallet/index.ts` | `notes` | **W3 Secret-hygiene** (silently-dropped account notes) |

These are evidence of unresolved, downstream-owned defects. Deleting any of them makes the gap invisible (DR-5).

### No other lint rule increased (per-rule, main → HEAD)

| Rule | main | HEAD |
| --- | --- | --- |
| react-hooks/immutability | 98 | **97** ↓ |
| react-hooks/exhaustive-deps | 61 | 61 |
| react-hooks/set-state-in-effect | 57 | **56** ↓ |
| import/no-named-as-default | 37 | 37 |
| react-hooks/preserve-manual-memoization | 25 | 25 |
| @typescript-eslint/no-unused-vars | 114 | **9** ↓ |
| react-hooks/refs | 7 | 7 |
| react-hooks/purity | 5 | 5 |
| **total** | **404** | **297** |

The two decreases are byproducts of the deletions (a forward-referenced helper in SettingsScreen; dead setState-in-effect writes). `preserve-manual-memoization` held at 25 — **no React Compiler bail-out was introduced** by removing HomeScreen's `wallet`/`allAccounts`/`viewMode` subscriptions and the unrendered `calculateNativeTokenEquivalent` memo.

### Ratchet

`--max-warnings` lowered **404 → 297** in `package.json`; `lint-baseline.json` regenerated (`npm run lint:baseline`); `npm run lint:baseline:check` passes.

### Gates
- `npm run typecheck` — clean
- `npm run lint` — exit 0
- `npm test -- --ci` — **96 suites / 1532 tests** green
- `npm run lint:baseline:check` — passes
- Codex diff review — **CLEAN**

### Device QA
Home (balances / asset-list / view-mode toggle / pull-to-refresh after account switch), Settings, Notification Settings, and the remote-signer scanner render+navigate. Per **HT-218** this is batched into the pre-release device pass — **not a merge gate** for this PR.

https://claude.ai/code/session_01AL4EmUSYAiVXEstBgKqDmv