### PR TITLE
refactor(hooks): stabilize exhaustive-deps handles and memos (TASK-238)

### DIFF
--- a/lint-baseline.json
+++ b/lint-baseline.json
@@ -2,14 +2,14 @@
   "$comment": "Committed ESLint baseline for the `npm run lint` ratchet (PLAN-229 DR-2). Regenerate with `npm run lint:baseline`; verify with `npm run lint:baseline:check`. The `lint` script's --max-warnings MUST equal totals.warnings. Lower it in the same PR that clears the warnings. It never goes up.",
   "totals": {
     "errors": 0,
-    "warnings": 272,
+    "warnings": 260,
     "filesLinted": 432,
-    "filesWithFindings": 95
+    "filesWithFindings": 92
   },
   "rules": {
     "@typescript-eslint/no-unused-vars": 9,
     "import/no-named-as-default": 37,
-    "react-hooks/exhaustive-deps": 36,
+    "react-hooks/exhaustive-deps": 24,
     "react-hooks/immutability": 97,
     "react-hooks/preserve-manual-memoization": 25,
     "react-hooks/purity": 5,
@@ -27,9 +27,8 @@
     },
     "src/components/UnifiedTransactionAuthModal.tsx": {
       "errors": 0,
-      "warnings": 5,
+      "warnings": 4,
       "rules": {
-        "react-hooks/exhaustive-deps": 1,
         "react-hooks/immutability": 1,
         "react-hooks/set-state-in-effect": 3
       }
@@ -41,13 +40,6 @@
         "import/no-named-as-default": 1,
         "react-hooks/exhaustive-deps": 1,
         "react-hooks/set-state-in-effect": 1
-      }
-    },
-    "src/components/account/AddAccountModal.tsx": {
-      "errors": 0,
-      "warnings": 1,
-      "rules": {
-        "react-hooks/exhaustive-deps": 1
       }
     },
     "src/components/account/RenameAccountModal.tsx": {
@@ -344,9 +336,8 @@
     },
     "src/screens/remoteSigner/SignRequestScannerScreen.tsx": {
       "errors": 0,
-      "warnings": 2,
+      "warnings": 1,
       "rules": {
-        "react-hooks/exhaustive-deps": 1,
         "react-hooks/immutability": 1
       }
     },
@@ -355,13 +346,6 @@
       "warnings": 1,
       "rules": {
         "react-hooks/set-state-in-effect": 1
-      }
-    },
-    "src/screens/settings/BackupWalletScreen.tsx": {
-      "errors": 0,
-      "warnings": 1,
-      "rules": {
-        "react-hooks/exhaustive-deps": 1
       }
     },
     "src/screens/settings/NotificationSettingsScreen.tsx": {
@@ -457,17 +441,15 @@
     },
     "src/screens/wallet/AccountSearchScreen.tsx": {
       "errors": 0,
-      "warnings": 2,
+      "warnings": 1,
       "rules": {
-        "react-hooks/exhaustive-deps": 1,
         "react-hooks/set-state-in-effect": 1
       }
     },
     "src/screens/wallet/AssetDetailScreen.tsx": {
       "errors": 0,
-      "warnings": 3,
+      "warnings": 2,
       "rules": {
-        "react-hooks/exhaustive-deps": 1,
         "react-hooks/set-state-in-effect": 2
       }
     },
@@ -511,18 +493,11 @@
         "react-hooks/preserve-manual-memoization": 3
       }
     },
