### PR TITLE
fix(hooks): adjudicate exhaustive-deps — fix stale-closure bugs, document deliberate omissions (TASK-246)

### DIFF
--- a/lint-baseline.json
+++ b/lint-baseline.json
@@ -2,14 +2,13 @@
   "$comment": "Committed ESLint baseline for the `npm run lint` ratchet (PLAN-229 DR-2). Regenerate with `npm run lint:baseline`; verify with `npm run lint:baseline:check`. The `lint` script's --max-warnings MUST equal totals.warnings. Lower it in the same PR that clears the warnings. It never goes up.",
   "totals": {
     "errors": 0,
-    "warnings": 227,
-    "filesLinted": 437,
-    "filesWithFindings": 83
+    "warnings": 208,
+    "filesLinted": 440,
+    "filesWithFindings": 82
   },
   "rules": {
     "@typescript-eslint/no-unused-vars": 5,
     "import/no-named-as-default": 30,
-    "react-hooks/exhaustive-deps": 19,
     "react-hooks/immutability": 96,
     "react-hooks/preserve-manual-memoization": 25,
     "react-hooks/purity": 5,
@@ -35,10 +34,9 @@
     },
     "src/components/account/AccountAvatar.tsx": {
       "errors": 0,
-      "warnings": 3,
+      "warnings": 2,
       "rules": {
         "import/no-named-as-default": 1,
-        "react-hooks/exhaustive-deps": 1,
         "react-hooks/set-state-in-effect": 1
       }
     },
@@ -87,9 +85,8 @@
     },
     "src/components/common/NFTThemeSelector.tsx": {
       "errors": 0,
-      "warnings": 3,
+      "warnings": 2,
       "rules": {
-        "react-hooks/exhaustive-deps": 1,
         "react-hooks/immutability": 1,
         "react-hooks/set-state-in-effect": 1
       }
@@ -139,18 +136,10 @@
     },
     "src/components/nft/CollectionBrowser.tsx": {
       "errors": 0,
-      "warnings": 3,
+      "warnings": 2,
       "rules": {
-        "react-hooks/exhaustive-deps": 1,
         "react-hooks/immutability": 1,
         "react-hooks/preserve-manual-memoization": 1
-      }
-    },
-    "src/components/rekey/AirgapVerificationFlow.tsx": {
-      "errors": 0,
-      "warnings": 1,
-      "rules": {
-        "react-hooks/exhaustive-deps": 1
       }
     },
     "src/components/remoteSigner/AnimatedQRCode.tsx": {
@@ -193,9 +182,8 @@
     },
     "src/components/swap/TokenSelector.tsx": {
       "errors": 0,
-      "warnings": 2,
+      "warnings": 1,
       "rules": {
-        "react-hooks/exhaustive-deps": 1,
         "react-hooks/immutability": 1
       }
     },
@@ -240,9 +228,8 @@
     },
     "src/screens/account/MnemonicImportScreen.tsx": {
       "errors": 0,
-      "warnings": 2,
+      "warnings": 1,
       "rules": {
-        "react-hooks/exhaustive-deps": 1,
         "react-hooks/preserve-manual-memoization": 1
       }
     },
@@ -283,9 +270,8 @@
     },
     "src/screens/remoteSigner/ImportFromOnlineWalletScreen.tsx": {
       "errors": 0,
-      "warnings": 2,
+      "warnings": 1,
       "rules": {
-        "react-hooks/exhaustive-deps": 1,
         "react-hooks/set-state-in-effect": 1
       }
     },
@@ -305,9 +291,8 @@
     },
     "src/screens/settings/NotificationSettingsScreen.tsx": {
       "errors": 0,
-      "warnings": 2,
+      "warnings": 1,
       "rules": {
-        "react-hooks/exhaustive-deps": 1,
         "react-hooks/immutability": 1
       }
     },
