### PR TITLE
fix(navigation): run discarded async service teardown on unmount (TASK-243)

### DIFF
--- a/lint-baseline.json
+++ b/lint-baseline.json
@@ -3,7 +3,7 @@
   "totals": {
     "errors": 0,
     "warnings": 260,
-    "filesLinted": 432,
+    "filesLinted": 434,
     "filesWithFindings": 92
   },
   "rules": {

--- a/src/navigation/AppNavigator.tsx
+++ b/src/navigation/AppNavigator.tsx
@@ -13,9 +13,7 @@ import {
   TouchableOpacity,
   TouchableOpacityProps,
   StyleSheet,
-  Platform,
 } from 'react-native';
-import { detectPlatform } from '@/platform/detection';
 import { BottomSheetModalProvider } from '@gorhom/bottom-sheet';
 import { useTheme } from '@/contexts/ThemeContext';
 import { useThemedStyles } from '@/hooks/useThemedStyles';
@@ -57,11 +55,7 @@ import CreateWalletScreen from '@/screens/onboarding/CreateWalletScreen';
 import KeyregConfirmScreen from '@/screens/transaction/KeyregConfirmScreen';
 import AppCallConfirmScreen from '@/screens/transaction/AppCallConfirmScreen';
 import AppInfoModal from '@/screens/app/AppInfoModal';
-import {
-  useAppMode,
-  getAppModeEarly,
-  useRemoteSignerStore,
-} from '@/store/remoteSignerStore';
+import { useAppMode, useRemoteSignerStore } from '@/store/remoteSignerStore';
 import { useWalletStore } from '@/store/walletStore';
 import {
   hideSplashScreen,
@@ -71,23 +65,16 @@ import { RemoteSignerRequest } from '@/types/remoteSigner';
 import SecuritySetupScreen from '@/screens/onboarding/SecuritySetupScreen';
 import AuthGuard from '@/components/AuthGuard';
 import { AuthProvider, useAuth } from '@/contexts/AuthContext';
-import { MultiAccountWalletService } from '@/services/wallet';
-import { WalletConnectService } from '@/services/walletconnect';
-import { DeepLinkService } from '@/services/deeplink';
-import { extensionDeepLinkHandler } from '@/services/deeplink/extensionHandler';
-import { ledgerTransportService } from '@/services/ledger/transport';
-import { isWalletConnectUri } from '@/services/walletconnect/utils';
 import { useNetworkStore } from '@/store/networkStore';
-import { notificationService } from '@/services/notifications';
 import { NetworkId } from '@/types/network';
 import { TransactionInfo, WalletAccount } from '@/types/wallet';
 import { ScannedAccount } from '@/utils/accountQRParser';
 import { NFTToken, ARC72Collection } from '@/types/nft';
 import { SerializableClaimableItem } from '@/types/claimable';
 import { NFTBackground } from '@/components/common/NFTBackground';
-import { TransactionRequestQueue } from '@/services/walletconnect/TransactionRequestQueue';
 import { FABRadialMenu } from '@/components/navigation/FABRadialMenu';
 import { useUpdateStore } from '@/store/updateStore';
+import { initializeServices } from './serviceBootstrap';
 
 // Import TransactionHistoryScreen directly to avoid async-require issues in EAS builds
 import TransactionHistoryScreen from '@/screens/wallet/TransactionHistoryScreen';
@@ -1360,6 +1347,17 @@ function NavigationActivityWrapper() {
 export default function AppNavigator() {
   const navigationRef = useRef<any>(null);
   const initializationRef = useRef<boolean>(false);
+  // Holds the teardown produced by the async initializeServices() below. The
+  // effect boots services asynchronously, so its own synchronous return can't
+  // capture the closure directly (awaiting it would wrap it in a Promise and
+  // discard it). initializeServices assigns the teardown here; the effect's
+  // synchronous cleanup invokes it on unmount. See TASK-243.
+  const cleanupRef = useRef<(() => void) | undefined>(undefined);
+  // Tracks whether the mount effect has torn down. It is reset at the START of
+  // every effect run (including StrictMode's second pass, where the guard below
+  // skips re-init) so a boot that finishes while the component is LIVE is never
+  // mistaken for one that finished after unmount. See TASK-243.
+  const disposedRef = useRef<boolean>(false);
   const { initializeNetwork } = useNetworkStore();
 
   // For extensions, don't use any linking config - this completely disables URL-based navigation
@@ -1367,349 +1365,41 @@ export default function AppNavigator() {
   const linkingConfig = undefined;
 
   useEffect(() => {
-    // Prevent double initialization (can happen with StrictMode or fast remounts)
+    disposedRef.current = false;
+
+    // Synchronous teardown. initializeServices assigns the real teardown to
+    // cleanupRef once its async boot reaches the WalletConnect/notification
+    // wiring; on unmount we invoke whatever is there (undefined if boot hasn't
+    // gotten that far yet — in which case the boot tears itself down via
+    // isDisposed). This restores the WalletConnect handler unregister and
+    // extensionDeepLinkHandler/notificationService cleanup on unmount.
+    const runCleanup = () => {
+      disposedRef.current = true;
+      // Reading cleanupRef.current at cleanup time is INTENTIONAL and the whole
+      // point (TASK-243): the async boot assigns the teardown AFTER this effect
+      // body returns, so we must read the latest value on unmount. Copying
+      // .current into a variable in the effect body would capture undefined
+      // (boot hasn't completed) and defeat the teardown.
+      cleanupRef.current?.();
+    };
+
+    // Prevent double initialization (can happen with StrictMode or fast
+    // remounts). Even when the guard skips re-init we STILL return the teardown
+    // wiring, so under StrictMode the live (second) effect tears services down
+    // on the real unmount instead of leaving the discarded first pass to do it.
     if (initializationRef.current) {
-      return;
+      return runCleanup;
     }
     initializationRef.current = true;
 
-    const initializeServices = async () => {
-      try {
-        // Kick off remote-signer store hydration EARLY (F-03 cross-stage
-        // parallelization). Previously it started only once MainTabNavigator
-        // mounted (behind the AppStack render gate), daisy-chaining it after the
-        // first frame. Starting it here runs it concurrently with AppStack's
-        // checkInitialRoute and the service init below. It reuses the same
-        // getAppModeEarly() promise awaited just below, and its initialize() is
-        // coalesced, so the later MainTabNavigator mount-effect call dedupes onto
-        // this in-flight pass rather than starting a second one. Fire-and-forget:
-        // it must not block service init.
-        void useRemoteSignerStore.getState().initialize();
+    initializeServices({
+      navigationRef,
+      initializeNetwork,
+      cleanupRef,
+      isDisposed: () => disposedRef.current,
+    });
 
-        // Get app mode BEFORE initializing network services
-        // This avoids a race condition with store hydration
-        const appMode = await getAppModeEarly();
-        const isSignerMode = appMode === 'signer';
-
-        // Initialize Network store (needed in both modes for basic config)
-        await initializeNetwork();
-
-        // Kick off wallet store hydration EARLY too (F-03). It previously started
-        // only when HomeScreen/AirgapHomeScreen mounted — the last of three
-        // render gates. Starting it here (well ahead of that gate) lets the
-        // wallet/account list + persisted balance cache load during startup.
-        // It is kept AFTER initializeNetwork() on purpose: walletStore.initialize
-        // reads the ACTIVE network to key the balance cache, matching where the
-        // Home mount effect ran it (always post-network-init). Its initialize()
-        // coalescer dedupes the later Home mount-effect call. Fire-and-forget.
-        void useWalletStore.getState().initialize();
-
-        // Variables for cleanup - only defined if services are initialized
-        let wcService: WalletConnectService | null = null;
-        let onProposal: ((proposal: any) => void) | null = null;
-        let onRequest: ((requestEvent: any) => Promise<void>) | null = null;
-
-        // Whether the deferred (off-critical-path) per-account subscribe should
-        // run. Set once the notification service is initialized and a push token
-        // is registered; the actual subscribe is scheduled after startup.
-        let shouldSubscribeAccounts = false;
-
-        // Independent service inits run in parallel via Promise.allSettled, each
-        // with its own try/catch so one failure never blocks the others or app
-        // startup. Ordering constraints are preserved WITHIN each branch.
-        const parallelInits: Promise<unknown>[] = [];
-
-        // Skip internet-dependent services in signer mode (air-gapped device)
-        if (!isSignerMode) {
-          // --- Branch: WalletConnect (init + handler attach kept ATOMIC) ---
-          // WalletConnect installs its own handlers during initialize(); the
-          // AppNavigator navigation handlers must attach to that same initialized
-          // instance, so init and .on(...) stay together in one unit.
-          const initWalletConnect = async () => {
-            try {
-              wcService = WalletConnectService.getInstance();
-              await wcService.initialize();
-
-              // Listen for WalletConnect session proposals and navigate to approval screen
-              onProposal = (proposal: any) => {
-                try {
-                  if (navigationRef.current?.isReady?.()) {
-                    // Close any open QR scanner first when possible
-                    if (navigationRef.current.canGoBack?.()) {
-                      navigationRef.current.goBack();
-                    }
-                    // Then navigate to session proposal
-                    navigationRef.current.navigate(
-                      'WalletConnectSessionProposal',
-                      {
-                        proposal,
-                      }
-                    );
-                  }
-                } catch (err) {
-                  console.error(
-                    'Failed to navigate to WalletConnectSessionProposal:',
-                    err
-                  );
-                }
-              };
-              wcService.on('session_proposal', onProposal);
-
-              onRequest = async (requestEvent: any) => {
-                try {
-                  if (navigationRef.current?.isReady?.()) {
-                    // Get current route name
-                    const currentRoute =
-                      navigationRef.current.getCurrentRoute();
-
-                    // Check if we're already on the TransactionRequestScreen
-                    if (
-                      currentRoute?.name === 'WalletConnectTransactionRequest'
-                    ) {
-                      // Enqueue the request instead of navigating immediately
-                      console.log(
-                        '[AppNavigator] Currently on transaction screen, enqueueing request'
-                      );
-                      await TransactionRequestQueue.enqueue({
-                        id: requestEvent.id,
-                        topic: requestEvent.topic,
-                        params: requestEvent.params,
-                      });
-                    } else {
-                      // Navigate immediately if not on transaction screen
-                      navigationRef.current.navigate(
-                        'WalletConnectTransactionRequest',
-                        { requestEvent }
-                      );
-                    }
-                  }
-                } catch (err) {
-                  console.error(
-                    'Failed to handle WalletConnect transaction request:',
-                    err
-                  );
-                }
-              };
-              wcService.on('session_request', onRequest);
-
-              console.log('WalletConnect service initialized');
-            } catch (error) {
-              console.warn(
-                'Failed to initialize WalletConnect service:',
-                error
-              );
-              // Don't block app startup for WalletConnect initialization failures
-            }
-          };
-
-          // --- Branch: DeepLink -> Notifications (ordered, NOT raced) ---
-          // DeepLink.initialize() installs the notification-tap handler, so it
-          // must run BEFORE notificationService.initialize() to avoid racing
-          // cold-start notification routing; they share one sequential branch.
-          const initDeepLinkAndNotifications = async () => {
-            // DeepLink.initialize() installs the notification-tap handler. It
-            // MUST complete before notificationService.initialize() processes a
-            // cold-start notification response: notification init marks the
-            // initial notification as handled and, if no tap handler is set,
-            // buffers it in memory with nothing to route it — permanently
-            // dropping it. Track success so a DeepLink failure GATES (skips)
-            // notification init rather than silently consuming that response.
-            let deepLinkTapHandlerReady = false;
-            try {
-              const deepLinkService = DeepLinkService.getInstance();
-              if (navigationRef.current) {
-                deepLinkService.setNavigationRef(navigationRef.current);
-              }
-              await deepLinkService.initialize();
-              // initialize() installs the notification-tap handler on success
-              deepLinkTapHandlerReady = true;
-
-              // Initialize extension-specific deep link handling (for WalletConnect URIs from getvoi.app)
-              if (Platform.OS === 'web' && detectPlatform() === 'extension') {
-                extensionDeepLinkHandler.initialize(async (uri: string) => {
-                  console.log('[AppNavigator] Extension received WC URI:', uri);
-                  if (isWalletConnectUri(uri)) {
-                    await deepLinkService.testDeepLink(uri);
-                  }
-                });
-              }
-
-              console.log('DeepLink service initialized');
-            } catch (error) {
-              console.warn('Failed to initialize DeepLink service:', error);
-              // Don't block app startup for DeepLink initialization failures
-            }
-
-            // Only initialize notifications once the notification-tap handler is
-            // installed. If DeepLink init failed, skip notification init so a
-            // cold-start notification response is not consumed and dropped with
-            // no handler to route it (matches the original serial behavior,
-            // where a DeepLink failure short-circuited notification init).
-            if (!deepLinkTapHandlerReady) {
-              console.warn(
-                '[AppNavigator] Skipping notification init: DeepLink notification-tap handler not installed (would drop cold-start notification)'
-              );
-              return;
-            }
-
-            // Initialize push notification service (after DeepLink so the
-            // notification-tap handler is installed before cold-start routing)
-            try {
-              await notificationService.initialize();
-              console.log('Notification service initialized');
-
-              // Check if user has a wallet, then register the push token
-              const wallet = await MultiAccountWalletService.getCurrentWallet();
-              if (wallet && wallet.accounts.length > 0) {
-                // Register push token if permissions granted
-                const token = await notificationService.registerPushToken();
-                if (token) {
-                  // Defer the expensive per-account subscribe (N sequential
-                  // Supabase round-trips) off the critical path; it re-reads the
-                  // wallet at run time so startup-created accounts are included.
-                  shouldSubscribeAccounts = true;
-                }
-              }
-            } catch (error) {
-              console.warn(
-                'Failed to initialize notification services:',
-                error
-              );
-              // Don't block app startup for notification initialization failures
-            }
-          };
-
-          parallelInits.push(
-            initWalletConnect(),
-            initDeepLinkAndNotifications()
-          );
-        } else {
-          console.log(
-            '[AppNavigator] Signer mode: skipping network services (WalletConnect, DeepLink, Notifications)'
-          );
-        }
-
-        // --- Branch: Ledger transport (useful in BOTH modes) ---
-        // F-24: only eagerly initialize the Ledger transport at boot when the
-        // user has a previously paired Ledger persisted. This loads that
-        // device's metadata into the in-memory map so rekey/signing
-        // getDevices() consumers (keyManager) see it, WITHOUT pulling
-        // ble-plx/rxjs into the cold-boot eval graph or starting a permanent
-        // 15s health-check interval for the ~100% of users who never use a
-        // Ledger. Users with no persisted device defer init to the first Ledger
-        // screen (DeviceDiscovery) / first signing attempt (keyManager), which
-        // call initialize() themselves.
-        const initLedger = async () => {
-          try {
-            const initialized =
-              await ledgerTransportService.initializeIfPersistedDevices({
-                enableBle: true,
-                enableUsb: true,
-              });
-            console.log(
-              initialized
-                ? 'Ledger transport service initialized'
-                : 'Ledger transport init deferred (no persisted devices)'
-            );
-          } catch (error) {
-            console.warn(
-              'Failed to initialize Ledger transport service:',
-              error
-            );
-            // Don't block app startup for Ledger initialization failures
-          }
-        };
-        parallelInits.push(initLedger());
-
-        // Run the independent inits concurrently; allSettled + per-branch
-        // try/catch guarantees a single failure cannot block the others.
-        await Promise.allSettled(parallelInits);
-
-        // Reset + process the TransactionRequestQueue on the critical path (NOT
-        // a deferred sibling) so stale processing state is cleared and any
-        // persisted request is handled before we accept new startup requests.
-        // Runs after WalletConnect init so queued requests can be serviced.
-        if (!isSignerMode) {
-          // Reset stale processing state from previous session (prevents deadlock after crash)
-          await TransactionRequestQueue.setProcessing(false);
-
-          // Process any pending transaction requests from the queue
-          try {
-            const hasQueuedRequests =
-              !(await TransactionRequestQueue.isEmpty());
-            if (hasQueuedRequests) {
-              console.log(
-                '[AppNavigator] Processing queued transaction requests on startup'
-              );
-              const nextRequest = await TransactionRequestQueue.peek();
-              if (nextRequest && navigationRef.current) {
-                // Dequeue and navigate to the first request
-                await TransactionRequestQueue.dequeue();
-                navigationRef.current.navigate(
-                  'WalletConnectTransactionRequest',
-                  {
-                    requestEvent: nextRequest,
-                    version: nextRequest.version,
-                  }
-                );
-              }
-            }
-          } catch (error) {
-            console.error(
-              '[AppNavigator] Failed to process queued requests:',
-              error
-            );
-          }
-        }
-
-        // Defer per-account notification subscribe OFF the critical path.
-        // Re-read the wallet here so accounts created during startup are
-        // included (constraint: defer only AFTER re-reading the wallet). This is
-        // fire-and-forget so it never delays time-to-interactive.
-        if (shouldSubscribeAccounts) {
-          void (async () => {
-            try {
-              const wallet = await MultiAccountWalletService.getCurrentWallet();
-              if (wallet && wallet.accounts.length > 0) {
-                // Subscribe ALL accounts to notifications (not just active one)
-                // Watch accounts will have message notifications disabled by default
-                await notificationService.subscribeAllAccounts(wallet.accounts);
-
-                // TODO: Re-enable realtime subscription when needed
-                // Currently disabled to reduce server load - using polling instead
-                // const allAddresses = wallet.accounts.map(a => a.address);
-                // await realtimeService.subscribeToAddresses(allAddresses);
-              }
-            } catch (error) {
-              console.warn(
-                'Failed to subscribe accounts to notifications:',
-                error
-              );
-            }
-          })();
-        }
-
-        return () => {
-          try {
-            if (wcService && onProposal) {
-              wcService.off?.('session_proposal', onProposal);
-            }
-            if (wcService && onRequest) {
-              wcService.off?.('session_request', onRequest);
-            }
-            if (!isSignerMode) {
-              extensionDeepLinkHandler.cleanup();
-              notificationService.cleanup();
-            }
-            // realtimeService.cleanup(); // Disabled - realtime subscription not active
-          } catch {}
-        };
-      } catch (error) {
-        console.error('Failed to initialize services:', error);
-      }
-    };
-
-    initializeServices();
+    return runCleanup;
     // eslint-disable-next-line react-hooks/exhaustive-deps -- whole-app service boot; runs once (guarded by initializationRef) and initializeNetwork is read at the mount commit. Re-running on its identity would re-boot services.
   }, []);
 

--- a/src/navigation/__tests__/serviceBootstrap.test.ts
+++ b/src/navigation/__tests__/serviceBootstrap.test.ts
@@ -1,0 +1,252 @@
+/**
+ * Regression test for TASK-243.
+ *
+ * AppNavigator's service-boot effect declared `initializeServices` as an async
+ * function that RETURNED a teardown closure (WalletConnect session_proposal /
+ * session_request unregister + extensionDeepLinkHandler.cleanup /
+ * notificationService.cleanup). The effect invoked it as a bare statement, so
+ * that returned closure was wrapped in a Promise and DISCARDED — the effect
+ * returned `undefined` and no teardown ever ran on unmount.
+ *
+ * The fix hoists the teardown into a `cleanupRef` the async boot assigns, which
+ * the effect's SYNCHRONOUS return invokes on unmount. Mounting the full
+ * AppNavigator under jest is impractical (its ~70-screen native module graph
+ * won't load), so the boot body was extracted verbatim into
+ * `serviceBootstrap.ts` (deps injected) — the smallest unit that still exercises
+ * the REAL init + teardown wiring. This test drives that unit directly:
+ * it runs the real boot, then invokes the captured teardown (the unmount
+ * simulation) and asserts every unregister/cleanup fires.
+ *
+ * All services/stores are mocked as opaque effect sinks — the test only asserts
+ * the wiring calls them; no key/mnemonic/network material is fabricated.
+ */
+
+import { initializeServices } from '../serviceBootstrap';
+
+// --- Mock leaves (all prefixed `mock` so jest can hoist them into factories) ---
+const mockWcService = {
+  initialize: jest.fn(async () => {}),
+  on: jest.fn(),
+  off: jest.fn(),
+};
+const mockDeepLinkService = {
+  setNavigationRef: jest.fn(),
+  initialize: jest.fn(async () => {}),
+  testDeepLink: jest.fn(async () => {}),
+};
+const mockExtensionDeepLinkHandler = {
+  initialize: jest.fn(),
+  cleanup: jest.fn(),
+};
+const mockNotificationService = {
+  initialize: jest.fn(async () => {}),
+  registerPushToken: jest.fn(async () => null as string | null),
+  subscribeAllAccounts: jest.fn(async () => {}),
+  cleanup: jest.fn(),
+};
+const mockTxnQueue = {
+  enqueue: jest.fn(async () => {}),
+  setProcessing: jest.fn(async () => {}),
+  isEmpty: jest.fn(async () => true),
+  peek: jest.fn(async () => null),
+  dequeue: jest.fn(async () => {}),
+};
+// Mutable app mode driven per test ('user' vs 'signer').
+let mockAppMode = 'user';
+
+jest.mock('@/store/remoteSignerStore', () => ({
+  useRemoteSignerStore: {
+    getState: () => ({ initialize: jest.fn(async () => {}) }),
+  },
+  getAppModeEarly: jest.fn(async () => mockAppMode),
+}));
+
+jest.mock('@/store/walletStore', () => ({
+  useWalletStore: {
+    getState: () => ({ initialize: jest.fn(async () => {}) }),
+  },
+}));
+
+jest.mock('@/services/walletconnect', () => ({
+  WalletConnectService: { getInstance: jest.fn(() => mockWcService) },
+}));
+
+jest.mock('@/services/deeplink', () => ({
+  DeepLinkService: { getInstance: jest.fn(() => mockDeepLinkService) },
+}));
+
+// Getter exports: jest hoists these factories above the `const mock*`
+// declarations, so a direct reference would capture `undefined`. A getter
+// defers the read to use-time, once the consts are initialized.
+jest.mock('@/services/deeplink/extensionHandler', () => ({
+  get extensionDeepLinkHandler() {
+    return mockExtensionDeepLinkHandler;
+  },
+}));
+
+jest.mock('@/services/walletconnect/utils', () => ({
+  isWalletConnectUri: jest.fn(() => false),
+}));
+
+jest.mock('@/services/notifications', () => ({
+  get notificationService() {
+    return mockNotificationService;
+  },
+}));
+
+jest.mock('@/services/wallet', () => ({
+  MultiAccountWalletService: { getCurrentWallet: jest.fn(async () => null) },
+}));
+
+jest.mock('@/services/ledger/transport', () => ({
+  ledgerTransportService: {
+    initializeIfPersistedDevices: jest.fn(async () => false),
+  },
+}));
+
+jest.mock('@/services/walletconnect/TransactionRequestQueue', () => ({
+  get TransactionRequestQueue() {
+    return mockTxnQueue;
+  },
+}));
+
+jest.mock('@/platform/detection', () => ({
+  detectPlatform: jest.fn(() => 'mobile'),
+}));
+
+const makeCleanupRef = () => ({
+  current: undefined as (() => void) | undefined,
+});
+
+describe('serviceBootstrap.initializeServices — TASK-243 teardown wiring', () => {
+  beforeEach(() => {
+    // jest.config `clearMocks: true` resets call history; only the mutable app
+    // mode needs resetting.
+    mockAppMode = 'user';
+  });
+
+  it('captures a teardown that unregisters BOTH WalletConnect handlers and cleans up deep-link + notifications on unmount', async () => {
+    const cleanupRef = makeCleanupRef();
+    const initializeNetwork = jest.fn(async () => {});
+
+    await initializeServices({
+      navigationRef: { current: null },
+      initializeNetwork,
+      cleanupRef,
+    });
+
+    // Init actually ran and the WC handler registration (unchanged by the fix)
+    // is reachable for BOTH events.
+    expect(initializeNetwork).toHaveBeenCalledTimes(1);
+    expect(mockWcService.on).toHaveBeenCalledWith(
+      'session_proposal',
+      expect.any(Function)
+    );
+    expect(mockWcService.on).toHaveBeenCalledWith(
+      'session_request',
+      expect.any(Function)
+    );
+
+    // The core of the fix: a teardown was actually captured (before, it was
+    // wrapped in a discarded Promise and lost).
+    expect(typeof cleanupRef.current).toBe('function');
+
+    // ...and nothing has torn down yet — the teardown only runs on unmount.
+    expect(mockWcService.off).not.toHaveBeenCalled();
+    expect(mockExtensionDeepLinkHandler.cleanup).not.toHaveBeenCalled();
+    expect(mockNotificationService.cleanup).not.toHaveBeenCalled();
+
+    // Simulate the effect's synchronous unmount cleanup.
+    cleanupRef.current!();
+
+    // BOTH WalletConnect handlers are unregistered...
+    expect(mockWcService.off).toHaveBeenCalledWith(
+      'session_proposal',
+      expect.any(Function)
+    );
+    expect(mockWcService.off).toHaveBeenCalledWith(
+      'session_request',
+      expect.any(Function)
+    );
+    // ...and the deep-link + notification services are cleaned up.
+    expect(mockExtensionDeepLinkHandler.cleanup).toHaveBeenCalledTimes(1);
+    expect(mockNotificationService.cleanup).toHaveBeenCalledTimes(1);
+  });
+
+  it('tears services down IMMEDIATELY when the effect already unmounted before boot completed (isDisposed)', async () => {
+    // Models a fast unmount / Fast Refresh before boot finished: the effect's
+    // synchronous cleanup already ran (no-op, teardown did not exist yet), so
+    // the boot must not leave the WalletConnect handlers registered against a
+    // dead navigator — it runs the teardown as soon as it is assigned.
+    const cleanupRef = makeCleanupRef();
+
+    await initializeServices({
+      navigationRef: { current: null },
+      initializeNetwork: jest.fn(async () => {}),
+      cleanupRef,
+      isDisposed: () => true,
+    });
+
+    // Handlers were registered during boot...
+    expect(mockWcService.on).toHaveBeenCalledWith(
+      'session_proposal',
+      expect.any(Function)
+    );
+    expect(mockWcService.on).toHaveBeenCalledWith(
+      'session_request',
+      expect.any(Function)
+    );
+    // ...and torn straight back down because the component was already gone.
+    expect(mockWcService.off).toHaveBeenCalledWith(
+      'session_proposal',
+      expect.any(Function)
+    );
+    expect(mockWcService.off).toHaveBeenCalledWith(
+      'session_request',
+      expect.any(Function)
+    );
+    expect(mockExtensionDeepLinkHandler.cleanup).toHaveBeenCalledTimes(1);
+    expect(mockNotificationService.cleanup).toHaveBeenCalledTimes(1);
+  });
+
+  it('does NOT auto-tear-down when still mounted (isDisposed false) — teardown waits for unmount', async () => {
+    const cleanupRef = makeCleanupRef();
+
+    await initializeServices({
+      navigationRef: { current: null },
+      initializeNetwork: jest.fn(async () => {}),
+      cleanupRef,
+      isDisposed: () => false,
+    });
+
+    // A teardown is captured but must NOT have run — the component is live.
+    expect(typeof cleanupRef.current).toBe('function');
+    expect(mockWcService.off).not.toHaveBeenCalled();
+    expect(mockExtensionDeepLinkHandler.cleanup).not.toHaveBeenCalled();
+    expect(mockNotificationService.cleanup).not.toHaveBeenCalled();
+  });
+
+  it('in signer mode, the captured teardown skips the network-service cleanup (air-gapped: nothing was registered)', async () => {
+    mockAppMode = 'signer';
+    const cleanupRef = makeCleanupRef();
+
+    await initializeServices({
+      navigationRef: { current: null },
+      initializeNetwork: jest.fn(async () => {}),
+      cleanupRef,
+    });
+
+    // A teardown is still captured (the ref is always assigned)...
+    expect(typeof cleanupRef.current).toBe('function');
+
+    // ...but signer mode never boots the network services, so nothing was
+    // registered and running the teardown must be a safe no-op.
+    expect(mockWcService.on).not.toHaveBeenCalled();
+
+    cleanupRef.current!();
+
+    expect(mockWcService.off).not.toHaveBeenCalled();
+    expect(mockExtensionDeepLinkHandler.cleanup).not.toHaveBeenCalled();
+    expect(mockNotificationService.cleanup).not.toHaveBeenCalled();
+  });
+});

--- a/src/navigation/serviceBootstrap.ts
+++ b/src/navigation/serviceBootstrap.ts
@@ -1,0 +1,382 @@
+import { Platform } from 'react-native';
+
+import { detectPlatform } from '@/platform/detection';
+import {
+  getAppModeEarly,
+  useRemoteSignerStore,
+} from '@/store/remoteSignerStore';
+import { useWalletStore } from '@/store/walletStore';
+import { WalletConnectService } from '@/services/walletconnect';
+import { DeepLinkService } from '@/services/deeplink';
+import { extensionDeepLinkHandler } from '@/services/deeplink/extensionHandler';
+import { isWalletConnectUri } from '@/services/walletconnect/utils';
+import { notificationService } from '@/services/notifications';
+import { MultiAccountWalletService } from '@/services/wallet';
+import { ledgerTransportService } from '@/services/ledger/transport';
+import { TransactionRequestQueue } from '@/services/walletconnect/TransactionRequestQueue';
+
+/**
+ * Whole-app service boot, extracted verbatim from AppNavigator's mount effect
+ * (TASK-243) so the async init + teardown can be unit-tested without mounting
+ * the full navigator (its 70-screen module graph is impractical to load under
+ * jest). The init logic and ordering are UNCHANGED from the inline version;
+ * only the surrounding closure captures (navigationRef, initializeNetwork,
+ * cleanupRef) are now injected as `deps`.
+ *
+ * TASK-243 fix: instead of `return () => {...}` (which the async function would
+ * resolve into a Promise the effect discards), the teardown is assigned to
+ * `deps.cleanupRef.current`. The effect's SYNCHRONOUS cleanup invokes that ref
+ * on unmount, so the WalletConnect handler unregister and
+ * extensionDeepLinkHandler/notificationService cleanup actually run.
+ */
+export interface InitializeServicesDeps {
+  /** The NavigationContainer ref; read lazily inside the WC handlers. */
+  navigationRef: { current: any };
+  /** networkStore.initializeNetwork, read at the mount commit. */
+  initializeNetwork: () => Promise<void>;
+  /**
+   * Mutable holder the effect's synchronous cleanup invokes on unmount. This
+   * function assigns the teardown here once boot reaches the point where the
+   * services that need tearing down have been wired up.
+   */
+  cleanupRef: { current: (() => void) | undefined };
+  /**
+   * Returns true if the mount effect has ALREADY torn down (the component
+   * unmounted) while this async boot was still in flight — e.g. a fast
+   * unmount or a dev Fast Refresh boundary before boot finished. When that
+   * happens the effect's synchronous cleanup found `cleanupRef.current`
+   * undefined and no-op'd, yet this boot still went on to register the
+   * WalletConnect handlers etc. So once the teardown is assigned below we
+   * invoke it immediately, rather than leaking those registrations against an
+   * unmounted navigator. Defaults to never-disposed. (TASK-243.)
+   */
+  isDisposed?: () => boolean;
+}
+
+export const initializeServices = async ({
+  navigationRef,
+  initializeNetwork,
+  cleanupRef,
+  isDisposed,
+}: InitializeServicesDeps): Promise<void> => {
+  try {
+    // Kick off remote-signer store hydration EARLY (F-03 cross-stage
+    // parallelization). Previously it started only once MainTabNavigator
+    // mounted (behind the AppStack render gate), daisy-chaining it after the
+    // first frame. Starting it here runs it concurrently with AppStack's
+    // checkInitialRoute and the service init below. It reuses the same
+    // getAppModeEarly() promise awaited just below, and its initialize() is
+    // coalesced, so the later MainTabNavigator mount-effect call dedupes onto
+    // this in-flight pass rather than starting a second one. Fire-and-forget:
+    // it must not block service init.
+    void useRemoteSignerStore.getState().initialize();
+
+    // Get app mode BEFORE initializing network services
+    // This avoids a race condition with store hydration
+    const appMode = await getAppModeEarly();
+    const isSignerMode = appMode === 'signer';
+
+    // Initialize Network store (needed in both modes for basic config)
+    await initializeNetwork();
+
+    // Kick off wallet store hydration EARLY too (F-03). It previously started
+    // only when HomeScreen/AirgapHomeScreen mounted — the last of three
+    // render gates. Starting it here (well ahead of that gate) lets the
+    // wallet/account list + persisted balance cache load during startup.
+    // It is kept AFTER initializeNetwork() on purpose: walletStore.initialize
+    // reads the ACTIVE network to key the balance cache, matching where the
+    // Home mount effect ran it (always post-network-init). Its initialize()
+    // coalescer dedupes the later Home mount-effect call. Fire-and-forget.
+    void useWalletStore.getState().initialize();
+
+    // Variables for cleanup - only defined if services are initialized
+    let wcService: WalletConnectService | null = null;
+    let onProposal: ((proposal: any) => void) | null = null;
+    let onRequest: ((requestEvent: any) => Promise<void>) | null = null;
+
+    // Whether the deferred (off-critical-path) per-account subscribe should
+    // run. Set once the notification service is initialized and a push token
+    // is registered; the actual subscribe is scheduled after startup.
+    let shouldSubscribeAccounts = false;
+
+    // Independent service inits run in parallel via Promise.allSettled, each
+    // with its own try/catch so one failure never blocks the others or app
+    // startup. Ordering constraints are preserved WITHIN each branch.
+    const parallelInits: Promise<unknown>[] = [];
+
+    // Skip internet-dependent services in signer mode (air-gapped device)
+    if (!isSignerMode) {
+      // --- Branch: WalletConnect (init + handler attach kept ATOMIC) ---
+      // WalletConnect installs its own handlers during initialize(); the
+      // AppNavigator navigation handlers must attach to that same initialized
+      // instance, so init and .on(...) stay together in one unit.
+      const initWalletConnect = async () => {
+        try {
+          wcService = WalletConnectService.getInstance();
+          await wcService.initialize();
+
+          // Listen for WalletConnect session proposals and navigate to approval screen
+          onProposal = (proposal: any) => {
+            try {
+              if (navigationRef.current?.isReady?.()) {
+                // Close any open QR scanner first when possible
+                if (navigationRef.current.canGoBack?.()) {
+                  navigationRef.current.goBack();
+                }
+                // Then navigate to session proposal
+                navigationRef.current.navigate('WalletConnectSessionProposal', {
+                  proposal,
+                });
+              }
+            } catch (err) {
+              console.error(
+                'Failed to navigate to WalletConnectSessionProposal:',
+                err
+              );
+            }
+          };
+          wcService.on('session_proposal', onProposal);
+
+          onRequest = async (requestEvent: any) => {
+            try {
+              if (navigationRef.current?.isReady?.()) {
+                // Get current route name
+                const currentRoute = navigationRef.current.getCurrentRoute();
+
+                // Check if we're already on the TransactionRequestScreen
+                if (currentRoute?.name === 'WalletConnectTransactionRequest') {
+                  // Enqueue the request instead of navigating immediately
+                  console.log(
+                    '[AppNavigator] Currently on transaction screen, enqueueing request'
+                  );
+                  await TransactionRequestQueue.enqueue({
+                    id: requestEvent.id,
+                    topic: requestEvent.topic,
+                    params: requestEvent.params,
+                  });
+                } else {
+                  // Navigate immediately if not on transaction screen
+                  navigationRef.current.navigate(
+                    'WalletConnectTransactionRequest',
+                    { requestEvent }
+                  );
+                }
+              }
+            } catch (err) {
+              console.error(
+                'Failed to handle WalletConnect transaction request:',
+                err
+              );
+            }
+          };
+          wcService.on('session_request', onRequest);
+
+          console.log('WalletConnect service initialized');
+        } catch (error) {
+          console.warn('Failed to initialize WalletConnect service:', error);
+          // Don't block app startup for WalletConnect initialization failures
+        }
+      };
+
+      // --- Branch: DeepLink -> Notifications (ordered, NOT raced) ---
+      // DeepLink.initialize() installs the notification-tap handler, so it
+      // must run BEFORE notificationService.initialize() to avoid racing
+      // cold-start notification routing; they share one sequential branch.
+      const initDeepLinkAndNotifications = async () => {
+        // DeepLink.initialize() installs the notification-tap handler. It
+        // MUST complete before notificationService.initialize() processes a
+        // cold-start notification response: notification init marks the
+        // initial notification as handled and, if no tap handler is set,
+        // buffers it in memory with nothing to route it — permanently
+        // dropping it. Track success so a DeepLink failure GATES (skips)
+        // notification init rather than silently consuming that response.
+        let deepLinkTapHandlerReady = false;
+        try {
+          const deepLinkService = DeepLinkService.getInstance();
+          if (navigationRef.current) {
+            deepLinkService.setNavigationRef(navigationRef.current);
+          }
+          await deepLinkService.initialize();
+          // initialize() installs the notification-tap handler on success
+          deepLinkTapHandlerReady = true;
+
+          // Initialize extension-specific deep link handling (for WalletConnect URIs from getvoi.app)
+          if (Platform.OS === 'web' && detectPlatform() === 'extension') {
+            extensionDeepLinkHandler.initialize(async (uri: string) => {
+              console.log('[AppNavigator] Extension received WC URI:', uri);
+              if (isWalletConnectUri(uri)) {
+                await deepLinkService.testDeepLink(uri);
+              }
+            });
+          }
+
+          console.log('DeepLink service initialized');
+        } catch (error) {
+          console.warn('Failed to initialize DeepLink service:', error);
+          // Don't block app startup for DeepLink initialization failures
+        }
+
+        // Only initialize notifications once the notification-tap handler is
+        // installed. If DeepLink init failed, skip notification init so a
+        // cold-start notification response is not consumed and dropped with
+        // no handler to route it (matches the original serial behavior,
+        // where a DeepLink failure short-circuited notification init).
+        if (!deepLinkTapHandlerReady) {
+          console.warn(
+            '[AppNavigator] Skipping notification init: DeepLink notification-tap handler not installed (would drop cold-start notification)'
+          );
+          return;
+        }
+
+        // Initialize push notification service (after DeepLink so the
+        // notification-tap handler is installed before cold-start routing)
+        try {
+          await notificationService.initialize();
+          console.log('Notification service initialized');
+
+          // Check if user has a wallet, then register the push token
+          const wallet = await MultiAccountWalletService.getCurrentWallet();
+          if (wallet && wallet.accounts.length > 0) {
+            // Register push token if permissions granted
+            const token = await notificationService.registerPushToken();
+            if (token) {
+              // Defer the expensive per-account subscribe (N sequential
+              // Supabase round-trips) off the critical path; it re-reads the
+              // wallet at run time so startup-created accounts are included.
+              shouldSubscribeAccounts = true;
+            }
+          }
+        } catch (error) {
+          console.warn('Failed to initialize notification services:', error);
+          // Don't block app startup for notification initialization failures
+        }
+      };
+
+      parallelInits.push(initWalletConnect(), initDeepLinkAndNotifications());
+    } else {
+      console.log(
+        '[AppNavigator] Signer mode: skipping network services (WalletConnect, DeepLink, Notifications)'
+      );
+    }
+
+    // --- Branch: Ledger transport (useful in BOTH modes) ---
+    // F-24: only eagerly initialize the Ledger transport at boot when the
+    // user has a previously paired Ledger persisted. This loads that
+    // device's metadata into the in-memory map so rekey/signing
+    // getDevices() consumers (keyManager) see it, WITHOUT pulling
+    // ble-plx/rxjs into the cold-boot eval graph or starting a permanent
+    // 15s health-check interval for the ~100% of users who never use a
+    // Ledger. Users with no persisted device defer init to the first Ledger
+    // screen (DeviceDiscovery) / first signing attempt (keyManager), which
+    // call initialize() themselves.
+    const initLedger = async () => {
+      try {
+        const initialized =
+          await ledgerTransportService.initializeIfPersistedDevices({
+            enableBle: true,
+            enableUsb: true,
+          });
+        console.log(
+          initialized
+            ? 'Ledger transport service initialized'
+            : 'Ledger transport init deferred (no persisted devices)'
+        );
+      } catch (error) {
+        console.warn('Failed to initialize Ledger transport service:', error);
+        // Don't block app startup for Ledger initialization failures
+      }
+    };
+    parallelInits.push(initLedger());
+
+    // Run the independent inits concurrently; allSettled + per-branch
+    // try/catch guarantees a single failure cannot block the others.
+    await Promise.allSettled(parallelInits);
+
+    // Reset + process the TransactionRequestQueue on the critical path (NOT
+    // a deferred sibling) so stale processing state is cleared and any
+    // persisted request is handled before we accept new startup requests.
+    // Runs after WalletConnect init so queued requests can be serviced.
+    if (!isSignerMode) {
+      // Reset stale processing state from previous session (prevents deadlock after crash)
+      await TransactionRequestQueue.setProcessing(false);
+
+      // Process any pending transaction requests from the queue
+      try {
+        const hasQueuedRequests = !(await TransactionRequestQueue.isEmpty());
+        if (hasQueuedRequests) {
+          console.log(
+            '[AppNavigator] Processing queued transaction requests on startup'
+          );
+          const nextRequest = await TransactionRequestQueue.peek();
+          if (nextRequest && navigationRef.current) {
+            // Dequeue and navigate to the first request
+            await TransactionRequestQueue.dequeue();
+            navigationRef.current.navigate('WalletConnectTransactionRequest', {
+              requestEvent: nextRequest,
+              version: nextRequest.version,
+            });
+          }
+        }
+      } catch (error) {
+        console.error(
+          '[AppNavigator] Failed to process queued requests:',
+          error
+        );
+      }
+    }
+
+    // Defer per-account notification subscribe OFF the critical path.
+    // Re-read the wallet here so accounts created during startup are
+    // included (constraint: defer only AFTER re-reading the wallet). This is
+    // fire-and-forget so it never delays time-to-interactive.
+    if (shouldSubscribeAccounts) {
+      void (async () => {
+        try {
+          const wallet = await MultiAccountWalletService.getCurrentWallet();
+          if (wallet && wallet.accounts.length > 0) {
+            // Subscribe ALL accounts to notifications (not just active one)
+            // Watch accounts will have message notifications disabled by default
+            await notificationService.subscribeAllAccounts(wallet.accounts);
+
+            // TODO: Re-enable realtime subscription when needed
+            // Currently disabled to reduce server load - using polling instead
+            // const allAddresses = wallet.accounts.map(a => a.address);
+            // await realtimeService.subscribeToAddresses(allAddresses);
+          }
+        } catch (error) {
+          console.warn('Failed to subscribe accounts to notifications:', error);
+        }
+      })();
+    }
+
+    // Hand the teardown to the effect via cleanupRef so its synchronous
+    // return can run it on unmount. Returning it from this async function
+    // would resolve it into a discarded Promise (the original TASK-243
+    // defect), so no teardown ever ran.
+    cleanupRef.current = () => {
+      try {
+        if (wcService && onProposal) {
+          wcService.off?.('session_proposal', onProposal);
+        }
+        if (wcService && onRequest) {
+          wcService.off?.('session_request', onRequest);
+        }
+        if (!isSignerMode) {
+          extensionDeepLinkHandler.cleanup();
+          notificationService.cleanup();
+        }
+        // realtimeService.cleanup(); // Disabled - realtime subscription not active
+      } catch {}
+    };
+
+    // If the mount effect already unmounted while this boot was in flight, its
+    // synchronous cleanup ran BEFORE the teardown existed (no-op). Now that the
+    // teardown is assigned, run it immediately so the services just registered
+    // above are not left bound to a torn-down navigator. (TASK-243.)
+    if (isDisposed?.()) {
+      cleanupRef.current();
+    }
+  } catch (error) {
+    console.error('Failed to initialize services:', error);
+  }
+};


### PR DESCRIPTION
## What & why (TASK-243)

`AppNavigator`'s service-boot `useEffect` declared `initializeServices` as an **async** function that **returned a teardown closure** — unregistering the WalletConnect `session_proposal`/`session_request` handlers and calling `extensionDeepLinkHandler.cleanup()` / `notificationService.cleanup()`. But the effect invoked it as a bare statement (`initializeServices();`), so the returned closure was wrapped in a Promise and **discarded**; the effect returned `undefined` and **no teardown ever ran** on unmount. On a root remount (app-mode switch) or a dev Fast Refresh boundary, the WalletConnect service kept handlers bound to a torn-down navigator and the deep-link/notification subscriptions leaked.

## Fix mechanism

- Hoist the teardown into a `cleanupRef` (`useRef`) that the boot **assigns** (`cleanupRef.current = () => {…}`) instead of returning. The effect's **synchronous** return invokes `cleanupRef.current?.()` on unmount — so the teardown actually runs.
- **`initializationRef` once-only guard preserved exactly** (`if (initializationRef.current) return … ; initializationRef.current = true;`) and the init ordering is **unchanged** — only how the teardown is wired back to the effect changed.
- **Robustness (from Codex round 1):** the guard + async boot could still lose the teardown on a fast unmount / StrictMode double-invoke. Two teardown-wiring-only additions:
  - The **guarded early-return now also returns the sync cleanup**, so under StrictMode the *live* (second) effect tears services down on the real unmount.
  - A component-level **`disposedRef`** (reset at the start of every effect run) lets the boot detect it finished *after* unmount (`isDisposed`) and run the teardown immediately — handlers are never left bound to a dead navigator. Because `disposedRef` is reset on the live (second) StrictMode pass, services are **not** torn down while the component is still mounted.
- **WalletConnect handler registration logic is unchanged** — the boot body was moved **verbatim** into `serviceBootstrap.ts` (deps `navigationRef` / `initializeNetwork` / `cleanupRef` / `isDisposed` injected); only the closure captures changed.

## Test approach

Mounting the full `AppNavigator` under jest is impractical (its ~70-screen native module graph — AsyncStorage, expo-notifications/secure-store, reanimated, etc. — won't load), so per the acceptance's sanctioned fallback the boot body was extracted into `serviceBootstrap.ts` — the smallest unit that still exercises the **real** init + teardown wiring. `src/navigation/__tests__/serviceBootstrap.test.ts` drives the real boot with the services mocked as effect sinks and asserts:

1. The captured teardown unregisters **both** WC handlers (`wcService.off('session_proposal'|'session_request')`) **and** runs `extensionDeepLinkHandler.cleanup` + `notificationService.cleanup` — and that nothing tears down until the teardown is invoked.
2. `isDisposed() === true` (unmounted before boot finished) → the boot tears services down **immediately**.
3. `isDisposed() === false` (still live) → teardown is captured but does **not** run.
4. Signer mode → teardown is a safe no-op (no network services were registered).

## Guard preservation

The `initializationRef` once-only guard is preserved verbatim and still prevents double-init; init runs exactly once in the original order. Verified by reading the diff and confirmed CLEAN by Codex.

## Warning count / ratchet (DR-9)

The defect is not lint-flagged, so the **warning count did not move: 260 → 260**. `--max-warnings` stays **260**. `lint-baseline.json` regenerated: the only delta is `filesLinted` 432 → 434 (the two new files); `warnings`/`filesWithFindings` unchanged. `npm run lint:baseline:check` passes.

## Gates

- `npm run typecheck` — clean (0)
- `npm run lint` — exit 0 (260 warnings)
- `npm test -- --ci` — green, **97 suites / 1536 tests** (was 96/1532; +1 suite, +4 tests)
- `npm run lint:baseline:check` — passes
- Codex review — **CLEAN**

## Device QA

Batched pre-release per HT-218: cold start should show unchanged boot behavior; after a dev Fast Refresh, connect a dApp and confirm there is **no doubled `session_proposal` handler** and that unmount/remount does not leak or double-register handlers.

https://claude.ai/code/session_01AL4EmUSYAiVXEstBgKqDmv