### PR TITLE
fix(rekey): restore inert isProcessing guards during in-flight rekey (TASK-252)

### DIFF
--- a/lint-baseline.json
+++ b/lint-baseline.json
@@ -2,12 +2,12 @@
   "$comment": "Committed ESLint baseline for the `npm run lint` ratchet (PLAN-229 DR-2). Regenerate with `npm run lint:baseline`; verify with `npm run lint:baseline:check`. The `lint` script's --max-warnings MUST equal totals.warnings. Lower it in the same PR that clears the warnings. It never goes up.",
   "totals": {
     "errors": 0,
-    "warnings": 259,
-    "filesLinted": 435,
+    "warnings": 258,
+    "filesLinted": 436,
     "filesWithFindings": 92
   },
   "rules": {
-    "@typescript-eslint/no-unused-vars": 8,
+    "@typescript-eslint/no-unused-vars": 7,
     "import/no-named-as-default": 37,
     "react-hooks/exhaustive-deps": 24,
     "react-hooks/immutability": 97,
@@ -505,9 +505,8 @@
     },
     "src/screens/wallet/RekeyAccountScreen.tsx": {
       "errors": 0,
-      "warnings": 4,
+      "warnings": 3,
       "rules": {
-        "@typescript-eslint/no-unused-vars": 1,
         "import/no-named-as-default": 1,
         "react-hooks/set-state-in-effect": 2
       }

--- a/package.json
+++ b/package.json
@@ -7,7 +7,7 @@
     "android": "expo run:android",
     "ios": "expo run:ios",
     "web": "expo start --web",
-    "lint": "eslint src/ --max-warnings 259",
+    "lint": "eslint src/ --max-warnings 258",
     "lint:fix": "eslint src/ --fix",
     "lint:baseline": "node scripts/lint-baseline.mjs --write",
     "lint:baseline:check": "node scripts/lint-baseline.mjs --check",

--- a/src/screens/wallet/RekeyAccountScreen.tsx
+++ b/src/screens/wallet/RekeyAccountScreen.tsx
@@ -550,137 +550,164 @@ export default function RekeyAccountScreen() {
     };
 
     setCurrentRequest(request);
+    // Mark the rekey as in-flight BEFORE the auth/signing modal opens. The
+    // signing window is [here .. handleAuthComplete/handleAuthCancel], and the
+    // guards below (network-selector `disabled`, Ledger picker `isBusy`) exist
+    // to lock that window — setting it in handleAuthComplete would flip it true
+    // only after signing already finished, leaving both guards inert.
+    setIsProcessing(true);
     setShowAuthModal(true);
   };
 
   const handleAuthComplete = async (success: boolean, result?: any) => {
-    setShowAuthModal(false);
-    setCurrentRequest(null);
+    // Wrap the whole completion path so isProcessing is cleared on EVERY exit
+    // (success, each metadata-update catch, the failure Alert, or any throw
+    // between them). A permanently-true flag would wedge the screen.
+    try {
+      setShowAuthModal(false);
+      setCurrentRequest(null);
 
-    if (success && result?.transactionId) {
-      // Apply Ledger metadata update if needed
-      if (rekeyFlow === 'ledger' && selectedLedgerAccount && sourceAccount) {
-        try {
-          await applyLedgerMetadataUpdate(sourceAccount, selectedLedgerAccount);
-        } catch (metadataError) {
-          console.warn(
-            'Failed to update Ledger rekey metadata:',
-            metadataError
-          );
-        }
-      }
-
-      // Apply Airgap metadata update if needed
-      if (rekeyFlow === 'airgap' && selectedAirgapAccount && sourceAccount) {
-        try {
-          await applyAirgapMetadataUpdate(sourceAccount, selectedAirgapAccount);
-        } catch (metadataError) {
-          console.warn(
-            'Failed to update airgap rekey metadata:',
-            metadataError
-          );
-        }
-      }
-
-      // Apply reverse rekey metadata update - convert back to standard account
-      if (rekeyFlow === 'reverse' && sourceAccount) {
-        try {
-          // Convert the rekeyed account back to standard
-          const rekeyInfo = { isRekeyed: false, authAddress: undefined };
-          const updatedAccount = await rekeyManager.updateAccountWithRekeyInfo(
-            sourceAccount,
-            rekeyInfo,
-            wallet!
-          );
-
-          if (updatedAccount.type !== sourceAccount.type) {
-            await MultiAccountWalletService.updateAccountMetadata(
-              updatedAccount
-            );
-
-            const currentState = useWalletStore.getState();
-            if (currentState.wallet) {
-              useWalletStore.setState({
-                wallet: {
-                  ...currentState.wallet,
-                  accounts: currentState.wallet.accounts.map((candidate) =>
-                    candidate.id === updatedAccount.id
-                      ? updatedAccount
-                      : candidate
-                  ),
-                },
-              });
-            }
-          }
-        } catch (metadataError) {
-          console.warn(
-            'Failed to update reverse rekey metadata:',
-            metadataError
-          );
-        }
-      }
-
-      // Refresh account data
-      if (sourceAccount) {
-        setTimeout(async () => {
+      if (success && result?.transactionId) {
+        // Apply Ledger metadata update if needed
+        if (rekeyFlow === 'ledger' && selectedLedgerAccount && sourceAccount) {
           try {
-            await loadAccountBalance(sourceAccount.id, true); // Force refresh after rekey
-          } catch (refreshError) {
-            console.warn('Failed to refresh account data:', refreshError);
+            await applyLedgerMetadataUpdate(
+              sourceAccount,
+              selectedLedgerAccount
+            );
+          } catch (metadataError) {
+            console.warn(
+              'Failed to update Ledger rekey metadata:',
+              metadataError
+            );
           }
-        }, 3000);
-      }
-
-      const title =
-        rekeyFlow === 'reverse'
-          ? 'Rekey Removed'
-          : rekeyFlow === 'ledger'
-            ? 'Ledger Rekey Successful'
-            : rekeyFlow === 'airgap'
-              ? 'Airgap Rekey Successful'
-              : 'Rekey Successful';
-
-      const message =
-        rekeyFlow === 'reverse'
-          ? `Account rekey has been removed successfully!\n\nYou now have full control of this account again.\n\nTransaction ID: ${result.transactionId.slice(0, 8)}...`
-          : rekeyFlow === 'ledger'
-            ? `Account has been rekeyed to your Ledger device successfully!\n\nTransaction ID: ${result.transactionId.slice(0, 8)}...`
-            : rekeyFlow === 'airgap'
-              ? `Account has been rekeyed to your airgap signer successfully!\n\nFuture transactions will require signing via QR code.\n\nTransaction ID: ${result.transactionId.slice(0, 8)}...`
-              : `Account has been rekeyed successfully!\n\nTransaction ID: ${result.transactionId.slice(0, 8)}...`;
-
-      Alert.alert(title, message, [
-        {
-          text: 'OK',
-          onPress: () => navigation.goBack(),
-        },
-      ]);
-    } else {
-      // Handle error
-      let errorMessage =
-        result instanceof Error ? result.message : 'Unknown error occurred';
-
-      if (rekeyFlow === 'reverse') {
-        if (errorMessage.includes('auth')) {
-          errorMessage +=
-            '\n\nTip: Make sure you have signing authority for this account.';
-        } else if (errorMessage.includes('insufficient funds')) {
-          errorMessage +=
-            '\n\nTip: You need a small amount of VOI to pay for the transaction fee.';
         }
-      }
 
-      Alert.alert(
-        rekeyFlow === 'reverse' ? 'Remove Rekey Failed' : 'Rekey Failed',
-        errorMessage
-      );
+        // Apply Airgap metadata update if needed
+        if (rekeyFlow === 'airgap' && selectedAirgapAccount && sourceAccount) {
+          try {
+            await applyAirgapMetadataUpdate(
+              sourceAccount,
+              selectedAirgapAccount
+            );
+          } catch (metadataError) {
+            console.warn(
+              'Failed to update airgap rekey metadata:',
+              metadataError
+            );
+          }
+        }
+
+        // Apply reverse rekey metadata update - convert back to standard account
+        if (rekeyFlow === 'reverse' && sourceAccount) {
+          try {
+            // Convert the rekeyed account back to standard
+            const rekeyInfo = { isRekeyed: false, authAddress: undefined };
+            const updatedAccount =
+              await rekeyManager.updateAccountWithRekeyInfo(
+                sourceAccount,
+                rekeyInfo,
+                wallet!
+              );
+
+            if (updatedAccount.type !== sourceAccount.type) {
+              await MultiAccountWalletService.updateAccountMetadata(
+                updatedAccount
+              );
+
+              const currentState = useWalletStore.getState();
+              if (currentState.wallet) {
+                useWalletStore.setState({
+                  wallet: {
+                    ...currentState.wallet,
+                    accounts: currentState.wallet.accounts.map((candidate) =>
+                      candidate.id === updatedAccount.id
+                        ? updatedAccount
+                        : candidate
+                    ),
+                  },
+                });
+              }
+            }
+          } catch (metadataError) {
+            console.warn(
+              'Failed to update reverse rekey metadata:',
+              metadataError
+            );
+          }
+        }
+
+        // Refresh account data
+        if (sourceAccount) {
+          setTimeout(async () => {
+            try {
+              await loadAccountBalance(sourceAccount.id, true); // Force refresh after rekey
+            } catch (refreshError) {
+              console.warn('Failed to refresh account data:', refreshError);
+            }
+          }, 3000);
+        }
+
+        const title =
+          rekeyFlow === 'reverse'
+            ? 'Rekey Removed'
+            : rekeyFlow === 'ledger'
+              ? 'Ledger Rekey Successful'
+              : rekeyFlow === 'airgap'
+                ? 'Airgap Rekey Successful'
+                : 'Rekey Successful';
+
+        const message =
+          rekeyFlow === 'reverse'
+            ? `Account rekey has been removed successfully!\n\nYou now have full control of this account again.\n\nTransaction ID: ${result.transactionId.slice(0, 8)}...`
+            : rekeyFlow === 'ledger'
+              ? `Account has been rekeyed to your Ledger device successfully!\n\nTransaction ID: ${result.transactionId.slice(0, 8)}...`
+              : rekeyFlow === 'airgap'
+                ? `Account has been rekeyed to your airgap signer successfully!\n\nFuture transactions will require signing via QR code.\n\nTransaction ID: ${result.transactionId.slice(0, 8)}...`
+                : `Account has been rekeyed successfully!\n\nTransaction ID: ${result.transactionId.slice(0, 8)}...`;
+
+        Alert.alert(title, message, [
+          {
+            text: 'OK',
+            onPress: () => navigation.goBack(),
+          },
+        ]);
+      } else {
+        // Handle error
+        let errorMessage =
+          result instanceof Error ? result.message : 'Unknown error occurred';
+
+        if (rekeyFlow === 'reverse') {
+          if (errorMessage.includes('auth')) {
+            errorMessage +=
+              '\n\nTip: Make sure you have signing authority for this account.';
+          } else if (errorMessage.includes('insufficient funds')) {
+            errorMessage +=
+              '\n\nTip: You need a small amount of VOI to pay for the transaction fee.';
+          }
+        }
+
+        Alert.alert(
+          rekeyFlow === 'reverse' ? 'Remove Rekey Failed' : 'Rekey Failed',
+          errorMessage
+        );
+      }
+    } finally {
+      setIsProcessing(false);
     }
   };
 
   const handleAuthCancel = () => {
-    setShowAuthModal(false);
-    authController.resetAfterDismiss();
-    setCurrentRequest(null);
+    // Dismissal is an exit from the in-flight window too. Clear the guard in a
+    // finally so a throw from resetAfterDismiss (the modal is already hidden by
+    // then) can't leave isProcessing stuck true and wedge the screen.
+    try {
+      setShowAuthModal(false);
+      authController.resetAfterDismiss();
+      setCurrentRequest(null);
+    } finally {
+      setIsProcessing(false);
+    }
   };
 
   if (!sourceAccount) {

--- a/src/screens/wallet/__tests__/RekeyAccountScreen.test.tsx
+++ b/src/screens/wallet/__tests__/RekeyAccountScreen.test.tsx
@@ -1,0 +1,301 @@
+/**
+ * TASK-252 — the `isProcessing` guard on RekeyAccountScreen.
+ *
+ * The bug: `setIsProcessing` was never called, so `isProcessing` was frozen at
+ * `false` and the two guards written against it were inert — during an in-flight
+ * rekey (a change of signing authority) a user could still switch the target
+ * network out from under the operation via the network selector (`disabled=
+ * {isProcessing}`), and the Ledger picker never entered its busy state.
+ *
+ * The fix sets `isProcessing` true in `handleStartRekey` BEFORE the auth/signing
+ * modal opens — the modal-open span IS the in-flight signing window — and clears
+ * it on every exit: a top-level `try/finally` in `handleAuthComplete` (success,
+ * every metadata-update catch, the failure Alert, or any throw) AND in
+ * `handleAuthCancel`. A permanently-true flag would wedge the screen, so these
+ * tests pin both directions: locked while the modal is open, released after
+ * success, after error, and after cancellation.
+ *
+ * This is a guard-state test only — the rekey request, its submission, and
+ * signing-authority resolution are exercised by the service-layer rekey suites
+ * and are deliberately mocked out here.
+ */
+
+import React from 'react';
+import { render, fireEvent, act, waitFor } from '@testing-library/react-native';
+import { AccountType } from '@/types/wallet';
+
+// ---------------------------------------------------------------------------
+// Fixtures (mock-prefixed so jest.mock factories may close over them).
+// ---------------------------------------------------------------------------
+const mockSourceAccount = {
+  id: 'src',
+  address: 'SOURCE_ADDR',
+  label: 'Source Account',
+  type: AccountType.STANDARD,
+};
+const mockTargetAccount = {
+  id: 'tgt',
+  address: 'TARGET_ADDR',
+  label: 'Target Account',
+  type: AccountType.STANDARD,
+};
+
+const mockLoadAccountBalance = jest.fn(async () => {});
+const mockWalletState = {
+  wallet: { accounts: [mockSourceAccount, mockTargetAccount] },
+  loadAccountBalance: mockLoadAccountBalance,
+};
+
+function mockUseWalletStore(selector: (state: unknown) => unknown) {
+  return selector(mockWalletState);
+}
+mockUseWalletStore.getState = () => mockWalletState;
+mockUseWalletStore.setState = jest.fn();
+
+// ---------------------------------------------------------------------------
+// Module mocks
+// ---------------------------------------------------------------------------
+jest.mock('@/store/walletStore', () => ({
+  useWalletStore: mockUseWalletStore,
+}));
+
+jest.mock('@/services/network', () => ({
+  NetworkService: {
+    getInstance: () => ({
+      getAccountRekeyInfo: jest.fn(async () => ({
+        isRekeyed: false,
+        authAddress: undefined,
+      })),
+    }),
+  },
+}));
+
+jest.mock('@/services/transactions', () => ({
+  TransactionService: {
+    // No validation errors → the proceed button is enabled and handleProceed
+    // reaches its confirmation Alert.
+    validateRekeyTransaction: jest.fn(async () => []),
+  },
+}));
+
+jest.mock('@/services/wallet', () => ({
+  MultiAccountWalletService: { updateAccountMetadata: jest.fn(async () => {}) },
+}));
+
+jest.mock('@/services/wallet/rekeyManager', () => ({
+  __esModule: true,
+  default: { updateAccountWithRekeyInfo: jest.fn() },
+}));
+
+jest.mock('@/services/auth/transactionAuthController', () => ({
+  useTransactionAuthController: () => ({
+    cleanup: jest.fn(),
+    resetAfterDismiss: jest.fn(),
+  }),
+}));
+
+jest.mock('@/utils/address', () => ({
+  formatAddress: (address: string) => address,
+}));
+
+jest.mock('@/contexts/ThemeContext', () => ({
+  useTheme: () => ({ theme: require('@/constants/themes').lightTheme }),
+}));
+
+const mockNavigation = {
+  goBack: jest.fn(),
+  getParent: () => ({ navigate: jest.fn() }),
+};
+jest.mock('@react-navigation/native', () => ({
+  useRoute: () => ({ params: { accountId: 'src' } }),
+  useNavigation: () => mockNavigation,
+}));
+
+jest.mock('@expo/vector-icons', () => ({ Ionicons: () => null }), {
+  virtual: true,
+});
+
+jest.mock('react-native-safe-area-context', () => ({
+  SafeAreaView: ({ children }: { children: React.ReactNode }) => children,
+  initialWindowMetrics: null,
+}));
+
+jest.mock('@/components/common/UniversalHeader', () => ({
+  __esModule: true,
+  default: () => null,
+}));
+jest.mock('@/components/account/AccountAvatar', () => ({
+  __esModule: true,
+  default: () => null,
+}));
+jest.mock('@/components/ledger/RekeyToLedger', () => ({
+  __esModule: true,
+  default: () => null,
+}));
+jest.mock('@/components/rekey/AirgapVerificationFlow', () => ({
+  __esModule: true,
+  default: () => null,
+}));
+
+// The real auth modal drives native signing; here it just exposes its
+// visibility plus one press target per exit path so a test can complete or
+// cancel exactly as the screen's callbacks expect.
+jest.mock('@/components/UnifiedTransactionAuthModal', () => {
+  const { View, Text, Pressable } = require('react-native');
+  return {
+    __esModule: true,
+    default: ({
+      visible,
+      onComplete,
+      onCancel,
+    }: {
+      visible: boolean;
+      onComplete: (success: boolean, result?: unknown) => void;
+      onCancel: () => void;
+    }) =>
+      visible ? (
+        <View>
+          <Text testID="auth-modal-open">open</Text>
+          <Pressable
+            testID="auth-complete-success"
+            onPress={() => onComplete(true, { transactionId: 'abcdef1234' })}
+          >
+            <Text>ok</Text>
+          </Pressable>
+          <Pressable
+            testID="auth-complete-error"
+            onPress={() => onComplete(false, new Error('signing failed'))}
+          >
+            <Text>err</Text>
+          </Pressable>
+          <Pressable testID="auth-cancel" onPress={() => onCancel()}>
+            <Text>cancel</Text>
+          </Pressable>
+        </View>
+      ) : null,
+  };
+});
+
+import { Alert } from 'react-native';
+import RekeyAccountScreen from '../RekeyAccountScreen';
+
+// ---------------------------------------------------------------------------
+// Helpers
+// ---------------------------------------------------------------------------
+const VOI_NETWORK = 'Voi Network';
+const ALGO_NETWORK = 'Algorand';
+
+/** Flush pending effects (rekey-info fetch, async validation). */
+const settle = () => act(async () => {});
+
+/** Invoke a button on the most recent Alert.alert call, as the UI would. */
+function pressAlertButton(label: string) {
+  const spy = Alert.alert as unknown as jest.Mock;
+  const calls = spy.mock.calls;
+  const buttons = calls[calls.length - 1][2] as {
+    text: string;
+    onPress?: () => void;
+  }[];
+  const button = buttons.find((b) => b.text === label);
+  expect(button).toBeDefined();
+  act(() => {
+    button!.onPress?.();
+  });
+}
+
+/**
+ * Select the target account and confirm through to the auth modal, leaving the
+ * screen in its in-flight state (modal open, isProcessing true).
+ */
+async function startRekeyToInFlight(screen: ReturnType<typeof render>) {
+  fireEvent.press(screen.getByText('Target Account'));
+  // Async validation must resolve (to []) before the proceed button enables.
+  await settle();
+  await waitFor(() => expect(screen.getByText('Rekey Account')).toBeEnabled());
+
+  fireEvent.press(screen.getByText('Rekey Account'));
+  // handleProceed shows the "Confirm Rekey Operation" alert; confirming it is
+  // what calls handleStartRekey → setIsProcessing(true) + opens the modal.
+  pressAlertButton('Continue');
+  expect(screen.getByTestId('auth-modal-open')).toBeTruthy();
+}
+
+beforeEach(() => {
+  jest.spyOn(Alert, 'alert').mockImplementation(() => {});
+});
+
+afterEach(() => {
+  jest.restoreAllMocks();
+});
+
+describe('RekeyAccountScreen — isProcessing guard (TASK-252)', () => {
+  it('leaves the network selector enabled before a rekey is started', async () => {
+    const screen = render(<RekeyAccountScreen />);
+    await settle();
+
+    expect(screen.getByText(VOI_NETWORK)).toBeEnabled();
+    expect(screen.getByText(ALGO_NETWORK)).toBeEnabled();
+  });
+
+  it('disables the network selector while a rekey is in flight and re-enables it after completion', async () => {
+    const screen = render(<RekeyAccountScreen />);
+    await settle();
+
+    await startRekeyToInFlight(screen);
+
+    // In-flight: the user must not be able to switch the target network mid-sign.
+    expect(screen.getByText(VOI_NETWORK)).toBeDisabled();
+    expect(screen.getByText(ALGO_NETWORK)).toBeDisabled();
+
+    // Signing completes (success path) — the finally releases the guard. The
+    // success branch schedules a 3s balance refresh; catch it under fake timers
+    // and drop it so nothing leaks past the test.
+    jest.useFakeTimers();
+    try {
+      await act(async () => {
+        fireEvent.press(screen.getByTestId('auth-complete-success'));
+      });
+      jest.clearAllTimers();
+    } finally {
+      jest.useRealTimers();
+    }
+
+    expect(screen.queryByTestId('auth-modal-open')).toBeNull();
+    expect(screen.getByText(VOI_NETWORK)).toBeEnabled();
+    expect(screen.getByText(ALGO_NETWORK)).toBeEnabled();
+  });
+
+  it('re-enables the network selector after a failed completion', async () => {
+    const screen = render(<RekeyAccountScreen />);
+    await settle();
+
+    await startRekeyToInFlight(screen);
+    expect(screen.getByText(ALGO_NETWORK)).toBeDisabled();
+
+    // The error branch of handleAuthComplete still runs through the finally.
+    await act(async () => {
+      fireEvent.press(screen.getByTestId('auth-complete-error'));
+    });
+
+    expect(screen.getByText(VOI_NETWORK)).toBeEnabled();
+    expect(screen.getByText(ALGO_NETWORK)).toBeEnabled();
+  });
+
+  it('re-enables the network selector after the auth modal is cancelled', async () => {
+    const screen = render(<RekeyAccountScreen />);
+    await settle();
+
+    await startRekeyToInFlight(screen);
+    expect(screen.getByText(ALGO_NETWORK)).toBeDisabled();
+
+    // Dismissal is an exit too — a permanently-true flag here would wedge the
+    // screen, which is strictly worse than the original inert guard.
+    await act(async () => {
+      fireEvent.press(screen.getByTestId('auth-cancel'));
+    });
+
+    expect(screen.queryByTestId('auth-modal-open')).toBeNull();
+    expect(screen.getByText(VOI_NETWORK)).toBeEnabled();
+    expect(screen.getByText(ALGO_NETWORK)).toBeEnabled();
+  });
+});


### PR DESCRIPTION
## What & why

`RekeyAccountScreen` declared `isProcessing` state but **never called `setIsProcessing`**, so it was frozen at `false` and both consumers were inert on a screen that changes account signing authority:

- `disabled={isProcessing}` on the **network-selector** button — a user could switch the target network mid-rekey.
- `isBusy={isProcessing}` on the **Ledger account picker** — it never entered its busy state.

## The fix (guard restoration only)

The in-flight signing window is the span the auth modal is open — between `handleStartRekey` opening it and `handleAuthComplete`/`handleAuthCancel` firing. So:

- **Set `setIsProcessing(true)` in `handleStartRekey` BEFORE `setShowAuthModal(true)`.** Setting it in `handleAuthComplete` (which runs *after* signing) would flip it true only once signing was already done, leaving both guards inert during the exact window they protect.
- **Clear it on every exit via `try/finally`:** `handleAuthComplete`'s body is wrapped so success, each metadata-update catch, the failure Alert, and any throw between them all clear it. `handleAuthCancel` is likewise wrapped in `try/finally` so a throw from `resetAfterDismiss` (modal already hidden by then) can't leave the flag stuck true. A permanently-true `isProcessing` would wedge the screen — strictly worse than the original inert guard — so both directions are guaranteed.

**Untouched:** the rekey request construction, its submission / auth-modal wiring, `rekeyManager`, and signing-authority resolution are unchanged — only `setIsProcessing` calls plus the enclosing `try/finally` were added. Confirmed by Codex review (**CLEAN**).

## Tests

New `src/screens/wallet/__tests__/RekeyAccountScreen.test.tsx` (follows the existing screen-test patterns):
- network selector **enabled** before a rekey starts;
- **disabled** while the auth modal is open (in-flight);
- **re-enabled** after successful completion, after a failed completion, and after cancellation.

Existing `services/**/__tests__` rekey suites pass unmodified. Full suite: **99 suites / 1546 tests** green.

## Ratchet (DR-9)

- `@typescript-eslint/no-unused-vars` **8 → 7** (clears the `setIsProcessing` survivor).
- `--max-warnings` **259 → 258**; `lint-baseline.json` regenerated in this PR; `lint:baseline:check` passes. No other rule changed.

## Gates

`typecheck` clean · `lint` exit 0 (258 warnings, 0 errors) · `test --ci` green · `lint:baseline:check` OK · Codex **CLEAN**.

## Device QA (batched pre-release per HT-218)

Run one real rekey and confirm: the network selector locks during signing, and the screen is **not wedged** afterward (selector re-enables on success and on cancel).

https://claude.ai/code/session_01AL4EmUSYAiVXEstBgKqDmv