### PR TITLE
chore(hooks): document deliberate exhaustive-deps omissions (TASK-237)

### DIFF
--- a/lint-baseline.json
+++ b/lint-baseline.json
@@ -2,14 +2,14 @@
   "$comment": "Committed ESLint baseline for the `npm run lint` ratchet (PLAN-229 DR-2). Regenerate with `npm run lint:baseline`; verify with `npm run lint:baseline:check`. The `lint` script's --max-warnings MUST equal totals.warnings. Lower it in the same PR that clears the warnings. It never goes up.",
   "totals": {
     "errors": 0,
-    "warnings": 297,
+    "warnings": 272,
     "filesLinted": 432,
-    "filesWithFindings": 98
+    "filesWithFindings": 95
   },
   "rules": {
     "@typescript-eslint/no-unused-vars": 9,
     "import/no-named-as-default": 37,
-    "react-hooks/exhaustive-deps": 61,
+    "react-hooks/exhaustive-deps": 36,
     "react-hooks/immutability": 97,
     "react-hooks/preserve-manual-memoization": 25,
     "react-hooks/purity": 5,
@@ -19,18 +19,17 @@
   "files": {
     "src/components/UnifiedAuthModal.tsx": {
       "errors": 0,
-      "warnings": 3,
+      "warnings": 2,
       "rules": {
-        "react-hooks/exhaustive-deps": 1,
         "react-hooks/immutability": 1,
         "react-hooks/set-state-in-effect": 1
       }
     },
     "src/components/UnifiedTransactionAuthModal.tsx": {
       "errors": 0,
-      "warnings": 6,
+      "warnings": 5,
       "rules": {
-        "react-hooks/exhaustive-deps": 2,
+        "react-hooks/exhaustive-deps": 1,
         "react-hooks/immutability": 1,
         "react-hooks/set-state-in-effect": 3
       }
@@ -42,13 +41,6 @@
         "import/no-named-as-default": 1,
         "react-hooks/exhaustive-deps": 1,
         "react-hooks/set-state-in-effect": 1
-      }
-    },
-    "src/components/account/AccountRecipientModal.tsx": {
-      "errors": 0,
-      "warnings": 1,
-      "rules": {
-        "react-hooks/exhaustive-deps": 1
       }
     },
     "src/components/account/AddAccountModal.tsx": {
@@ -125,9 +117,9 @@
     },
     "src/components/common/NFTThemeSelector.tsx": {
       "errors": 0,
-      "warnings": 5,
+      "warnings": 4,
       "rules": {
-        "react-hooks/exhaustive-deps": 2,
+        "react-hooks/exhaustive-deps": 1,
         "react-hooks/immutability": 1,
         "react-hooks/set-state-in-effect": 2
       }
@@ -178,9 +170,8 @@
     },
     "src/components/network/NetworkSwitcher.tsx": {
       "errors": 0,
-      "warnings": 2,
+      "warnings": 1,
       "rules": {
-        "react-hooks/exhaustive-deps": 1,
         "react-hooks/immutability": 1
       }
     },
@@ -195,9 +186,9 @@
     },
     "src/components/rekey/AirgapVerificationFlow.tsx": {
       "errors": 0,
-      "warnings": 2,
+      "warnings": 1,
       "rules": {
-        "react-hooks/exhaustive-deps": 2
+        "react-hooks/exhaustive-deps": 1
       }
     },
     "src/components/remoteSigner/AnimatedQRCode.tsx": {
@@ -216,9 +207,8 @@
     },
     "src/components/remoteSigner/SignerAuthModal.tsx": {
       "errors": 0,
-      "warnings": 5,
+      "warnings": 4,
       "rules": {
-        "react-hooks/exhaustive-deps": 1,
         "react-hooks/immutability": 1,
         "react-hooks/purity": 1,
         "react-hooks/set-state-in-effect": 2
@@ -233,26 +223,24 @@
     },
     "src/components/swap/RouteDetailModal.tsx": {
       "errors": 0,
-      "warnings": 3,
+      "warnings": 2,
       "rules": {
-        "react-hooks/exhaustive-deps": 1,
         "react-hooks/immutability": 1,
         "react-hooks/set-state-in-effect": 1
       }
     },
     "src/components/swap/SlippageSettingsModal.tsx": {
       "errors": 0,
-      "warnings": 2,
+      "warnings": 1,
       "rules": {
-        "react-hooks/exhaustive-deps": 1,
         "react-hooks/set-state-in-effect": 1
       }
     },
     "src/components/swap/TokenSelector.tsx": {
       "errors": 0,
-      "warnings": 4,
+      "warnings": 3,
       "rules": {
-        "react-hooks/exhaustive-deps": 2,
+        "react-hooks/exhaustive-deps": 1,
         "react-hooks/immutability": 1,
         "react-hooks/set-state-in-effect": 1
       }
@@ -274,9 +262,8 @@
     },
     "src/contexts/AuthContext.tsx": {
       "errors": 0,
-      "warnings": 6,
+      "warnings": 5,
       "rules": {
-        "react-hooks/exhaustive-deps": 1,
         "react-hooks/immutability": 3,
         "react-hooks/purity": 1,
         "react-hooks/refs": 1
@@ -284,17 +271,9 @@
     },
     "src/contexts/ThemeContext.tsx": {
       "errors": 0,
-      "warnings": 2,
-      "rules": {
-        "react-hooks/exhaustive-deps": 1,
-        "react-hooks/set-state-in-effect": 1
-      }
-    },
-    "src/navigation/AppNavigator.tsx": {
-      "errors": 0,
       "warnings": 1,
       "rules": {
-        "react-hooks/exhaustive-deps": 1
+        "react-hooks/set-state-in-effect": 1
       }
     },
     "src/screens/account/LedgerAccountImportScreen.tsx": {
@@ -315,17 +294,15 @@
     },
     "src/screens/app/AppInfoModal.tsx": {
       "errors": 0,
-      "warnings": 2,
+      "warnings": 1,
       "rules": {
-        "react-hooks/exhaustive-deps": 1,
         "react-hooks/immutability": 1
       }
     },
     "src/screens/auth/LockScreen.tsx": {
       "errors": 0,
-      "warnings": 2,
+      "warnings": 1,
       "rules": {
-        "react-hooks/exhaustive-deps": 1,
         "react-hooks/immutability": 1
       }
     },
@@ -520,25 +497,16 @@
     },
     "src/screens/wallet/CollectionDetailScreen.tsx": {
       "errors": 0,
-      "warnings": 2,
-      "rules": {
-        "react-hooks/exhaustive-deps": 1,
-        "react-hooks/immutability": 1
-      }
-    },
-    "src/screens/wallet/DiscoverScreen.tsx": {
-      "errors": 0,
       "warnings": 1,
       "rules": {
-        "react-hooks/exhaustive-deps": 1
+        "react-hooks/immutability": 1
       }
     },
     "src/screens/wallet/HomeScreen.tsx": {
       "errors": 0,
-      "warnings": 9,
+      "warnings": 7,
       "rules": {
         "import/no-named-as-default": 1,
-        "react-hooks/exhaustive-deps": 2,
         "react-hooks/immutability": 3,
         "react-hooks/preserve-manual-memoization": 3
       }
@@ -583,9 +551,9 @@
     },
     "src/screens/wallet/SwapScreen.tsx": {
       "errors": 0,
-      "warnings": 10,
+      "warnings": 9,
       "rules": {
-        "react-hooks/exhaustive-deps": 2,
+        "react-hooks/exhaustive-deps": 1,
         "react-hooks/immutability": 3,
         "react-hooks/refs": 4,
         "react-hooks/set-state-in-effect": 1
@@ -609,18 +577,17 @@
     },
     "src/screens/wallet/TransactionHistoryScreen.tsx": {
       "errors": 0,
-      "warnings": 7,
+      "warnings": 6,
       "rules": {
-        "react-hooks/exhaustive-deps": 4,
+        "react-hooks/exhaustive-deps": 3,
         "react-hooks/immutability": 1,
         "react-hooks/preserve-manual-memoization": 2
       }
     },
     "src/screens/wallet/UniversalTransactionSigningScreen.tsx": {
       "errors": 0,
-      "warnings": 2,
+      "warnings": 1,
       "rules": {
-        "react-hooks/exhaustive-deps": 1,
         "react-hooks/immutability": 1
       }
     },
@@ -640,19 +607,17 @@
     },
     "src/screens/walletconnect/SessionsScreen.tsx": {
       "errors": 0,
-      "warnings": 3,
+      "warnings": 2,
       "rules": {
-        "react-hooks/exhaustive-deps": 1,
         "react-hooks/immutability": 1,
         "react-hooks/preserve-manual-memoization": 1
       }
     },
     "src/screens/walletconnect/TransactionRequestScreen.tsx": {
       "errors": 0,
-      "warnings": 6,
+      "warnings": 4,
       "rules": {
         "@typescript-eslint/no-unused-vars": 2,
-        "react-hooks/exhaustive-deps": 2,
         "react-hooks/immutability": 2
       }
     },

--- a/package.json
+++ b/package.json
@@ -7,7 +7,7 @@
     "android": "expo run:android",
     "ios": "expo run:ios",
     "web": "expo start --web",
-    "lint": "eslint src/ --max-warnings 297",
+    "lint": "eslint src/ --max-warnings 272",
     "lint:fix": "eslint src/ --fix",
     "lint:baseline": "node scripts/lint-baseline.mjs --write",
     "lint:baseline:check": "node scripts/lint-baseline.mjs --check",

--- a/src/components/UnifiedAuthModal.tsx
+++ b/src/components/UnifiedAuthModal.tsx
@@ -105,6 +105,7 @@ export default function UnifiedAuthModal({
     if (visible && shouldUseBiometrics && !biometricAttempted) {
       promptBiometric();
     }
+    // eslint-disable-next-line react-hooks/exhaustive-deps -- biometric auto-prompt on open; fires on the visible/biometric/attempted gates, promptBiometric is read at that commit and must not re-fire on its own identity.
   }, [visible, shouldUseBiometrics, biometricAttempted]);
 
   // Reset state when modal opens

--- a/src/components/UnifiedTransactionAuthModal.tsx
+++ b/src/components/UnifiedTransactionAuthModal.tsx
@@ -133,6 +133,7 @@ export default function UnifiedTransactionAuthModal({
       setBiometricAttempted(true);
       handleBiometricAuth();
     }
+    // eslint-disable-next-line react-hooks/exhaustive-deps -- biometric auto-prompt, once per open (guarded by biometricAttempted); fires on the visible/authState gates, handleBiometricAuth is read at that commit and must not re-fire on its own identity.
   }, [
     visible,
     authState.state,

--- a/src/components/account/AccountRecipientModal.tsx
+++ b/src/components/account/AccountRecipientModal.tsx
@@ -60,6 +60,7 @@ export default function AccountRecipientModal({
     if (!friendsStore.isInitialized) {
       friendsStore.initialize();
     }
+    // eslint-disable-next-line react-hooks/exhaustive-deps -- init-once when uninitialized; friendsStore is a stable store handle, only its .isInitialized slice should re-trigger this.
   }, [friendsStore.isInitialized]);
 
   // Use percentage-based snap point for better compatibility with BottomSheetModal

--- a/src/components/common/NFTThemeSelector.tsx
+++ b/src/components/common/NFTThemeSelector.tsx
@@ -62,6 +62,7 @@ export default function NFTThemeSelector({
     if (visible && viewMode === 'my-nfts' && activeAccount) {
       loadMyNFTs();
     }
+    // eslint-disable-next-line react-hooks/exhaustive-deps -- load on open, keyed on visible/account-address/viewMode; activeAccount is tracked via its stable .address slice and loadMyNFTs is read at that commit, so neither should re-trigger on object/function identity.
   }, [visible, activeAccount?.address, viewMode]);
 
   // Reset view when tab changes

--- a/src/components/network/NetworkSwitcher.tsx
+++ b/src/components/network/NetworkSwitcher.tsx
@@ -143,6 +143,7 @@ export default function NetworkSwitcher({
       // Refresh network statuses when modal opens
       handleRefresh();
     }
+    // eslint-disable-next-line react-hooks/exhaustive-deps -- refresh on open, keyed on visible; handleRefresh is read at that commit.
   }, [visible]);
 
   const handleRefresh = async () => {

--- a/src/components/rekey/AirgapVerificationFlow.tsx
+++ b/src/components/rekey/AirgapVerificationFlow.tsx
@@ -248,6 +248,7 @@ export function AirgapVerificationFlow({
   const handleRetry = useCallback(() => {
     setError(null);
     buildVerificationTransaction();
+    // eslint-disable-next-line react-hooks/exhaustive-deps -- deps hand-mirror buildVerificationTransaction's inputs (targetAccount.address, networkId), both listed here. A future read added there must be mirrored here, or this airgap-rekey retry would silently re-run with stale input.
   }, [targetAccount.address, networkId]);
 
   const handleBackToQR = useCallback(() => {

--- a/src/components/remoteSigner/SignerAuthModal.tsx
+++ b/src/components/remoteSigner/SignerAuthModal.tsx
@@ -122,6 +122,7 @@ export default function SignerAuthModal({
     if (visible && biometricAvailable && !isVerifying) {
       handleBiometricAuth();
     }
+    // eslint-disable-next-line react-hooks/exhaustive-deps -- biometric auto-prompt on open; keyed on visible/biometricAvailable. handleBiometricAuth and the isVerifying guard are read at that commit; re-prompting when isVerifying flips is not wanted.
   }, [visible, biometricAvailable]);
 
   // Handle lockout timer

--- a/src/components/swap/RouteDetailModal.tsx
+++ b/src/components/swap/RouteDetailModal.tsx
@@ -83,6 +83,7 @@ export const RouteDetailModal: React.FC<RouteDetailModalProps> = ({
       setLoading(true);
       setRouteSteps([]);
     }
+    // eslint-disable-next-line react-hooks/exhaustive-deps -- open/close animation + load, keyed on visible/route; slideAnim is a stable Animated ref and loadRouteDetails is read at that commit.
   }, [visible, route]);
 
   const loadRouteDetails = async () => {

--- a/src/components/swap/SlippageSettingsModal.tsx
+++ b/src/components/swap/SlippageSettingsModal.tsx
@@ -67,6 +67,7 @@ export const SlippageSettingsModal: React.FC<SlippageSettingsModalProps> = ({
         useNativeDriver: true,
       }).start();
     }
+    // eslint-disable-next-line react-hooks/exhaustive-deps -- open/close animation keyed on visible/currentSlippage; slideAnim is a stable Animated ref that never changes identity.
   }, [visible, currentSlippage]);
 
   const handlePresetSelect = (slippage: number) => {

--- a/src/components/swap/TokenSelector.tsx
+++ b/src/components/swap/TokenSelector.tsx
@@ -129,6 +129,7 @@ export const TokenSelector: React.FC<TokenSelectorProps> = ({
       }).start();
       setSearchQuery('');
     }
+    // eslint-disable-next-line react-hooks/exhaustive-deps -- open/close animation keyed on visible; slideAnim is a stable Animated ref that never changes identity.
   }, [visible]);
 
   // Load tokens when modal opens and balance is available

--- a/src/contexts/AuthContext.tsx
+++ b/src/contexts/AuthContext.tsx
@@ -223,6 +223,7 @@ export function AuthProvider({ children }: { children: React.ReactNode }) {
       if (backgroundTimer.current) clearTimeout(backgroundTimer.current);
       removeAppStateListener();
     };
+    // eslint-disable-next-line react-hooks/exhaustive-deps -- mount-once boot: checkInitialAuthState() + setupAppStateListener() run once per launch. The AppState handler reads backgroundedAtRef.current (not closed-over state) by design (see ref comment above), so this must NOT re-subscribe on render; the cleanup captured here is the correct one-per-mount teardown.
   }, []);
 
   // Sync auth state to DeepLinkService for pending notification handling, and to

