### PR TITLE
refactor(network): disambiguate NetworkService instance vs class export (TASK-253)

### DIFF
--- a/lint-baseline.json
+++ b/lint-baseline.json
@@ -2,13 +2,13 @@
   "$comment": "Committed ESLint baseline for the `npm run lint` ratchet (PLAN-229 DR-2). Regenerate with `npm run lint:baseline`; verify with `npm run lint:baseline:check`. The `lint` script's --max-warnings MUST equal totals.warnings. Lower it in the same PR that clears the warnings. It never goes up.",
   "totals": {
     "errors": 0,
-    "warnings": 249,
+    "warnings": 242,
     "filesLinted": 437,
-    "filesWithFindings": 91
+    "filesWithFindings": 89
   },
   "rules": {
     "@typescript-eslint/no-unused-vars": 5,
-    "import/no-named-as-default": 37,
+    "import/no-named-as-default": 30,
     "react-hooks/exhaustive-deps": 19,
     "react-hooks/immutability": 96,
     "react-hooks/preserve-manual-memoization": 25,
@@ -485,9 +485,8 @@
     },
     "src/screens/wallet/HomeScreen.tsx": {
       "errors": 0,
-      "warnings": 7,
+      "warnings": 6,
       "rules": {
-        "import/no-named-as-default": 1,
         "react-hooks/immutability": 3,
         "react-hooks/preserve-manual-memoization": 3
       }
@@ -607,9 +606,9 @@
     },
     "src/services/secure/simplifiedKeyManager.ts": {
       "errors": 0,
-      "warnings": 2,
+      "warnings": 1,
       "rules": {
-        "import/no-named-as-default": 2
+        "import/no-named-as-default": 1
       }
     },
     "src/services/swap/index.ts": {
@@ -621,26 +620,12 @@
     },
     "src/services/transactions/arc200.ts": {
       "errors": 0,
-      "warnings": 2,
-      "rules": {
-        "import/no-named-as-default": 2
-      }
-    },
-    "src/services/transactions/arc72.ts": {
-      "errors": 0,
-      "warnings": 2,
-      "rules": {
-        "import/no-named-as-default": 2
-      }
-    },
-    "src/services/transactions/index.ts": {
-      "errors": 0,
       "warnings": 1,
       "rules": {
         "import/no-named-as-default": 1
       }
     },
