### PR TITLE
fix(hooks): clear purity/refs — lazy init, stable Animated.Value, scoped disables (TASK-242)

### DIFF
--- a/lint-baseline.json
+++ b/lint-baseline.json
@@ -2,17 +2,15 @@
   "$comment": "Committed ESLint baseline for the `npm run lint` ratchet (PLAN-229 DR-2). Regenerate with `npm run lint:baseline`; verify with `npm run lint:baseline:check`. The `lint` script's --max-warnings MUST equal totals.warnings. Lower it in the same PR that clears the warnings. It never goes up.",
   "totals": {
     "errors": 0,
-    "warnings": 208,
+    "warnings": 196,
     "filesLinted": 440,
-    "filesWithFindings": 82
+    "filesWithFindings": 80
   },
   "rules": {
     "@typescript-eslint/no-unused-vars": 5,
     "import/no-named-as-default": 30,
     "react-hooks/immutability": 96,
     "react-hooks/preserve-manual-memoization": 25,
-    "react-hooks/purity": 5,
-    "react-hooks/refs": 7,
     "react-hooks/set-state-in-effect": 40
   },
   "files": {
@@ -107,9 +105,8 @@
     },
     "src/components/ledger/DeviceDiscovery.tsx": {
       "errors": 0,
-      "warnings": 2,
+      "warnings": 1,
       "rules": {
-        "react-hooks/purity": 1,
         "react-hooks/set-state-in-effect": 1
       }
     },
@@ -158,18 +155,10 @@
     },
     "src/components/remoteSigner/SignerAuthModal.tsx": {
       "errors": 0,
-      "warnings": 4,
+      "warnings": 3,
       "rules": {
         "react-hooks/immutability": 1,
-        "react-hooks/purity": 1,
         "react-hooks/set-state-in-effect": 2
-      }
-    },
-    "src/components/social/FriendListItem.tsx": {
-      "errors": 0,
-      "warnings": 1,
-      "rules": {
-        "react-hooks/purity": 1
       }
     },
     "src/components/swap/RouteDetailModal.tsx": {
@@ -204,11 +193,9 @@
     },
     "src/contexts/AuthContext.tsx": {
       "errors": 0,
-      "warnings": 5,
+      "warnings": 3,
       "rules": {
-        "react-hooks/immutability": 3,
-        "react-hooks/purity": 1,
-        "react-hooks/refs": 1
+        "react-hooks/immutability": 3
       }
     },
     "src/contexts/ThemeContext.tsx": {
@@ -343,10 +330,9 @@
     },
     "src/screens/social/MessagesInboxScreen.tsx": {
       "errors": 0,
-      "warnings": 4,
+      "warnings": 3,
       "rules": {
-        "react-hooks/preserve-manual-memoization": 3,
-        "react-hooks/purity": 1
+        "react-hooks/preserve-manual-memoization": 3
       }
     },
     "src/screens/social/MyProfileScreen.tsx": {
@@ -454,10 +440,9 @@
     },
     "src/screens/wallet/SwapScreen.tsx": {
       "errors": 0,
-      "warnings": 8,
+      "warnings": 4,
       "rules": {
         "react-hooks/immutability": 3,
-        "react-hooks/refs": 4,
         "react-hooks/set-state-in-effect": 1
       }
     },
