### PR TITLE
fix(send): resolve ARC-0090 prefill against route network; adjudicate fee/envoi effects (TASK-245)

### DIFF
--- a/lint-baseline.json
+++ b/lint-baseline.json
@@ -2,19 +2,19 @@
   "$comment": "Committed ESLint baseline for the `npm run lint` ratchet (PLAN-229 DR-2). Regenerate with `npm run lint:baseline`; verify with `npm run lint:baseline:check`. The `lint` script's --max-warnings MUST equal totals.warnings. Lower it in the same PR that clears the warnings. It never goes up.",
   "totals": {
     "errors": 0,
-    "warnings": 256,
+    "warnings": 249,
     "filesLinted": 437,
     "filesWithFindings": 91
   },
   "rules": {
     "@typescript-eslint/no-unused-vars": 5,
     "import/no-named-as-default": 37,
-    "react-hooks/exhaustive-deps": 24,
-    "react-hooks/immutability": 97,
+    "react-hooks/exhaustive-deps": 19,
+    "react-hooks/immutability": 96,
     "react-hooks/preserve-manual-memoization": 25,
     "react-hooks/purity": 5,
     "react-hooks/refs": 7,
-    "react-hooks/set-state-in-effect": 56
+    "react-hooks/set-state-in-effect": 55
   },
   "files": {
     "src/components/UnifiedAuthModal.tsx": {
@@ -512,12 +512,11 @@
     },
     "src/screens/wallet/SendScreen.tsx": {
       "errors": 0,
-      "warnings": 14,
+      "warnings": 7,
       "rules": {
         "import/no-named-as-default": 1,
-        "react-hooks/exhaustive-deps": 8,
-        "react-hooks/immutability": 1,
-        "react-hooks/set-state-in-effect": 4
+        "react-hooks/exhaustive-deps": 3,
+        "react-hooks/set-state-in-effect": 3
       }
     },
     "src/screens/wallet/SwapScreen.tsx": {

--- a/package.json
+++ b/package.json
@@ -7,7 +7,7 @@
     "android": "expo run:android",
     "ios": "expo run:ios",
     "web": "expo start --web",
-    "lint": "eslint src/ --max-warnings 256",
+    "lint": "eslint src/ --max-warnings 249",
     "lint:fix": "eslint src/ --fix",
     "lint:baseline": "node scripts/lint-baseline.mjs --write",
     "lint:baseline:check": "node scripts/lint-baseline.mjs --check",

--- a/src/screens/wallet/SendScreen.tsx
+++ b/src/screens/wallet/SendScreen.tsx
@@ -96,17 +96,19 @@ export default function SendScreen() {
   const route = useRoute();
   const routeParams = route.params as SendScreenRouteParams | undefined;
 
-  // Network selection state - defaults to route param or current network
-  const [selectedNetworkId, setSelectedNetworkId] = useState<NetworkId>(
-    (routeParams?.networkId as NetworkId) || currentNetwork
-  );
-
-  // Update selected network when route params change
-  useEffect(() => {
-    if (routeParams?.networkId) {
-      setSelectedNetworkId(routeParams.networkId as NetworkId);
-    }
-  }, [routeParams?.networkId]);
+  // The screen's base/default network — the network used when no asset override
+  // is active. DERIVED (not state) straight from the route param, falling back
+  // to the global current network. TASK-245 item 2: this used to be state
+  // seeded by an initializer AND mirrored from `routeParams.networkId` via a
+  // set-state-in-effect. That mirror committed the new network one render LATE,
+  // which created the item-1 ordering hazard — a sibling effect reading
+  // `selectedNetworkId` in the same commit as a route change saw the PREVIOUS
+  // value. Deriving makes the route network visible in the SAME render and
+  // removes the mirror effect. Safe to derive because the UI never mutates this
+  // base network directly: the asset selector sets `selectedAsset` (whose
+  // networkId feeds `effectiveNetworkId` at :340), never `selectedNetworkId`.
+  const selectedNetworkId: NetworkId =
+    (routeParams?.networkId as NetworkId) || currentNetwork;
 
   const [recipientInput, setRecipientInput] = useState('');
   const [recipientAddress, setRecipientAddress] = useState('');
@@ -219,6 +221,19 @@ export default function SendScreen() {
           : undefined;
         const rawAmount = BigInt(routeParams.amount);
 
+        // TASK-245 item 1: resolve the asset's decimals against the network the
+        // DEEP LINK names — read from `routeParams` DIRECTLY, never from
+        // `selectedNetworkId`. On an already-mounted Send screen the route
+        // change and this effect commit in the same pass; the base network is
+        // now derived (so it is already fresh), but reading the raw route param
+        // here makes the decimals lookup provably independent of any render/
+        // effect ordering. Resolving against the wrong (previous) network is the
+        // magnitude bug this fixes: e.g. asset 12345 at 6 decimals on the
+        // link's network vs 2 on the stale one turns a "1" into "10000". Falls
+        // back to the global current network only when the link omits one.
+        const prefillNetworkId: NetworkId =
+          (routeParams.networkId as NetworkId) || currentNetwork;
+
         (async () => {
           let decimals: number;
           if (assetIdRaw === undefined || assetIdRaw === 0) {
@@ -226,9 +241,9 @@ export default function SendScreen() {
           } else {
             try {
               const info =
-                await NetworkService.getInstance(
-                  selectedNetworkId
-                ).getAssetInfo(assetIdRaw);
+                await NetworkService.getInstance(prefillNetworkId).getAssetInfo(
+                  assetIdRaw
+                );
               const rawDecimals = info?.params?.decimals;
               if (rawDecimals === undefined || rawDecimals === null) {
                 // Params unavailable (e.g. a 404 resolves to null): don't
@@ -288,7 +303,10 @@ export default function SendScreen() {
     return () => {
       cancelled = true;
     };
-  }, [routeParams]);
+    // `currentNetwork` is the fallback network for the decimals lookup when the
+    // deep link omits one (see prefillNetworkId above); it must be a dependency
+    // so the prefill re-resolves if that fallback changes.
+  }, [routeParams, currentNetwork]);
 
   const activeAccount = useActiveAccount();
 
@@ -1027,20 +1045,59 @@ export default function SendScreen() {
 
   // Removed problematic useEffect that was causing infinite balance reloading
 
+  // TASK-245 item 3 — DECISION: the fee is NOT re-estimated on a bare
+  // selectedAsset / selectedNetworkId change; it is keyed on `amount` only.
+  // Rationale (recorded, not a silent omission): every user path that changes
+  // the asset or the effective network — NetworkAssetSelector.onSelect and
+  // handleAssetSelect — CLEARS `amount` to '' and resets `estimatedFee` to 0.
+  // So a network/asset switch never leaves a stale fee sitting next to a live
+  // amount: the fee shows 0 until the user re-enters an amount, and THAT entry
+  // re-runs this effect, at which point `updateFeeEstimate` reads the current
+  // `effectiveNetworkId` / `effectiveAssetId` (fresh closure values) and
+  // estimates against the new network/asset. Re-estimating on the selection
+  // change alone would be a no-op (no amount to price). `updateFeeEstimate` is a
+  // fresh closure each render and is declared below by design; adding it to the
+  // deps would re-run this effect every render.
   useEffect(() => {
     if (amount && parseFloat(amount) > 0) {
+      // eslint-disable-next-line react-hooks/immutability -- updateFeeEstimate is declared later (see note above); the effect runs post-commit when the binding exists.
       updateFeeEstimate();
     }
+    // eslint-disable-next-line react-hooks/exhaustive-deps -- intentional: keyed on `amount` only (see the item-3 note above); updateFeeEstimate omitted on purpose.
   }, [amount]);
 
-  // Fee estimation for NFT transfers
+  // Fee estimation for NFT transfers. Same item-3 decision: keyed on the token +
+  // recipient (an NFT transfer has no user-entered amount), not on the asset/
+  // network selection, and updateFeeEstimate reads the token's own network.
   useEffect(() => {
     if (contextNftToken && recipientAddress) {
       updateFeeEstimate();
     }
+    // eslint-disable-next-line react-hooks/exhaustive-deps -- intentional: updateFeeEstimate omitted on purpose (see the item-3 note above).
   }, [contextNftToken, recipientAddress]);
 
-  // Name resolution effect with debouncing
+  // Name resolution effect with debouncing.
+  //
+  // TASK-245 item 4 — DECISION (recorded, not a silent disable): `isEnvoiEnabled`
+  // is read here but intentionally OMITTED from the dependency array, so a
+  // network switch after a name is typed does NOT re-run resolution and a
+  // previously-resolved name -> address pair persists across the switch. This is
+  // safe — it cannot misdirect funds — for reasons verified against the code:
+  //   1. Envoi is a SINGLE GLOBAL registry (services/envoi hits one host,
+  //      api.envoi.sh, with NO network parameter), so a given name maps to the
+  //      same concrete address regardless of the selected network.
+  //   2. The actual resolution (`resolveAddressOrName`) and name/address
+  //      classification (`isLikelyEnvoiName`) gate on the GLOBAL
+  //      `VoiNetworkService.isFeatureAvailable('envoi')` flag — NOT on this
+  //      screen's `isEnvoiEnabled`. `isEnvoiEnabled` (derived from
+  //      selectedNetworkId) only decides whether to STORE the name for DISPLAY
+  //      and whether to run the type-ahead search below; it never changes the
+  //      address that gets sent.
+  //   3. The resolved CONCRETE address is shown on this screen and re-shown on
+  //      the TransactionConfirmation screen before signing, so the user always
+  //      sees the real destination.
+  // Adding `isEnvoiEnabled` to the deps would only re-trigger identical
+  // resolutions (churn) without any correctness benefit, so it is left out.
   useEffect(() => {
     const resolveRecipient = async () => {
       if (!recipientInput.trim()) {
@@ -1105,6 +1162,7 @@ export default function SendScreen() {
     return () => {
       clearTimeout(timeoutId);
     };
+    // eslint-disable-next-line react-hooks/exhaustive-deps -- `isEnvoiEnabled` intentionally omitted; see the item-4 decision note above this effect.
   }, [recipientInput, recipientAddress, resolvedName]);
 
   useEffect(() => {
@@ -1175,6 +1233,7 @@ export default function SendScreen() {
       cancelled = true;
       clearTimeout(timeoutId);
     };
+    // eslint-disable-next-line react-hooks/exhaustive-deps -- `isEnvoiEnabled` intentionally omitted (item-4 decision above the name-resolution effect): a network switch does not re-run the type-ahead search, but Envoi is a single global registry so a stale search/resolution never changes the sent address.
   }, [recipientInput, resolvedName]);
 
   const handleSearchResultSelect = (result: EnvoiSearchResult) => {

--- a/src/screens/wallet/__tests__/SendScreen.test.tsx
+++ b/src/screens/wallet/__tests__/SendScreen.test.tsx
@@ -47,6 +47,9 @@ let mockTokenMappings: unknown[];
 
 const mockGetAccountBalance = jest.fn();
 const mockEstimateTransactionCost = jest.fn();
+// Shared spy so a test can assert which NETWORK the ARC-0090 prefill resolved
+// the asset's decimals against (getInstance(networkId).getAssetInfo(assetId)).
+const mockGetAssetInfo = jest.fn();
 
 const mockNetworkConfigs: Record<
   string,
@@ -64,7 +67,7 @@ jest.mock('@/services/network', () => ({
     getInstance: (networkId: string) => ({
       getAccountBalance: (address: string) =>
         mockGetAccountBalance(networkId, address),
-      getAssetInfo: jest.fn(async () => null),
+      getAssetInfo: (assetId: number) => mockGetAssetInfo(networkId, assetId),
       getSingleAssetBalance: jest.fn(async () => null),
       getAlgodClient: () => ({
         accountInformation: () => ({
@@ -324,6 +327,9 @@ beforeEach(() => {
 
   mockEstimateTransactionCost.mockReset();
   mockEstimateTransactionCost.mockResolvedValue({ fee: 1000 });
+
+  mockGetAssetInfo.mockReset();
+  mockGetAssetInfo.mockResolvedValue(null);
 });
 
 // Flush pending promises/effects (balance fetch, asset options, mappings).
@@ -499,6 +505,67 @@ describe('SendScreen native minimum-balance math (TASK-239)', () => {
     });
     expect(screen.getByLabelText(MAX_LABEL)).toBeTruthy();
     expect(screen.queryByText(/exceeds spendable balance/i)).toBeNull();
+    await settle();
+  });
+});
+
+describe('SendScreen ARC-0090 prefill network resolution (TASK-245 item 1)', () => {
+  it('resolves the prefill decimals against the deep-link networkId, not the previously-mounted network', async () => {
+    // Asset 12345 carries DIFFERENT decimals per network: 6 on VOI, 2 on ALGO.
+    // The prefill converts the URI's RAW base-unit amount to a display amount
+    // using those decimals, so the network it looks them up on decides the
+    // magnitude the user sees.
+    mockGetAssetInfo.mockImplementation((networkId: string) =>
+      Promise.resolve({ params: { decimals: networkId === VOI ? 6 : 2 } })
+    );
+
+    // The screen is ALREADY MOUNTED sitting on ALGORAND (no route network yet).
+    mockCurrentNetwork = ALGO;
+    mockRouteParams = undefined;
+    const screen = render(<SendScreen />);
+    await settle();
+
+    // A deep link now arrives on the already-mounted screen, naming VOI + asset
+    // 12345 + a raw base-unit amount of 1_000_000. On an already-mounted screen
+    // the sibling network-setter has not committed VOI yet when the prefill
+    // runs — the bug resolved decimals against the STALE ALGORAND network.
+    mockRouteParams = { networkId: VOI, asset: '12345', amount: '1000000' };
+    await act(async () => {
+      screen.rerender(<SendScreen />);
+    });
+    await settle();
+
+    // The decimals lookup MUST have gone to VOI (the link's network), never to
+    // the stale ALGORAND network the screen was previously on.
+    const assetInfoNetworks = mockGetAssetInfo.mock.calls.map((c) => c[0]);
+    expect(assetInfoNetworks).toContain(VOI);
+    expect(assetInfoNetworks).not.toContain(ALGO);
+    // And it looked up the asset the link named.
+    expect(mockGetAssetInfo).toHaveBeenCalledWith(VOI, 12345);
+
+    // Magnitude proof: 1_000_000 raw / 10^6 (VOI decimals) = "1". The stale
+    // network (ALGO, 2 decimals) would have prefilled "10000" — a 100x error.
+    expect(screen.getByDisplayValue('1')).toBeTruthy();
+    expect(screen.queryByDisplayValue('10000')).toBeNull();
+    await settle();
+  });
+
+  it('resolves against the route network even when the global current network differs', async () => {
+    // Cold-start equivalent: mounted directly with the deep link. Global network
+    // is ALGO, but the link names VOI — the prefill must still use VOI.
+    mockGetAssetInfo.mockImplementation((networkId: string) =>
+      Promise.resolve({ params: { decimals: networkId === VOI ? 6 : 2 } })
+    );
+    mockCurrentNetwork = ALGO;
+    mockRouteParams = { networkId: VOI, asset: '12345', amount: '1000000' };
+
+    const screen = render(<SendScreen />);
+    await settle();
+
+    expect(mockGetAssetInfo).toHaveBeenCalledWith(VOI, 12345);
+    const assetInfoNetworks = mockGetAssetInfo.mock.calls.map((c) => c[0]);
+    expect(assetInfoNetworks).not.toContain(ALGO);
+    expect(screen.getByDisplayValue('1')).toBeTruthy();
     await settle();
   });
 });


### PR DESCRIPTION
## TASK-245 — SendScreen route-network cluster (four items, one indivisible PR per DR-8)

All four items read/write the same two state values (`selectedNetworkId`, `selectedAsset`) and depend on effect ordering, so they ship together. Root cause held throughout: **React runs effects in declaration order within a commit, and state set by an earlier effect is not visible to a later effect in the same pass.**

### Item 1 — ARC-0090 prefill (CONFIRMED DEFECT — fixed with test)
The deep-link prefill resolved the asset's decimals via `NetworkService.getInstance(selectedNetworkId).getAssetInfo(...)` to convert the URI's RAW base-unit amount into a display amount. `selectedNetworkId` was state the sibling mirror effect set from `routeParams.networkId` one commit late, so on an **already-mounted** SendScreen the prefill ran against the **previous** network. A link to `{networkId:'voi-mainnet', asset:'12345', amount:'1000000'}` resolved asset 12345 against the stale network; if decimals differ (6 vs 2) the field prefilled `10000` instead of `1` — a 100x magnitude error.

**Fix:** the prefill now resolves decimals against `routeParams.networkId` **directly** (fallback `currentNetwork`). The `cancelled` guard and the decimals-unavailable fail-safe (skip prefill rather than guess) are preserved. `SendScreen.tsx:205`

**Test** (extends the TASK-239 suite, `src/screens/wallet/__tests__/SendScreen.test.tsx`): navigating to an already-mounted SendScreen with new params carrying a different `networkId` + asset + raw amount asserts `getAssetInfo` is called against the NEW network (`getInstance` arg), never the stale one, and that the resulting magnitude is `1` not `10000`. Verified the test **fails on `main`** (records `["algorand-mainnet"]`) and passes on HEAD. A cold-start variant is included.

### Item 2 — routeParams prop-mirror (reconciled with item 1)
`selectedNetworkId` is now **derived** (`routeParams.networkId || currentNetwork`) instead of state seeded by an initializer and mirrored via a `set-state-in-effect`. The route network is now visible in the **same render**, which removes the ordering hazard at its root and deletes the mirror effect. Safe because the UI never mutates the base network directly — the asset selector sets `selectedAsset` (whose networkId feeds `effectiveNetworkId`), never `selectedNetworkId`. `SendScreen.tsx:91`

### Item 3 — fee re-estimation (recorded DECISION: disabled-with-written-reason)
**Decision:** the fee is **not** re-estimated on a bare `selectedAsset`/`selectedNetworkId` change; it stays keyed on `amount`. Every switch path (`NetworkAssetSelector.onSelect`, `handleAssetSelect`) clears `amount` to `''` and resets the fee to 0, so a switch never leaves a stale fee beside a live amount; the next amount entry re-estimates against the current effective network/asset (read at call time). Re-estimating on the selection alone would be a no-op. Documented in-code with an `eslint-disable` carrying the reason; the forward-reference (`updateFeeEstimate` declared later) is likewise documented. `SendScreen.tsx:1048`

### Item 4 — Envoi cross-network persistence (recorded DECISION: disabled-with-written-reason — highest risk)
**Decision:** `isEnvoiEnabled` stays out of the resolve/search effect deps. Verified by reading the resolver: Envoi is a **single global registry** (`services/envoi` hits `api.envoi.sh` with **no** network parameter), and the actual resolution (`resolveAddressOrName`) and classification (`isLikelyEnvoiName`) gate on the **global** `VoiNetworkService.isFeatureAvailable('envoi')` flag — not this screen's `isEnvoiEnabled`, which governs only display/type-ahead. A resolved name→address that persists across a network switch therefore cannot misdirect funds: the concrete address is shown here and re-shown on the confirmation screen before signing. Documented in-code with the safety rationale. `SendScreen.tsx:1081`, `:1235`

### STOP-AND-ASK boundary — not hit
Change is confined to money-DISPLAY and effect ordering. No transaction construction/signing changes; `services/transactions` and the read-side spendable math (TASK-239) are untouched.

## Per-rule ratchet deltas (regenerated — DR-9)
SendScreen 14 → 7. `--max-warnings` 256 → **249**, baseline regenerated and re-committed.

| rule | before | after |
|---|---|---|
| react-hooks/exhaustive-deps | 24 | 19 (−5) |
| react-hooks/immutability | 97 | 96 (−1) |
| react-hooks/set-state-in-effect | 56 | 55 (−1) |
| react-hooks/preserve-manual-memoization | 25 | 25 (unchanged) |
| **total** | **256** | **249 (−7)** |

## Gates
- `npm run typecheck` clean (tsc 0)
- `npm run lint` exit 0 (249 warnings)
- `npm run lint:baseline:check` OK (matches artifact; pin = 249)
- `npm test -- --ci` green: 100 suites / 1551 tests (1549 + 2 new)
- Codex review: **CLEAN** (round 1)

## Device-QA matrix (batched pre-release per HT-218)
- [ ] Follow a Voi ARC-0090 URI with amount+asset from a **cold start** AND from an **already-open** Send screen — both prefill the **same magnitude**.
- [ ] Switch asset and network without touching the amount — confirm the displayed fee (0 after switch, correct on next amount entry).
- [ ] Type an Envoi name, switch network mid-entry — verify the resolved address shown matches what is actually sent.
- [ ] Full send on both networks.

https://claude.ai/code/session_01AL4EmUSYAiVXEstBgKqDmv