@@ -334,10 +319,9 @@
     },
     "src/screens/social/AddFriendScreen.tsx": {
       "errors": 0,
-      "warnings": 5,
+      "warnings": 4,
       "rules": {
         "import/no-named-as-default": 1,
-        "react-hooks/exhaustive-deps": 1,
         "react-hooks/immutability": 1,
         "react-hooks/set-state-in-effect": 2
       }
@@ -374,10 +358,9 @@
     },
     "src/screens/social/NewMessageScreen.tsx": {
       "errors": 0,
-      "warnings": 5,
+      "warnings": 4,
       "rules": {
         "import/no-named-as-default": 1,
-        "react-hooks/exhaustive-deps": 1,
         "react-hooks/immutability": 1,
         "react-hooks/preserve-manual-memoization": 1,
         "react-hooks/set-state-in-effect": 1
@@ -446,9 +429,8 @@
     },
     "src/screens/wallet/NFTScreen.tsx": {
       "errors": 0,
-      "warnings": 7,
+      "warnings": 5,
       "rules": {
-        "react-hooks/exhaustive-deps": 2,
         "react-hooks/immutability": 2,
         "react-hooks/preserve-manual-memoization": 2,
         "react-hooks/set-state-in-effect": 1
@@ -464,18 +446,16 @@
     },
     "src/screens/wallet/SendScreen.tsx": {
       "errors": 0,
-      "warnings": 7,
+      "warnings": 4,
       "rules": {
         "import/no-named-as-default": 1,
-        "react-hooks/exhaustive-deps": 3,
         "react-hooks/set-state-in-effect": 3
       }
     },
     "src/screens/wallet/SwapScreen.tsx": {
       "errors": 0,
-      "warnings": 9,
+      "warnings": 8,
       "rules": {
-        "react-hooks/exhaustive-deps": 1,
         "react-hooks/immutability": 3,
         "react-hooks/refs": 4,
         "react-hooks/set-state-in-effect": 1
@@ -483,10 +463,9 @@
     },
     "src/screens/wallet/TransactionConfirmationScreen.tsx": {
       "errors": 0,
-      "warnings": 5,
+      "warnings": 3,
       "rules": {
         "import/no-named-as-default": 1,
-        "react-hooks/exhaustive-deps": 2,
         "react-hooks/immutability": 2
       }
     },
@@ -499,9 +478,8 @@
     },
     "src/screens/wallet/TransactionHistoryScreen.tsx": {
       "errors": 0,
-      "warnings": 4,
+      "warnings": 3,
       "rules": {
-        "react-hooks/exhaustive-deps": 1,
         "react-hooks/immutability": 1,
         "react-hooks/preserve-manual-memoization": 2
       }

--- a/package.json
+++ b/package.json
@@ -7,7 +7,7 @@
     "android": "expo run:android",
     "ios": "expo run:ios",
     "web": "expo start --web",
-    "lint": "eslint src/ --max-warnings 227",
+    "lint": "eslint src/ --max-warnings 208",
     "lint:fix": "eslint src/ --fix",
     "lint:baseline": "node scripts/lint-baseline.mjs --write",
     "lint:baseline:check": "node scripts/lint-baseline.mjs --check",

--- a/src/components/account/AccountAvatar.tsx
+++ b/src/components/account/AccountAvatar.tsx
@@ -267,7 +267,11 @@ export default function AccountAvatar({
     return () => {
       avatarCallbacks.get(address)?.delete(updateCallback);
     };
-  }, [address, useEnvoiAvatar, size]);
+    // account?.avatarUrl is read to seed the avatar; include it so a prop-level
+    // avatar change re-seeds instead of showing the previous account's avatar.
+    // (The store lookup at getState() stays intentionally non-reactive per the
+    // note above — it would loop.)
+  }, [address, useEnvoiAvatar, size, account?.avatarUrl]);
 
   const handleAvatarError = () => {
     setAvatarError(true);

--- a/src/components/common/NFTThemeSelector.tsx
+++ b/src/components/common/NFTThemeSelector.tsx
@@ -1,4 +1,10 @@
-import React, { useState, useEffect, useMemo, useCallback } from 'react';
+import React, {
+  useState,
+  useEffect,
+  useMemo,
+  useCallback,
+  useRef,
+} from 'react';
 import {
   View,
   Text,
@@ -36,6 +42,14 @@ export default function NFTThemeSelector({
   const styles = useMemo(() => createStyles(theme, insets), [theme, insets]);
   const { setNFTTheme } = useTheme();
   const activeAccount = useActiveAccount();
+
+  // Track the active account address so an in-flight collection/ownership load
+  // can detect a mid-flight account switch and refuse to write a stale result
+  // (the HomeScreen:546 ref-recheck pattern applied to an account-keyed load).
+  const activeAccountAddressRef = useRef(activeAccount?.address);
+  useEffect(() => {
+    activeAccountAddressRef.current = activeAccount?.address;
+  }, [activeAccount?.address]);
 
   // State management
   const [activeTab, setActiveTab] = useState<TabType>('my-nfts');
@@ -81,24 +95,38 @@ export default function NFTThemeSelector({
   const loadMyNFTs = useCallback(async () => {
     if (!activeAccount) return;
 
+    // Guard against a mid-flight account switch: a slow previous-account fetch
+    // must not overwrite the newer account's list (same race as the collection
+    // load below).
+    const requestAddress = activeAccount.address;
+
     try {
       setIsLoadingMyNFTs(true);
       const response = await NFTService.fetchUserNFTs(activeAccount.address);
+      if (activeAccountAddressRef.current !== requestAddress) return;
       const nftsWithImages = response.tokens.filter((token) =>
         NFTService.hasValidImage(token)
       );
       setMyNFTs(nftsWithImages);
     } catch (error) {
+      if (activeAccountAddressRef.current !== requestAddress) return;
       console.error('Failed to load NFTs:', error);
       Alert.alert('Error', 'Failed to load NFTs. Please try again.');
     } finally {
-      setIsLoadingMyNFTs(false);
+      if (activeAccountAddressRef.current === requestAddress) {
+        setIsLoadingMyNFTs(false);
+      }
     }
   }, [activeAccount]);
 
   const loadCollectionTokens = useCallback(
     async (reset = false) => {
       if (!selectedCollection) return;
+
+      // Address this load is for; compared against the live ref after each await
+      // so a slow previous-account fetch can never overwrite a newer account's
+      // ownership map / token list.
+      const requestAddress = activeAccount?.address;
 
       try {
         if (reset) {
@@ -111,6 +139,7 @@ export default function NFTThemeSelector({
             const userNFTs = await NFTService.fetchUserNFTs(
               activeAccount.address
             );
+            if (activeAccountAddressRef.current !== requestAddress) return;
             const ownership = NFTService.createOwnershipMap(userNFTs.tokens);
             setOwnershipMap(ownership);
           }
@@ -125,6 +154,7 @@ export default function NFTThemeSelector({
             nextToken: reset ? undefined : nextToken,
           }
         );
+        if (activeAccountAddressRef.current !== requestAddress) return;
 
         if (reset) {
           setCollectionTokens(response.tokens);
@@ -141,19 +171,30 @@ export default function NFTThemeSelector({
           'Failed to load collection tokens. Please try again.'
         );
       } finally {
-        setIsLoadingCollectionTokens(false);
-        setLoadingMore(false);
+        // Only the load that still owns the active account clears the spinners,
+        // so a bailed stale load can't flip loading state under the newer one.
+        if (activeAccountAddressRef.current === requestAddress) {
+          setIsLoadingCollectionTokens(false);
+          setLoadingMore(false);
+        }
       }
     },
     [selectedCollection, nextToken, activeAccount]
   );
 
-  // Load collection tokens when collection is selected
+  // Load collection tokens when the collection, the view, OR the active account
+  // changes — keying on activeAccount?.address is the bug fix: switching accounts
+  // with a collection open must rebuild the ownership map for the new account
+  // (TASK-246). loadCollectionTokens is intentionally omitted from the deps: its
+  // identity also tracks `nextToken` (which the load itself sets), so listing it
+  // would double-fire the reset load; it is read at the current commit and the
+  // body re-checks activeAccountAddressRef after each await.
   useEffect(() => {
     if (selectedCollection && viewMode === 'collection-tokens') {
       loadCollectionTokens(true);
     }
-  }, [selectedCollection, viewMode]);
+    // eslint-disable-next-line react-hooks/exhaustive-deps -- keyed on collection/viewMode/activeAccount?.address so ownership rebuilds on account switch; loadCollectionTokens omitted on purpose (its nextToken-tracking identity would double-fire the reset load) and is read at the current commit.
+  }, [selectedCollection, viewMode, activeAccount?.address]);
 
   const handleCollectionPress = (collection: ARC72Collection) => {
     setSelectedCollection(collection);

--- a/src/components/common/__tests__/NFTThemeSelector.ownership.test.tsx
+++ b/src/components/common/__tests__/NFTThemeSelector.ownership.test.tsx
@@ -1,0 +1,139 @@
+/**
+ * TASK-246 — NFTThemeSelector stale-ownership bug.
+ *
+ * The bug: the collection-tokens load effect keyed only on
+ * [selectedCollection, viewMode]. loadCollectionTokens builds the "owned" badge
+ * map from the ACTIVE account's NFTs, so switching accounts while a collection
+ * was open left the previous account's ownership markers on screen — the effect
+ * never re-fired because neither the collection nor the view mode changed.
+ *
+ * The fix keys the effect on activeAccount?.address as well (and re-checks a
+ * live address ref after each await so a slow previous-account fetch can't
+ * clobber the newer one). This test drives an account switch with a collection
+ * open and asserts the ownership map rebuilds for the new account — it fails
+ * against the pre-fix [selectedCollection, viewMode] dependency array.
+ */
+
+import React from 'react';
+import { render, fireEvent, waitFor } from '@testing-library/react-native';
+import { lightTheme } from '@/constants/themes';
+
+// Active account is swapped between renders via this mutable fixture.
+let mockActiveAccount: { id: string; address: string } = {
+  id: 'a',
+  address: 'ADDR_A',
+};
+
+jest.mock('@/store/walletStore', () => ({
+  useActiveAccount: () => mockActiveAccount,
+}));
+
+jest.mock('@/contexts/ThemeContext', () => ({
+  useTheme: () => ({ setNFTTheme: jest.fn() }),
+}));
+
+jest.mock('react-native-safe-area-context', () => ({
+  useSafeAreaInsets: () => ({ top: 0, bottom: 0, left: 0, right: 0 }),
+}));
+
+jest.mock('@expo/vector-icons', () => ({ Ionicons: () => null }), {
+  virtual: true,
+});
+
+// Ownership map keyed by `${contractId}:${tokenId}` so the test can read which
+// account's NFTs the map was built from.
+const mockFetchUserNFTs = jest.fn(async (address: string) => ({
+  tokens:
+    address === 'ADDR_A'
+      ? [{ contractId: 1, tokenId: 'a1' }]
+      : [{ contractId: 1, tokenId: 'b1' }],
+}));
+
+jest.mock('@/services/nft', () => ({
+  NFTService: {
+    fetchUserNFTs: (address: string) => mockFetchUserNFTs(address),
+    createOwnershipMap: (tokens: { contractId: number; tokenId: string }[]) =>
+      new Set(tokens.map((t) => `${t.contractId}:${t.tokenId}`)),
+    fetchTokensByCollection: jest.fn(async () => ({
+      tokens: [],
+      nextToken: undefined,
+    })),
+    hasValidImage: () => true,
+    getDisplayName: () => 'name',
+  },
+}));
+
+// CollectionBrowser mock: one press target that selects a fake collection.
+jest.mock('@/components/nft/CollectionBrowser', () => {
+  const { Pressable, Text } = require('react-native');
+  return {
+    __esModule: true,
+    default: ({
+      onCollectionPress,
+    }: {
+      onCollectionPress: (c: unknown) => void;
+    }) => (
+      <Pressable
+        testID="pick-collection"
+        onPress={() =>
+          onCollectionPress({ contractId: 1, name: 'Coll', totalSupply: 10 })
+        }
+      >
+        <Text>pick</Text>
+      </Pressable>
+    ),
+  };
+});
+
+// NFTGridView mock: surfaces the ownership map so the test can inspect it.
+jest.mock('@/components/nft/NFTGridView', () => {
+  const { Text } = require('react-native');
+  return {
+    __esModule: true,
+    default: ({ ownershipMap }: { ownershipMap?: Set<string> }) => (
+      <Text testID="ownership">
+        {'ids=' +
+          Array.from(ownershipMap ?? [])
+            .sort()
+            .join(',')}
+      </Text>
+    ),
+  };
+});
+
+import NFTThemeSelector from '../NFTThemeSelector';
+
+describe('NFTThemeSelector ownership map (TASK-246)', () => {
+  beforeEach(() => {
+    mockActiveAccount = { id: 'a', address: 'ADDR_A' };
+    mockFetchUserNFTs.mockClear();
+  });
+
+  it('rebuilds the ownership map when the account switches with a collection open', async () => {
+    const { getByText, getByTestId, rerender } = render(
+      <NFTThemeSelector visible onClose={jest.fn()} theme={lightTheme} />
+    );
+
+    // Open a collection: Browse Collections tab -> pick a collection.
+    fireEvent.press(getByText('Browse Collections'));
+    fireEvent.press(getByTestId('pick-collection'));
+
+    // Ownership reflects account A.
+    await waitFor(() =>
+      expect(getByTestId('ownership').props.children).toBe('ids=1:a1')
+    );
+    expect(mockFetchUserNFTs).toHaveBeenCalledWith('ADDR_A');
+
+    // Switch to account B with the collection still open.
+    mockActiveAccount = { id: 'b', address: 'ADDR_B' };
+    rerender(
+      <NFTThemeSelector visible onClose={jest.fn()} theme={lightTheme} />
+    );
+
+    // Ownership must rebuild for account B (pre-fix it stayed 1:a1).
+    await waitFor(() =>
+      expect(getByTestId('ownership').props.children).toBe('ids=1:b1')
+    );
+    expect(mockFetchUserNFTs).toHaveBeenCalledWith('ADDR_B');
+  });
+});

--- a/src/components/nft/CollectionBrowser.tsx
+++ b/src/components/nft/CollectionBrowser.tsx
@@ -45,9 +45,15 @@ export default function CollectionBrowser({
     return () => clearTimeout(timer);
   }, [searchQuery]);
 
-  // Load collections when search changes
+  // Reload the collection list (reset) whenever the debounced search changes.
+  // loadCollections is intentionally omitted: it is a useCallback whose identity
+  // also tracks `nextToken` (set by the load itself as the user paginates), so
+  // listing it would re-fire the reset load on every page fetch. Keyed on
+  // debouncedSearchQuery — the only input that should reset the list — and
+  // loadCollections is read at the current commit.
   useEffect(() => {
     loadCollections(true);
+    // eslint-disable-next-line react-hooks/exhaustive-deps -- keyed on debouncedSearchQuery; loadCollections omitted on purpose (its nextToken-tracking identity would re-fire the reset load during pagination) and is read at the current commit.
   }, [debouncedSearchQuery]);
 
   const loadCollections = useCallback(

--- a/src/components/rekey/AirgapVerificationFlow.tsx
+++ b/src/components/rekey/AirgapVerificationFlow.tsx
@@ -237,6 +237,7 @@ export function AirgapVerificationFlow({
         setState('error');
       }
     },
+    // eslint-disable-next-line react-hooks/exhaustive-deps -- onVerificationSuccess is NOT invoked in this handler (success is signalled via setState('success'); the parent's handler runs on the user's Continue tap at onPress={onVerificationSuccess}), so keeping it here is behaviour-neutral. It is retained as a defensive hand-mirror (matching handleRetry at :251) so that if a future edit ever calls it inside this airgap-rekey handler the dep is already correct rather than silently stale. Removing it — what the rule suggests — would also change nothing today; we do not rely on the caller passing a stable handler.
     [signingRequest, targetAccount.address, onVerificationSuccess]
   );
 

--- a/src/components/swap/TokenSelector.tsx
+++ b/src/components/swap/TokenSelector.tsx
@@ -3,7 +3,7 @@
  * Allows users to select tokens for swapping
  */
 
-import React, { useState, useEffect, useMemo } from 'react';
+import React, { useState, useEffect, useMemo, useRef } from 'react';
 import {
   View,
   Text,
@@ -70,6 +70,11 @@ export const TokenSelector: React.FC<TokenSelectorProps> = ({
     null
   );
 
+  // Monotonic id for the token load: a config change starts a newer load, and
+  // only the newest load is allowed to write `tokens` / clear `loading`, so a
+  // slow earlier request can't resolve last and overwrite the fresh list.
+  const loadTokensRequestRef = useRef(0);
+
   // Get account address from store
   const accounts = useWalletStore((state) => state.wallet?.accounts);
   const currentAccount = accounts?.find((acc) => acc.id === accountId);
@@ -79,8 +84,13 @@ export const TokenSelector: React.FC<TokenSelectorProps> = ({
     (state) => state.accountStates[accountId]?.balance
   );
 
-  // Load balance for the specific network when modal opens
+  // Load balance for the specific network when modal opens. Cancellation-guarded
+  // so that when the account or network changes mid-fetch, the prior fetch cannot
+  // resolve last and write a stale prior-account/prior-network balance into
+  // networkBalance (which would then feed a stale token list via loadTokens).
   useEffect(() => {
+    let cancelled = false;
+
     const loadNetworkBalance = async () => {
       if (!visible || !currentAccount?.address) return;
 
@@ -94,20 +104,26 @@ export const TokenSelector: React.FC<TokenSelectorProps> = ({
           const balance = await networkService.getAccountBalance(
             currentAccount.address
           );
+          if (cancelled) return;
           setNetworkBalance(balance);
         } else {
           // For VOI network, use the store balance
+          if (cancelled) return;
           setNetworkBalance(singleNetworkBalance || null);
         }
       } catch (error) {
         console.error('Error loading network balance:', error);
-        setNetworkBalance(singleNetworkBalance || null);
+        if (!cancelled) setNetworkBalance(singleNetworkBalance || null);
       } finally {
-        setLoadingBalance(false);
+        if (!cancelled) setLoadingBalance(false);
       }
     };
 
     loadNetworkBalance();
+
+    return () => {
+      cancelled = true;
+    };
   }, [visible, currentAccount?.address, networkId, singleNetworkBalance]);
 
   // Use network-specific balance or fallback to single network balance
@@ -144,14 +160,24 @@ export const TokenSelector: React.FC<TokenSelectorProps> = ({
     // eslint-disable-next-line react-hooks/exhaustive-deps -- open/close animation keyed on visible; slideAnim is a stable Animated ref that never changes identity.
   }, [visible]);
 
-  // Load tokens when modal opens and balance is available
+  // Load tokens when the modal opens, the balance arrives, OR the config that
+  // shapes the list changes while the modal stays open (TASK-246 bug fix):
+  // networkId picks the token universe/provider, excludeTokenId hides the paired
+  // token, and ownedOnly filters to held tokens — a change to any of these must
+  // rebuild the list. loadTokens is intentionally omitted: it is a plain
+  // render-scope function (new identity every render) read at the current commit,
+  // so listing it would re-fire the load on every render. All listed deps are
+  // props / derived-stable values that do not change as a result of the load, so
+  // there is no reload loop.
   useEffect(() => {
     if (visible && accountBalance) {
       loadTokens();
     }
-  }, [visible, accountBalance]);
+    // eslint-disable-next-line react-hooks/exhaustive-deps -- keyed on visible + the config that shapes the list (accountBalance, networkId, excludeTokenId, ownedOnly); loadTokens is a plain render-scope function read at the current commit and omitted on purpose so its per-render identity can't retrigger the load.
+  }, [visible, accountBalance, networkId, excludeTokenId, ownedOnly]);
 
   const loadTokens = async () => {
+    const requestId = ++loadTokensRequestRef.current;
     setLoading(true);
     try {
       const provider = SwapService.getProvider(networkId);
@@ -205,11 +231,17 @@ export const TokenSelector: React.FC<TokenSelectorProps> = ({
         return a.symbol.localeCompare(b.symbol);
       });
 
+      // A newer config load has superseded this one — don't overwrite its list.
+      if (requestId !== loadTokensRequestRef.current) return;
       setTokens(sorted);
     } catch (error) {
       console.error('Error loading tokens:', error);
     } finally {
-      setLoading(false);
+      // Only the newest load owns the spinner, so a bailed stale load can't flip
+      // loading off under the newer one.
+      if (requestId === loadTokensRequestRef.current) {
+        setLoading(false);
+      }
     }
   };
 

--- a/src/components/swap/__tests__/TokenSelector.reload.test.tsx
+++ b/src/components/swap/__tests__/TokenSelector.reload.test.tsx
@@ -1,0 +1,85 @@
+/**
+ * TASK-246 — TokenSelector stale token-list bug.
+ *
+ * The bug: the token-load effect keyed only on [visible, accountBalance], while
+ * loadTokens also reads networkId, excludeTokenId and ownedOnly. Changing any of
+ * those config props while the modal stayed open left the previously-built list
+ * on screen — the effect never re-fired.
+ *
+ * The fix adds networkId, excludeTokenId and ownedOnly to the effect deps. This
+ * test opens the selector, then changes excludeTokenId while it stays visible and
+ * asserts the list rebuilds (the newly-excluded token disappears and the
+ * previously-excluded one returns). It fails against the pre-fix dependency array.
+ */
+
+import React from 'react';
+import { render, waitFor } from '@testing-library/react-native';
+import { NetworkId } from '@/types/network';
+
+jest.mock('@/contexts/ThemeContext', () => ({
+  useTheme: () => ({ theme: require('@/constants/themes').lightTheme }),
+}));
+
+jest.mock('@expo/vector-icons', () => ({ Ionicons: () => null }), {
+  virtual: true,
+});
+
+jest.mock('expo-image', () => ({ Image: () => null }));
+
+jest.mock('@/utils/tokenImages', () => ({ getTokenImageSource: () => null }));
+
+// Store: one account with a VOI balance so accountBalance is truthy and the
+// load path uses the store balance (no NetworkService round-trip).
+const mockState = {
+  wallet: { accounts: [{ id: 'acc1', address: 'ADDR1' }] },
+  accountStates: { acc1: { balance: { amount: 1000000, assets: [] } } },
+};
+jest.mock('@/store/walletStore', () => ({
+  useWalletStore: (selector: (s: unknown) => unknown) => selector(mockState),
+}));
+
+jest.mock('@/services/network', () => ({
+  NetworkService: { getInstance: () => ({ getAccountBalance: jest.fn() }) },
+}));
+
+const TOKENS = [
+  { id: 1, symbol: 'AAA', name: 'Token A', decimals: 6 },
+  { id: 2, symbol: 'BBB', name: 'Token B', decimals: 6 },
+  { id: 3, symbol: 'CCC', name: 'Token C', decimals: 6 },
+];
+jest.mock('@/services/swap', () => ({
+  SwapService: {
+    getProvider: () => ({ getTokens: async () => TOKENS }),
+  },
+}));
+
+import { TokenSelector } from '../TokenSelector';
+
+describe('TokenSelector token list (TASK-246)', () => {
+  it('rebuilds the list when excludeTokenId changes while the modal stays open', async () => {
+    const props = {
+      visible: true,
+      accountId: 'acc1',
+      networkId: NetworkId.VOI_MAINNET,
+      onClose: jest.fn(),
+      onSelect: jest.fn(),
+    };
+
+    const { getByText, queryByText, rerender } = render(
+      <TokenSelector {...props} excludeTokenId={2} />
+    );
+
+    // Initially token 2 (BBB) is excluded.
+    await waitFor(() => expect(getByText('AAA')).toBeTruthy());
+    expect(getByText('CCC')).toBeTruthy();
+    expect(queryByText('BBB')).toBeNull();
+
+    // Change the excluded token while the modal stays open.
+    rerender(<TokenSelector {...props} excludeTokenId={1} />);
+
+    // List must rebuild: BBB returns, AAA (now excluded) disappears.
+    await waitFor(() => expect(getByText('BBB')).toBeTruthy());
+    expect(getByText('CCC')).toBeTruthy();
+    expect(queryByText('AAA')).toBeNull();
+  });
+});

--- a/src/screens/account/MnemonicImportScreen.tsx
+++ b/src/screens/account/MnemonicImportScreen.tsx
@@ -415,6 +415,17 @@ export default function MnemonicImportScreen({ navigation, route }: Props) {
       handleWordChange,
       handleWordFocus,
       handleWordBlur,
+      // Theme tokens the row reads: listing them re-renders the word rows on a
+      // light/dark switch (previously frozen). Purely visual — no mnemonic-
+      // handling logic depends on these (TASK-246).
+      theme.colors.border,
+      theme.colors.card,
+      theme.colors.error,
+      theme.colors.errorLight,
+      theme.colors.success,
+      theme.colors.text,
+      theme.colors.textSecondary,
+      themeColors.placeholder,
     ]
   );
 

--- a/src/screens/remoteSigner/ImportFromOnlineWalletScreen.tsx
+++ b/src/screens/remoteSigner/ImportFromOnlineWalletScreen.tsx
@@ -240,7 +240,9 @@ export default function ImportFromOnlineWalletScreen() {
         privateKeyBytes?.fill(0);
       }
     },
-    [networkId]
+    // refresh is a stable walletStore action (same instance handleComplete already
+    // depends on); include it so this handler always calls the live refresh.
+    [networkId, refresh]
   );
 
   const handleScanError = useCallback((errorMessage: string) => {

--- a/src/screens/settings/NotificationSettingsScreen.tsx
+++ b/src/screens/settings/NotificationSettingsScreen.tsx
@@ -327,11 +327,17 @@ export default function NotificationSettingsScreen() {
     setSelectedAccount(activeAccount);
   }
 
-  // Reload preferences when selected account changes
+  // Reload preferences when the selected account's address changes. Keyed on
+  // selectedAccount?.address — the content-stable slice that scopes the prefs.
+  // loadPreferences (a plain render-scope function) and the full selectedAccount
+  // object are intentionally omitted: loadPreferences reads selectedAccount fresh
+  // at call time, so listing either would only add identity-churn re-runs. This
+  // display is read-only and the writes read the address fresh.
   useEffect(() => {
     if (selectedAccount) {
       loadPreferences();
     }
+    // eslint-disable-next-line react-hooks/exhaustive-deps -- keyed on selectedAccount?.address; loadPreferences and the full selectedAccount object are read at the current commit and omitted on purpose to avoid identity-churn re-runs.
   }, [selectedAccount?.address]);
 
   const loadPreferences = async () => {

--- a/src/screens/social/AddFriendScreen.tsx
+++ b/src/screens/social/AddFriendScreen.tsx
@@ -85,6 +85,7 @@ export default function AddFriendScreen() {
     return () => {
       clearTimeout(timeoutId);
     };
+    // eslint-disable-next-line react-hooks/exhaustive-deps -- debounced search keyed on searchQuery. handleSearch is declared BELOW this effect, so it cannot be listed here without a temporal-dead-zone error; the trailing setTimeout captures it from the scheduling render. It is a stable useCallback over the getFriend store action (a Zustand action, stable identity), so the captured reference never goes stale, and getFriend only annotates isAlreadyFriend on results — it never changes which query is searched.
   }, [searchQuery]);
 
   const handleSearch = useCallback(

--- a/src/screens/social/NewMessageScreen.tsx
+++ b/src/screens/social/NewMessageScreen.tsx
@@ -203,6 +203,7 @@ export default function NewMessageScreen() {
 
       return () => clearTimeout(timeoutId);
     }
+    // eslint-disable-next-line react-hooks/exhaustive-deps -- debounced search keyed on searchQuery + friends. handleEnvoiSearch is declared BELOW this effect, so it cannot be listed here without a temporal-dead-zone error; the trailing setTimeout captures it from the scheduling render. handleEnvoiSearch tracks searchQuery + friends, which are exactly the deps this effect re-runs on, so the captured closure is always current for the query being searched.
   }, [searchQuery, friends]);
 
   const handleEnvoiSearch = useCallback(

--- a/src/screens/wallet/NFTScreen.tsx
+++ b/src/screens/wallet/NFTScreen.tsx
@@ -1,4 +1,4 @@
-import React, { useState, useEffect, useCallback } from 'react';
+import React, { useState, useEffect, useCallback, useRef } from 'react';
 import {
   View,
   Text,
@@ -53,6 +53,14 @@ export default function NFTScreen() {
   const activeAccount = useActiveAccount();
   const { theme, setNFTTheme } = useTheme();
 
+  // Track the active account address so an in-flight collection/ownership load
+  // can detect a mid-flight account switch and refuse to write a stale result
+  // (the HomeScreen:546 ref-recheck pattern applied to an account-keyed load).
+  const activeAccountAddressRef = useRef(activeAccount?.address);
+  useEffect(() => {
+    activeAccountAddressRef.current = activeAccount?.address;
+  }, [activeAccount?.address]);
+
   // Tab and view state
   const [activeTab, setActiveTab] = useState<TabType>('my-nfts');
   const [viewMode, setViewMode] = useState<ViewMode>('my-nfts');
@@ -80,11 +88,16 @@ export default function NFTScreen() {
   const [isAddAccountModalVisible, setIsAddAccountModalVisible] =
     useState(false);
 
-  // Load my NFTs on mount
+  // Load my NFTs on mount / account switch. Keyed on activeAccount?.address +
+  // viewMode; the full activeAccount object and loadMyNFTs are intentionally
+  // omitted — .address is the content-stable slice that actually scopes the
+  // load, and loadMyNFTs (a useCallback that tracks activeAccount identity) is
+  // read at the current commit, so listing either would only add spurious runs.
   useEffect(() => {
     if (activeAccount && viewMode === 'my-nfts') {
       loadMyNFTs();
     }
+    // eslint-disable-next-line react-hooks/exhaustive-deps -- keyed on activeAccount?.address + viewMode; the full activeAccount object and loadMyNFTs are read at the current commit and omitted on purpose to avoid identity-churn re-runs.
   }, [activeAccount?.address, viewMode]);
 
   // Reset view when tab changes
@@ -98,35 +111,56 @@ export default function NFTScreen() {
     }
   }, [activeTab]);
 
-  // Load collection tokens when collection is selected
+  // Load collection tokens when the collection, the view, OR the active account
+  // changes — keying on activeAccount?.address is the bug fix: switching accounts
+  // with a collection open must rebuild the ownership map for the new account
+  // (TASK-246). loadCollectionTokens is intentionally omitted: its identity also
+  // tracks `nextTokensToken` (set by the load itself), so listing it would
+  // double-fire the reset load; it is read at the current commit and the body
+  // re-checks activeAccountAddressRef after each await.
   useEffect(() => {
     if (selectedCollection && viewMode === 'collection-tokens') {
       loadCollectionTokens(true);
     }
-  }, [selectedCollection, viewMode]);
+    // eslint-disable-next-line react-hooks/exhaustive-deps -- keyed on collection/viewMode/activeAccount?.address so ownership rebuilds on account switch; loadCollectionTokens omitted on purpose (its nextTokensToken-tracking identity would double-fire the reset load) and is read at the current commit.
+  }, [selectedCollection, viewMode, activeAccount?.address]);
 
   const loadMyNFTs = useCallback(async () => {
     if (!activeAccount) return;
 
+    // Guard against a mid-flight account switch: a slow previous-account fetch
+    // must not overwrite the newer account's list (same race as the collection
+    // load above).
+    const requestAddress = activeAccount.address;
+
     try {
       setIsLoadingMyNFTs(true);
       const response = await NFTService.fetchUserNFTs(activeAccount.address);
+      if (activeAccountAddressRef.current !== requestAddress) return;
       const tokensWithNetwork = response.tokens.map((token) => ({
         ...token,
         networkId: NetworkId.VOI_MAINNET,
       }));
       setMyNFTs(tokensWithNetwork);
     } catch (error) {
+      if (activeAccountAddressRef.current !== requestAddress) return;
       console.error('Failed to load NFTs:', error);
       Alert.alert('Error', 'Failed to load your NFTs. Please try again.');
     } finally {
-      setIsLoadingMyNFTs(false);
+      if (activeAccountAddressRef.current === requestAddress) {
+        setIsLoadingMyNFTs(false);
+      }
     }
   }, [activeAccount]);
 
   const loadCollectionTokens = useCallback(
     async (reset = false) => {
       if (!selectedCollection) return;
+
+      // Address this load is for; compared against the live ref after each await
+      // so a slow previous-account fetch can never overwrite a newer account's
+      // ownership map / token list.
+      const requestAddress = activeAccount?.address;
 
       try {
         if (reset) {
@@ -139,6 +173,7 @@ export default function NFTScreen() {
             const userNFTs = await NFTService.fetchUserNFTs(
               activeAccount.address
             );
+            if (activeAccountAddressRef.current !== requestAddress) return;
             const ownership = NFTService.createOwnershipMap(userNFTs.tokens);
             setOwnershipMap(ownership);
           }
@@ -153,6 +188,7 @@ export default function NFTScreen() {
             nextToken: reset ? undefined : nextTokensToken,
           }
         );
+        if (activeAccountAddressRef.current !== requestAddress) return;
 
         if (reset) {
           setCollectionTokens(response.tokens);
@@ -169,8 +205,12 @@ export default function NFTScreen() {
           'Failed to load collection tokens. Please try again.'
         );
       } finally {
-        setIsLoadingCollectionTokens(false);
-        setLoadingMoreTokens(false);
+        // Only the load that still owns the active account clears the spinners,
+        // so a bailed stale load can't flip loading state under the newer one.
+        if (activeAccountAddressRef.current === requestAddress) {
+          setIsLoadingCollectionTokens(false);
+          setLoadingMoreTokens(false);
+        }
       }
     },
     [selectedCollection, nextTokensToken, activeAccount]

--- a/src/screens/wallet/SendScreen.tsx
+++ b/src/screens/wallet/SendScreen.tsx
@@ -769,6 +769,7 @@ export default function SendScreen() {
     return () => {
       cancelled = true;
     };
+    // eslint-disable-next-line react-hooks/exhaustive-deps -- keyed on activeAccount?.address (the content-stable slice that scopes this asset-options build); the full activeAccount object is read at the current commit and omitted on purpose — its identity churns on every store update while .address is what actually re-runs the builder. This mirrors the hand-mirror dep pattern the file uses at the amountError memo (:1018); no money-path logic changes (TASK-246 documents this deliberate omission owned by the SendScreen PRs).
   }, [
     activeAccount?.address,
     initialAssetId,
@@ -884,6 +885,7 @@ export default function SendScreen() {
     return () => {
       isCancelled = true;
     };
+    // eslint-disable-next-line react-hooks/exhaustive-deps -- keyed on activeAccount?.address (the content-stable slice that scopes the signing-capability probe); the full activeAccount object is read at the current commit and omitted on purpose to avoid identity-churn re-runs, matching the file's hand-mirror pattern (TASK-246; no money-path logic changes).
   }, [activeAccount?.address]);
 
   // Get network config for selected network
@@ -960,6 +962,7 @@ export default function SendScreen() {
     return asset?.symbol || contextAssetName || 'Token';
   };
 
+  // eslint-disable-next-line react-hooks/exhaustive-deps -- the rule reports THIS definition (it attributes an unstable useCallback dep at :1370 to getAssetDecimals itself), so the directive must sit here, not on the hook call. getAssetDecimals is deliberately left un-memoized so the file can hand-mirror its inputs at each call site (see the amountError memo at :1018 and the useFocusEffect at :1370 that lists it) rather than wrapping it in useCallback. It feeds the money path (parseAmountToBaseUnits at :981/:1025, the amount placeholder, and the review payload at :1598); restructuring it is owned by the SendScreen PRs (TASK-239/245), so this pass documents the omission without a logic change (TASK-246).
   const getAssetDecimals = () => {
     // Use selectedAsset if available
     const option = getCurrentAssetOption();

--- a/src/screens/wallet/SwapScreen.tsx
+++ b/src/screens/wallet/SwapScreen.tsx
@@ -307,6 +307,7 @@ export default function SwapScreen() {
       setQuoteError(null);
       setQuoteLoading(false);
     }
+    // eslint-disable-next-line react-hooks/exhaustive-deps -- keyed on the quote inputs (inputToken, outputToken, inputAmount, slippage); fetchQuote is a plain render-scope function invoked inside the trailing debounce setTimeout and guarded by quoteRequestIdRef, so it is read at fire time. Listing it (new identity every render) would restart the 400ms debounce on every render, so it is omitted on purpose.
   }, [inputToken, outputToken, inputAmount, slippage]);
 
   const fetchQuote = async (requestId: number) => {

--- a/src/screens/wallet/TransactionConfirmationScreen.tsx
+++ b/src/screens/wallet/TransactionConfirmationScreen.tsx
@@ -101,17 +101,32 @@ export default function TransactionConfirmationScreen() {
     params.fromAccount?.id || ''
   );
 
+  // Display-only: resolves the recipient's Envoi profile for the header. Does
+  // NOT feed anything that is signed or confirmed (the transaction is built from
+  // route params and signed via the auth controller). Keyed on the one input
+  // loadEnvoiProfile reads (params.recipient); loadEnvoiProfile is a plain
+  // render-scope function read at the current commit and omitted on purpose so
+  // its per-render identity can't re-fire the lookup.
   useEffect(() => {
     loadEnvoiProfile();
+    // eslint-disable-next-line react-hooks/exhaustive-deps -- display-only Envoi lookup keyed on params.recipient; loadEnvoiProfile is a render-scope helper read at the current commit and intentionally not listed.
   }, [params.recipient]);
 
+  // Display-only: picks a fallback token image from other networks in the same
+  // mapping. Not part of the signing/confirmation data. Keyed on the params that
+  // select the image AND multiNetworkBalance, so a balance that arrives after the
+  // first run refreshes the image. Only loadFallbackImage — a plain render-scope
+  // function read at the current commit — is omitted, so its per-render identity
+  // can't re-fire the lookup.
   useEffect(() => {
     loadFallbackImage();
+    // eslint-disable-next-line react-hooks/exhaustive-deps -- display-only fallback-image lookup keyed on the mapping/asset/network params + multiNetworkBalance; only loadFallbackImage (a plain render-scope function read at the current commit) is omitted, and nothing here affects what is signed.
   }, [
     params.mappingId,
     params.assetImageUrl,
     params.assetId,
     selectedNetworkId,
+    multiNetworkBalance,
   ]);
 
   useEffect(() => {

--- a/src/screens/wallet/TransactionHistoryScreen.tsx
+++ b/src/screens/wallet/TransactionHistoryScreen.tsx
@@ -99,11 +99,19 @@ export default function TransactionHistoryScreen() {
       ? accountState.transactionsError.message
       : null;
 
+  // Reload transactions when the active account changes. Keyed on
+  // activeAccount?.id — the content-stable slice that scopes the history.
+  // The full activeAccount object and the loadTransactions / updateActivity
+  // helpers are intentionally omitted: they read the current account fresh, so
+  // listing them would only add identity-churn re-runs. (This is the account
+  // effect, distinct from the ARC-200 metadata effect below whose
+  // assetMetadataCache dep is a deliberate recompute trigger and is untouched.)
   useEffect(() => {
     if (activeAccount) {
       loadTransactions();
     }
     updateActivity();
+    // eslint-disable-next-line react-hooks/exhaustive-deps -- keyed on activeAccount?.id; the full activeAccount object and loadTransactions/updateActivity are read at the current commit and omitted on purpose to avoid identity-churn re-runs.
   }, [activeAccount?.id]);
 
   // Load token metadata for ARC-200 transactions

--- a/src/screens/wallet/__tests__/NFTScreen.ownership.test.tsx
+++ b/src/screens/wallet/__tests__/NFTScreen.ownership.test.tsx
@@ -1,0 +1,151 @@
+/**
+ * TASK-246 — NFTScreen stale-ownership bug (sibling of the NFTThemeSelector one).
+ *
+ * NFTScreen's collection-tokens load effect had the same defect: keyed only on
+ * [selectedCollection, viewMode] while loadCollectionTokens builds the owned-
+ * badge map from the active account's NFTs. Switching accounts with a collection
+ * open kept the previous account's ownership markers.
+ *
+ * The fix keys the effect on activeAccount?.address (plus a live-address ref
+ * re-check after each await). This test drives an account switch with a
+ * collection open and asserts the ownership map rebuilds for the new account.
+ */
+
+import React from 'react';
+import { render, fireEvent, waitFor } from '@testing-library/react-native';
+
+let mockActiveAccount: { id: string; address: string } = {
+  id: 'a',
+  address: 'ADDR_A',
+};
+
+jest.mock('@/store/walletStore', () => ({
+  useActiveAccount: () => mockActiveAccount,
+}));
+
+jest.mock('@react-navigation/native', () => ({
+  useNavigation: () => ({ dispatch: jest.fn(), navigate: jest.fn() }),
+  CommonActions: { navigate: jest.fn() },
+}));
+
+jest.mock('@/contexts/ThemeContext', () => ({
+  useTheme: () => ({
+    theme: require('@/constants/themes').lightTheme,
+    setNFTTheme: jest.fn(),
+  }),
+}));
+
+jest.mock('@expo/vector-icons', () => ({ Ionicons: () => null }), {
+  virtual: true,
+});
+
+jest.mock('react-native-safe-area-context', () => ({
+  SafeAreaView: ({ children }: { children: React.ReactNode }) => children,
+}));
+
+jest.mock('@/components/common/UniversalHeader', () => ({
+  __esModule: true,
+  default: () => null,
+}));
+jest.mock('@/components/account/AccountListModal', () => ({
+  __esModule: true,
+  default: () => null,
+}));
+jest.mock('@/components/account/AddAccountModal', () => ({
+  __esModule: true,
+  default: () => null,
+}));
+jest.mock('@/components/common/NFTBackground', () => ({
+  NFTBackground: ({ children }: { children: React.ReactNode }) => children,
+}));
+jest.mock('@/components/common/GlassCard', () => ({
+  GlassCard: ({ children }: { children: React.ReactNode }) => children,
+}));
+
+jest.mock('@/components/nft/CollectionBrowser', () => {
+  const { Pressable, Text } = require('react-native');
+  return {
+    __esModule: true,
+    default: ({
+      onCollectionPress,
+    }: {
+      onCollectionPress: (c: unknown) => void;
+    }) => (
+      <Pressable
+        testID="pick-collection"
+        onPress={() =>
+          onCollectionPress({ contractId: 1, name: 'Coll', totalSupply: 10 })
+        }
+      >
+        <Text>pick</Text>
+      </Pressable>
+    ),
+  };
+});
+
+jest.mock('@/components/nft/NFTGridView', () => {
+  const { Text } = require('react-native');
+  return {
+    __esModule: true,
+    default: ({ ownershipMap }: { ownershipMap?: Set<string> }) => (
+      <Text testID="ownership">
+        {'ids=' +
+          Array.from(ownershipMap ?? [])
+            .sort()
+            .join(',')}
+      </Text>
+    ),
+  };
+});
+
+const mockFetchUserNFTs = jest.fn(async (address: string) => ({
+  tokens:
+    address === 'ADDR_A'
+      ? [{ contractId: 1, tokenId: 'a1' }]
+      : [{ contractId: 1, tokenId: 'b1' }],
+}));
+
+jest.mock('@/services/nft', () => ({
+  NFTService: {
+    fetchUserNFTs: (address: string) => mockFetchUserNFTs(address),
+    createOwnershipMap: (tokens: { contractId: number; tokenId: string }[]) =>
+      new Set(tokens.map((t) => `${t.contractId}:${t.tokenId}`)),
+    fetchTokensByCollection: jest.fn(async () => ({
+      tokens: [],
+      nextToken: undefined,
+    })),
+    hasValidImage: () => true,
+    getDisplayName: () => 'name',
+  },
+}));
+
+import NFTScreen from '../NFTScreen';
+
+describe('NFTScreen ownership map (TASK-246)', () => {
+  beforeEach(() => {
+    mockActiveAccount = { id: 'a', address: 'ADDR_A' };
+    mockFetchUserNFTs.mockClear();
+  });
+
+  it('rebuilds the ownership map when the account switches with a collection open', async () => {
+    const { getByText, getByTestId, rerender } = render(<NFTScreen />);
+
+    // Open a collection: Collections tab -> pick a collection.
+    fireEvent.press(getByText('Collections'));
+    fireEvent.press(getByTestId('pick-collection'));
+
+    await waitFor(() =>
+      expect(getByTestId('ownership').props.children).toBe('ids=1:a1')
+    );
+    expect(mockFetchUserNFTs).toHaveBeenCalledWith('ADDR_A');
+
+    // Switch to account B with the collection still open.
+    mockActiveAccount = { id: 'b', address: 'ADDR_B' };
+    rerender(<NFTScreen />);
+
+    await waitFor(() =>
+      expect(getByTestId('ownership').props.children).toBe('ids=1:b1')
+    );
+    expect(mockFetchUserNFTs).toHaveBeenCalledWith('ADDR_B');
+  });
+});


### PR DESCRIPTION
## What

Adjudicates **every** remaining `react-hooks/exhaustive-deps` warning (19 sites): each is **fixed-with-test** or **disabled-with-a-specific-written-reason**. No bare disable, no bare warning left behind (Wave 4 of PLAN-229 / TASK-246).

`grep -rn 'exhaustive-deps' src/ | grep -v -- ' -- '` → nothing.

## The two confirmed stale-closure BUGS (fixed + tested)

1. **`NFTThemeSelector.tsx` `loadCollectionTokens`** — the effect keyed on `[selectedCollection, viewMode]` but the helper builds the owned-badge map from the **active account**. Switching accounts with a collection open left the previous account's ownership markers. **Fix:** key the effect on `activeAccount?.address`, and re-check a live `activeAccountAddressRef` after each `await` so a slow previous-account fetch can't clobber the newer one (the `HomeScreen:546` model). Loop-safe: `.address` doesn't change as a result of the load.
2. **`TokenSelector.tsx` `loadTokens`** — keyed on `[visible, accountBalance]` but reads `networkId` / `excludeTokenId` / `ownedOnly` → stale token list on config change. **Fix:** add those deps (all props/derived-stable → no loop) + a monotonic `loadTokensRequestRef` guard so a late config load can't overwrite the fresh list + cancellation-guard the network-balance fetch so a stale prior-account/prior-network balance can't publish.

A **third instance of bug #1** was found while reading the benign list: **`NFTScreen.tsx` `loadCollectionTokens`** is the identical stale-ownership bug — fixed the same way (a disable there would have silenced a real bug). All three components' `loadMyNFTs` got the same ref-recheck guard against the mid-flight-switch race.

**Tests (3, each verified to fail without its fix):**
- `NFTThemeSelector.ownership.test.tsx` — ownership map rebuilds `1:a1 → 1:b1` on account switch.
- `NFTScreen.ownership.test.tsx` — same, for the screen.
- `TokenSelector.reload.test.tsx` — list rebuilds when `excludeTokenId` changes while the modal stays open.

## Genuine missing deps fixed (no disable)

- **`AccountAvatar.tsx`** — add `account?.avatarUrl` (a prop change now re-seeds the avatar). `useEffect`, no memo risk.
- **`ImportFromOnlineWalletScreen.tsx`** — add `refresh` (a stable `walletStore` action `handleComplete` already depends on).
- **`MnemonicImportScreen.tsx`** — add the theme tokens the word-row renderer reads, so rows recolor on a light/dark switch (previously frozen). Purely visual — **no mnemonic-handling logic touched**. Confirmed it did **not** trip `preserve-manual-memoization`.

## Deliberate omissions — disabled with a specific reason

| Site | Reason (summary) |
| --- | --- |
| `AirgapVerificationFlow:240` | **Sensitive/rekey.** `onVerificationSuccess` is **not invoked** in this handler (success = `setState('success')`; the parent's handler runs on the Continue button at `:416`), so keeping/removing it is behaviour-neutral — retained as a defensive hand-mirror. No auth/signing/rekey behaviour changed. |
| `TransactionConfirmationScreen:106/:110` | **Signing screen.** Display-only Envoi-profile / fallback-image loads that feed nothing signed; keyed on their real inputs. `:110` now lists `multiNetworkBalance` so a late balance refreshes the image; only the plain loader fn is omitted. |
| `CollectionBrowser:51` | Keyed on `debouncedSearchQuery`; `loadCollections` omitted (its `nextToken`-tracking identity would re-fire the reset load during pagination). |
| `NotificationSettingsScreen:335` | Keyed on `selectedAccount?.address`; loader + full object read fresh, display-only. |
| `AddFriendScreen:88`, `NewMessageScreen:206` | Debounced search; the helper is **declared below the effect** (TDZ — can't be listed) and captured by the scheduling render; stable/tracks the same keys. |
| `NFTScreen:88` (`loadMyNFTs`) | Keyed on `activeAccount?.address` + `viewMode`; full object + loader omitted (identity churn). |
| `SwapScreen:310` | Debounced quote with `quoteRequestIdRef` guard; `fetchQuote` is plain and read at fire time. |
| `TransactionHistoryScreen:107` | Keyed on `activeAccount?.id`. **This is the account-load effect, NOT the ARC-200 metadata effect** — its `assetMetadataCache` recompute-trigger dep is untouched. |
| `SendScreen:772/:887/:963` | Owned by TASK-239/245. Documented disables **only** (comment, no logic change) citing the file's hand-mirror pattern; `:963` `getAssetDecimals` is left un-memoized (money path). |

## Sensitive-site handling

No auth / signing / rekey / mnemonic behaviour was changed. Every sensitive site was a disable-with-documented-reason (the expected outcome), not a behaviour fix — no stop-and-ask boundary was hit.

## Warning counts (regenerated, not hand-carried)

| | before | after |
| --- | --- | --- |
| `react-hooks/exhaustive-deps` | 19 | **0** |
| `react-hooks/preserve-manual-memoization` | 25 | 25 (unchanged) |
| **total** | **227** | **208** (−19) |

**Ratchet:** `--max-warnings` 227 → **208**; `lint-baseline.json` regenerated in this PR; `npm run lint:baseline:check` passes.

## Gates

- `npm run typecheck` → 0
- `npm run lint` → exit 0 (208 warnings, 0 errors)
- `npm test -- --ci` → **103 suites / 1554 tests** green (100 + 3 new files; 1551 + 3)
- `npm run lint:baseline:check` → passes
- **Codex** read-only review → **CLEAN** (after 3 rounds of findings, all fixed: TokenSelector late-load overwrite race, TransactionConfirmation `multiNetworkBalance`, debounce disable wording accuracy, `loadMyNFTs` stale-request guard)

## Device QA (batched pre-release per HT-218)

- Switch accounts with an NFT collection open (both NFTScreen and the NFT theme selector) → owned badges refresh for the new account.
- Open the swap token selector, change network / from-token / owned-only → list refreshes; switch accounts mid-open → no stale balances.

https://claude.ai/code/session_01AL4EmUSYAiVXEstBgKqDmv