--- a/src/contexts/ThemeContext.tsx
+++ b/src/contexts/ThemeContext.tsx
@@ -110,6 +110,7 @@ export const ThemeProvider: React.FC<ThemeProviderProps> = ({ children }) => {
       backgroundUrl,
       selectedPalette
     );
+    // eslint-disable-next-line react-hooks/exhaustive-deps -- deps hand-mirror getCurrentBaseThemeMode()'s reads (themeMode, systemColorScheme), both already listed below; the helper is a plain component-scope fn read at the current commit. Mirror any new read it gains here.
   }, [
     nftThemeData,
     nftExtractedColors,

--- a/src/navigation/AppNavigator.tsx
+++ b/src/navigation/AppNavigator.tsx
@@ -1710,6 +1710,7 @@ export default function AppNavigator() {
     };
 
     initializeServices();
+    // eslint-disable-next-line react-hooks/exhaustive-deps -- whole-app service boot; runs once (guarded by initializationRef) and initializeNetwork is read at the mount commit. Re-running on its identity would re-boot services.
   }, []);
 
   // Load dismissed update ID from storage on mount

--- a/src/screens/app/AppInfoModal.tsx
+++ b/src/screens/app/AppInfoModal.tsx
@@ -76,6 +76,7 @@ export default function AppInfoModal() {
 
   useEffect(() => {
     loadAppInfo();
+    // eslint-disable-next-line react-hooks/exhaustive-deps -- load the modal's subject, keyed on params.appId/networkId; loadAppInfo is read at that commit.
   }, [params.appId, networkId]);
 
   const loadAppInfo = async () => {

--- a/src/screens/auth/LockScreen.tsx
+++ b/src/screens/auth/LockScreen.tsx
@@ -158,6 +158,7 @@ export default function LockScreen() {
     if (authState.biometricEnabled) {
       promptBiometric();
     }
+    // eslint-disable-next-line react-hooks/exhaustive-deps -- biometric prompt when biometrics become enabled, keyed on authState.biometricEnabled; promptBiometric is read at that commit and must not re-fire on its own identity.
   }, [authState.biometricEnabled]);
 
   const promptBiometric = async () => {

--- a/src/screens/wallet/AssetDetailScreen.tsx
+++ b/src/screens/wallet/AssetDetailScreen.tsx
@@ -455,7 +455,7 @@ export default function AssetDetailScreen() {
   useEffect(() => {
     loadTransactions();
     updateActivity();
-    // eslint-disable-next-line react-hooks/exhaustive-deps
+    // eslint-disable-next-line react-hooks/exhaustive-deps -- deps hand-mirror loadTransactions' inputs (accountId, assetId, effectiveBalance, networkId) plus currentAccount; loadTransactions & updateActivity are read at the current commit, so listing them would only re-run on their identity. Mirror any new read added to loadTransactions here.
   }, [accountId, assetId, effectiveBalance, networkId, currentAccount]);
 
   const onRefresh = async () => {

--- a/src/screens/wallet/CollectionDetailScreen.tsx
+++ b/src/screens/wallet/CollectionDetailScreen.tsx
@@ -53,6 +53,7 @@ export default function CollectionDetailScreen() {
 
   useEffect(() => {
     loadInitialData();
+    // eslint-disable-next-line react-hooks/exhaustive-deps -- load once on mount; loadInitialData is read at the mount commit.
   }, []);
 
   const loadInitialData = async () => {

--- a/src/screens/wallet/DiscoverScreen.tsx
+++ b/src/screens/wallet/DiscoverScreen.tsx
@@ -33,6 +33,7 @@ export default function DiscoverScreen() {
         `window.location.href = '${getDiscoverUrl()}';`
       );
     }
+    // eslint-disable-next-line react-hooks/exhaustive-deps -- reload handler keyed on route.params.reload/theme.mode; getDiscoverUrl is read at that commit.
   }, [route.params?.reload, theme.mode]);
 
   return (

--- a/src/screens/wallet/HomeScreen.tsx
+++ b/src/screens/wallet/HomeScreen.tsx
@@ -154,8 +154,7 @@ export default function HomeScreen() {
     if (!__DEV__) {
       checkForUpdate({ silent: true });
     }
-    // Only run once on mount
-    // eslint-disable-next-line react-hooks/exhaustive-deps
+    // eslint-disable-next-line react-hooks/exhaustive-deps -- silent startup update check; run once on mount, checkForUpdate is read at the mount commit.
   }, []);
 
   // Entrance animations
@@ -211,6 +210,7 @@ export default function HomeScreen() {
     };
 
     animateEntrance();
+    // eslint-disable-next-line react-hooks/exhaustive-deps -- entrance animation runs once on mount; the *Opacity/*TranslateY are stable useSharedValue handles that never change identity.
   }, []);
 
   const initialize = useWalletStore((state) => state.initialize);
@@ -373,6 +373,7 @@ export default function HomeScreen() {
   useEffect(() => {
     initializeWallet();
     updateActivity();
+    // eslint-disable-next-line react-hooks/exhaustive-deps -- load wallet data + mark activity once on mount (see comment above: kept separate so the remote-signer store init does not re-trigger initialize()); both are read at the mount commit.
   }, []);
 
   // Initialize the remote-signer store (used to resolve app mode) once it is not
@@ -526,7 +527,7 @@ export default function HomeScreen() {
     };
 
     loadData();
-    // eslint-disable-next-line react-hooks/exhaustive-deps
+    // eslint-disable-next-line react-hooks/exhaustive-deps -- reload keyed on activeAccount.id / isMultiNetworkView; the store loader fns are deliberately omitted (their identity churn would loop) and loadData re-checks activeAccountIdRef/viewModeRef after every await, so a stale closure can never write to the wrong account.
   }, [
     activeAccount?.id,
     isMultiNetworkView,

--- a/src/screens/wallet/MultiNetworkAssetScreen.tsx
+++ b/src/screens/wallet/MultiNetworkAssetScreen.tsx
@@ -84,7 +84,7 @@ export default function MultiNetworkAssetScreen() {
 
   useEffect(() => {
     updateActivity();
-    // eslint-disable-next-line react-hooks/exhaustive-deps
+    // eslint-disable-next-line react-hooks/exhaustive-deps -- one-time activity ping on mount; updateActivity is read at the mount commit and should not re-run on its identity.
   }, []);
 
   const onRefresh = useCallback(async () => {

--- a/src/screens/wallet/SendScreen.tsx
+++ b/src/screens/wallet/SendScreen.tsx
@@ -918,7 +918,7 @@ export default function SendScreen() {
     } catch {
       return 'Enter a valid amount';
     }
-    // eslint-disable-next-line react-hooks/exhaustive-deps
+    // eslint-disable-next-line react-hooks/exhaustive-deps -- deps hand-mirror the inputs of the helpers this memo calls (getCurrentAssetOption / getAssetDecimals / getSpendableBase): amount, accountBalance, estimatedFee, effectiveAssetId, selectedAsset, assetOptions. Those helpers are read at the current commit; mirror any new read they gain here.
   }, [
     amount,
     accountBalance,

--- a/src/screens/wallet/SwapScreen.tsx
+++ b/src/screens/wallet/SwapScreen.tsx
@@ -196,6 +196,7 @@ export default function SwapScreen() {
   useEffect(() => {
     loadInitialTokens();
     loadStoredSlippage();
+    // eslint-disable-next-line react-hooks/exhaustive-deps -- load once on mount (comment above: NOT on network change — handleNetworkChange owns that); both loaders are read at the mount commit.
   }, []);
 
   useEffect(() => {

--- a/src/screens/wallet/TransactionHistoryScreen.tsx
+++ b/src/screens/wallet/TransactionHistoryScreen.tsx
@@ -261,6 +261,7 @@ export default function TransactionHistoryScreen() {
         />
       );
     },
+    // eslint-disable-next-line react-hooks/exhaustive-deps -- assetMetadataCache is a DELIBERATE recompute trigger: getAssetMetadata reads it internally, so ESLint calls it "unnecessary" for not appearing in the body. Removing it would stop rows re-rendering when resolved ASA params land and freeze transaction amounts at the 0-decimals fallback.
     [
       activeAccount?.address,
       accountState.balance?.assets,

--- a/src/screens/wallet/TransactionResultScreen.tsx
+++ b/src/screens/wallet/TransactionResultScreen.tsx
@@ -64,8 +64,7 @@ export default function TransactionResultScreen() {
   // (params.isSuccess drives the icon/title/color below). Fire-and-forget.
   useEffect(() => {
     hapticNotify(params.isSuccess ? 'success' : 'error');
-    // Result params are fixed for a given screen instance; fire once on mount.
-    // eslint-disable-next-line react-hooks/exhaustive-deps
+    // eslint-disable-next-line react-hooks/exhaustive-deps -- fire once on mount; result params are fixed for a given screen instance, so params.isSuccess never changes under this instance.
   }, []);
 
   const handleViewInExplorer = async () => {

--- a/src/screens/wallet/UniversalTransactionSigningScreen.tsx
+++ b/src/screens/wallet/UniversalTransactionSigningScreen.tsx
@@ -111,6 +111,7 @@ export default function UniversalTransactionSigningScreen({
       // Clean up callback registry when unmounting
       clearNavigationCallbacks(callbackId);
     };
+    // eslint-disable-next-line react-hooks/exhaustive-deps -- mount-once: parseTransactions runs once; the cleanup captures authController (a stable useState(() => new TransactionAuthController()) handle) and callbackId (stable route param), so the one-per-mount teardown targets the right instance.
   }, []);
 
   // Network display info, derived from the (stable) route params. Previously a

--- a/src/screens/walletconnect/SessionsScreen.tsx
+++ b/src/screens/walletconnect/SessionsScreen.tsx
@@ -44,6 +44,7 @@ export default function SessionsScreen({ navigation }: Props) {
 
   useEffect(() => {
     loadSessions();
+    // eslint-disable-next-line react-hooks/exhaustive-deps -- load once on mount; loadSessions is a stable useCallback([]) read at the mount commit.
   }, []);
 
   const loadSessions = useCallback(async () => {

--- a/src/screens/walletconnect/TransactionRequestScreen.tsx
+++ b/src/screens/walletconnect/TransactionRequestScreen.tsx
@@ -115,6 +115,7 @@ export default function TransactionRequestScreen({ navigation, route }: Props) {
 
   useEffect(() => {
     loadAccountsAndTransactions();
+    // eslint-disable-next-line react-hooks/exhaustive-deps -- load once on mount; loadAccountsAndTransactions is read at the mount commit.
   }, []);
 
   useEffect(() => {
@@ -128,6 +129,7 @@ export default function TransactionRequestScreen({ navigation, route }: Props) {
     if (autoRetry && selectedAccount) {
       handleApprove();
     }
+    // eslint-disable-next-line react-hooks/exhaustive-deps -- one-shot auto-retry trigger keyed on autoRetry/selectedAccount; handleApprove is read at that commit and must not re-fire on its own identity.
   }, [autoRetry, selectedAccount]);
 
   const loadAccountsAndTransactions = async () => {


### PR DESCRIPTION
## TASK-237 — Wave 2 of the ESLint burndown (PLAN-229). 100% comment lines.

Adds reasoned `-- <reason>` disables to **deliberate** `react-hooks/exhaustive-deps` omissions, normalizes the existing bare disables, and documents the hand-mirrored dep arrays. **No executable source changed** — every `src/` diff line is a comment. The only non-comment changes are the mandated ratchet artifacts (`package.json` pin + regenerated `lint-baseline.json`) per DR-9.

### exhaustive-deps delta
**61 → 36** (−25). Total warnings **297 → 272**. It does **not** reach zero — the remaining 36 fixable sites are left for **TASK-238** (stabilize handles / wrap in useMemo).

Only `react-hooks/exhaustive-deps` moved; every other rule is byte-identical in `lint-baseline.json` (immutability 97, set-state-in-effect 56, import/no-named-as-default 37, preserve-manual-memoization 25, no-unused-vars 9, refs 7, purity 5).

### What was disabled (25 count-reducing sites)
- **Mount-once `[]`**: AuthContext (mount-once boot; ref-based app-lock path — the comment covers the mount effect only, not the TASK-242-gated lines 167/199), AppNavigator (service boot, guarded by `initializationRef`), SessionsScreen, TransactionRequestScreen (loadAccountsAndTransactions), UniversalTransactionSigningScreen (stable `useTransactionAuthController` cleanup), CollectionDetailScreen, SwapScreen (loadInitialTokens), HomeScreen (entrance animation + wallet init).
- **Open-once / open-scoped modals**: UnifiedAuthModal, UnifiedTransactionAuthModal, SignerAuthModal (biometric auto-prompt), NFTThemeSelector (loadMyNFTs, keyed on account-address slice), RouteDetailModal / SlippageSettingsModal / TokenSelector (open/close `slideAnim` animations — stable Animated ref), NetworkSwitcher, AppInfoModal, AccountRecipientModal (init-once).
- **Focus / one-shot / enable**: DiscoverScreen (reload trigger), TransactionRequestScreen (one-shot autoRetry), LockScreen (biometric-enable prompt).
- **Hand-mirrored dep arrays** (comment names the mirrored helper): ThemeContext (`getCurrentBaseThemeMode`), AirgapVerificationFlow (`buildVerificationTransaction` — airgap rekey; a future third read would silently retry with stale input), AssetDetailScreen (`loadTransactions`, via the normalized bare disable), SendScreen (`getCurrentAssetOption`/`getAssetDecimals`/`getSpendableBase`, via the normalized bare disable).
- **Deliberate recompute trigger**: TransactionHistoryScreen `assetMetadataCache` — dep **kept**, disable explains ESLint calls it "unnecessary" only because `getAssetMetadata` reads it internally; removing it would freeze amounts at the 0-decimals fallback.

### 6 bare disables normalized to `-- reason`
AssetDetailScreen, SendScreen, TransactionResultScreen, MultiNetworkAssetScreen, HomeScreen ×2. `grep -rn 'exhaustive-deps' src/ | grep -v -- ' -- '` now returns nothing.

### Left for TASK-238 (36 remaining) — NOT disabled
- **"X makes deps change / wrap in useMemo/useCallback"** stabilize-handle candidates: UnifiedTransactionAuthModal:200, AddAccountModal:61, SignRequestScannerScreen:86, AccountSearchScreen:200, RekeyAccountScreen:98/101, SendScreen:857, TransactionHistoryScreen:80 (×2).
- **"unnecessary dependency"** removals (not the deliberate assetMetadataCache): AirgapVerificationFlow:240, BackupWalletScreen:101, AssetDetailScreen:195, NFTScreen:400.
- **Value-keyed screen reloads** (stabilize the helper + track it): CollectionBrowser:51, NFTScreen:88/106, NotificationSettingsScreen:327, SwapScreen:309, TransactionConfirmationScreen:106/110, TransactionHistoryScreen:98, AddFriendScreen:88, NewMessageScreen:206, AccountAvatar:270.
- **SendScreen route/network/fee/envoi effect cluster** (W4 behavior minefield): SendScreen:290, :666, :781, :937, :944, :1011, :1081.
- **Hoist/stabilize**: MnemonicImportScreen:412 (theme.colors.*), MultiNetworkAssetScreen:171 (`ALLOWED_VOI_OPT_IN_ASSET_IDS` — component-scope literal to hoist), ImportFromOnlineWalletScreen:243.

### ⚠️ Potential bugs flagged (deliberately left as live warnings, NOT silenced)
Codex review caught two sites I had initially disabled that are **genuine stale-closure omissions** — reverted so they stay visible for TASK-238:
- **NFTThemeSelector.tsx:150** — the `loadCollectionTokens` effect keys on `[selectedCollection, viewMode]` but `loadCollectionTokens` reads `activeAccount` to build the ownership map. Switching accounts while a collection is open leaves stale ownership markers.
- **TokenSelector.tsx:136** — the `loadTokens` effect keys on `[visible, accountBalance]` but `loadTokens` reads `networkId`, `excludeTokenId`, `ownedOnly`. Changing any while the modal stays open retains tokens fetched/filtered/sorted for the prior config.

No `useCallback(fn, [])` long-lived-subscriber shape was found among the 61 warnings.

### Gates
- `npm run typecheck` — clean (exit 0)
- `npm run lint` — exit 0 (272 warnings / 0 errors)
- `npm test -- --ci` — 96 suites / 1532 tests green
- `npm run lint:baseline:check` — passes (272, pin matches artifact)
- Codex review — **CLEAN** (round 2, after reverting the two real omissions)

https://claude.ai/code/session_01AL4EmUSYAiVXEstBgKqDmv