### PR TITLE
refactor(screens): derive-during-render / key-reset for benign set-state effects (TASK-247)

### DIFF
--- a/lint-baseline.json
+++ b/lint-baseline.json
@@ -2,9 +2,9 @@
   "$comment": "Committed ESLint baseline for the `npm run lint` ratchet (PLAN-229 DR-2). Regenerate with `npm run lint:baseline`; verify with `npm run lint:baseline:check`. The `lint` script's --max-warnings MUST equal totals.warnings. Lower it in the same PR that clears the warnings. It never goes up.",
   "totals": {
     "errors": 0,
-    "warnings": 242,
+    "warnings": 227,
     "filesLinted": 437,
-    "filesWithFindings": 89
+    "filesWithFindings": 83
   },
   "rules": {
     "@typescript-eslint/no-unused-vars": 5,
@@ -14,7 +14,7 @@
     "react-hooks/preserve-manual-memoization": 25,
     "react-hooks/purity": 5,
     "react-hooks/refs": 7,
-    "react-hooks/set-state-in-effect": 55
+    "react-hooks/set-state-in-effect": 40
   },
   "files": {
     "src/components/UnifiedAuthModal.tsx": {
@@ -42,28 +42,7 @@
         "react-hooks/set-state-in-effect": 1
       }
     },
-    "src/components/account/RenameAccountModal.tsx": {
-      "errors": 0,
-      "warnings": 1,
-      "rules": {
-        "react-hooks/set-state-in-effect": 1
-      }
-    },
-    "src/components/assets/AssetFilterModal.tsx": {
-      "errors": 0,
-      "warnings": 1,
-      "rules": {
-        "react-hooks/set-state-in-effect": 1
-      }
-    },
     "src/components/assets/AssetOptInModal.tsx": {
-      "errors": 0,
-      "warnings": 1,
-      "rules": {
-        "react-hooks/set-state-in-effect": 1
-      }
-    },
-    "src/components/assets/MultiNetworkAssetItem.tsx": {
       "errors": 0,
       "warnings": 1,
       "rules": {
@@ -80,10 +59,9 @@
     },
     "src/components/backup/PasswordInputModal.tsx": {
       "errors": 0,
-      "warnings": 3,
+      "warnings": 2,
       "rules": {
-        "react-hooks/preserve-manual-memoization": 2,
-        "react-hooks/set-state-in-effect": 1
+        "react-hooks/preserve-manual-memoization": 2
       }
     },
     "src/components/common/GlassButton.tsx": {
@@ -109,11 +87,11 @@
     },
     "src/components/common/NFTThemeSelector.tsx": {
       "errors": 0,
-      "warnings": 4,
+      "warnings": 3,
       "rules": {
         "react-hooks/exhaustive-deps": 1,
         "react-hooks/immutability": 1,
-        "react-hooks/set-state-in-effect": 2
+        "react-hooks/set-state-in-effect": 1
       }
     },
     "src/components/common/UniversalHeader.tsx": {
@@ -123,19 +101,11 @@
         "react-hooks/immutability": 2
       }
     },
-    "src/components/debug/DebugLogsModal.tsx": {
+    "src/components/ledger/ConnectionModal.tsx": {
       "errors": 0,
       "warnings": 1,
       "rules": {
-        "react-hooks/set-state-in-effect": 1
-      }
-    },
-    "src/components/ledger/ConnectionModal.tsx": {
-      "errors": 0,
-      "warnings": 2,
-      "rules": {
-        "import/no-named-as-default": 1,
-        "react-hooks/set-state-in-effect": 1
+        "import/no-named-as-default": 1
       }
     },
     "src/components/ledger/DeviceDiscovery.tsx": {
@@ -221,20 +191,12 @@
         "react-hooks/set-state-in-effect": 1
       }
     },
-    "src/components/swap/SlippageSettingsModal.tsx": {
-      "errors": 0,
-      "warnings": 1,
-      "rules": {
-        "react-hooks/set-state-in-effect": 1
-      }
-    },
     "src/components/swap/TokenSelector.tsx": {
       "errors": 0,
-      "warnings": 3,
+      "warnings": 2,
       "rules": {
         "react-hooks/exhaustive-deps": 1,
-        "react-hooks/immutability": 1,
-        "react-hooks/set-state-in-effect": 1
+        "react-hooks/immutability": 1
       }
     },
     "src/components/transaction/TransactionAddressDisplay.tsx": {
@@ -327,13 +289,6 @@
         "react-hooks/set-state-in-effect": 1
       }
     },