@@ -489,13 +474,6 @@
       "warnings": 1,
       "rules": {
         "react-hooks/immutability": 1
-      }
-    },
-    "src/screens/wallet/VerifyBackupScreen.tsx": {
-      "errors": 0,
-      "warnings": 2,
-      "rules": {
-        "react-hooks/refs": 2
       }
     },
     "src/screens/walletconnect/SessionProposalScreen.tsx": {

--- a/package.json
+++ b/package.json
@@ -7,7 +7,7 @@
     "android": "expo run:android",
     "ios": "expo run:ios",
     "web": "expo start --web",
-    "lint": "eslint src/ --max-warnings 208",
+    "lint": "eslint src/ --max-warnings 196",
     "lint:fix": "eslint src/ --fix",
     "lint:baseline": "node scripts/lint-baseline.mjs --write",
     "lint:baseline:check": "node scripts/lint-baseline.mjs --check",

--- a/src/components/ledger/DeviceDiscovery.tsx
+++ b/src/components/ledger/DeviceDiscovery.tsx
@@ -47,12 +47,20 @@ const DeviceItem = ({
   onPress,
   styles,
 }: DeviceItemProps) => {
-  // Determine if this is a recently discovered device (within last 30 seconds)
-  const isRecentlyDiscovered = useMemo(() => {
-    const lastSeenTime = new Date(device.lastSeen).getTime();
-    const now = Date.now();
-    return now - lastSeenTime < 30000; // 30 seconds
-  }, [device.lastSeen]);
+  // Determine if this is a recently discovered device (within last 30 seconds).
+  // The window is relative to the current time, which is NOT a hook dependency:
+  // the previous `useMemo(..., [device.lastSeen])` froze the flag so the
+  // 30-second window could never expire. Drive it off a coarse ticking clock
+  // instead — Date.now() is read in the lazy initializer and the interval
+  // callback (both outside render), never in the render body, so the value is a
+  // real reactive dependency that decays on its own.
+  const [nowTick, setNowTick] = useState(() => Date.now());
+  useEffect(() => {
+    const id = setInterval(() => setNowTick(Date.now()), 10000);
+    return () => clearInterval(id);
+  }, []);
+  const lastSeenTime = new Date(device.lastSeen).getTime();
+  const isRecentlyDiscovered = nowTick - lastSeenTime < 30000; // 30 seconds
 
   // Format last connected/seen info
   const lastConnectionInfo = useMemo(() => {

--- a/src/components/remoteSigner/SignerAuthModal.tsx
+++ b/src/components/remoteSigner/SignerAuthModal.tsx
@@ -179,6 +179,7 @@ export default function SignerAuthModal({
 
         if (attempts >= MAX_ATTEMPTS) {
           setIsLocked(true);
+          // eslint-disable-next-line react-hooks/purity -- False positive: this Date.now() runs inside handlePinSubmit, an async event handler invoked on submit (after `await verifyPin`), NOT during render. Reading the wall clock at call time to stamp the lockout expiry is correct here. No biometric/auth behavior changed.
           setLockUntil(Date.now() + LOCKOUT_DURATION);
           setError('Too many attempts. Try again in 30 seconds.');
         } else {

--- a/src/components/social/FriendListItem.tsx
+++ b/src/components/social/FriendListItem.tsx
@@ -29,6 +29,7 @@ export default function FriendListItem({
   const formatLastInteraction = (timestamp?: number): string => {
     if (!timestamp) return 'No recent activity';
 
+    // eslint-disable-next-line react-hooks/purity -- Relative-time formatter for a friend-list row. Reading the wall clock during render is intentional; the label ("5m ago") is coarse and the list re-renders on friend-data updates and screen focus, so any residual staleness until the next render is acceptable for this surface (no ticking clock warranted for a potentially long list).
     const now = Date.now();
     const diff = now - timestamp;
 

--- a/src/contexts/AuthContext.tsx
+++ b/src/contexts/AuthContext.tsx
@@ -164,7 +164,12 @@ const withTimeout = <T,>(
 };
 
 export function AuthProvider({ children }: { children: React.ReactNode }) {
-  const [authState, setAuthState] = useState<AuthState>({
+  // Lazy initializer: the seed runs exactly once (React keeps only the first
+  // render's value anyway), so evaluating Date.now() here — instead of in a
+  // plain object literal re-created and discarded every render — is both a
+  // Rules-of-React-clean read (impure call outside render) and zero behavioral
+  // change: lastActivity is still seeded to mount time.
+  const [authState, setAuthState] = useState<AuthState>(() => ({
     isLocked: true,
     isAuthenticated: false,
     sessionId: null,
@@ -177,7 +182,7 @@ export function AuthProvider({ children }: { children: React.ReactNode }) {
     authChecked: false,
     hasWallet: false,
     pinSetupResume: false,
-  });
+  }));
 
   const activityTimer = useRef<NodeJS.Timeout | undefined>(undefined);
   const sessionTimer = useRef<NodeJS.Timeout | undefined>(undefined);
@@ -196,6 +201,7 @@ export function AuthProvider({ children }: { children: React.ReactNode }) {
   // latest activity/auth flags and route through the single lock() (below)
   // rather than mutating state inline (needed so lock's session teardown runs).
   const authStateRef = useRef(authState);
+  // eslint-disable-next-line react-hooks/refs -- HT-250 (Option A): the mirror is written in the render body ON PURPOSE. This ref is the inactivity-lock source of truth (ACTIVITY_CHECK_INTERVAL reads authStateRef.current). Deferring the write into an effect flushes it AFTER paint, reopening exactly the suspend-before-commit lock-BYPASS window the :186-193 ref comment documents (a commit skipped by the OS suspending the JS runtime would leave the interval reading stale auth flags). Must NOT be relocated to useEffect/useLayoutEffect. TASK-248 carries this one documented refs exception when promoting the rule to error.
   authStateRef.current = authState;
 
   // TASK-222: one-shot latch for the cross-store boot reconcile. checkInitialAuthState

--- a/src/screens/social/MessagesInboxScreen.tsx
+++ b/src/screens/social/MessagesInboxScreen.tsx
@@ -302,6 +302,7 @@ export default function MessagesInboxScreen() {
 
   // Format timestamp
   const formatTimestamp = (timestamp: number): string => {
+    // eslint-disable-next-line react-hooks/purity -- Relative-time formatter for an inbox thread row. Reading the wall clock during render is intentional; the label ("5m", "2h") is coarse and the inbox re-renders on message polling and screen focus, so any residual staleness until the next render is acceptable for this surface (no ticking clock warranted for a potentially long thread list).
     const now = Date.now();
     const diff = now - timestamp;
 

--- a/src/screens/wallet/SwapScreen.tsx
+++ b/src/screens/wallet/SwapScreen.tsx
@@ -933,8 +933,12 @@ export default function SwapScreen() {
     );
   };
 
-  // Skeleton animation for loading state
-  const skeletonAnim = useRef(new Animated.Value(0)).current;
+  // Skeleton animation for loading state. useState factory (not
+  // useRef(new Animated.Value(0)).current) so the Animated.Value is allocated
+  // once and stable across renders — the ref form constructed and discarded a
+  // fresh Animated.Value on every render and read a ref during render. Skeleton
+  // shimmer only; no quote/swap math depends on this.
+  const [skeletonAnim] = useState(() => new Animated.Value(0));
 
   useEffect(() => {
     let animation: Animated.CompositeAnimation | null = null;

--- a/src/screens/wallet/VerifyBackupScreen.tsx
+++ b/src/screens/wallet/VerifyBackupScreen.tsx
@@ -77,6 +77,7 @@ export default function VerifyBackupScreen() {
       targetRef.current = { id: resolved.id, address: resolved.address };
     }
   }
+  // eslint-disable-next-line react-hooks/refs -- Deliberate write-then-read latch (see :59-64). The target is resolved on the FIRST render where resolution is possible and then PINNED for the screen's lifetime. The store is live: a dynamically-resolved target would let a mid-quiz active-account change mark account B as verified using account A's displayed phrase. Reading targetRef.current here is the pin. The naive "correct" refactor is actively dangerous and is guarded by a real test (VerifyBackupScreen.test.tsx). Carve-out per TASK-242; NOT to be rewritten.
   const target = targetRef.current;
 
   const [mnemonic, setMnemonic] = useState<string>('');


### PR DESCRIPTION
Wave 3 of the ESLint warning burndown (TASK-242). Clears **react-hooks/purity 5→0** and **react-hooks/refs 7→0**; total ratchet **208→196**.

## HT-250 decision honored
`AuthContext.tsx :199` — `authStateRef.current = authState` was **LEFT IN THE RENDER BODY** with a scoped inline disable, **NOT relocated** to a `useEffect`/`useLayoutEffect`. Per HT-250 (Option A) and the file's own `:186-193` rationale: deferring the mirror into an effect flushes it *after* paint, reopening the suspend-before-commit lock-BYPASS window that comment documents (a commit the OS skips by suspending the JS runtime would leave `ACTIVITY_CHECK_INTERVAL` reading stale auth flags). This is the one documented refs exception **TASK-248** carries when it promotes the rule to `error`.

## Per-site fix / disable

**Purity (5→0)**
- `AuthContext.tsx :171` — non-lazy `useState({...lastActivity: Date.now()...})` → **lazy initializer** `useState(() => ({...}))`. Zero behavioral change (only the first render's seed was ever retained); the impure read now runs once, outside render.
- `DeviceDiscovery.tsx :53` — **real bug fixed.** The recency flag was `useMemo(..., [device.lastSeen])` with `Date.now()` read inside, so the 30-second window could never expire. Now driven off a coarse ticking clock (`Date.now()` read only in the lazy init + interval callback, never in render), so the window actually decays.
- `FriendListItem.tsx :32` / `MessagesInboxScreen.tsx :305` — relative-time formatters, **scoped disable-with-reason.** The wall-clock read during render is intentional and residual staleness until the next natural re-render is acceptable for these list surfaces (no ticking clock warranted for potentially long lists).
- `SignerAuthModal.tsx :182` — **scoped disable** (false positive). `Date.now()` runs inside the async submit handler `handlePinSubmit` (after `await verifyPin`), not during render. **No biometric/auth behavior changed.**

**Refs (7→0)**
- `AuthContext.tsx :199` — left + scoped disable (see HT-250 above).
- `SwapScreen.tsx :937/:969` — skeleton `Animated.Value` via `useState(() => new Animated.Value(0))[0]` instead of `useRef(new Animated.Value(0)).current` — allocated once, stable across renders, no ref read in render (clears both the alloc and the `.interpolate` sites = 4 warnings). Skeleton shimmer only; no quote/swap logic touched.
- `VerifyBackupScreen.tsx :80` — **scoped disable, NOT a rewrite.** The write-then-read `targetRef` latch pins the verification target on the first resolvable render so a live active-account change can't mark account B verified using account A's displayed phrase. Guarded by `VerifyBackupScreen.test.tsx`; the naive "correct" refactor is actively dangerous.

## Deltas & ratchet
- react-hooks/purity: **5 → 0**
- react-hooks/refs: **7 → 0**
- total warnings: **208 → 196** (−12)
- `lint-baseline.json` regenerated and `--max-warnings` lowered to `196` in the same PR; `lint:baseline:check` passes.
- **NO rule severity changed** — purity/refs stay `warn` (TASK-248 promotes them later, DR-7). `eslint.config.js` untouched.

## Gates
- `npm run typecheck` — clean (0)
- `npm run lint` — exit 0 (196 warnings, 0 errors)
- `npm test -- --ci` — 103 suites / 1554 tests green
- `npm run lint:baseline:check` — passes
- `src/contexts/__tests__/AuthContext.test.tsx` — **passes UNMODIFIED** (53/53)
- Codex diff review — CLEAN

## Device QA (batched pre-release per HT-218)
To verify on-device before release: (a) leave the app idle past the configured timeout → auto-lock still fires; (b) no early lock immediately after a settings change or a foreground/background cycle; (c) background past and within the grace window → lock/unlock decision unchanged.

https://claude.ai/code/session_01AL4EmUSYAiVXEstBgKqDmv