### PR TITLE
fix(secrets): drop duplicate in-state recovery phrase; persist imported account notes (TASK-244)

### DIFF
--- a/lint-baseline.json
+++ b/lint-baseline.json
@@ -2,12 +2,12 @@
   "$comment": "Committed ESLint baseline for the `npm run lint` ratchet (PLAN-229 DR-2). Regenerate with `npm run lint:baseline`; verify with `npm run lint:baseline:check`. The `lint` script's --max-warnings MUST equal totals.warnings. Lower it in the same PR that clears the warnings. It never goes up.",
   "totals": {
     "errors": 0,
-    "warnings": 258,
-    "filesLinted": 436,
-    "filesWithFindings": 92
+    "warnings": 256,
+    "filesLinted": 437,
+    "filesWithFindings": 91
   },
   "rules": {
-    "@typescript-eslint/no-unused-vars": 7,
+    "@typescript-eslint/no-unused-vars": 5,
     "import/no-named-as-default": 37,
     "react-hooks/exhaustive-deps": 24,
     "react-hooks/immutability": 97,
@@ -373,9 +373,8 @@
     },
     "src/screens/settings/ShowRecoveryPhraseScreen.tsx": {
       "errors": 0,
-      "warnings": 2,
+      "warnings": 1,
       "rules": {
-        "@typescript-eslint/no-unused-vars": 1,
         "react-hooks/set-state-in-effect": 1
       }
     },
