### PR TITLE
fix(auth-modal): latch init/biometric/cancel in refs the reset effect cannot erase (TASK-241)

### DIFF
--- a/lint-baseline.json
+++ b/lint-baseline.json
@@ -2,15 +2,15 @@
   "$comment": "Committed ESLint baseline for the `npm run lint` ratchet (PLAN-229 DR-2). Regenerate with `npm run lint:baseline`; verify with `npm run lint:baseline:check`. The `lint` script's --max-warnings MUST equal totals.warnings. Lower it in the same PR that clears the warnings. It never goes up.",
   "totals": {
     "errors": 0,
-    "warnings": 191,
-    "filesLinted": 441,
+    "warnings": 188,
+    "filesLinted": 442,
     "filesWithFindings": 78
   },
   "rules": {
     "import/no-named-as-default": 30,
     "react-hooks/immutability": 96,
     "react-hooks/preserve-manual-memoization": 25,
-    "react-hooks/set-state-in-effect": 40
+    "react-hooks/set-state-in-effect": 37
   },
   "files": {
     "src/components/UnifiedAuthModal.tsx": {
@@ -23,10 +23,9 @@
     },
     "src/components/UnifiedTransactionAuthModal.tsx": {
       "errors": 0,
-      "warnings": 4,
+      "warnings": 1,
       "rules": {
-        "react-hooks/immutability": 1,
-        "react-hooks/set-state-in-effect": 3
+        "react-hooks/immutability": 1
       }
     },
     "src/components/account/AccountAvatar.tsx": {

--- a/package.json
+++ b/package.json
@@ -7,7 +7,7 @@
     "android": "expo run:android",
     "ios": "expo run:ios",
     "web": "expo start --web",
-    "lint": "eslint src/ --max-warnings 191",
+    "lint": "eslint src/ --max-warnings 188",
     "lint:fix": "eslint src/ --fix",
     "lint:baseline": "node scripts/lint-baseline.mjs --write",
     "lint:baseline:check": "node scripts/lint-baseline.mjs --check",

--- a/src/components/UnifiedTransactionAuthModal.tsx
+++ b/src/components/UnifiedTransactionAuthModal.tsx
@@ -1,4 +1,4 @@
-import React, { useEffect, useState, useCallback, useRef } from 'react';
+import { useEffect, useState, useCallback, useRef } from 'react';
 import {
   Modal,
   View,
@@ -53,10 +53,31 @@ export default function UnifiedTransactionAuthModal({
     controller.getState()
   );
   const [pin, setPin] = useState('');
-  const [initialized, setInitialized] = useState(false);
-  const [biometricAttempted, setBiometricAttempted] = useState(false);
-  const [userCancelled, setUserCancelled] = useState(false);
   const [isVerifying, setIsVerifying] = useState(false);
+
+  // --- Auth-flow latches (TASK-241) --------------------------------------
+  // initialized / biometricAttempted / userCancelled are REFS, not state, so
+  // the reset logic can never erase them on a stray re-render or when the
+  // controller bounces back to `idle` via resetAfterDismiss(). Invariants they
+  // protect on the shared transaction-signing auth modal:
+  //   • initializeSigningFlow runs EXACTLY ONCE per open (visible false→true) —
+  //     never again while `visible` stays true, even after a cancel/error drives
+  //     the controller back to `idle`.
+  //   • The biometric auto-prompt fires EXACTLY ONCE per open.
+  //   • An explicit-cancel latch (userCancelled) SURVIVES the intervening
+  //     resetAfterDismiss()-driven `idle` until the modal genuinely closes/reopens
+  //     — the bug the old useState + idle-keyed reset effect had (HT-254 Option A).
+  // The visibility-transition effect below is the SOLE owner of these latches:
+  //   initialized/biometricAttempted reset on a genuine close (visible→false)
+  //   AND a genuine open (false→true); userCancelled clears ONLY on a genuine
+  //   open (false→true). Because these are refs (no re-render on write), NOTHING
+  //   that renders may branch on their VALUES — they are control-flow only.
+  const initializedRef = useRef(false);
+  const biometricAttemptedRef = useRef(false);
+  const userCancelledRef = useRef(false);
+  // Tracks previous visibility so the transition effect can distinguish a
+  // genuine open/close from an in-place re-render.
+  const wasVisibleRef = useRef(visible);
 
   // Guard to prevent onComplete from being called multiple times per auth flow
   // This prevents double-submission when the onComplete prop reference changes during re-renders
@@ -68,30 +89,57 @@ export default function UnifiedTransactionAuthModal({
     return unsubscribe;
   }, [controller]);
 
-  // Initialize signing flow when modal becomes visible with a request (only once per open)
-  // Do NOT restart after user rejection/error - only start on first open
+  // Visibility-transition effect — the SOLE owner of the auth-flow latches
+  // (TASK-241). Declared BEFORE the init effect so that on a genuine open the
+  // userCancelled latch is already cleared before init reads it.
+  useEffect(() => {
+    const wasVisible = wasVisibleRef.current;
+    if (!wasVisible && visible) {
+      // Genuine OPEN (false→true): start a fresh flow. Clearing userCancelled
+      // here (and never on close) is exactly what lets an explicit-cancel latch
+      // survive a resetAfterDismiss()-driven `idle` while `visible` stays true.
+      initializedRef.current = false;
+      biometricAttemptedRef.current = false;
+      userCancelledRef.current = false;
+      hasCalledOnComplete.current = false;
+    } else if (wasVisible && !visible) {
+      // Genuine CLOSE (true→false): reset the controller and clear the
+      // init/biometric latches for the next open. userCancelled is left as-is —
+      // it is cleared on the next genuine open, above.
+      controller.resetAfterDismiss();
+      initializedRef.current = false;
+      biometricAttemptedRef.current = false;
+      hasCalledOnComplete.current = false;
+    }
+    wasVisibleRef.current = visible;
+  }, [visible, controller]);
+
+  // Initialize signing flow when modal becomes visible with a request.
+  // Latched via initializedRef so it fires EXACTLY ONCE per open, and via
+  // userCancelledRef so it never restarts after a user cancel/error while
+  // `visible` stays true. The refs are not reactive deps; this effect re-runs on
+  // the visible/request/authState gates and the guards read the latest ref values.
   useEffect(() => {
     if (
       visible &&
       request &&
       authState.state === 'idle' &&
-      !initialized &&
-      !userCancelled &&
+      !initializedRef.current &&
+      !userCancelledRef.current &&
       !authState.error &&
       !authState.ledgerError
     ) {
-      // Don't restart after errors or cancellation
+      // Latch synchronously BEFORE the async initializeSigningFlow so a
+      // re-render inside the determineAuthRequirements window can't double-invoke.
       console.log('UnifiedTransactionAuthModal: initializeSigningFlow');
+      initializedRef.current = true;
       controller.initializeSigningFlow(request);
-      setInitialized(true);
     }
   }, [
     visible,
     request,
     controller,
     authState.state,
-    initialized,
-    userCancelled,
     authState.error,
     authState.ledgerError,
   ]);
@@ -109,17 +157,6 @@ export default function UnifiedTransactionAuthModal({
     }
   }, [authState.state, authState.result, onComplete]);
 
-  // Reset controller when modal is hidden (after parent closes it)
-  // Use a ref to track previous visibility and only reset on transition from visible to hidden
-  const wasVisibleRef = React.useRef(visible);
-  useEffect(() => {
-    if (wasVisibleRef.current && !visible) {
-      // Modal was just hidden - reset controller
-      controller.resetAfterDismiss();
-    }
-    wasVisibleRef.current = visible;
-  }, [visible, controller]);
-
   // Auto-prompt for biometric auth when available (only once per open)
   useEffect(() => {
     if (
@@ -127,31 +164,20 @@ export default function UnifiedTransactionAuthModal({
       authState.state === 'authenticating' &&
       authState.biometricAvailable &&
       !authState.isLocked &&
-      !biometricAttempted &&
+      !biometricAttemptedRef.current &&
       !authState.isLedgerFlow
     ) {
-      setBiometricAttempted(true);
+      biometricAttemptedRef.current = true;
       handleBiometricAuth();
     }
-    // eslint-disable-next-line react-hooks/exhaustive-deps -- biometric auto-prompt, once per open (guarded by biometricAttempted); fires on the visible/authState gates, handleBiometricAuth is read at that commit and must not re-fire on its own identity.
+    // eslint-disable-next-line react-hooks/exhaustive-deps -- biometric auto-prompt, once per open (latched via biometricAttemptedRef); fires on the visible/authState gates, handleBiometricAuth is read at that commit and must not re-fire on its own identity.
   }, [
     visible,
     authState.state,
     authState.biometricAvailable,
     authState.isLocked,
-    biometricAttempted,
     authState.isLedgerFlow,
   ]);
-
-  // Reset guards when modal closes or controller resets
-  useEffect(() => {
-    if (!visible || authState.state === 'idle') {
-      setInitialized(false);
-      setBiometricAttempted(false);
-      setUserCancelled(false);
-      hasCalledOnComplete.current = false;
-    }
-  }, [visible, authState.state]);
 
   const handleNumberPress = (number: string) => {
     if (
@@ -202,9 +228,13 @@ export default function UnifiedTransactionAuthModal({
     controller.cancel();
     controller.resetAfterDismiss();
     setPin('');
-    setInitialized(false);
-    setBiometricAttempted(false);
-    setUserCancelled(true); // Mark that user explicitly cancelled
+    initializedRef.current = false;
+    biometricAttemptedRef.current = false;
+    // Latch the explicit cancel. resetAfterDismiss() above drives the controller
+    // back to `idle`, but this ref survives it (the reset effect no longer keys
+    // on `idle`), so the init effect will NOT restart the flow while `visible`
+    // stays true. Cleared on the next genuine open.
+    userCancelledRef.current = true;
     onCancel();
   }, [controller, onCancel]);
 
@@ -823,7 +853,7 @@ export default function UnifiedTransactionAuthModal({
   };
 
   const handleCloseAfterError = () => {
-    setUserCancelled(true);
+    userCancelledRef.current = true;
     controller.resetAfterDismiss();
     onCancel();
   };
@@ -975,7 +1005,7 @@ export default function UnifiedTransactionAuthModal({
       onRequestClose={() => {
         // Only allow closing if not processing
         if (authState.state !== 'processing' && authState.state !== 'signing') {
-          setUserCancelled(true); // Mark as cancelled even if closed via system
+          userCancelledRef.current = true; // Mark as cancelled even if closed via system
           handleCancel();
         }
       }}

--- a/src/components/__tests__/UnifiedTransactionAuthModal.initOnce.test.tsx
+++ b/src/components/__tests__/UnifiedTransactionAuthModal.initOnce.test.tsx
@@ -1,0 +1,263 @@
+/**
+ * TASK-241 — UnifiedTransactionAuthModal init/cancel latch (HT-254 Option A).
+ *
+ * The shared transaction-signing auth modal must call
+ * `controller.initializeSigningFlow` EXACTLY ONCE per open (visible false→true)
+ * and must NOT restart the flow after an explicit cancel while `visible` stays
+ * true — even though `handleCancel` → `resetAfterDismiss()` drives the controller
+ * back to `idle`.
+ *
+ * The pre-fix bug: `initialized`/`biometricAttempted`/`userCancelled` were
+ * useState flags and a reset effect keyed on `authState.state === 'idle'` erased
+ * all three on the very next commit after a cancel. So the moment the controller
+ * bounced back to `idle` (which `resetAfterDismiss` does synchronously), the
+ * cancel latch was wiped and the init effect re-fired — re-initializing the
+ * signing flow while the modal was still visible. This test reproduces that
+ * churn (a transient return to `idle`, and a cancel-with-visible-still-true) and
+ * asserts init stays at a single invocation. It fails against the useState
+ * implementation and passes once the flags are refs the reset can't erase.
+ */
+
+import React from 'react';
+import { render, fireEvent, act, waitFor } from '@testing-library/react-native';
+
+jest.mock('@/contexts/ThemeContext', () => ({
+  useTheme: () => ({ theme: require('@/constants/themes').lightTheme }),
+}));
+
+// Types-only at runtime; avoid loading the heavy controller / native ledger deps.
+jest.mock('@/services/auth/transactionAuthController', () => ({}));
+jest.mock('@/services/transactions/unifiedSigner', () => ({}));
+
+jest.mock('@expo/vector-icons', () => ({ Ionicons: () => null }), {
+  virtual: true,
+});
+
+jest.mock('@/components/remoteSigner', () => ({
+  AnimatedQRCode: () => null,
+  AnimatedQRScanner: () => null,
+}));
+
+jest.mock('@/services/remoteSigner', () => ({
+  RemoteSignerService: {
+    decodePayload: jest.fn(),
+    encodePayload: jest.fn(() => ''),
+  },
+}));
+
+jest.mock('@/types/remoteSigner', () => ({
+  isRemoteSignerResponse: jest.fn(() => false),
+}));
+
+jest.mock('@/utils/haptics', () => ({ hapticNotify: jest.fn() }));
+
+import UnifiedTransactionAuthModal from '../UnifiedTransactionAuthModal';
+
+// Mirrors TransactionAuthController.getInitialState() — the shape the modal reads.
+function idleState(overrides: Record<string, unknown> = {}) {
+  return {
+    state: 'idle',
+    error: null,
+    requiresPin: true,
+    requiresBiometric: false,
+    biometricAvailable: false,
+    pinAttempts: 0,
+    maxPinAttempts: 5,
+    isLocked: false,
+    isLedgerFlow: false,
+    ledgerStatus: 'idle',
+    ledgerDevice: null,
+    ledgerError: null,
+    isRemoteSignerFlow: false,
+    remoteSignerStatus: 'idle',
+    remoteSignerRequest: null,
+    remoteSignerError: null,
+    signingProgress: null,
+    result: null,
+    ...overrides,
+  };
+}
+
+// Minimal stateful fake of TransactionAuthController: a subscribe/emit bus plus
+// spies for the methods the modal drives. resetAfterDismiss() emits `idle` to
+// subscribers, exactly like the real controller — that emission is what used to
+// trigger the erase-the-latch bug.
+function makeController(initial = idleState()) {
+  let state: ReturnType<typeof idleState> = initial;
+  const listeners = new Set<(s: unknown) => void>();
+  const emit = (next: ReturnType<typeof idleState>) => {
+    state = next;
+    listeners.forEach((l) => l({ ...state }));
+  };
+  return {
+    getState: jest.fn(() => ({ ...state })),
+    subscribe: jest.fn((fn: (s: unknown) => void) => {
+      listeners.add(fn);
+      return () => listeners.delete(fn);
+    }),
+    initializeSigningFlow: jest.fn(async () => {
+      // Async determineAuthRequirements window: intentionally does NOT emit a
+      // state change here, so the modal stays `idle` while init is "in flight".
+    }),
+    cancel: jest.fn(),
+    resetAfterDismiss: jest.fn(() => emit(idleState())),
+    authenticateWithPin: jest.fn(async () => false),
+    authenticateWithBiometrics: jest.fn(async () => {}),
+    retryLedgerConnection: jest.fn(),
+    startRemoteSignerScan: jest.fn(),
+    processRemoteSignerResponse: jest.fn(async () => {}),
+    cancelRemoteSignerFlow: jest.fn(),
+    _emit: emit,
+  };
+}
+
+const asController = (c: ReturnType<typeof makeController>): any => c;
+
+describe('UnifiedTransactionAuthModal init/cancel latch (TASK-241)', () => {
+  const request = { kind: 'test-request' } as unknown as never;
+
+  it('initializes exactly once per open across re-renders and a transient return to idle', async () => {
+    const controller = makeController();
+    const onComplete = jest.fn();
+    const onCancel = jest.fn();
+
+    const { rerender } = render(
+      <UnifiedTransactionAuthModal
+        visible
+        controller={asController(controller)}
+        request={request}
+        onComplete={onComplete}
+        onCancel={onCancel}
+        message="msg-1"
+      />
+    );
+
+    await waitFor(() =>
+      expect(controller.initializeSigningFlow).toHaveBeenCalledTimes(1)
+    );
+
+    // Parent re-renders during the async init window (state still idle): a
+    // benign prop change must not re-invoke init.
+    rerender(
+      <UnifiedTransactionAuthModal
+        visible
+        controller={asController(controller)}
+        request={request}
+        onComplete={onComplete}
+        onCancel={onCancel}
+        message="msg-2"
+      />
+    );
+    expect(controller.initializeSigningFlow).toHaveBeenCalledTimes(1);
+
+    // Controller progresses to authenticating, then bounces back to idle (what
+    // resetAfterDismiss does mid-flow). The pre-fix reset effect cleared the
+    // `initialized` flag on that idle emission and re-fired init. With refs it
+    // must NOT.
+    await act(async () => {
+      controller._emit(idleState({ state: 'authenticating' }));
+    });
+    await act(async () => {
+      controller._emit(idleState());
+    });
+
+    expect(controller.initializeSigningFlow).toHaveBeenCalledTimes(1);
+  });
+
+  it('does not re-initialize after handleCancel while visible stays true', async () => {
+    const controller = makeController();
+    const onComplete = jest.fn();
+    // onCancel deliberately does NOT flip visible=false — models a consumer that
+    // shows a confirm dialog / awaits a WalletConnect reject / animates dismiss.
+    const onCancel = jest.fn();
+
+    const { getByText, rerender } = render(
+      <UnifiedTransactionAuthModal
+        visible
+        controller={asController(controller)}
+        request={request}
+        onComplete={onComplete}
+        onCancel={onCancel}
+        message="msg"
+      />
+    );
+
+    await waitFor(() =>
+      expect(controller.initializeSigningFlow).toHaveBeenCalledTimes(1)
+    );
+
+    // Explicit cancel. handleCancel calls resetAfterDismiss(), which emits idle.
+    await act(async () => {
+      fireEvent.press(getByText('Cancel'));
+    });
+    expect(onCancel).toHaveBeenCalledTimes(1);
+    expect(controller.cancel).toHaveBeenCalledTimes(1);
+
+    // visible stays true; force another parent re-render for good measure.
+    rerender(
+      <UnifiedTransactionAuthModal
+        visible
+        controller={asController(controller)}
+        request={request}
+        onComplete={onComplete}
+        onCancel={onCancel}
+        message="msg-after-cancel"
+      />
+    );
+
+    // Simulate a later clean transition back to idle while visible stays true
+    // (e.g. the confirm dialog / async reject settles and the controller
+    // re-emits). The pre-fix reset effect erased the cancel latch on this idle
+    // and re-fired init; the ref latch must keep it suppressed.
+    await act(async () => {
+      controller._emit(idleState({ state: 'authenticating' }));
+    });
+    await act(async () => {
+      controller._emit(idleState());
+    });
+
+    // The cancel latch must survive the resetAfterDismiss-driven idle: init is
+    // NOT called again while visible stays true.
+    expect(controller.initializeSigningFlow).toHaveBeenCalledTimes(1);
+  });
+
+  it('re-initializes on a genuine reopen after cancel (close then open)', async () => {
+    const controller = makeController();
+    const onComplete = jest.fn();
+    const onCancel = jest.fn();
+
+    const props = (visible: boolean) => ({
+      visible,
+      controller: asController(controller),
+      request,
+      onComplete,
+      onCancel,
+      message: 'msg',
+    });
+
+    const { getByText, rerender } = render(
+      <UnifiedTransactionAuthModal {...props(true)} />
+    );
+
+    await waitFor(() =>
+      expect(controller.initializeSigningFlow).toHaveBeenCalledTimes(1)
+    );
+
+    await act(async () => {
+      fireEvent.press(getByText('Cancel'));
+    });
+
+    // Genuine close (visible true→false): clears init/biometric latches.
+    rerender(<UnifiedTransactionAuthModal {...props(false)} />);
+
+    // Genuine reopen (visible false→true): clears the userCancelled latch first,
+    // then the init effect re-initializes for the new open.
+    await act(async () => {
+      rerender(<UnifiedTransactionAuthModal {...props(true)} />);
+    });
+
+    await waitFor(() =>
+      expect(controller.initializeSigningFlow).toHaveBeenCalledTimes(2)
+    );
+  });
+});


### PR DESCRIPTION
## What & why (TASK-241, HT-254 Option A: refs)

`UnifiedTransactionAuthModal` is the shared auth modal for the transaction-signing path. It tracked `initialized` / `biometricAttempted` / `userCancelled` as `useState` flags, and a reset effect keyed on `authState.state === 'idle'` cleared all three. `handleCancel` calls `resetAfterDismiss()`, which drives the controller back to `idle` — so the explicit-cancel latch was **erased on the very next commit**, and the init effect could restart the signing flow.

Rated **preventive**: today all six consumer screens set `visible=false` synchronously in `onCancel`, so nothing regresses. It breaks the moment a consumer's `onCancel` shows a "Discard?" alert, awaits a WalletConnect `reject()`, or animates the dismiss. The human chose **Option A (HT-254): make the flags refs the reset effect cannot erase, and document the invariant.**

## The refs approach + transition logic

The three flags are now `useRef`. A single **visibility-transition effect** is the sole owner of their lifecycle, and is **declared before the init effect** so the cancel latch is already cleared when a genuine open re-initializes:

- **initialized / biometricAttempted** — reset on a genuine **close** (`visible`→false) and a genuine **open** (false→true), so a reopened modal re-initializes and re-prompts biometrics.
- **userCancelled** — cleared **only** on a genuine **open** (false→true), so the explicit-cancel latch **survives** an intervening `resetAfterDismiss()`-driven `idle` while `visible` stays true.
- **initializedRef** is latched **synchronously before** the async `initializeSigningFlow`, so a re-render inside the `determineAuthRequirements` window can't double-invoke.

Guaranteed invariant (documented at the ref declarations): **init runs exactly once per open**, the **biometric prompt fires exactly once per open**, and the **cancel latch survives** until a genuine close/reopen. The refs are **control-flow only** — grep confirms nothing rendered branches on their values, so no stale-UI risk from moving off `useState`.

## Test (the gate)

New `src/components/__tests__/UnifiedTransactionAuthModal.initOnce.test.tsx`:
1. `initializeSigningFlow` runs **exactly once** per `(visible, request)` across a parent re-render mid-init and a transient return to `idle`.
2. **NOT** re-invoked after `handleCancel` while `visible` stays true (cancel latch survives the `resetAfterDismiss` idle).
3. **Re-initializes** on a genuine reopen (close then open).

Cases 1 and 2 **fail against the pre-fix `useState` implementation** and pass on the fix (verified by stashing the component change). Case 3 documents the reopen invariant.

## Warning deltas + ratchet (DR-9)

Converting the three setState-in-effect calls to ref writes clears this file's `set-state-in-effect` warnings:

| metric | before | after |
| --- | --- | --- |
| total warnings | 191 | **188** |
| react-hooks/set-state-in-effect | 40 | **37** |

Ratchet regenerated: `package.json` `--max-warnings` lowered **191 → 188**, `lint-baseline.json` re-committed in this PR, `npm run lint:baseline:check` passes (188 → 188, matches pin).

## Gates

- `npm run typecheck` — clean (exit 0)
- `npm run lint` — exit 0
- `npm test -- --ci` — green: **105 suites / 1553 tests** (was 104 / 1550; +1 suite / +3 tests)
- `npm run lint:baseline:check` — passes
- Codex auth-flow review — **CLEAN**

## Device QA

One WalletConnect sign, one rekey confirm, one cancel-then-reopen, with the **same biometric-prompt count** as before — batched pre-release per **HT-218**, not a merge gate.

https://claude.ai/code/session_01AL4EmUSYAiVXEstBgKqDmv