-    "src/services/wallet/rekeyManager.ts": {
+    "src/services/transactions/arc72.ts": {
       "errors": 0,
       "warnings": 1,
       "rules": {
@@ -698,9 +683,9 @@
     },
     "src/utils/address.ts": {
       "errors": 0,
-      "warnings": 2,
+      "warnings": 1,
       "rules": {
-        "import/no-named-as-default": 2
+        "import/no-named-as-default": 1
       }
     },
     "src/utils/animations.ts": {

--- a/package.json
+++ b/package.json
@@ -7,7 +7,7 @@
     "android": "expo run:android",
     "ios": "expo run:ios",
     "web": "expo start --web",
-    "lint": "eslint src/ --max-warnings 249",
+    "lint": "eslint src/ --max-warnings 242",
     "lint:fix": "eslint src/ --fix",
     "lint:baseline": "node scripts/lint-baseline.mjs --write",
     "lint:baseline:check": "node scripts/lint-baseline.mjs --check",

--- a/src/screens/wallet/HomeScreen.tsx
+++ b/src/screens/wallet/HomeScreen.tsx
@@ -40,7 +40,7 @@ import {
   useMultiNetworkBalance,
   useAssetNetworkFilter,
 } from '@/store/walletStore';
-import VoiNetworkService, { NetworkStatus } from '@/services/network';
+import { networkService, NetworkStatus } from '@/services/network';
 import { formatCurrency } from '@/utils/formatting';
 import { useCurrentNetworkConfig } from '@/store/networkStore';
 import { NetworkId } from '@/types/network';
@@ -442,7 +442,8 @@ export default function HomeScreen() {
         // within a short TTL, so on cold boot this reuses the status networkStore
         // already fetched during init (or shares its in-flight probe) rather than
         // issuing a duplicate ~15s request, and never delays the first balance.
-        const networkHealthPromise = VoiNetworkService.checkNetworkHealth()
+        const networkHealthPromise = networkService
+          .checkNetworkHealth()
           .then((status) => {
             if (
               viewModeRef.current === currentViewMode &&
@@ -990,7 +991,7 @@ export default function HomeScreen() {
       const [networkHealth] = await Promise.allSettled([
         // Explicit refresh (pull-to-refresh) must reflect current connectivity,
         // so bypass the short-TTL cache.
-        VoiNetworkService.checkNetworkHealth({ force: true }),
+        networkService.checkNetworkHealth({ force: true }),
       ]);
 
       if (networkHealth.status === 'fulfilled') {

--- a/src/screens/wallet/SendScreen.tsx
+++ b/src/screens/wallet/SendScreen.tsx
@@ -1088,7 +1088,7 @@ export default function SendScreen() {
   //      same concrete address regardless of the selected network.
   //   2. The actual resolution (`resolveAddressOrName`) and name/address
   //      classification (`isLikelyEnvoiName`) gate on the GLOBAL
-  //      `VoiNetworkService.isFeatureAvailable('envoi')` flag — NOT on this
+  //      `networkService.isFeatureAvailable('envoi')` flag — NOT on this
   //      screen's `isEnvoiEnabled`. `isEnvoiEnabled` (derived from
   //      selectedNetworkId) only decides whether to STORE the name for DISPLAY
   //      and whether to run the type-ahead search below; it never changes the

--- a/src/services/network/index.ts
+++ b/src/services/network/index.ts
@@ -1822,7 +1822,8 @@ export class NetworkService {
   }
 }
 
-export default NetworkService.getInstance();
-
-// Backwards compatibility exports
-export const VoiNetworkService = NetworkService;
+// Singleton NetworkService instance for the currently selected network.
+// Lowercase name = the instance (matching the `rekeyManager` convention);
+// the `NetworkService` class is exported by name above for callers that need
+// a per-network instance via `NetworkService.getInstance(networkId)`.
+export const networkService = NetworkService.getInstance();

--- a/src/services/secure/simplifiedKeyManager.ts
+++ b/src/services/secure/simplifiedKeyManager.ts
@@ -13,7 +13,7 @@ import {
   SimpleLedgerSigningRequest,
 } from '@/services/ledger/simpleLedgerSigner';
 import algosdk, { Transaction } from 'algosdk';
-import VoiNetworkService from '@/services/network';
+import { networkService } from '@/services/network';
 
 /**
  * Simplified Key Manager
@@ -212,8 +212,7 @@ export class SimplifiedKeyManager {
 
           case AccountType.WATCH:
             // For watch accounts, check if they're rekeyed to an account we control
-            const rekeyInfo =
-              await VoiNetworkService.getAccountRekeyInfo(address);
+            const rekeyInfo = await networkService.getAccountRekeyInfo(address);
             if (rekeyInfo.isRekeyed && rekeyInfo.authAddress) {
               const signerAccount = wallet.accounts.find(
                 (acc) => acc.address === rekeyInfo.authAddress

--- a/src/services/transactions/__tests__/construction.test.ts
+++ b/src/services/transactions/__tests__/construction.test.ts
@@ -49,7 +49,7 @@ jest.mock('@/services/network', () => {
   };
   return {
     __esModule: true,
-    default: svc, // VoiNetworkService (default import in the services)
+    networkService: svc, // default-network singleton (named import in the services)
     NetworkService: { getInstance: () => svc },
   };
 });

--- a/src/services/transactions/arc200.ts
+++ b/src/services/transactions/arc200.ts
@@ -1,5 +1,8 @@
 import algosdk from 'algosdk';
-import VoiNetworkService, { NetworkService } from '@/services/network';
+import {
+  networkService as defaultNetworkService,
+  NetworkService,
+} from '@/services/network';
 import MimirApiService from '@/services/mimir';
 
 // ARC-200 transfer ABI definition
@@ -149,10 +152,10 @@ export class Arc200TransactionService {
     params: Arc200TransferParams
   ): Promise<Arc200TransactionGroup> {
     try {
-      // Use the networkId from params, or default to VoiNetworkService for backwards compatibility
+      // Use the networkId from params, or default to defaultNetworkService for backwards compatibility
       const networkService = params.networkId
         ? NetworkService.getInstance(params.networkId as any)
-        : VoiNetworkService;
+        : defaultNetworkService;
       const suggestedParams = await networkService.getSuggestedParams();
 
       if (!algosdk.isValidAddress(params.from)) {
@@ -374,10 +377,10 @@ export class Arc200TransactionService {
     needsMbrPayment: boolean;
   }> {
     try {
-      // Use the networkId from params, or default to VoiNetworkService for backwards compatibility
+      // Use the networkId from params, or default to defaultNetworkService for backwards compatibility
       const networkService = params.networkId
         ? NetworkService.getInstance(params.networkId as any)
-        : VoiNetworkService;
+        : defaultNetworkService;
 
       const baseFee = await networkService.estimateTransactionFee();
       const hasBalance = await this.checkRecipientBalance(
@@ -422,7 +425,7 @@ export class Arc200TransactionService {
     try {
       const networkService = params.networkId
         ? NetworkService.getInstance(params.networkId as any)
-        : VoiNetworkService;
+        : defaultNetworkService;
       const suggestedParams = await networkService.getSuggestedParams();
 
       if (!algosdk.isValidAddress(params.from)) {
@@ -631,7 +634,7 @@ export class Arc200TransactionService {
 
     const networkService = networkId
       ? NetworkService.getInstance(networkId as any)
-      : VoiNetworkService;
+      : defaultNetworkService;
     const suggestedParams = await networkService.getSuggestedParams();
 
     const allTransactions: algosdk.Transaction[] = [];
@@ -712,7 +715,7 @@ export class Arc200TransactionService {
   }> {
     const networkService = networkId
       ? NetworkService.getInstance(networkId as any)
-      : VoiNetworkService;
+      : defaultNetworkService;
 
     const baseFee = await networkService.estimateTransactionFee();
 

--- a/src/services/transactions/arc72.ts
+++ b/src/services/transactions/arc72.ts
@@ -1,5 +1,8 @@
 import algosdk from 'algosdk';
-import VoiNetworkService, { NetworkService } from '@/services/network';
+import {
+  networkService as defaultNetworkService,
+  NetworkService,
+} from '@/services/network';
 import MimirApiService from '@/services/mimir';
 
 // ARC-72 transfer ABI definition
@@ -104,10 +107,10 @@ export class Arc72TransactionService {
     params: Arc72TransferParams
   ): Promise<Arc72TransactionGroup> {
     try {
-      // Use the networkId from params, or default to VoiNetworkService for backwards compatibility
+      // Use the networkId from params, or default to defaultNetworkService for backwards compatibility
       const networkService = params.networkId
         ? NetworkService.getInstance(params.networkId as any)
-        : VoiNetworkService;
+        : defaultNetworkService;
       const suggestedParams = await networkService.getSuggestedParams();
 
       if (!algosdk.isValidAddress(params.from)) {
@@ -321,10 +324,10 @@ export class Arc72TransactionService {
     needsMbrPayment: boolean;
   }> {
     try {
-      // Use the networkId from params, or default to VoiNetworkService for backwards compatibility
+      // Use the networkId from params, or default to defaultNetworkService for backwards compatibility
       const networkService = params.networkId
         ? NetworkService.getInstance(params.networkId as any)
-        : VoiNetworkService;
+        : defaultNetworkService;
 
       const baseFee = await networkService.estimateTransactionFee();
       const hasTokens = await this.checkRecipientBalance(

--- a/src/services/transactions/index.ts
+++ b/src/services/transactions/index.ts
@@ -1,5 +1,8 @@
 import algosdk from 'algosdk';
-import VoiNetworkService, { NetworkService } from '@/services/network';
+import {
+  networkService as defaultNetworkService,
+  NetworkService,
+} from '@/services/network';
 import { NetworkId } from '@/types/network';
 import {
   WalletAccount,
@@ -294,7 +297,7 @@ export class TransactionService {
     try {
       const networkService = params.networkId
         ? NetworkService.getInstance(params.networkId)
-        : VoiNetworkService;
+        : defaultNetworkService;
       const suggestedParams = await networkService.getSuggestedParams();
 
       if (!algosdk.isValidAddress(params.from)) {
@@ -340,7 +343,7 @@ export class TransactionService {
     try {
       const networkService = params.networkId
         ? NetworkService.getInstance(params.networkId)
-        : VoiNetworkService;
+        : defaultNetworkService;
       const suggestedParams = await networkService.getSuggestedParams();
 
       if (!algosdk.isValidAddress(params.from)) {
@@ -819,7 +822,7 @@ export class TransactionService {
       // Use the network specified in params, or default to Voi mainnet
       const networkService = params.networkId
         ? NetworkService.getInstance(params.networkId)
-        : VoiNetworkService;
+        : defaultNetworkService;
 
       const accountBalance = await networkService.getAccountBalance(
         params.from
@@ -1050,7 +1053,7 @@ export class TransactionService {
       // Use the network specified in params, or default to Voi mainnet
       const networkService = params.networkId
         ? NetworkService.getInstance(params.networkId)
-        : VoiNetworkService;
+        : defaultNetworkService;
 
       const fee = await networkService.estimateTransactionFee();
       const total: number | bigint = params.assetId
@@ -1166,7 +1169,7 @@ export class TransactionService {
     try {
       const networkService = params.networkId
         ? NetworkService.getInstance(params.networkId)
-        : VoiNetworkService;
+        : defaultNetworkService;
       const suggestedParams = await networkService.getSuggestedParams();
 
       if (!algosdk.isValidAddress(params.fromAddress)) {
@@ -1232,7 +1235,7 @@ export class TransactionService {
     try {
       const networkService = params.networkId
         ? NetworkService.getInstance(params.networkId)
-        : VoiNetworkService;
+        : defaultNetworkService;
       const suggestedParams = await networkService.getSuggestedParams();
 
       if (!algosdk.isValidAddress(params.fromAddress)) {
@@ -1283,7 +1286,7 @@ export class TransactionService {
     try {
       const networkService = params.networkId
         ? NetworkService.getInstance(params.networkId)
-        : VoiNetworkService;
+        : defaultNetworkService;
       const suggestedParams = await networkService.getSuggestedParams();
 
       if (!algosdk.isValidAddress(params.signerAddress)) {
@@ -1344,7 +1347,7 @@ export class TransactionService {
       // Get network service and check rekey status
       const networkService = networkId
         ? NetworkService.getInstance(networkId)
-        : VoiNetworkService;
+        : defaultNetworkService;
       const accountBalance =
         await networkService.getAccountBalance(fromAddress);
       const isCurrentlyRekeyed = accountBalance.rekeyInfo?.isRekeyed;
@@ -1772,7 +1775,7 @@ export class TransactionService {
     const baseDelayMs = 500;
     const networkService = networkId
       ? NetworkService.getInstance(networkId)
-      : VoiNetworkService;
+      : defaultNetworkService;
 
     // Compute the expected txId from the signed blob up front so that a commit
     // whose response was lost can still be reported as success (rather than a

--- a/src/services/wallet/__tests__/rekeyManager.test.ts
+++ b/src/services/wallet/__tests__/rekeyManager.test.ts
@@ -54,7 +54,7 @@ jest.mock('@/services/ledger/transport', () => ({
 const mockGetMultipleAccountRekeyInfo = jest.fn();
 jest.mock('@/services/network', () => ({
   __esModule: true,
-  default: {
+  networkService: {
     getMultipleAccountRekeyInfo: (addresses: string[]) =>
       mockGetMultipleAccountRekeyInfo(addresses),
   },

--- a/src/services/wallet/rekeyManager.ts
+++ b/src/services/wallet/rekeyManager.ts
@@ -11,7 +11,7 @@ import {
   LedgerTransportMedium,
   LedgerAccountError,
 } from '@/types/wallet';
-import VoiNetworkService, { RekeyInfo } from '@/services/network';
+import { networkService, RekeyInfo } from '@/services/network';
 import { ledgerTransportService } from '@/services/ledger/transport';
 
 export interface SigningAuthorityCheck {
@@ -139,7 +139,7 @@ export class RekeyManager {
 
       // Get rekey info for all accounts
       const rekeyInfoMap =
-        await VoiNetworkService.getMultipleAccountRekeyInfo(allAddresses);
+        await networkService.getMultipleAccountRekeyInfo(allAddresses);
 
       const rekeyedAccounts: string[] = [];
       const signingAuthorities: Record<string, SigningAuthorityCheck> = {};

--- a/src/store/__tests__/accountErrorScoping.test.ts
+++ b/src/store/__tests__/accountErrorScoping.test.ts
@@ -36,7 +36,6 @@ jest.mock('@/services/network', () => ({
       getCurrentNetworkId: () => mockGetCurrentNetworkId(),
     }),
   },
-  VoiNetworkService: {},
 }));
 
 jest.mock('@/services/wallet', () => ({

--- a/src/store/__tests__/loadAccountBalance.dedup.test.ts
+++ b/src/store/__tests__/loadAccountBalance.dedup.test.ts
@@ -26,7 +26,6 @@ jest.mock('@/services/network', () => ({
       getCurrentNetworkId: () => mockGetCurrentNetworkId(),
     }),
   },
-  VoiNetworkService: {},
 }));
 
 jest.mock('@/services/wallet', () => ({

--- a/src/utils/__tests__/address.test.ts
+++ b/src/utils/__tests__/address.test.ts
@@ -6,7 +6,7 @@ import algosdk from 'algosdk';
 // getName/getAddress resolvers exist but we never exercise real resolution.
 jest.mock('@/services/network', () => ({
   __esModule: true,
-  default: { isFeatureAvailable: jest.fn(() => false) },
+  networkService: { isFeatureAvailable: jest.fn(() => false) },
 }));
 
 jest.mock('@/services/envoi', () => {
@@ -28,10 +28,10 @@ import {
   isLikelyEnvoiName,
   clearFormatCache,
 } from '../address';
-import VoiNetworkService from '@/services/network';
+import { networkService } from '@/services/network';
 import EnvoiService from '@/services/envoi';
 
-const mockNetwork = VoiNetworkService as unknown as {
+const mockNetwork = networkService as unknown as {
   isFeatureAvailable: jest.Mock;
 };
 const mockEnvoi = EnvoiService as unknown as {

--- a/src/utils/address.ts
+++ b/src/utils/address.ts
@@ -1,6 +1,6 @@
 import algosdk from 'algosdk';
 import EnvoiService, { EnvoiNameInfo } from '@/services/envoi';
-import VoiNetworkService from '@/services/network';
+import { networkService } from '@/services/network';
 
 // Cache for formatted address results to maintain stable references
 const formatCache = new Map<
@@ -48,7 +48,7 @@ export const formatAddressWithName = async (
 
   // Try to get name from Envoi if it's enabled on current network
   let nameInfo: EnvoiNameInfo | null = null;
-  if (VoiNetworkService.isFeatureAvailable('envoi')) {
+  if (networkService.isFeatureAvailable('envoi')) {
     const envoiService = EnvoiService.getInstance();
     nameInfo = await envoiService.getName(address);
   }
@@ -169,7 +169,7 @@ export const resolveAddressOrName = async (
   // If it looks like an Envoi name and Envoi is enabled, try to resolve it
   if (
     EnvoiService.isValidNameFormat(trimmed) &&
-    VoiNetworkService.isFeatureAvailable('envoi')
+    networkService.isFeatureAvailable('envoi')
   ) {
     const envoiService = EnvoiService.getInstance();
     const nameInfo = await envoiService.getAddress(trimmed);
@@ -189,7 +189,7 @@ export const isLikelyEnvoiName = (input: string): boolean => {
   }
 
   // If Envoi is not enabled on current network, no input can be an Envoi name
-  if (!VoiNetworkService.isFeatureAvailable('envoi')) {
+  if (!networkService.isFeatureAvailable('envoi')) {
     return false;
   }
 


### PR DESCRIPTION
## The problem

`src/services/network/index.ts` bound one identifier, `VoiNetworkService`, to **two different things**:
- `export default NetworkService.getInstance()` — the **instance** (what default-importers got)
- `export const VoiNetworkService = NetworkService` — the **class** (what a named import would get)

So `VoiNetworkService` meant the instance when default-imported and the class when named-imported. Moving or copying a call between a default-import consumer and a named-import consumer silently swaps class for instance — a latent bug `tsc` cannot always catch (static-vs-instance overlap on a singleton). `import/no-named-as-default` was the only automated detector.

## The rename (pure refactor, no behavior change)

- Removed both ambiguous exports. The singleton is now `export const networkService = NetworkService.getInstance()` — lowercase name states the kind (instance), matching the `rekeyManager` convention. The class stays exported by name as `NetworkService` for per-network instances via `NetworkService.getInstance(networkId)`.
- The `export default` and the `VoiNetworkService` alias are gone.
- Every consumer migrated to the named import:
  - Direct instance callers — `utils/address.ts`, `screens/wallet/HomeScreen.tsx`, `services/secure/simplifiedKeyManager.ts`, `services/wallet/rekeyManager.ts` — `import { networkService }` and call instance methods on it.
  - Ternary-fallback callers — `services/transactions/index.ts`, `arc200.ts`, `arc72.ts` — already have a **local** `const networkService` var, so they import `{ networkService as defaultNetworkService }` to avoid a self-reference; only the fallback branch (`: defaultNetworkService`) and comments change.
  - Test mocks (`address.test.ts`, `construction.test.ts`, `rekeyManager.test.ts`) and two stale store mocks (`loadAccountBalance.dedup.test.ts`, `accountErrorScoping.test.ts` — dropped their dead `VoiNetworkService: {}` entry) updated. Stale comment in `SendScreen.tsx` fixed.

## Instance-vs-class safety

Every migrated call site verified: instance methods (`isFeatureAvailable`, `checkNetworkHealth`, `getAccountRekeyInfo`, `getMultipleAccountRekeyInfo`, `getSuggestedParams`, `estimateTransactionFee`, `getAccountBalance`) are called on `networkService`/`defaultNetworkService`; the class `NetworkService` is used only via the static `getInstance(...)`. No instance method on the class or vice versa.

## Grep-completeness

`grep -rn "VoiNetworkService" src/` → **returns nothing**. Zero ambiguous bindings remain; no back-compat alias kept.

## `import/no-named-as-default` delta

**37 → 30** (−7). The 7 removed were exactly the `VoiNetworkService` default-import warnings (message: "Using exported name 'VoiNetworkService' as identifier for default import"). The residual 30 are the intentional `export default Class.getInstance()` singleton convention across other services (`EnvoiService`, `MimirApiService`, etc.) that TASK-248 will measure. No other rule count moved.

## Ratchet (DR-9)

`lint-baseline.json` regenerated: **249 → 242 warnings, 0 errors**. `package.json` `--max-warnings` lowered to 242 in this same PR. `npm run lint:baseline:check` passes. Only `import/no-named-as-default` moved (37→30); all other rule counts unchanged.

## Gates

- `npm run typecheck` — clean (0)
- `npm run lint` — exit 0
- `npm test -- --ci` — **100 suites / 1551 tests, all green**
- `npm run lint:baseline:check` — OK (242, pins 242)

## No behavior change

Two non-rename hunks, both justified: prettier reflowed `HomeScreen.tsx:445` and `simplifiedKeyManager.ts:215` because `networkService` is 3 chars shorter than `VoiNetworkService`, flipping the line-wrap decision — cosmetic only.

## Codex review

Verdict: **CLEAN**.

https://claude.ai/code/session_01AL4EmUSYAiVXEstBgKqDmv