@@ -640,13 +639,6 @@
       "warnings": 1,
       "rules": {
         "import/no-named-as-default": 1
-      }
-    },
-    "src/services/wallet/index.ts": {
-      "errors": 0,
-      "warnings": 1,
-      "rules": {
-        "@typescript-eslint/no-unused-vars": 1
       }
     },
     "src/services/wallet/rekeyManager.ts": {

--- a/package.json
+++ b/package.json
@@ -7,7 +7,7 @@
     "android": "expo run:android",
     "ios": "expo run:ios",
     "web": "expo start --web",
-    "lint": "eslint src/ --max-warnings 258",
+    "lint": "eslint src/ --max-warnings 256",
     "lint:fix": "eslint src/ --fix",
     "lint:baseline": "node scripts/lint-baseline.mjs --write",
     "lint:baseline:check": "node scripts/lint-baseline.mjs --check",

--- a/src/screens/settings/ShowRecoveryPhraseScreen.tsx
+++ b/src/screens/settings/ShowRecoveryPhraseScreen.tsx
@@ -44,7 +44,6 @@ export default function ShowRecoveryPhraseScreen() {
   const targetAddress = accountAddress ?? activeAccount?.address;
 
   const [mnemonic, setMnemonic] = useState<string>('');
-  const [mnemonicWords, setMnemonicWords] = useState<string[]>([]);
   const [isLoading, setIsLoading] = useState(false);
   const [isBlurred, setIsBlurred] = useState(true);
   const [hasCopied, setHasCopied] = useState(false);
@@ -70,7 +69,6 @@ export default function ShowRecoveryPhraseScreen() {
       const recoveredMnemonic =
         await SecureKeyManager.getMnemonic(targetAddress);
       setMnemonic(recoveredMnemonic);
-      setMnemonicWords(recoveredMnemonic.split(' '));
     } catch (error) {
       console.error('Failed to load mnemonic:', error);
 
@@ -203,7 +201,6 @@ export default function ShowRecoveryPhraseScreen() {
 
       // Clear sensitive data when component unmounts
       setMnemonic('');
-      setMnemonicWords([]);
 
       // If the recovery phrase is still sitting in the clipboard, wipe it now
       // rather than waiting out the 60s timer (and cancel that timer).

--- a/src/services/wallet/__tests__/importAuthAccount.test.ts
+++ b/src/services/wallet/__tests__/importAuthAccount.test.ts
@@ -1,0 +1,114 @@
+// Unit tests for TASK-244 (part 2): MultiAccountWalletService.importAuthAccount
+// must PERSIST the caller-supplied `notes` field rather than silently dropping
+// it. Prior to this fix `notes` was destructured from the request and never
+// written into the account metadata, so caller-supplied notes vanished with no
+// error and no warning.
+//
+// SECURITY / DR-3: every Algorand address used here is REAL, deterministically
+// derived through algosdk from a throwaway fixture seed (`makeAccount`). No
+// fabricated address or key material is used, and none is logged. `notes` is
+// plain user-supplied metadata — not secret material.
+//
+// The heavy/native leaves are module-mocked (the Ledger transport pulls in
+// untranspilable native ESM; the network + secure-storage modules touch native
+// storage), mirroring the pattern in importFromPrivateKey.test.ts. The wallet
+// mutation helpers (findAccountByAddress / addAccountToWallet) are spied so the
+// test exercises the real importAuthAccount body without touching persistence.
+
+jest.mock('@/services/ledger/transport', () => ({
+  ledgerTransportService: {},
+}));
+jest.mock('@/services/ledger/algorand', () => ({
+  ledgerAlgorandService: {},
+}));
+jest.mock('@/services/network', () => ({
+  NetworkService: {},
+}));
+jest.mock('../../secure/AccountSecureStorage', () => ({
+  AccountSecureStorage: {
+    getResetGeneration: jest.fn(() => 0),
+  },
+}));
+
+import { makeAccount } from '@/__tests__/fixtures/algorand';
+import {
+  AccountType,
+  ImportAuthAccountRequest,
+  NetworkAuthAccount,
+  RekeyedAccountMetadata,
+} from '@/types/wallet';
+import { NetworkId } from '@/types/network';
+import { MultiAccountWalletService } from '../index';
+
+// Real, deterministic accounts: the account being imported and the (Ledger)
+// address that holds signing authority over it.
+const ACCOUNT = makeAccount('import-auth-account:rekeyed');
+const AUTH = makeAccount('import-auth-account:authority');
+
+function makeNetworkAuthAccount(): NetworkAuthAccount {
+  return {
+    address: ACCOUNT.addr,
+    authAddress: AUTH.addr,
+    networkId: NetworkId.VOI_MAINNET,
+    networkName: 'Voi Mainnet',
+    existsInWallet: false,
+  };
+}
+
+describe('MultiAccountWalletService.importAuthAccount — notes persistence (TASK-244)', () => {
+  let addSpy: jest.SpyInstance;
+
+  beforeEach(() => {
+    // No existing account at either address → import proceeds as watch-only.
+    jest
+      .spyOn(MultiAccountWalletService, 'findAccountByAddress')
+      .mockResolvedValue(null);
+    // Stub the persistence write; capture what would be stored.
+    addSpy = jest
+      .spyOn(MultiAccountWalletService as any, 'addAccountToWallet')
+      .mockResolvedValue(undefined);
+  });
+
+  afterEach(() => {
+    jest.restoreAllMocks();
+  });
+
+  it('round-trips caller-supplied notes into the returned metadata', async () => {
+    const notes = 'cold storage — recovered 2026-07';
+    const request: ImportAuthAccountRequest = {
+      authAccount: makeNetworkAuthAccount(),
+      label: 'Recovered Auth Account',
+      notes,
+    };
+
+    const result = await MultiAccountWalletService.importAuthAccount(request);
+
+    expect(result.type).toBe(AccountType.REKEYED);
+    expect(result.notes).toBe(notes);
+  });
+
+  it('persists notes into the metadata handed to storage (not just the return value)', async () => {
+    const notes = 'imported via discovery flow';
+    const request: ImportAuthAccountRequest = {
+      authAccount: makeNetworkAuthAccount(),
+      notes,
+    };
+
+    await MultiAccountWalletService.importAuthAccount(request);
+
+    expect(addSpy).toHaveBeenCalledTimes(1);
+    const persisted = addSpy.mock.calls[0][0] as RekeyedAccountMetadata;
+    expect(persisted.notes).toBe(notes);
+  });
+
+  it('leaves notes undefined when the caller supplies none', async () => {
+    const request: ImportAuthAccountRequest = {
+      authAccount: makeNetworkAuthAccount(),
+      label: 'No Notes',
+    };
+
+    const result = await MultiAccountWalletService.importAuthAccount(request);
+
+    expect(result.notes).toBeUndefined();
+  });
+});

--- a/src/services/wallet/index.ts
+++ b/src/services/wallet/index.ts
@@ -1602,6 +1602,7 @@ export class MultiAccountWalletService {
         type: AccountType.REKEYED,
         label: label || `Auth Account (${authAccount.networkName})`,
         color: color || this.generateAccountColor(),
+        notes,
         isHidden: false,
         createdAt: new Date().toISOString(),
         importedAt: new Date().toISOString(),

--- a/src/types/wallet.ts
+++ b/src/types/wallet.ts
@@ -71,6 +71,7 @@ export interface RekeyedAccountMetadata extends BaseAccountMetadata {
   originalOwner?: boolean; // Whether this wallet was the original owner
   canSign: boolean; // Whether we have the signing key for the auth address
   rekeyedFrom?: string; // Original account address if we rekeyed it
+  notes?: string; // User notes about this account
 }
 
 // Ledger Account (hardware-controlled)


### PR DESCRIPTION
## TASK-244 — Wave 3 secret-hygiene (two security-reviewed no-unused-vars survivors)

Two small, independently-reviewed changes kept out of the bulk dead-code sweep so they get their own eyes.

### Part 1 — remove the redundant in-state recovery-phrase copy
`ShowRecoveryPhraseScreen.tsx` held a **second live copy** of the 25-word phrase in `mnemonicWords` state (`recoveredMnemonic.split(' ')`), set immediately after the real `setMnemonic(...)`. It was **never read** — display (`MnemonicDisplay`), clipboard copy, and share all use the primary `mnemonic` state. The array copy was invisible to anyone auditing "where does the mnemonic live" and would surface the phrase **twice** in any memory capture / crash-reporter state serialization / DevTools inspection.

Removed the `mnemonicWords` state, its population in the load path, and its clear in the unmount cleanup. **Phrase paths untouched:** secure-storage retrieval (`SecureKeyManager.getMnemonic`), reveal/blur toggle, `scheduleClipboardClear` 60s auto-wipe, copy-generation lock, share, and unmount cleanup are all unchanged. No new copy or log of the mnemonic was introduced. Grep now shows exactly one state binding holding mnemonic material in that screen.

### Part 2 — stop discarding imported account notes
`MultiAccountWalletService.importAuthAccount` destructured `notes` from the request then never wrote it into the account metadata — caller-supplied notes were silently dropped. `RekeyedAccountMetadata` had no `notes` field (only `WatchAccountMetadata` did), so `notes?: string` was added to `RekeyedAccountMetadata` (mirroring the watch-account shape) and carried into the metadata literal the same way `label`/`color` are. No other `importAuthAccount` behavior changed.

Added `src/services/wallet/__tests__/importAuthAccount.test.ts` (3 tests) asserting an imported auth account **round-trips its `notes`** — into both the returned metadata and the object handed to persistence — and leaves `notes` undefined when the caller supplies none.

### Lint ratchet (DR-9)
- `no-unused-vars`: **7 → 5** (clears both `mnemonicWords` and `notes`; these were the last two survivors)
- Total warnings: 258 → 256; `--max-warnings` lowered to **256**; `lint-baseline.json` regenerated (only `no-unused-vars` moved). `lint:baseline:check` passes.

### Gates
- `npm run typecheck` — clean (0)
- `npm run lint` — exit 0 (256 warnings, 0 errors)
- `npm run lint:baseline:check` — passes
- `npm test -- --ci` — green: **100 suites / 1549 tests** (was 99 / 1546; +1 suite, +3 tests)
- Codex secret-hygiene review — **CLEAN** (verified mnemonicWords never read; retrieval/auto-clear/blur unchanged; no new copy/log; notes persisted correctly)

### Device QA (batched pre-release per HT-218)
- Open **Settings → Show Recovery Phrase**: confirm the phrase still reveals, copies (with the 60s clipboard wipe), shares, and clears on navigate-away.
- Import an auth account **with notes**: confirm the notes persist on the imported account.

https://claude.ai/code/session_01AL4EmUSYAiVXEstBgKqDmv