### PR TITLE
fix(send): restore minimum-balance term in spendable-balance math (TASK-239)

### DIFF
--- a/lint-baseline.json
+++ b/lint-baseline.json
@@ -2,12 +2,12 @@
   "$comment": "Committed ESLint baseline for the `npm run lint` ratchet (PLAN-229 DR-2). Regenerate with `npm run lint:baseline`; verify with `npm run lint:baseline:check`. The `lint` script's --max-warnings MUST equal totals.warnings. Lower it in the same PR that clears the warnings. It never goes up.",
   "totals": {
     "errors": 0,
-    "warnings": 260,
-    "filesLinted": 434,
+    "warnings": 259,
+    "filesLinted": 435,
     "filesWithFindings": 92
   },
   "rules": {
-    "@typescript-eslint/no-unused-vars": 9,
+    "@typescript-eslint/no-unused-vars": 8,
     "import/no-named-as-default": 37,
     "react-hooks/exhaustive-deps": 24,
     "react-hooks/immutability": 97,
@@ -514,9 +514,8 @@
     },
     "src/screens/wallet/SendScreen.tsx": {
       "errors": 0,
-      "warnings": 15,
+      "warnings": 14,
       "rules": {
-        "@typescript-eslint/no-unused-vars": 1,
         "import/no-named-as-default": 1,
         "react-hooks/exhaustive-deps": 8,
         "react-hooks/immutability": 1,

--- a/package.json
+++ b/package.json
@@ -7,7 +7,7 @@
     "android": "expo run:android",
     "ios": "expo run:ios",
     "web": "expo start --web",
-    "lint": "eslint src/ --max-warnings 260",
+    "lint": "eslint src/ --max-warnings 259",
     "lint:fix": "eslint src/ --fix",
     "lint:baseline": "node scripts/lint-baseline.mjs --write",
     "lint:baseline:check": "node scripts/lint-baseline.mjs --check",

--- a/src/screens/wallet/SendScreen.tsx
+++ b/src/screens/wallet/SendScreen.tsx
@@ -40,6 +40,7 @@ import {
   AccountType,
   type WalletAccount,
   type AssetBalance,
+  type AccountBalance,
 } from '@/types/wallet';
 import {
   useCurrentNetwork,
@@ -312,12 +313,99 @@ export default function SendScreen() {
     assetId: number;
   } | null>(null);
 
-  // Balance for the selected asset
-  const [accountBalance, setAccountBalance] = useState<any>(null);
+  // Single-network AccountBalance for the effective transaction network, stored
+  // WITH the (address, networkId) identity it was loaded for. The native
+  // spendable/Max math must subtract THIS network's minimum-balance reserve;
+  // keying to the wrong network — or reusing a record after the account/network
+  // selection changes — is the money bug TASK-239 exists to fix. The identity is
+  // re-validated during render (see the `accountBalance` derivation below), so a
+  // mismatched or not-yet-loaded record is never used, regardless of when any
+  // async load commits.
+  const [accountBalanceRecord, setAccountBalanceRecord] = useState<{
+    address: string;
+    networkId: NetworkId;
+    balance: AccountBalance;
+  } | null>(null);
 
   const { balance: multiNetworkBalance } = useMultiNetworkBalance(
     activeAccount?.id || ''
   );
+
+  // The network this screen actually SENDS on. `selectedAsset` can point at a
+  // different network than `selectedNetworkId` — NetworkAssetSelector.onSelect
+  // sets the asset without touching selectedNetworkId — so the effective network
+  // is the coalesced value, the same expression used by fee estimation, the
+  // network-config memo and transaction construction. Compute it ONCE and share
+  // it; do not re-derive per call site.
+  const effectiveNetworkId: NetworkId =
+    selectedAsset?.networkId ?? selectedNetworkId;
+
+  // Identity-validated view of the loaded balance: non-null ONLY when the stored
+  // record was loaded for the CURRENT (address, effective network). Any
+  // mismatch — a fetch still in flight after the selection changed, or nothing
+  // loaded yet — yields null, and the native spendable path then treats it as
+  // UNSAFE (0n) rather than as `minBalance = 0`. This check runs during render,
+  // so no stale reserve can survive even a single render after the identity
+  // changes (correctness does not depend on effect ordering).
+  const accountBalance: AccountBalance | null =
+    accountBalanceRecord &&
+    accountBalanceRecord.address === activeAccount?.address &&
+    accountBalanceRecord.networkId === effectiveNetworkId
+      ? accountBalanceRecord.balance
+      : null;
+
+  // Load the single-network AccountBalance for the effective transaction network
+  // so the native spendable/Max math can subtract this network's minimum-balance
+  // reserve (the same single-network `minBalance` SwapScreen and the
+  // transactions service backstop use — NOT the cross-network aggregate from
+  // useMultiNetworkBalance). Keyed on the EFFECTIVE network, not
+  // selectedNetworkId, because selecting an asset on the other network changes
+  // where we send without touching selectedNetworkId. Mirrors the HomeScreen
+  // async-load pattern: the target identity is held in a ref and re-checked
+  // after the await, so a superseded fetch (account or network changed
+  // mid-flight) never writes a stale record. The stored record carries its own
+  // identity and is re-validated during render (above), so a stale record is
+  // never usable even before this effect's replacement commits.
+  const balanceIdentityRef = React.useRef<{
+    address: string | undefined;
+    networkId: NetworkId;
+  }>({ address: activeAccount?.address, networkId: effectiveNetworkId });
+
+  useEffect(() => {
+    const address = activeAccount?.address;
+    const networkId = effectiveNetworkId;
+    balanceIdentityRef.current = { address, networkId };
+    if (!address) return;
+
+    (async () => {
+      try {
+        const balance =
+          await NetworkService.getInstance(networkId).getAccountBalance(
+            address
+          );
+        // Re-check identity after the await (do not trust the dep array): a newer
+        // account/network selection may have superseded this run.
+        if (
+          balanceIdentityRef.current.address !== address ||
+          balanceIdentityRef.current.networkId !== networkId
+        ) {
+          return;
+        }
+        setAccountBalanceRecord({ address, networkId, balance });
+      } catch (error) {
+        if (
+          balanceIdentityRef.current.address !== address ||
+          balanceIdentityRef.current.networkId !== networkId
+        ) {
+          return;
+        }
+        console.error(
+          '[SendScreen] Failed to load account balance for spendable math:',
+          error
+        );
+      }
+    })();
+  }, [activeAccount?.address, effectiveNetworkId]);
 
   // The asset the send flow is scoped to (parsed from the route). Depended on
   // by the option builder below, so keep it memoized (and reactive to BOTH
@@ -787,8 +875,8 @@ export default function SendScreen() {
 
   // Get network config for the asset being sent (may differ from selectedNetworkId for multi-network assets)
   const transactionNetworkConfig = React.useMemo(() => {
-    return getNetworkConfig(selectedAsset?.networkId || selectedNetworkId);
-  }, [selectedAsset?.networkId, selectedNetworkId]);
+    return getNetworkConfig(effectiveNetworkId);
+  }, [effectiveNetworkId]);
 
   // Check if Envoi is available on the selected network
   const isEnvoiEnabled = selectedNetworkConfig.features.envoi;
@@ -885,8 +973,17 @@ export default function SendScreen() {
       : effectiveAssetId === 0 || !effectiveAssetId;
     try {
       if (isNative) {
-        const bal = BigInt(option?.balance ?? accountBalance?.amount ?? 0);
-        const minBal = BigInt(accountBalance?.minBalance ?? 0);
+        // Native spendable = balance - fee - minBalance. BOTH balance and reserve
+        // come from the SAME identity-validated record: `accountBalance` is null
+        // unless its stored (address, network) matches the current effective
+        // identity. When it is null (unloaded, or superseded by an in-flight
+        // fetch after the selection changed) native spendable is UNSAFE — return
+        // 0n (Max disappears; the validator rejects positive amounts) rather than
+        // silently treating the reserve as 0. Do NOT fall back to the older
+        // assetOptions snapshot (`option?.balance`) for the balance term here.
+        if (!accountBalance) return 0n;
+        const bal = BigInt(accountBalance.amount ?? 0);
+        const minBal = BigInt(accountBalance.minBalance ?? 0);
         const fee = BigInt(Math.trunc(estimatedFee || 0));
         const spendable = bal - fee - minBal;
         return spendable > 0n ? spendable : 0n;
@@ -918,7 +1015,7 @@ export default function SendScreen() {
     } catch {
       return 'Enter a valid amount';
     }
-    // eslint-disable-next-line react-hooks/exhaustive-deps -- deps hand-mirror the inputs of the helpers this memo calls (getCurrentAssetOption / getAssetDecimals / getSpendableBase): amount, accountBalance, estimatedFee, effectiveAssetId, selectedAsset, assetOptions. Those helpers are read at the current commit; mirror any new read they gain here.
+    // eslint-disable-next-line react-hooks/exhaustive-deps -- deps hand-mirror the inputs of the helpers this memo calls (getCurrentAssetOption / getAssetDecimals / getSpendableBase): amount, accountBalance, estimatedFee, effectiveAssetId, selectedAsset, assetOptions. `accountBalance` here is the identity-validated DERIVED value (it already folds in accountBalanceRecord, activeAccount.address and effectiveNetworkId), so listing it also covers the effective-network keying. Those helpers are read at the current commit; mirror any new read they gain here.
   }, [
     amount,
     accountBalance,
@@ -1260,7 +1357,7 @@ export default function SendScreen() {
           assetType === 'asa' ? (effectiveAssetId ?? undefined) : undefined,
         assetType,
         contractId,
-        networkId: selectedAsset?.networkId || selectedNetworkId,
+        networkId: effectiveNetworkId,
       });
 
       setEstimatedFee(cost.fee);

--- a/src/screens/wallet/__tests__/SendScreen.test.tsx
+++ b/src/screens/wallet/__tests__/SendScreen.test.tsx
@@ -1,0 +1,504 @@
+/**
+ * TASK-239 — money-math regression tests for SendScreen's native
+ * spendable/Max calculation.
+ *
+ * The bug: `accountBalance` state was declared but never populated, so
+ * `getSpendableBase()` read `minBalance ?? 0` and the Algorand minimum-balance
+ * reserve was silently dropped. The Max button (and the as-you-type validator)
+ * therefore proposed an amount the on-chain send would reject.
+ *
+ * The fix populates the balance from `NetworkService.getAccountBalance`, keyed
+ * to the EFFECTIVE transaction network (`selectedAsset?.networkId ??
+ * selectedNetworkId`), stored WITH its (address, networkId) identity, and
+ * validated during render — an unloaded/mismatched record makes native
+ * spendable 0n rather than reintroducing `minBalance = 0`.
+ *
+ * These tests assert the four behaviours the task calls out:
+ *   1. native Max/spendable = balance - fee - minBalance, and an amount equal to
+ *      `balance - fee` is now rejected;
+ *   2. dual-network: Max uses the SELECTED network's minBalance, never the
+ *      cross-network aggregate;
+ *   3. asset-switch across networks recomputes against the new network's MBR
+ *      (and takes the balance term from the validated record, not the older
+ *      assetOptions snapshot);
+ *   4. no stale MBR during load: immediately after an identity change, before
+ *      the fetch resolves, native spendable is 0n and Max is unavailable.
+ *
+ * The balance figures come entirely from a mocked NetworkService — nothing real.
+ */
+
+import React from 'react';
+import { render, fireEvent, act } from '@testing-library/react-native';
+import type { AccountBalance } from '@/types/wallet';
+
+const VOI = 'voi-mainnet';
+const ALGO = 'algorand-mainnet';
+
+// ---------------------------------------------------------------------------
+// Mutable per-test state (all `mock`-prefixed so jest.mock factories may close
+// over them; factory functions read them lazily at call time).
+// ---------------------------------------------------------------------------
+let mockActiveAccount: { id: string; address: string; type?: string } | null;
+let mockCurrentNetwork: string;
+let mockMultiNetworkBalance: unknown;
+let mockRouteParams: Record<string, unknown> | undefined;
+let mockBalances: Record<string, AccountBalance>;
+let mockTokenMappings: unknown[];
+
+const mockGetAccountBalance = jest.fn();
+const mockEstimateTransactionCost = jest.fn();
+
+const mockNetworkConfigs: Record<
+  string,
+  { nativeToken: string; features: { envoi: boolean } }
+> = {
+  [VOI]: { nativeToken: 'VOI', features: { envoi: true } },
+  [ALGO]: { nativeToken: 'ALGO', features: { envoi: false } },
+};
+
+// ---------------------------------------------------------------------------
+// Module mocks
+// ---------------------------------------------------------------------------
+jest.mock('@/services/network', () => ({
+  NetworkService: {
+    getInstance: (networkId: string) => ({
+      getAccountBalance: (address: string) =>
+        mockGetAccountBalance(networkId, address),
+      getAssetInfo: jest.fn(async () => null),
+      getSingleAssetBalance: jest.fn(async () => null),
+      getAlgodClient: () => ({
+        accountInformation: () => ({
+          do: async () => ({ amount: 0, assets: [] }),
+        }),
+        getAssetByID: () => ({ do: async () => ({ params: {} }) }),
+      }),
+    }),
+  },
+}));
+
+jest.mock('@/services/network/config', () => ({
+  getNetworkConfig: (networkId: string) =>
+    mockNetworkConfigs[networkId] ?? mockNetworkConfigs[VOI],
+}));
+
+jest.mock('@/services/transactions', () => ({
+  TransactionService: {
+    estimateTransactionCost: (...args: unknown[]) =>
+      mockEstimateTransactionCost(...args),
+    validateTransaction: jest.fn(async () => []),
+  },
+}));
+
+jest.mock('@/services/token-mapping', () => ({
+  __esModule: true,
+  default: {
+    getCachedMappings: () => mockTokenMappings,
+    getTokenMappings: async () => mockTokenMappings,
+  },
+}));
+
+jest.mock('@/services/secure/keyManager', () => ({
+  SecureKeyManager: {
+    getSigningInfo: jest.fn(async () => null),
+    getLedgerSigningInfo: jest.fn(async () => null),
+  },
+}));
+
+jest.mock('@/services/envoi', () => ({
+  __esModule: true,
+  default: { getInstance: () => ({ searchNames: jest.fn(async () => []) }) },
+}));
+
+jest.mock('@/utils/address', () => ({
+  resolveAddressOrName: jest.fn(async () => ''),
+  isLikelyEnvoiName: () => false,
+  formatAddress: (a: string) => a,
+}));
+
+jest.mock('@/store/walletStore', () => ({
+  useActiveAccount: () => mockActiveAccount,
+  useMultiNetworkBalance: () => ({ balance: mockMultiNetworkBalance }),
+}));
+
+jest.mock('@/store/networkStore', () => ({
+  useCurrentNetwork: () => mockCurrentNetwork,
+  useCurrentNetworkConfig: () => mockNetworkConfigs[mockCurrentNetwork],
+}));
+
+jest.mock('@react-navigation/native', () => ({
+  useRoute: () => ({ params: mockRouteParams }),
+  useNavigation: () => ({
+    navigate: jest.fn(),
+    goBack: jest.fn(),
+    setParams: jest.fn(),
+    dispatch: jest.fn(),
+  }),
+  CommonActions: { navigate: jest.fn() },
+  useFocusEffect: () => {},
+}));
+
+jest.mock('@/hooks/useThemedStyles', () => ({
+  useThemedStyles: () => ({}),
+  useThemeColors: () => ({}),
+}));
+
+jest.mock('@/contexts/ThemeContext', () => ({
+  useTheme: () => ({ theme: require('@/constants/themes').lightTheme }),
+}));
+
+jest.mock('expo-image', () => ({ Image: () => null }));
+
+jest.mock('react-native-safe-area-context', () => ({
+  SafeAreaView: ({ children }: { children: React.ReactNode }) => children,
+  initialWindowMetrics: null,
+}));
+
+jest.mock('@expo/vector-icons', () => ({ Ionicons: () => null }), {
+  virtual: true,
+});
+
+// Passthrough layout wrappers.
+const passthrough = (name: string) => {
+  const mod: Record<string, unknown> = {};
+  mod[name] = ({ children }: { children: React.ReactNode }) => children;
+  return mod;
+};
+jest.mock('@/components/common/NFTBackground', () =>
+  passthrough('NFTBackground')
+);
+jest.mock('@/components/common/KeyboardAwareScrollView', () => ({
+  __esModule: true,
+  default: ({ children }: { children: React.ReactNode }) => children,
+}));
+jest.mock('@/components/common/BlurredContainer', () =>
+  passthrough('BlurredContainer')
+);
+jest.mock('@/components/common/UniversalHeader', () => ({
+  __esModule: true,
+  default: () => null,
+}));
+jest.mock('@/components/common/GlassButton', () => ({
+  GlassButton: () => null,
+}));
+jest.mock('@/components/account/AccountListModal', () => ({
+  __esModule: true,
+  default: () => null,
+}));
+jest.mock('@/components/account/AddAccountModal', () => ({
+  __esModule: true,
+  default: () => null,
+}));
+jest.mock('@/components/account/AccountRecipientModal', () => ({
+  __esModule: true,
+  default: () => null,
+}));
+
+// The real selector renders `options`; the mock exposes one press target per
+// option so a test can switch the selected asset/network exactly as the UI
+// does (onSelect(networkId, assetId), which sets selectedAsset WITHOUT touching
+// selectedNetworkId).
+jest.mock('@/components/send/NetworkAssetSelector', () => {
+  const { View, Text, Pressable } = require('react-native');
+  return {
+    __esModule: true,
+    default: ({
+      options,
+      onSelect,
+      disabled,
+    }: {
+      options: { networkId: string; assetId: number }[];
+      onSelect: (networkId: string, assetId: number) => void;
+      disabled?: boolean;
+    }) => (
+      <View>
+        {options.map((o) => (
+          <Pressable
+            key={`${o.networkId}-${o.assetId}`}
+            testID={`asset-option-${o.networkId}-${o.assetId}`}
+            onPress={() => !disabled && onSelect(o.networkId, o.assetId)}
+          >
+            <Text>{`${o.networkId}:${o.assetId}`}</Text>
+          </Pressable>
+        ))}
+      </View>
+    ),
+  };
+});
+
+import SendScreen from '../SendScreen';
+
+// ---------------------------------------------------------------------------
+// Helpers
+// ---------------------------------------------------------------------------
+const bal = (
+  networkId: string,
+  amount: bigint,
+  minBalance: bigint
+): AccountBalance => ({
+  address: mockActiveAccount?.address ?? 'ADDR',
+  amount,
+  minBalance,
+  assets: [],
+});
+
+/** A multi-network balance carrying a native mapping present on both networks,
+ * so SendScreen builds two asset options (VOI + ALGO native) and renders the
+ * selector. `sourceAmounts` deliberately differs from the NetworkService
+ * figures to prove the spendable BALANCE term comes from the validated record,
+ * not this (older) snapshot. */
+const dualNativeMultiBalance = (sourceAmounts: {
+  voi: bigint;
+  algo: bigint;
+}) => ({
+  minBalance: 0n,
+  assets: [
+    {
+      isMapped: true,
+      mappingId: 'm0',
+      sourceBalances: [
+        {
+          networkId: VOI,
+          balance: {
+            assetId: 0,
+            amount: sourceAmounts.voi,
+            decimals: 6,
+            symbol: 'VOI',
+            name: 'Voi',
+          },
+        },
+        {
+          networkId: ALGO,
+          balance: {
+            assetId: 0,
+            amount: sourceAmounts.algo,
+            decimals: 6,
+            symbol: 'ALGO',
+            name: 'Algo',
+          },
+        },
+      ],
+    },
+  ],
+});
+
+const dualNativeMappings = [
+  {
+    mappingId: 'm0',
+    tokens: [
+      { networkId: VOI, assetId: 0 },
+      { networkId: ALGO, assetId: 0 },
+    ],
+  },
+];
+
+const MAX_LABEL = 'Send maximum spendable amount';
+const AMOUNT_PLACEHOLDER = '0.000000';
+
+function makeDeferred<T>() {
+  let resolve!: (value: T) => void;
+  const promise = new Promise<T>((r) => {
+    resolve = r;
+  });
+  return { promise, resolve };
+}
+
+beforeEach(() => {
+  mockActiveAccount = { id: 'a1', address: 'ADDR_VOI' };
+  mockCurrentNetwork = VOI;
+  mockMultiNetworkBalance = { minBalance: 0n, assets: [] };
+  mockRouteParams = undefined;
+  mockBalances = {};
+  mockTokenMappings = [];
+
+  mockGetAccountBalance.mockReset();
+  mockGetAccountBalance.mockImplementation((networkId: string) =>
+    Promise.resolve(
+      mockBalances[networkId] ?? {
+        address: 'ADDR',
+        amount: 0n,
+        minBalance: 0n,
+        assets: [],
+      }
+    )
+  );
+
+  mockEstimateTransactionCost.mockReset();
+  mockEstimateTransactionCost.mockResolvedValue({ fee: 1000 });
+});
+
+// Flush pending promises/effects (balance fetch, asset options, mappings).
+const settle = () => act(async () => {});
+
+describe('SendScreen native minimum-balance math (TASK-239)', () => {
+  it('subtracts the selected network minBalance from native Max', async () => {
+    // 5 VOI balance, 0.9 VOI reserve, 0.001 VOI fee (from the route param).
+    mockBalances[VOI] = bal(VOI, 5_000_000n, 900_000n);
+    mockRouteParams = { fee: '1000' };
+
+    const screen = render(<SendScreen />);
+    await settle();
+
+    const maxButton = await screen.findByLabelText(MAX_LABEL);
+    fireEvent.press(maxButton);
+
+    // balance - fee - minBalance = 5_000_000 - 1000 - 900_000 = 4_099_000.
+    // Before the fix (minBalance dropped) this would have filled "4.999".
+    const amountInput = screen.getByPlaceholderText(AMOUNT_PLACEHOLDER);
+    expect(amountInput.props.value).toBe('4.099');
+    expect(amountInput.props.value).not.toBe('4.999');
+    await settle();
+  });
+
+  it('rejects a native amount equal to balance - fee (reserve ignored)', async () => {
+    mockBalances[VOI] = bal(VOI, 5_000_000n, 900_000n);
+    mockRouteParams = { fee: '1000' };
+
+    const screen = render(<SendScreen />);
+    await settle();
+    await screen.findByLabelText(MAX_LABEL);
+
+    const amountInput = screen.getByPlaceholderText(AMOUNT_PLACEHOLDER);
+
+    // "4.999" == balance - fee. Spendable is 4.099, so this must error now.
+    // (Pre-fix, spendable == balance - fee, so this was wrongly accepted.)
+    fireEvent.changeText(amountInput, '4.999');
+    expect(screen.queryByText(/exceeds spendable balance/i)).toBeTruthy();
+
+    // The actual spendable amount is accepted.
+    fireEvent.changeText(amountInput, '4.099');
+    expect(screen.queryByText(/exceeds spendable balance/i)).toBeNull();
+    await settle();
+  });
+
+  it('uses only the SELECTED network MBR, never the cross-network aggregate', async () => {
+    // Both networks hold a reserve. A regression that subtracted the aggregate
+    // (multiNetworkBalance.minBalance, a documented cross-network SUM) would
+    // compute a smaller Max.
+    mockBalances[VOI] = bal(VOI, 5_000_000n, 900_000n);
+    mockBalances[ALGO] = bal(ALGO, 3_000_000n, 500_000n);
+    // Aggregate reserve = 0.9 + 0.5 = 1.4 VOI. Present but MUST be ignored.
+    mockMultiNetworkBalance = { minBalance: 1_400_000n, assets: [] };
+
+    const screen = render(<SendScreen />);
+    await settle();
+
+    const maxButton = await screen.findByLabelText(MAX_LABEL);
+    fireEvent.press(maxButton);
+
+    const amountInput = screen.getByPlaceholderText(AMOUNT_PLACEHOLDER);
+    // Correct (VOI-only): 5_000_000 - 0 - 900_000 = 4_100_000 -> "4.1".
+    // Aggregate bug would give 5_000_000 - 1_400_000 = 3_600_000 -> "3.6".
+    expect(amountInput.props.value).toBe('4.1');
+    expect(amountInput.props.value).not.toBe('3.6');
+
+    // The spend network's balance is fetched; the other network's is not summed.
+    const fetchedNetworks = mockGetAccountBalance.mock.calls.map((c) => c[0]);
+    expect(fetchedNetworks).toContain(VOI);
+    expect(fetchedNetworks).not.toContain(ALGO);
+    await settle();
+  });
+
+  it('recomputes Max against network B when an asset on B is selected while selectedNetworkId is A', async () => {
+    // selectedNetworkId stays VOI; selecting the ALGO asset only sets
+    // selectedAsset, so the effective network becomes ALGO.
+    mockBalances[VOI] = bal(VOI, 5_000_000n, 900_000n);
+    mockBalances[ALGO] = bal(ALGO, 3_000_000n, 500_000n);
+    mockMultiNetworkBalance = dualNativeMultiBalance({
+      voi: 5_000_000n,
+      algo: 3_000_000n,
+    });
+    mockTokenMappings = dualNativeMappings;
+
+    const screen = render(<SendScreen />);
+    await settle();
+    // Auto-selected VOI native — wait until its balance has loaded.
+    await screen.findByLabelText(MAX_LABEL);
+
+    // Switch to the ALGO asset (network B) — selectedNetworkId is still VOI.
+    await act(async () => {
+      fireEvent.press(screen.getByTestId(`asset-option-${ALGO}-0`));
+    });
+    await settle();
+
+    // Effective network is now ALGO: 3_000_000 - 500_000 = 2_500_000 -> "2.5",
+    // using ALGO's reserve (0.5), NOT VOI's (0.9). A test keyed to
+    // selectedNetworkId (still VOI) would instead compute VOI's reserve.
+    const maxButton = await screen.findByLabelText(MAX_LABEL);
+    fireEvent.press(maxButton);
+    const amountInput = screen.getByPlaceholderText(AMOUNT_PLACEHOLDER);
+    expect(amountInput.props.value).toBe('2.5');
+    await settle();
+  });
+
+  it('takes the native balance term from the validated record, not the assetOptions snapshot', async () => {
+    // The multi-network snapshot carries a STALE VOI amount (9.0); the fresh
+    // NetworkService record says 5.0. Round-4 of the design requires BOTH the
+    // balance and the reserve to come from the validated record.
+    mockBalances[VOI] = bal(VOI, 5_000_000n, 900_000n);
+    mockMultiNetworkBalance = dualNativeMultiBalance({
+      voi: 9_000_000n,
+      algo: 3_000_000n,
+    });
+    mockTokenMappings = dualNativeMappings;
+
+    const screen = render(<SendScreen />);
+    await settle();
+
+    const maxButton = await screen.findByLabelText(MAX_LABEL);
+    fireEvent.press(maxButton);
+
+    const amountInput = screen.getByPlaceholderText(AMOUNT_PLACEHOLDER);
+    // Record-based: 5_000_000 - 900_000 = 4_100_000 -> "4.1".
+    // Snapshot-based (the bug round-4 closes): 9_000_000 - 900_000 -> "8.1".
+    expect(amountInput.props.value).toBe('4.1');
+    expect(amountInput.props.value).not.toBe('8.1');
+    await settle();
+  });
+
+  it('treats native spendable as 0n (Max unavailable) while the new network balance is loading', async () => {
+    mockMultiNetworkBalance = dualNativeMultiBalance({
+      voi: 5_000_000n,
+      algo: 3_000_000n,
+    });
+    mockTokenMappings = dualNativeMappings;
+
+    // Control resolution per network so we can inspect the render BETWEEN an
+    // identity change and the fetch resolving.
+    const voiD = makeDeferred<AccountBalance>();
+    const algoD = makeDeferred<AccountBalance>();
+    mockGetAccountBalance.mockImplementation((networkId: string) =>
+      networkId === VOI ? voiD.promise : algoD.promise
+    );
+
+    const screen = render(<SendScreen />);
+    await settle();
+
+    // Resolve VOI: Max becomes available for the VOI reserve.
+    await act(async () => {
+      voiD.resolve(bal(VOI, 5_000_000n, 900_000n));
+    });
+    expect(screen.getByLabelText(MAX_LABEL)).toBeTruthy();
+
+    // Switch to ALGO but leave its fetch pending.
+    await act(async () => {
+      fireEvent.press(screen.getByTestId(`asset-option-${ALGO}-0`));
+    });
+
+    // The identity now mismatches the (VOI) record: native spendable is 0n, so
+    // Max is gone — NOT a figure derived from VOI's reserve.
+    expect(screen.queryByLabelText(MAX_LABEL)).toBeNull();
+
+    // And the validator rejects any positive amount while spendable is 0n.
+    const amountInput = screen.getByPlaceholderText(AMOUNT_PLACEHOLDER);
+    fireEvent.changeText(amountInput, '0.1');
+    expect(screen.queryByText(/exceeds spendable balance/i)).toBeTruthy();
+
+    // Once ALGO resolves, Max returns and the amount is within spendable again.
+    await act(async () => {
+      algoD.resolve(bal(ALGO, 3_000_000n, 500_000n));
+    });
+    expect(screen.getByLabelText(MAX_LABEL)).toBeTruthy();
+    expect(screen.queryByText(/exceeds spendable balance/i)).toBeNull();
+    await settle();
+  });
+});


### PR DESCRIPTION
## The bug

`SendScreen`'s `accountBalance` state was declared (`useState<any>(null)`) but **`setAccountBalance` was called nowhere**, so `accountBalance` was permanently `null`. `getSpendableBase()` read `BigInt(accountBalance?.minBalance ?? 0)` — so **minBal was always `0n`** and the Algorand minimum-balance requirement was silently dropped from native spendable/Max math. The wallet's own Max button proposed an amount its own validator (and the on-chain send) would reject.

## The design (four consensus amendments, all applied)

- **Populate the existing state** from `NetworkService.getInstance(<effectiveNetworkId>).getAccountBalance(<address>)` — the single-network `AccountBalance`, not the cross-network aggregate from `useMultiNetworkBalance` (that field is a documented sum across networks; subtracting it would be a different money bug).
- **Effective-network keying.** The network the screen sends on is `selectedAsset?.networkId ?? selectedNetworkId` (computed **once** and shared with the network-config memo and fee estimation). `NetworkAssetSelector.onSelect` sets `selectedAsset` without touching `selectedNetworkId`, so keying MBR to `selectedNetworkId` alone would subtract the wrong network's reserve when an asset on the other network is selected.
- **Identity validation during render.** The balance is stored with the `(address, networkId)` it was loaded for (`{ address, networkId, balance }`). A derived `accountBalance` is non-null **only** when the stored identity equals the current `(address, effective network)`. This is a render-time check, not a `useEffect` reset — so no stale reserve survives even a single render after the identity changes.
- **Unloaded/mismatched ⇒ native spendable is `0n`, never `minBalance = 0`.** Max renders only when `getSpendableBase() > 0n`, so it disappears while loading, and the validator rejects positive native amounts — rather than computing a figure that is wrong in the user's favor.
- **Both terms from the validated record.** `native spendable = record.balance.amount - fee - record.balance.minBalance` — the balance is no longer taken from the older `assetOptions` snapshot.
- Typed `AccountBalance | null` (imported from `@/types/wallet`) instead of `any`. Follows the `HomeScreen` async-load pattern: the target identity is held in a ref and re-checked after every await.

The `services/transactions/index.ts` bigint MBR re-check (defense-in-depth backstop) is **untouched**. Transaction construction/signing is untouched.

## Tests (first SendScreen RTL suite — 6 tests)

- native Max/spendable = `balance - fee - minBalance`;
- a native amount equal to `balance - fee` is now **rejected** (was wrongly accepted);
- **dual-network regression (mandatory):** Max uses the **selected** network's MBR only, never the cross-network aggregate — a test that would pass on the aggregate does not pass here;
- **asset-switch across networks:** selecting an asset on network B while `selectedNetworkId` is still A → Max uses **B's** MBR;
- balance term comes from the validated record, not the stale `assetOptions` snapshot;
- **no stale MBR during load:** in the render immediately after an identity change, before the fetch resolves, native spendable is `0n` and Max is unavailable.

## Ratchet

Clears the `setAccountBalance` no-unused-vars survivor: **no-unused-vars 9 → 8**, total **260 → 259**. `lint-baseline.json` regenerated and `--max-warnings` lowered to 259 in this PR. No other rule increased (verified — including `preserve-manual-memoization` under React Compiler, unchanged at 25).

## Gates

- `npm run typecheck` clean
- `npm run lint` exit 0 at the new 259 ceiling
- `npm test -- --ci`: **98 suites / 1542 tests** green (was 97/1536 + 6 new)
- `npm run lint:baseline:check` passes
- Codex money-math review: **CLEAN** (round 1)

## Device QA (batched pre-release per HT-218, not a merge gate)

On an account with several opt-ins: tap **Max** then **Send** — *"Transaction would violate minimum balance requirement"* must no longer appear.

https://claude.ai/code/session_01AL4EmUSYAiVXEstBgKqDmv