-    "src/screens/remoteSigner/RemoteSignerSettingsScreen.tsx": {
-      "errors": 0,
-      "warnings": 1,
-      "rules": {
-        "react-hooks/set-state-in-effect": 1
-      }
-    },
     "src/screens/remoteSigner/SignRequestScannerScreen.tsx": {
       "errors": 0,
       "warnings": 1,
@@ -350,11 +305,10 @@
     },
     "src/screens/settings/NotificationSettingsScreen.tsx": {
       "errors": 0,
-      "warnings": 4,
+      "warnings": 2,
       "rules": {
         "react-hooks/exhaustive-deps": 1,
-        "react-hooks/immutability": 1,
-        "react-hooks/set-state-in-effect": 2
+        "react-hooks/immutability": 1
       }
     },
     "src/screens/settings/SecuritySettingsScreen.tsx": {
@@ -398,10 +352,9 @@
     },
     "src/screens/social/FriendProfileScreen.tsx": {
       "errors": 0,
-      "warnings": 3,
+      "warnings": 2,
       "rules": {
-        "react-hooks/preserve-manual-memoization": 2,
-        "react-hooks/set-state-in-effect": 1
+        "react-hooks/preserve-manual-memoization": 2
       }
     },
     "src/screens/social/MessagesInboxScreen.tsx": {
@@ -447,9 +400,9 @@
     },
     "src/screens/wallet/AssetDetailScreen.tsx": {
       "errors": 0,
-      "warnings": 2,
+      "warnings": 1,
       "rules": {
-        "react-hooks/set-state-in-effect": 2
+        "react-hooks/set-state-in-effect": 1
       }
     },
     "src/screens/wallet/ClaimAllConfirmationScreen.tsx": {
@@ -503,10 +456,10 @@
     },
     "src/screens/wallet/RekeyAccountScreen.tsx": {
       "errors": 0,
-      "warnings": 3,
+      "warnings": 2,
       "rules": {
         "import/no-named-as-default": 1,
-        "react-hooks/set-state-in-effect": 2
+        "react-hooks/set-state-in-effect": 1
       }
     },
     "src/screens/wallet/SendScreen.tsx": {

--- a/package.json
+++ b/package.json
@@ -7,7 +7,7 @@
     "android": "expo run:android",
     "ios": "expo run:ios",
     "web": "expo start --web",
-    "lint": "eslint src/ --max-warnings 242",
+    "lint": "eslint src/ --max-warnings 227",
     "lint:fix": "eslint src/ --fix",
     "lint:baseline": "node scripts/lint-baseline.mjs --write",
     "lint:baseline:check": "node scripts/lint-baseline.mjs --check",

--- a/src/components/account/RenameAccountModal.tsx
+++ b/src/components/account/RenameAccountModal.tsx
@@ -1,4 +1,4 @@
-import React, { useEffect, useMemo, useState } from 'react';
+import React, { useMemo, useState } from 'react';
 import {
   Modal,
   View,
@@ -36,12 +36,20 @@ export default function RenameAccountModal({
   const [name, setName] = useState(initialName);
   const [hasEdited, setHasEdited] = useState(false);
 
-  useEffect(() => {
-    if (visible) {
-      setName(initialName);
-      setHasEdited(false);
-    }
-  }, [visible, initialName]);
+  // Reset the editable fields the moment the modal transitions to visible (or
+  // its initialName changes while open) by adjusting state during render off a
+  // tracked previous value — the React-canonical replacement for the old
+  // reset-in-effect. Resets at the exact same logical moment the effect did
+  // (visible/initialName change) without the extra post-paint render pass.
+  const [prevResetKey, setPrevResetKey] = useState<string | null>(null);
+  const resetKey = visible ? `open:${initialName}` : null;
+  if (resetKey !== null && resetKey !== prevResetKey) {
+    setPrevResetKey(resetKey);
+    setName(initialName);
+    setHasEdited(false);
+  } else if (resetKey === null && prevResetKey !== null) {
+    setPrevResetKey(null);
+  }
 
   const trimmedName = useMemo(() => name.trim(), [name]);
   const isNameValid = trimmedName.length > 0;

--- a/src/components/assets/AssetFilterModal.tsx
+++ b/src/components/assets/AssetFilterModal.tsx
@@ -1,4 +1,4 @@
-import React, { useState, useEffect } from 'react';
+import React, { useState } from 'react';
 import {
   Modal,
   View,
@@ -57,18 +57,25 @@ export default function AssetFilterModal({
     currentSettings.nativeTokensFirst
   );
 
-  // Sync state with currentSettings when modal opens
-  useEffect(() => {
-    if (visible) {
-      setSortBy(currentSettings.sortBy);
-      setSortOrder(currentSettings.sortOrder);
-      setBalanceThresholdText(
-        currentSettings.balanceThreshold?.toString() || ''
-      );
-      setValueThresholdText(currentSettings.valueThreshold?.toString() || '');
-      setNativeTokensFirst(currentSettings.nativeTokensFirst);
-    }
-  }, [visible, currentSettings]);
+  // Sync the editable fields with currentSettings the moment the modal
+  // transitions to visible (or its settings change while open) by adjusting
+  // state during render off a tracked previous value — the React-canonical
+  // replacement for the old reset-in-effect. Resets at the exact same logical
+  // moment the effect did, without the extra post-paint render pass and without
+  // changing the modal's slide-in mount timing.
+  const [prevSyncKey, setPrevSyncKey] = useState<AssetFilterSettings | null>(
+    null
+  );
+  if (visible && currentSettings !== prevSyncKey) {
+    setPrevSyncKey(currentSettings);
+    setSortBy(currentSettings.sortBy);
+    setSortOrder(currentSettings.sortOrder);
+    setBalanceThresholdText(currentSettings.balanceThreshold?.toString() || '');
+    setValueThresholdText(currentSettings.valueThreshold?.toString() || '');
+    setNativeTokensFirst(currentSettings.nativeTokensFirst);
+  } else if (!visible && prevSyncKey !== null) {
+    setPrevSyncKey(null);
+  }
 
   const handleApply = () => {
     const balanceThreshold = balanceThresholdText.trim()

--- a/src/components/assets/MultiNetworkAssetItem.tsx
+++ b/src/components/assets/MultiNetworkAssetItem.tsx
@@ -1,4 +1,4 @@
-import React, { useEffect, useState } from 'react';
+import React, { useState } from 'react';
 import { View, Text, TouchableOpacity, StyleSheet } from 'react-native';
 import { Image } from 'expo-image';
 import { Ionicons } from '@expo/vector-icons';
@@ -30,9 +30,16 @@ export default function MultiNetworkAssetItem({
   const [imageError, setImageError] = useState(false);
   const styles = useThemedStyles(createStyles);
 
-  useEffect(() => {
+  // Clear the image-load error the moment the item is bound to a different
+  // asset (or image URL) by adjusting state during render off a tracked key —
+  // the React-canonical replacement for the old reset-in-effect, resetting at
+  // the same logical moment without the extra post-paint render pass.
+  const assetImageKey = `${asset.mappingId}:${asset.assetId}:${asset.imageUrl}`;
+  const [prevAssetImageKey, setPrevAssetImageKey] = useState(assetImageKey);
+  if (assetImageKey !== prevAssetImageKey) {
+    setPrevAssetImageKey(assetImageKey);
     setImageError(false);
-  }, [asset.mappingId, asset.assetId, asset.imageUrl]);
+  }
 
   // Filter source balances based on network filter
   const getFilteredSourceBalances = () => {

--- a/src/components/backup/PasswordInputModal.tsx
+++ b/src/components/backup/PasswordInputModal.tsx
@@ -1,4 +1,4 @@
-import React, { useState, useEffect, useCallback } from 'react';
+import React, { useState, useCallback } from 'react';
 import {
   Modal,
   View,
@@ -47,8 +47,14 @@ export default function PasswordInputModal({
   const [showConfirmPassword, setShowConfirmPassword] = useState(false);
   const [hasEdited, setHasEdited] = useState(false);
 
-  // Reset state when modal becomes visible
-  useEffect(() => {
+  // Reset the editable fields the moment the modal transitions to visible by
+  // adjusting state during render off a tracked previous value — the
+  // React-canonical replacement for the old reset-in-effect. Resets at the
+  // exact same logical moment the effect did (visible going true), without the
+  // extra post-paint render pass and without altering the modal's fade timing.
+  const [prevVisible, setPrevVisible] = useState(visible);
+  if (visible !== prevVisible) {
+    setPrevVisible(visible);
     if (visible) {
       setPassword('');
       setConfirmPassword('');
@@ -56,7 +62,7 @@ export default function PasswordInputModal({
       setShowConfirmPassword(false);
       setHasEdited(false);
     }
-  }, [visible]);
+  }
 
   const passwordStrength = validatePasswordStrength(password);
   const passwordsMatch = password === confirmPassword;

--- a/src/components/common/NFTThemeSelector.tsx
+++ b/src/components/common/NFTThemeSelector.tsx
@@ -65,16 +65,18 @@ export default function NFTThemeSelector({
     // eslint-disable-next-line react-hooks/exhaustive-deps -- load on open, keyed on visible/account-address/viewMode; activeAccount is tracked via its stable .address slice and loadMyNFTs is read at that commit, so neither should re-trigger on object/function identity.
   }, [visible, activeAccount?.address, viewMode]);
 
-  // Reset view when tab changes
-  useEffect(() => {
-    if (activeTab === 'my-nfts') {
-      setViewMode('my-nfts');
-      setSelectedCollection(null);
-    } else {
-      setViewMode('browse-collections');
-      setSelectedCollection(null);
-    }
-  }, [activeTab]);
+  // Reset the view the moment the active tab changes by adjusting state during
+  // render off the tracked previous tab — the React-canonical replacement for
+  // the old reset-in-effect. Resets viewMode/selectedCollection at the same
+  // logical moment the effect did, without the extra post-paint render pass.
+  // (viewMode can't be fully derived from activeTab — handleCollectionPress
+  // moves it to 'collection-tokens' independently.)
+  const [prevActiveTab, setPrevActiveTab] = useState(activeTab);
+  if (activeTab !== prevActiveTab) {
+    setPrevActiveTab(activeTab);
+    setViewMode(activeTab === 'my-nfts' ? 'my-nfts' : 'browse-collections');
+    setSelectedCollection(null);
+  }
 
   const loadMyNFTs = useCallback(async () => {
     if (!activeAccount) return;

--- a/src/components/debug/DebugLogsModal.tsx
+++ b/src/components/debug/DebugLogsModal.tsx
@@ -23,14 +23,28 @@ export const DebugLogsModal: React.FC<DebugLogsModalProps> = ({
   visible,
   onClose,
 }) => {
-  const [logs, setLogs] = useState<LogEntry[]>([]);
+  // The initial snapshot is seeded by the lazy initializer (covers a first
+  // mount with visible already true, which the old effect handled post-mount).
+  const [logs, setLogs] = useState<LogEntry[]>(() =>
+    visible ? debugLogger.getLogs() : []
+  );
+
+  // Re-seed the current log snapshot the moment the modal transitions to
+  // visible by adjusting state during render off a tracked previous value — the
+  // React-canonical replacement for the old snapshot-in-effect. This re-seeds
+  // on every open (catching logs that arrived while closed) at the same logical
+  // moment the effect did. Only the live subscription stays in the effect.
+  const [prevVisible, setPrevVisible] = useState(visible);
+  if (visible !== prevVisible) {
+    setPrevVisible(visible);
+    if (visible) {
+      setLogs(debugLogger.getLogs());
+    }
+  }
 
   useEffect(() => {
     if (visible) {
-      // Get initial logs
-      setLogs(debugLogger.getLogs());
-
-      // Listen for new logs
+      // Listen for new logs while open.
       const removeListener = debugLogger.addListener(setLogs);
       return removeListener;
     }

--- a/src/components/ledger/ConnectionModal.tsx
+++ b/src/components/ledger/ConnectionModal.tsx
@@ -56,15 +56,35 @@ const LedgerConnectionModal: React.FC<LedgerConnectionModalProps> = ({
 
   const connectedDevice = ledgerTransportService.getConnectedDevice();
 
-  useEffect(() => {
+  // Reset transient status on close / pre-select a device on open, at render
+  // time off the tracked previous [visible, initialDeviceId, connectedDevice]
+  // tuple — the React-canonical replacement for the old reset/init effect,
+  // firing on exactly the same input changes (connectedDevice compared by
+  // identity, matching the effect's dep array) without the extra post-paint
+  // render pass. This adjusts UI selection + status only; it never initiates a
+  // Ledger connection (connectToDevice) or any signing. The live
+  // connect/disconnect event subscription stays in its own effect below.
+  // prevVisible seeds to false (not the current `visible`) so a first mount with
+  // visible already true still runs the open-branch pre-selection, matching the
+  // old effect's post-mount behaviour.
+  const [prevVisible, setPrevVisible] = useState(false);
+  const [prevInitialDeviceId, setPrevInitialDeviceId] =
+    useState(initialDeviceId);
+  const [prevConnectedDevice, setPrevConnectedDevice] =
+    useState(connectedDevice);
+  if (
+    visible !== prevVisible ||
+    initialDeviceId !== prevInitialDeviceId ||
+    connectedDevice !== prevConnectedDevice
+  ) {
+    setPrevVisible(visible);
+    setPrevInitialDeviceId(initialDeviceId);
+    setPrevConnectedDevice(connectedDevice);
     if (!visible) {
       setConnectionStatus('idle');
       setStatusMessage('');
       setError(null);
-      return;
-    }
-
-    if (initialDeviceId) {
+    } else if (initialDeviceId) {
       const initial = ledgerTransportService
         .getDevices()
         .find((device) => device.id === initialDeviceId);
@@ -75,7 +95,7 @@ const LedgerConnectionModal: React.FC<LedgerConnectionModalProps> = ({
       setSelectedDevice(connectedDevice);
       setConnectionStatus('connected');
     }
-  }, [visible, initialDeviceId, connectedDevice]);
+  }
 
   useEffect(() => {
     if (!visible) {

--- a/src/components/swap/SlippageSettingsModal.tsx
+++ b/src/components/swap/SlippageSettingsModal.tsx
@@ -45,15 +45,28 @@ export const SlippageSettingsModal: React.FC<SlippageSettingsModalProps> = ({
   const [isCustom, setIsCustom] = useState<boolean>(false);
   const [slideAnim] = useState(new Animated.Value(0));
 
+  // Seed the slippage selection the moment the modal transitions to visible (or
+  // its currentSlippage changes while open) by adjusting state during render off
+  // a tracked previous value — the React-canonical replacement for the old
+  // reset-in-effect. Resets at the same logical moment the effect did, without
+  // the extra post-paint render pass. The open/close animation stays in the
+  // effect below (imperative, not derivable).
+  const [prevSlippageKey, setPrevSlippageKey] = useState<string | null>(null);
+  const slippageKey = visible ? `open:${currentSlippage}` : null;
+  if (slippageKey !== null && slippageKey !== prevSlippageKey) {
+    setPrevSlippageKey(slippageKey);
+    setSelectedSlippage(currentSlippage);
+    const isPreset = PRESET_SLIPPAGES.includes(currentSlippage);
+    setIsCustom(!isPreset);
+    if (!isPreset) {
+      setCustomSlippage(currentSlippage.toString());
+    }
+  } else if (slippageKey === null && prevSlippageKey !== null) {
+    setPrevSlippageKey(null);
+  }
+
   useEffect(() => {
     if (visible) {
-      setSelectedSlippage(currentSlippage);
-      const isPreset = PRESET_SLIPPAGES.includes(currentSlippage);
-      setIsCustom(!isPreset);
-      if (!isPreset) {
-        setCustomSlippage(currentSlippage.toString());
-      }
-
       Animated.spring(slideAnim, {
         toValue: 1,
         useNativeDriver: true,
@@ -67,8 +80,8 @@ export const SlippageSettingsModal: React.FC<SlippageSettingsModalProps> = ({
         useNativeDriver: true,
       }).start();
     }
-    // eslint-disable-next-line react-hooks/exhaustive-deps -- open/close animation keyed on visible/currentSlippage; slideAnim is a stable Animated ref that never changes identity.
-  }, [visible, currentSlippage]);
+    // eslint-disable-next-line react-hooks/exhaustive-deps -- open/close animation keyed on visible; slideAnim is a stable Animated ref that never changes identity.
+  }, [visible]);
 
   const handlePresetSelect = (slippage: number) => {
     setSelectedSlippage(slippage);

--- a/src/components/swap/TokenSelector.tsx
+++ b/src/components/swap/TokenSelector.tsx
@@ -113,6 +113,19 @@ export const TokenSelector: React.FC<TokenSelectorProps> = ({
   // Use network-specific balance or fallback to single network balance
   const accountBalance = networkBalance || singleNetworkBalance;
 
+  // Clear the search box the moment the modal transitions to hidden by
+  // adjusting state during render off the tracked previous visibility — the
+  // React-canonical replacement for the old clear-in-effect. Clears at the same
+  // logical moment the effect did, without the extra post-paint render pass.
+  // The open/close animation stays in the effect below (imperative).
+  const [prevVisible, setPrevVisible] = useState(visible);
+  if (visible !== prevVisible) {
+    setPrevVisible(visible);
+    if (!visible) {
+      setSearchQuery('');
+    }
+  }
+
   useEffect(() => {
     if (visible) {
       Animated.spring(slideAnim, {
@@ -127,7 +140,6 @@ export const TokenSelector: React.FC<TokenSelectorProps> = ({
         duration: 200,
         useNativeDriver: true,
       }).start();
-      setSearchQuery('');
     }
     // eslint-disable-next-line react-hooks/exhaustive-deps -- open/close animation keyed on visible; slideAnim is a stable Animated ref that never changes identity.
   }, [visible]);

--- a/src/screens/remoteSigner/RemoteSignerSettingsScreen.tsx
+++ b/src/screens/remoteSigner/RemoteSignerSettingsScreen.tsx
@@ -98,7 +98,10 @@ export default function RemoteSignerSettingsScreen() {
   );
 
   const [isModeSwitching, setIsModeSwitching] = useState(false);
-  const [deviceName, setDeviceName] = useState('');
+  // Seed from the persisted config so a mount with signerConfig already present
+  // shows the stored name (the old effect populated it post-mount); the
+  // render-time mirror below keeps it in sync on later config changes.
+  const [deviceName, setDeviceName] = useState(signerConfig?.deviceName ?? '');
   const [isEditingName, setIsEditingName] = useState(false);
   const [showSetupModal, setShowSetupModal] = useState(false);
   const [setupDeviceName, setSetupDeviceName] = useState('');
@@ -115,11 +118,19 @@ export default function RemoteSignerSettingsScreen() {
     }
   }, [isInitialized, initialize]);
 
-  useEffect(() => {
+  // Mirror the persisted device name into the editable field whenever the
+  // signer config changes, by adjusting state during render off the tracked
+  // previous config — the React-canonical replacement for the old
+  // mirror-in-effect. Fires on the same [signerConfig] change the effect keyed
+  // on (identity), without the extra post-paint render pass. The field stays
+  // user-editable (onChangeText) between config changes.
+  const [prevSignerConfig, setPrevSignerConfig] = useState(signerConfig);
+  if (signerConfig !== prevSignerConfig) {
+    setPrevSignerConfig(signerConfig);
     if (signerConfig?.deviceName) {
       setDeviceName(signerConfig.deviceName);
     }
-  }, [signerConfig]);
+  }
 
   const handleModeSwitch = async (newMode: AppMode) => {
     if (newMode === appMode) return;

--- a/src/screens/settings/NotificationSettingsScreen.tsx
+++ b/src/screens/settings/NotificationSettingsScreen.tsx
@@ -138,10 +138,16 @@ function NumberInputSetting({
   const themeColors = useThemeColors();
   const [localValue, setLocalValue] = useState(value.toString());
 
-  // Update local value when prop changes
-  useEffect(() => {
+  // Mirror the prop into the editable field whenever it changes, by adjusting
+  // state during render off the tracked previous value — the React-canonical
+  // replacement for the old mirror-in-effect. Syncs at the same logical moment
+  // (value prop change) without the extra post-paint render pass; the field
+  // stays user-editable (handleChangeText) between prop changes.
+  const [prevValue, setPrevValue] = useState(value);
+  if (value !== prevValue) {
+    setPrevValue(value);
     setLocalValue(value.toString());
-  }, [value]);
+  }
 
   const handleChangeText = (text: string) => {
     // Only allow numbers
@@ -312,12 +318,14 @@ export default function NotificationSettingsScreen() {
   // Check if selected account is watch-only
   const isWatchAccount = selectedAccount?.type === AccountType.WATCH;
 
-  // Initialize selected account to active account
-  useEffect(() => {
-    if (!selectedAccount && activeAccount) {
-      setSelectedAccount(activeAccount);
-    }
-  }, [activeAccount, selectedAccount]);
+  // Initialize the selected account to the active account, at render time — the
+  // React-canonical replacement for the old init-in-effect. The guard is
+  // self-limiting (once selectedAccount is set, !selectedAccount is false), so
+  // this settles in one pass without the extra post-paint render the effect
+  // incurred; the account stays user-changeable via the picker afterwards.
+  if (!selectedAccount && activeAccount) {
+    setSelectedAccount(activeAccount);
+  }
 
   // Reload preferences when selected account changes
   useEffect(() => {

--- a/src/screens/social/FriendProfileScreen.tsx
+++ b/src/screens/social/FriendProfileScreen.tsx
@@ -72,9 +72,17 @@ export default function FriendProfileScreen() {
   const [isRefreshing, setIsRefreshing] = useState(false);
   const [notesDraft, setNotesDraft] = useState(friend?.notes ?? '');
 
-  useEffect(() => {
-    setNotesDraft(friend?.notes ?? '');
-  }, [friend?.notes]);
+  // Mirror the stored notes into the editable draft whenever they change, by
+  // adjusting state during render off the tracked previous value — the
+  // React-canonical replacement for the old mirror-in-effect. Syncs at the same
+  // logical moment (friend.notes change) without the extra post-paint render
+  // pass; the draft stays user-editable between changes.
+  const friendNotes = friend?.notes ?? '';
+  const [prevFriendNotes, setPrevFriendNotes] = useState(friendNotes);
+  if (friendNotes !== prevFriendNotes) {
+    setPrevFriendNotes(friendNotes);
+    setNotesDraft(friendNotes);
+  }
 
   // Save notes on unmount using ref to avoid dependency issues
   const notesRef = useRef({ envoiName: '', notes: '', draft: '' });

--- a/src/screens/wallet/AssetDetailScreen.tsx
+++ b/src/screens/wallet/AssetDetailScreen.tsx
@@ -200,9 +200,16 @@ export default function AssetDetailScreen() {
     assetId,
   ]);
 
-  // If networkId is provided, we need to get the balance from that specific network
+  // If networkId is provided, we need to get the balance from that specific
+  // network. Seed from the store-derived balance at mount (the old effect's
+  // synchronous mirror ran post-mount) so that if the derived balance later
+  // disappears before a refetch completes, this retains the last-known value as
+  // a fallback — exactly as before. The render-time mirror below keeps it in
+  // sync on subsequent networkId / derived-balance changes.
   const [networkSpecificBalance, setNetworkSpecificBalance] =
-    useState<AccountBalance | null>(null);
+    useState<AccountBalance | null>(() =>
+      networkId && derivedNetworkBalance ? derivedNetworkBalance : null
+    );
   const [networkSpecificTransactions, setNetworkSpecificTransactions] =
     useState<TransactionInfo[]>([]);
   const [isLoadingNetworkTransactions, setIsLoadingNetworkTransactions] =
@@ -221,18 +228,36 @@ export default function AssetDetailScreen() {
   // frame in which a newly-selected asset still looked "already loaded".
   const [attemptedLoadKey, setAttemptedLoadKey] = useState<string | null>(null);
 
-  useEffect(() => {
+  // The two synchronous branches of the old effect — clear the fetched balance
+  // when there is no network context, and mirror the store-derived balance when
+  // one is available — are adjusted during render off the tracked
+  // [networkId, derivedNetworkBalance] inputs the effect keyed on (TASK-247).
+  // This keeps networkSpecificBalance's value identical to before (still tracks
+  // derivedNetworkBalance) while dropping the extra post-paint render pass, in
+  // line with this screen's existing derive-during-render approach to avoid
+  // stale frames. Only the async network fetch stays in the effect below.
+  const [prevBalanceNetworkId, setPrevBalanceNetworkId] = useState(networkId);
+  const [prevDerivedNetworkBalance, setPrevDerivedNetworkBalance] = useState(
+    derivedNetworkBalance
+  );
+  if (
+    networkId !== prevBalanceNetworkId ||
+    derivedNetworkBalance !== prevDerivedNetworkBalance
+  ) {
+    setPrevBalanceNetworkId(networkId);
+    setPrevDerivedNetworkBalance(derivedNetworkBalance);
     if (!networkId) {
       setNetworkSpecificBalance(null);
-      return;
-    }
-
-    if (derivedNetworkBalance) {
+    } else if (derivedNetworkBalance) {
       setNetworkSpecificBalance(derivedNetworkBalance);
-      return;
     }
+    // else (network context, no derived balance): the effect below fetches it.
+  }
 
-    if (!currentAccount) {
+  useEffect(() => {
+    // Only the async network fetch remains here; fetch when we have a network
+    // context, no store-derived balance to use, and an account.
+    if (!networkId || derivedNetworkBalance || !currentAccount) {
       return;
     }
 

--- a/src/screens/wallet/RekeyAccountScreen.tsx
+++ b/src/screens/wallet/RekeyAccountScreen.tsx
@@ -284,6 +284,17 @@ export default function RekeyAccountScreen() {
     selectedNetworkId,
   ]);
 
+  // Auto-select the sole Ledger / airgap target account when exactly one is
+  // available (a pure UI convenience). This deliberately stays an effect rather
+  // than being converted to a render-time state adjustment (TASK-247): this is
+  // key-authority-adjacent code whose committed selection feeds the rekey
+  // validation and submission paths, so we keep its post-commit timing exactly
+  // as-is rather than perturb when the selection lands. The set-state-in-effect
+  // hint is suppressed for the whole effect on purpose — the effect is correct
+  // and behaviour must remain byte-identical (see TASK-247 stop-and-ask
+  // boundary). It never touches rekeyManager, submission, or authority
+  // resolution; it only pre-selects a target account in the UI.
+  /* eslint-disable react-hooks/set-state-in-effect -- intentional: key-authority-adjacent auto-select kept in an effect to preserve exact commit timing (TASK-247). */
   useEffect(() => {
     if (
       rekeyFlow === 'ledger' &&
@@ -307,6 +318,7 @@ export default function RekeyAccountScreen() {
     selectedLedgerAccount,
     selectedAirgapAccount,
   ]);
+  /* eslint-enable react-hooks/set-state-in-effect */
 
   const handleStandardAccountSelect = (account: StandardAccountMetadata) => {
     setSelectedStandardAccount(account);


### PR DESCRIPTION
## What & why

Wave 4 of the ESLint warning burn-down. Converts **benign** prop-mirror / modal-reset populations from `react-hooks/set-state-in-effect` to render-time state adjustment (the React-canonical "adjust state during render off a tracked previous value" idiom), keeping only genuinely async work — network fetches, live subscriptions, imperative animations — in effects.

Every site here was already guarded (no infinite loop existed); these were double-render inefficiencies. The render-time form drops the extra post-paint render pass while preserving each site's reset value and logical timing. It was chosen over a `key`-based remount specifically because it does **not** change any modal's entry/exit animation mount timing (a remount would).

## Warning counts (regenerated via `npm run lint:baseline`)

| Rule | Before | After |
|---|---|---|
| `react-hooks/set-state-in-effect` | 55 | **40** |
| `react-hooks/preserve-manual-memoization` | 25 | **25** (unchanged) |
| **total warnings** | 242 | **227** |

Ratchet lowered: `--max-warnings` 242 → 227, `lint-baseline.json` re-committed in this PR; `npm run lint:baseline:check` passes.

## Sites converted (14 sites, 15 warnings cleared)

- `RenameAccountModal`, `AssetFilterModal`, `PasswordInputModal`, `SlippageSettingsModal` — modal-open field resets (animation stays in its own effect for Slippage).
- `MultiNetworkAssetItem` — image-error reset on asset-identity change.
- `NFTThemeSelector` — tab-change view reset only (the `loadCollectionTokens` exhaustive-deps effect owned by TASK-246 untouched).
- `DebugLogsModal` — initial snapshot seed (lazy initializer + render-time re-seed on open); the live `addListener` subscription stays in the effect.
- `ConnectionModal` — UI status reset / device pre-select; the connect/disconnect event subscription stays in its own effect. UI selection + status only — never initiates a connection or signing.
- `TokenSelector` — clear-search-on-close only; the animation effect (its `:130` set-state site) and the `loadTokens` exhaustive-deps effect (TASK-246) are handled/left per scope.
- `RemoteSignerSettingsScreen` — device-name mirror (seeded from `signerConfig` at mount).
- `NotificationSettingsScreen` — `NumberInputSetting` prop mirror + self-limiting active-account init.
- `FriendProfileScreen` — notes-draft mirror.
- `AssetDetailScreen` — the two synchronous prop-mirror branches (clear-on-no-network, mirror store-derived balance); the async network fetch stays in the effect, `networkSpecificBalance` is lazy-seeded at mount so the stale fallback behaviour is preserved.

## Sites left (intentional)

- **`RekeyAccountScreen` (Ledger/airgap auto-select)** — key-authority-adjacent: its committed selection feeds the rekey validation/submission paths. Per the TASK-247 stop-and-ask boundary, the effect is left **byte-identical** and the hint is suppressed with a documented block `eslint-disable`, rather than converted. It never touches `rekeyManager`, submission, or authority resolution — it only pre-selects a target account in the UI. Acceptance "RekeyAccountScreen still auto-selects a single Ledger account" holds (behaviour unchanged).
- **`AccountAvatar`** — a legitimate async-loader + cross-instance avatar cache subscription; the synchronous seed is inseparable from the async work, so it stays.
- The ~async-loader effects, all auth/signing/mnemonic screens, and SendScreen (TASK-245) were not touched.

## Codex review

3 rounds → **CLEAN**. Rounds 1-2 caught first-mount gaps (a prev-tracker seeded to the current input skipped the mount-time population the old effect did) in DebugLogsModal, RemoteSignerSettingsScreen, ConnectionModal, and AssetDetailScreen; all fixed with lazy state initializers / a `false`-seeded `prevVisible`. Final round verified behavioural equivalence including first mount, that no async loader was wrongly converted, that the excluded flows were untouched, and no net-new `preserve-manual-memoization` warning.

## Gates

- `npm run typecheck` — clean (0)
- `npm run lint` — exit 0 (227 ≤ 227)
- `npm test -- --ci` — 100 suites / 1551 tests green
- `npm run lint:baseline:check` — passes

## Device QA (batched pre-release per HT-218)

- Open / close / reopen each touched modal and confirm it resets exactly as before, watching entry/exit animations (fade + slide sheets) for timing regressions.
- `RekeyAccountScreen` still auto-selects a single Ledger (and single airgap) account.
- `SwapScreen`/`TokenSelector` still clears the search box the instant the sheet closes.

https://claude.ai/code/session_01AL4EmUSYAiVXEstBgKqDmv