-    "src/screens/wallet/MultiNetworkAssetScreen.tsx": {
-      "errors": 0,
-      "warnings": 1,
-      "rules": {
-        "react-hooks/exhaustive-deps": 1
-      }
-    },
     "src/screens/wallet/NFTScreen.tsx": {
       "errors": 0,
-      "warnings": 8,
+      "warnings": 7,
       "rules": {
-        "react-hooks/exhaustive-deps": 3,
+        "react-hooks/exhaustive-deps": 2,
         "react-hooks/immutability": 2,
         "react-hooks/preserve-manual-memoization": 2,
         "react-hooks/set-state-in-effect": 1
@@ -530,11 +505,10 @@
     },
     "src/screens/wallet/RekeyAccountScreen.tsx": {
       "errors": 0,
-      "warnings": 6,
+      "warnings": 4,
       "rules": {
         "@typescript-eslint/no-unused-vars": 1,
         "import/no-named-as-default": 1,
-        "react-hooks/exhaustive-deps": 2,
         "react-hooks/set-state-in-effect": 2
       }
     },
@@ -577,9 +551,9 @@
     },
     "src/screens/wallet/TransactionHistoryScreen.tsx": {
       "errors": 0,
-      "warnings": 6,
+      "warnings": 4,
       "rules": {
-        "react-hooks/exhaustive-deps": 3,
+        "react-hooks/exhaustive-deps": 1,
         "react-hooks/immutability": 1,
         "react-hooks/preserve-manual-memoization": 2
       }

--- a/package.json
+++ b/package.json
@@ -7,7 +7,7 @@
     "android": "expo run:android",
     "ios": "expo run:ios",
     "web": "expo start --web",
-    "lint": "eslint src/ --max-warnings 272",
+    "lint": "eslint src/ --max-warnings 260",
     "lint:fix": "eslint src/ --fix",
     "lint:baseline": "node scripts/lint-baseline.mjs --write",
     "lint:baseline:check": "node scripts/lint-baseline.mjs --check",

--- a/src/components/UnifiedTransactionAuthModal.tsx
+++ b/src/components/UnifiedTransactionAuthModal.tsx
@@ -198,7 +198,7 @@ export default function UnifiedTransactionAuthModal({
     }
   };
 
-  const handleCancel = () => {
+  const handleCancel = useCallback(() => {
     controller.cancel();
     controller.resetAfterDismiss();
     setPin('');
@@ -206,7 +206,7 @@ export default function UnifiedTransactionAuthModal({
     setBiometricAttempted(false);
     setUserCancelled(true); // Mark that user explicitly cancelled
     onCancel();
-  };
+  }, [controller, onCancel]);
 
   const handleLedgerRetry = () => {
     controller.retryLedgerConnection();

--- a/src/components/account/AddAccountModal.tsx
+++ b/src/components/account/AddAccountModal.tsx
@@ -58,10 +58,10 @@ export default function AddAccountModal({
   );
 
   // Handle account creation - navigate to proper backup flow
-  const handleCreateAccount = async () => {
+  const handleCreateAccount = useCallback(async () => {
     onClose();
     onCreateAccount(); // This will navigate to CreateAccountScreen
-  };
+  }, [onClose, onCreateAccount]);
 
   // Open/close the bottom sheet based on visibility
   React.useEffect(() => {

--- a/src/screens/remoteSigner/SignRequestScannerScreen.tsx
+++ b/src/screens/remoteSigner/SignRequestScannerScreen.tsx
@@ -5,7 +5,13 @@
  * a transaction signing request from the wallet device.
  */
 
-import React, { useState, useEffect, useRef, useCallback } from 'react';
+import React, {
+  useState,
+  useEffect,
+  useRef,
+  useCallback,
+  useMemo,
+} from 'react';
 import {
   Alert,
   View,
@@ -83,10 +89,14 @@ export default function SignRequestScannerScreen() {
   const canvasRef = useRef<HTMLCanvasElement>(null);
 
   // Get addresses we can sign for (STANDARD accounts only)
-  const signableAddresses = new Set(
-    accounts
-      .filter((acc: AccountMetadata) => acc.type === AccountType.STANDARD)
-      .map((acc: AccountMetadata) => acc.address)
+  const signableAddresses = useMemo(
+    () =>
+      new Set(
+        accounts
+          .filter((acc: AccountMetadata) => acc.type === AccountType.STANDARD)
+          .map((acc: AccountMetadata) => acc.address)
+      ),
+    [accounts]
   );
 
   useEffect(() => {

--- a/src/screens/settings/BackupWalletScreen.tsx
+++ b/src/screens/settings/BackupWalletScreen.tsx
@@ -75,31 +75,28 @@ export default function BackupWalletScreen() {
     setShowPasswordModal(true);
   }, [accounts.length]);
 
-  const handlePasswordConfirm = useCallback(
-    async (password: string) => {
-      setShowPasswordModal(false);
-      setShowProgressModal(true);
-      setIsCreatingBackup(true);
-      setError(undefined);
+  const handlePasswordConfirm = useCallback(async (password: string) => {
+    setShowPasswordModal(false);
+    setShowProgressModal(true);
+    setIsCreatingBackup(true);
+    setError(undefined);
 
-      try {
-        const result = await BackupService.createBackup(password);
-        setBackupResult(result);
-        setShowProgressModal(false);
-        // Show success state - user will see save/share options in the UI
-      } catch (err) {
-        setShowProgressModal(false);
-        const message =
-          err instanceof BackupError
-            ? err.message
-            : 'Failed to create backup. Please try again.';
-        Alert.alert('Backup Failed', message, [{ text: 'OK' }]);
-      } finally {
-        setIsCreatingBackup(false);
-      }
-    },
-    [navigation]
-  );
+    try {
+      const result = await BackupService.createBackup(password);
+      setBackupResult(result);
+      setShowProgressModal(false);
+      // Show success state - user will see save/share options in the UI
+    } catch (err) {
+      setShowProgressModal(false);
+      const message =
+        err instanceof BackupError
+          ? err.message
+          : 'Failed to create backup. Please try again.';
+      Alert.alert('Backup Failed', message, [{ text: 'OK' }]);
+    } finally {
+      setIsCreatingBackup(false);
+    }
+  }, []);
 
   const handleCancel = useCallback(() => {
     setShowPasswordModal(false);

--- a/src/screens/wallet/AccountSearchScreen.tsx
+++ b/src/screens/wallet/AccountSearchScreen.tsx
@@ -197,31 +197,34 @@ export default function AccountSearchScreen() {
     [addFriend, removeFriend, getFriend]
   );
 
-  const renderAvatar = (item: SearchResult) => {
-    if (item.avatar) {
+  const renderAvatar = useCallback(
+    (item: SearchResult) => {
+      if (item.avatar) {
+        return (
+          <Image
+            source={{ uri: item.avatar }}
+            style={styles.avatar}
+            contentFit="cover"
+            cachePolicy="memory-disk"
+            recyclingKey={item.avatar}
+          />
+        );
+      }
+
+      // Fallback to AccountAvatar for generated avatars
       return (
-        <Image
-          source={{ uri: item.avatar }}
-          style={styles.avatar}
-          contentFit="cover"
-          cachePolicy="memory-disk"
-          recyclingKey={item.avatar}
+        <AccountAvatar
+          address={item.address}
+          size={48}
+          useEnvoiAvatar={false}
+          fallbackToGenerated={true}
+          showActiveIndicator={false}
+          showRekeyIndicator={false}
         />
       );
-    }
-
-    // Fallback to AccountAvatar for generated avatars
-    return (
-      <AccountAvatar
-        address={item.address}
-        size={48}
-        useEnvoiAvatar={false}
-        fallbackToGenerated={true}
-        showActiveIndicator={false}
-        showRekeyIndicator={false}
-      />
-    );
-  };
+    },
+    [styles]
+  );
 
   const renderSearchResult = useCallback(
     ({ item }: { item: SearchResult }) => {

--- a/src/screens/wallet/AssetDetailScreen.tsx
+++ b/src/screens/wallet/AssetDetailScreen.tsx
@@ -198,7 +198,6 @@ export default function AssetDetailScreen() {
     currentAccount?.address,
     mappingId,
     assetId,
-    specificNetworkConfig.nativeToken,
   ]);
 
   // If networkId is provided, we need to get the balance from that specific network

--- a/src/screens/wallet/MultiNetworkAssetScreen.tsx
+++ b/src/screens/wallet/MultiNetworkAssetScreen.tsx
@@ -54,6 +54,11 @@ type NetworkRowItem =
   | { type: 'balance'; source: NetworkBalanceSource }
   | { type: 'opt-in'; token: TokenReference };
 
+// Voi tokens the user could opt into. Limited to a hardcoded whitelist:
+// aALGO (302189) and aUSDC (302190). Module-scope so it keeps a stable
+// identity across renders.
+const ALLOWED_VOI_OPT_IN_ASSET_IDS = [302189, 302190];
+
 export default function MultiNetworkAssetScreen() {
   const styles = useThemedStyles(createStyles);
   const themeColors = useThemeColors();
@@ -141,8 +146,6 @@ export default function MultiNetworkAssetScreen() {
 
   // Compute Voi tokens that user could opt into (but hasn't yet)
   // Limited to specific whitelisted tokens: aALGO (302189) and aUSDC (302190)
-  const ALLOWED_VOI_OPT_IN_ASSET_IDS = [302189, 302190];
-
   const missingVoiOptIns = useMemo(() => {
     if (!mappedAsset || !mappedAsset.mappingId) return [];
 

--- a/src/screens/wallet/NFTScreen.tsx
+++ b/src/screens/wallet/NFTScreen.tsx
@@ -397,7 +397,7 @@ export default function NFTScreen() {
         </GlassCard>
       </View>
     ),
-    [styles, theme]
+    [theme]
   );
 
   const renderContent = () => {

--- a/src/screens/wallet/RekeyAccountScreen.tsx
+++ b/src/screens/wallet/RekeyAccountScreen.tsx
@@ -1,4 +1,4 @@
-import React, { useState, useEffect, useCallback } from 'react';
+import React, { useState, useEffect, useCallback, useMemo } from 'react';
 import {
   View,
   Text,
@@ -95,13 +95,20 @@ export default function RekeyAccountScreen() {
   const standardAccounts = wallet?.accounts.filter(
     (acc) => acc.type === AccountType.STANDARD && acc.id !== params.accountId
   ) as StandardAccountMetadata[];
-  const ledgerAccounts = (wallet?.accounts.filter(
-    (acc) => acc.type === AccountType.LEDGER
-  ) ?? []) as LedgerAccountMetadata[];
-  const airgapAccounts = (wallet?.accounts.filter(
-    (acc) =>
-      acc.type === AccountType.REMOTE_SIGNER && acc.id !== params.accountId
-  ) ?? []) as RemoteSignerAccountMetadata[];
+  const ledgerAccounts = useMemo(
+    () =>
+      (wallet?.accounts.filter((acc) => acc.type === AccountType.LEDGER) ??
+        []) as LedgerAccountMetadata[],
+    [wallet?.accounts]
+  );
+  const airgapAccounts = useMemo(
+    () =>
+      (wallet?.accounts.filter(
+        (acc) =>
+          acc.type === AccountType.REMOTE_SIGNER && acc.id !== params.accountId
+      ) ?? []) as RemoteSignerAccountMetadata[],
+    [wallet?.accounts, params.accountId]
+  );
 
   // Check if source account is rekeyed on the selected network
   const isSourceRekeyed = networkRekeyInfo?.isRekeyed === true;

--- a/src/screens/wallet/TransactionHistoryScreen.tsx
+++ b/src/screens/wallet/TransactionHistoryScreen.tsx
@@ -1,4 +1,10 @@
-import React, { useState, useEffect, useCallback, useRef } from 'react';
+import React, {
+  useState,
+  useEffect,
+  useCallback,
+  useRef,
+  useMemo,
+} from 'react';
 import {
   View,
   Text,
@@ -77,10 +83,13 @@ export default function TransactionHistoryScreen() {
   // Read the shared `recentTransactions` array only while it holds the
   // ACCOUNT-WIDE history — AssetDetailScreen loads a single asset's history
   // into the same array, and rendering that here would be the wrong list.
-  const allTransactions =
-    accountState.recentTransactionsScope === ALL_TRANSACTIONS_SCOPE
-      ? accountState.recentTransactions || []
-      : EMPTY_TRANSACTIONS;
+  const allTransactions = useMemo(
+    () =>
+      accountState.recentTransactionsScope === ALL_TRANSACTIONS_SCOPE
+        ? accountState.recentTransactions || []
+        : EMPTY_TRANSACTIONS,
+    [accountState.recentTransactionsScope, accountState.recentTransactions]
+  );
   // Not the shared `lastError` (every other loader clears it) and not any
   // transaction error either — only an ACCOUNT-WIDE one. AssetDetailScreen
   // writes asset-scoped failures into the same field, and rendering those here


### PR DESCRIPTION
## What

Mechanical stabilization of the exhaustive-deps warning subset (PLAN-229 W2, final W2 task). **No effect body logic is modified** — only dep arrays, memo wrappers, one hoisted module const, and hook imports. Verified by eye and by Codex.

## Changes

**Memo wraps** (value was always fresh, defeating the surrounding memo):
- `signableAddresses` → `useMemo` (SignRequestScannerScreen)
- `ledgerAccounts`, `airgapAccounts` → `useMemo` (RekeyAccountScreen)
- `allTransactions` → `useMemo` (TransactionHistoryScreen — cleared 2 double-reported warnings)
- `renderAvatar` → `useCallback` (AccountSearchScreen)
- `handleCreateAccount` → `useCallback` (AddAccountModal)
- `handleCancel` → `useCallback` (UnifiedTransactionAuthModal)

**Unnecessary outer-scope deps removed** (genuinely stable/unread):
- `styles` (module-scope `StyleSheet.create`) — NFTScreen
- `navigation` (unread in the callback body) — BackupWalletScreen
- `specificNetworkConfig.nativeToken` (unread in the memo body) — AssetDetailScreen

**Hoisted module const:** `ALLOWED_VOI_OPT_IN_ASSET_IDS` → module scope (MultiNetworkAssetScreen).

## Lint deltas (regenerated per-rule breakdown)

| Rule | Before | After |
| --- | --- | --- |
| react-hooks/exhaustive-deps | 36 | **24** (-12) |
| react-hooks/preserve-manual-memoization | 25 | **25** (no regression) |
| **TOTAL warnings** | **272** | **260** (-12) |

React Compiler is in INFER mode; each memo wrap was checked for `preserve-manual-memoization` trades. None appeared — the -12 exhaustive-deps gain flows straight through to the total. No wrap was backed out.

## Backed out / left for TASK-246 (W4)

- **`getAssetDecimals` (SendScreen) intentionally NOT wrapped.** It calls the unmemoized `getCurrentAssetOption`/`getCurrentAsset` helpers, so a `useCallback` wrap would stay unstable AND spawn new cascade warnings on its own dep array rather than reduce the count. Left for TASK-246.
- **4 behavior-changing out-of-scope sites untouched** (absent from the diff): `NFTThemeSelector:154`, `TokenSelector` loadTokens `:140`, `MnemonicImportScreen:412`, `AirgapVerificationFlow:240`. Routed to TASK-246.

The TokenSelector / SlippageSettingsModal animated-value effects and HomeScreen entrance-animation effect (the "stable-handle" bucket) were already suppressed by a prior W1 sweep and carry zero exhaustive-deps warnings today, so no change was needed there.

## Ratchet

`--max-warnings` lowered `272 → 260`; `lint-baseline.json` regenerated in this PR. `npm run lint:baseline:check` passes.

## Gates

- `npm run typecheck` — clean (0)
- `npm run lint` — exit 0 (260 ≤ 260)
- `npm run lint:baseline:check` — passes
- `npm test -- --ci` — 96 suites / 1532 tests green
- Codex review — CLEAN

## Device QA (batched pre-release per HT-218)

- Remote-signer QR scan still rejects a request for a non-STANDARD address (the `signableAddresses` `useMemo` is the signing gate; identical set contents, now stable identity).
- `AccountSearchScreen` FlatList scrolls without item flicker (`renderAvatar` now stable via `useCallback([styles])`).

https://claude.ai/code/session_01AL4EmUSYAiVXEstBgKqDmv