### PR TITLE
chore(lint): promote purity/refs to error, retire no-named-as-default, finalize documented floor (TASK-248)

### DIFF
--- a/eslint.config.js
+++ b/eslint.config.js
@@ -21,31 +21,121 @@ module.exports = [
       'import/no-unresolved': 'off',
 
       // React Compiler is enabled (app.config.js experiments.reactCompiler).
-      // eslint-plugin-react-hooks v7 ships the compiler's *advisory* rules at
-      // "error", but the actual compiler compiles 185/185 components
-      // (react-compiler-healthcheck, no incompatible libraries) and tolerates
-      // the patterns these flag: Reanimated `SharedValue.value = …` writes,
-      // forward-referenced effect helpers (no runtime TDZ), and manual
-      // memoization it can't statically prove. Keep them as WARN — visible
-      // optimization hints that don't block the error gate. Genuine
-      // Rules-of-React bugs these caught were fixed in code (WC param mutation,
-      // mnemonic reshuffle, derivable setStates). rules-of-hooks and
-      // error-boundaries stay at ERROR — those are real correctness bugs.
+      // eslint-plugin-react-hooks v7 ships the compiler's *advisory* Rules-of-React
+      // diagnostics at "error"; several fire on patterns that are correct in this
+      // codebase, so they are held at `warn` — visible and ratcheted (see the
+      // --max-warnings pin below) rather than blocking the error gate. rules-of-
+      // hooks and error-boundaries stay at their preset ERROR — those are real
+      // correctness bugs. Genuine Rules-of-React bugs these advisory rules caught
+      // were fixed in code, not silenced (WC param mutation, mnemonic reshuffle,
+      // derivable setStates).
       //
-      // MIGRATION POLICY (not permanent): as the codebase is cleaned up, tighten
-      // these back toward `error` per-rule — the cheap wins first (purity,
-      // set-state-in-effect where genuinely derivable), leaving immutability at
-      // warn for as long as Reanimated `.value` writes trip it.
+      // EVERY COUNT BELOW IS REGENERABLE. The per-rule totals (96 / 37 / 25) are
+      // the `rules` object in lint-baseline.json — run `npm run lint:baseline` and
+      // read them. The structural sub-splits are recovered from the diagnostic
+      // text with `npx eslint src/ -f json` grouped by message. No number here is
+      // hand-carried. (The former "185/185 components (react-compiler-healthcheck)"
+      // justification was STRUCK in TASK-248: that tool is in neither package.json
+      // nor node_modules and no script runs it, so nobody could reproduce it.)
       //
-      // These are `warn`, not `off`, because `npm run lint` runs under a
-      // ratchet: `--max-warnings` is pinned to the count in lint-baseline.json,
-      // so a new warning fails CI and the ceiling only ever moves down. Counts
-      // are regenerated with `npm run lint:baseline` — see CONTRIBUTING.md.
+      // react-hooks/immutability = 96 — all structural, two diagnostics under one
+      // id:
+      //   • 58 "This value cannot be modified" — Reanimated `useSharedValue().value
+      //     = …` writes in callbacks / worklets / effects. Never during render,
+      //     never React-owned state: the Reanimated SharedValue API working as
+      //     designed. Stays at `warn` for as long as that API trips the rule.
+      //   • 38 "Cannot access variable before it is declared" — forward-referenced
+      //     deferred helper consts (a hook body referencing a `const` declared
+      //     lower in the same scope, only ever invoked after mount). Runtime-safe:
+      //     the reference executes after declaration, so no TDZ hit.
+      //
+      // react-hooks/set-state-in-effect = 37 — effect-driven setState, none a
+      //   correctness bug. Two shapes (inspect the sites via `npx eslint src/ -f
+      //   json`): (a) async-loader effects — `useEffect(() => { load().then(
+      //   setState) }, [dep])`, the canonical RN data-fetch pattern (e.g.
+      //   ThemeContext loadThemeData, the screen data loaders); the value is
+      //   fetched, genuinely not derivable during render. (b) synchronous
+      //   initialize / reset-on-transition effects — seeding or clearing local
+      //   state when a prop / visibility / data input changes (e.g. resetting a
+      //   modal's fields when it opens, UnifiedAuthModal / AssetOptInModal; seeding
+      //   AccountAvatar from its account prop; SendScreen defaulting the asset id).
+      //   These ARE refactorable — remounting via a `key`, or lifting/restructuring
+      //   the state — so they are a retained pattern, not an immovable one; kept at
+      //   `warn` because each is correct as written and the restructure is churn
+      //   this PR does not take on, NOT because it is impossible. (This category
+      //   was absent from the plan's original ~128 floor estimate — it is the
+      //   correction from the PLAN-229 exit-gate reconciliation.)
+      //
+      // react-hooks/preserve-manual-memoization = 25 — all structural: React
+      //   Compiler bail-outs ("Compilation Skipped: Existing memoization could not
+      //   be preserved"). The compiler announces it SKIPPED optimizing a component
+      //   and emits the source unchanged, so the hand-written useMemo/useCallback
+      //   survives intact — zero correctness risk. Not evidence of successful
+      //   compilation, just of a component the compiler declined.
+      //
+      // These stay `warn`, not `off`, because `npm run lint` runs under a ratchet:
+      // `--max-warnings` is pinned to lint-baseline.json's total, so a new warning
+      // fails CI and the ceiling only ever moves down. Regenerate with
+      // `npm run lint:baseline`.
+      //
+      // MIGRATION POLICY: as each advisory rule reaches 0 it is promoted back to
+      // `error` in a separate post-soak PR (DR-7). purity and refs were cleared to
+      // 0 by TASK-242 and promoted to `error` below in TASK-248. The three above
+      // remain at `warn` because their residual is structural, not debt.
       'react-hooks/immutability': 'warn',
       'react-hooks/set-state-in-effect': 'warn',
       'react-hooks/preserve-manual-memoization': 'warn',
-      'react-hooks/purity': 'warn',
-      'react-hooks/refs': 'warn',
+      // Promoted warn → error in TASK-248 (DR-7, post-soak) — both were cleared to
+      // 0 by TASK-242 and have soaked on main. FIVE documented inline disables keep
+      // the reported counts at 0, so `npm run lint` stays green with the rules at
+      // `error` (each disable carries its full rationale at the site):
+      //   refs (2): AuthContext.tsx:204 — render-body ref mirror, the inactivity-
+      //     lock source of truth; deferring it into an effect reopens a suspend-
+      //     before-commit lock-BYPASS window. VerifyBackupScreen.tsx:80 —
+      //     account-guard write-then-read latch pinned on first render, backed by a
+      //     real test.
+      //   purity (3): SignerAuthModal.tsx:182 — `Date.now()` inside an async submit
+      //     handler (not render). FriendListItem.tsx:32 and
+      //     MessagesInboxScreen.tsx:305 — intentional coarse relative-time wall-
+      //     clock reads in a list-row render, re-rendered on data/focus.
+      // If either rule ever reports > 0, a real site regressed — fix the site, do
+      // not downgrade the rule. (Line numbers drift; re-locate the full set with
+      // `grep -rn "eslint-disable.*react-hooks/\(purity\|refs\)" src/`.)
+      'react-hooks/purity': 'error',
+      'react-hooks/refs': 'error',
+
+      // import/no-named-as-default — turned OFF in TASK-248 after re-measurement.
+      // The rule fires when a default import's local name matches one of the same
+      // module's named exports. The ONE genuine named-vs-default ambiguity it ever
+      // caught here — services/network/index.ts default-exporting an *instance*
+      // while aliasing the *class* as `VoiNetworkService`, imported inconsistently
+      // by utils/address.ts vs store/walletStore.ts — was disambiguated by a rename
+      // in TASK-253 (PR #166) and no longer appears in the report.
+      //
+      // The residual after that fix — measured while the rule was still on — is 30
+      // production hits + 2 test-file hits, ALL the idiomatic default-export
+      // pattern this rule flags as a false positive:
+      //   • 11 (production) the `export default SomeClass.getInstance()` singleton
+      //     convention (mimir, messaging, price, algorand-price, snowball,
+      //     rekeyManager, auth-account-discovery): the default is the shared
+      //     instance, the named class export exists for typing/tests, and consumers
+      //     deliberately want the instance.
+      //   • 19 (production) where the default IS the named binding — `export class
+      //     EnvoiService` + `export default EnvoiService` (envoi; the React
+      //     components DeviceDiscovery / AccountImport / AirgapVerificationFlow);
+      //     plus the third-party `@walletconnect/universal-provider`, whose named
+      //     `UniversalProvider` is a `typeof` alias of its default `Provider`.
+      //     Default and named resolve to the same value — zero ambiguity.
+      //   • 2 (test) jest default imports of the same singletons/bindings to mock
+      //     or use them (AlgorandPriceService, EnvoiService) — the pattern the
+      //     former test-scoped override existed for.
+      // None is a real named-vs-default mix-up, so the rule now yields only noise.
+      // Re-confirm before adding new default-exported classes with the command
+      // below — it reports 32 (= 30 production + 2 test) because `--rule` forces the
+      // rule on everywhere, including the test files the config no longer suppresses
+      // separately:
+      //   npx eslint src/ --rule '{"import/no-named-as-default":"warn"}'
+      'import/no-named-as-default': 'off',
 
       // Unused-variable hygiene. eslint-config-expo/flat/utils/typescript.js
       // already configures this rule as { vars:'all', args:'none',
@@ -101,8 +191,8 @@ module.exports = [
     },
     rules: {
       'import/first': 'off',
-      // Tests import default exports (services/stores) to jest.mock them.
-      'import/no-named-as-default': 'off',
+      // (import/no-named-as-default is off globally as of TASK-248, so the former
+      // test-scoped override for jest.mock default imports is no longer needed.)
       // Tests legitimately use require(): jest hoists jest.mock() factories above
       // the import block and forbids them from closing over out-of-scope imports,
       // so require() inside a factory is the only legal form; other specs stub or

--- a/lint-baseline.json
+++ b/lint-baseline.json
@@ -2,12 +2,11 @@
   "$comment": "Committed ESLint baseline for the `npm run lint` ratchet (PLAN-229 DR-2). Regenerate with `npm run lint:baseline`; verify with `npm run lint:baseline:check`. The `lint` script's --max-warnings MUST equal totals.warnings. Lower it in the same PR that clears the warnings. It never goes up.",
   "totals": {
     "errors": 0,
-    "warnings": 188,
+    "warnings": 158,
     "filesLinted": 442,
-    "filesWithFindings": 78
+    "filesWithFindings": 63
   },
   "rules": {
-    "import/no-named-as-default": 30,
     "react-hooks/immutability": 96,
     "react-hooks/preserve-manual-memoization": 25,
     "react-hooks/set-state-in-effect": 37
@@ -30,9 +29,8 @@
     },
     "src/components/account/AccountAvatar.tsx": {
       "errors": 0,
-      "warnings": 2,
+      "warnings": 1,
       "rules": {
-        "import/no-named-as-default": 1,
         "react-hooks/set-state-in-effect": 1
       }
     },
@@ -45,9 +43,8 @@
     },
     "src/components/auth-account/AuthAccountDiscovery.tsx": {
       "errors": 0,
-      "warnings": 3,
+      "warnings": 2,
       "rules": {
-        "import/no-named-as-default": 1,
         "react-hooks/immutability": 2
       }
     },
@@ -92,13 +89,6 @@
       "warnings": 2,
       "rules": {
         "react-hooks/immutability": 2
-      }
-    },
-    "src/components/ledger/ConnectionModal.tsx": {
-      "errors": 0,
-      "warnings": 1,
-      "rules": {
-        "import/no-named-as-default": 1
       }
     },
     "src/components/ledger/DeviceDiscovery.tsx": {
@@ -174,13 +164,6 @@
         "react-hooks/immutability": 1
       }
     },
-    "src/components/transaction/TransactionAddressDisplay.tsx": {
-      "errors": 0,
-      "warnings": 1,
-      "rules": {
-        "import/no-named-as-default": 1
-      }
-    },
     "src/components/walletconnect/QRScanner.tsx": {
       "errors": 0,
       "warnings": 2,
@@ -205,9 +188,8 @@
     },
     "src/screens/account/LedgerAccountImportScreen.tsx": {
       "errors": 0,
-      "warnings": 4,
+      "warnings": 3,
       "rules": {
-        "import/no-named-as-default": 1,
         "react-hooks/set-state-in-effect": 3
       }
     },
@@ -304,18 +286,16 @@
     },
     "src/screens/social/AddFriendScreen.tsx": {
       "errors": 0,
-      "warnings": 4,
+      "warnings": 3,
       "rules": {
-        "import/no-named-as-default": 1,
         "react-hooks/immutability": 1,
         "react-hooks/set-state-in-effect": 2
       }
     },
     "src/screens/social/ChatScreen.tsx": {
       "errors": 0,
-      "warnings": 4,
+      "warnings": 3,
       "rules": {
-        "import/no-named-as-default": 1,
         "react-hooks/preserve-manual-memoization": 3
       }
     },
@@ -342,9 +322,8 @@
     },
     "src/screens/social/NewMessageScreen.tsx": {
       "errors": 0,
-      "warnings": 4,
+      "warnings": 3,
       "rules": {
-        "import/no-named-as-default": 1,
         "react-hooks/immutability": 1,
         "react-hooks/preserve-manual-memoization": 1,
         "react-hooks/set-state-in-effect": 1
@@ -352,9 +331,8 @@
     },
     "src/screens/wallet/AccountInfoScreen.tsx": {
       "errors": 0,
-      "warnings": 3,
+      "warnings": 2,
       "rules": {
-        "import/no-named-as-default": 1,
         "react-hooks/set-state-in-effect": 2
       }
     },
@@ -374,17 +352,15 @@
     },
     "src/screens/wallet/ClaimAllConfirmationScreen.tsx": {
       "errors": 0,
-      "warnings": 3,
+      "warnings": 2,
       "rules": {
-        "import/no-named-as-default": 1,
         "react-hooks/set-state-in-effect": 2
       }
     },
     "src/screens/wallet/ClaimTokenScreen.tsx": {
       "errors": 0,
-      "warnings": 3,
+      "warnings": 2,
       "rules": {
-        "import/no-named-as-default": 1,
         "react-hooks/set-state-in-effect": 2
       }
     },
@@ -422,17 +398,15 @@
     },
     "src/screens/wallet/RekeyAccountScreen.tsx": {
       "errors": 0,
-      "warnings": 2,
+      "warnings": 1,
       "rules": {
-        "import/no-named-as-default": 1,
         "react-hooks/set-state-in-effect": 1
       }
     },
     "src/screens/wallet/SendScreen.tsx": {
       "errors": 0,
-      "warnings": 4,
+      "warnings": 3,
       "rules": {
-        "import/no-named-as-default": 1,
         "react-hooks/set-state-in-effect": 3
       }
     },
@@ -446,17 +420,9 @@
     },
     "src/screens/wallet/TransactionConfirmationScreen.tsx": {
       "errors": 0,
-      "warnings": 3,
+      "warnings": 2,
       "rules": {
-        "import/no-named-as-default": 1,
         "react-hooks/immutability": 2
-      }
-    },
-    "src/screens/wallet/TransactionDetailScreen.tsx": {
-      "errors": 0,
-      "warnings": 1,
-      "rules": {
-        "import/no-named-as-default": 1
       }
     },
     "src/screens/wallet/TransactionHistoryScreen.tsx": {
@@ -494,90 +460,6 @@
       "warnings": 2,
       "rules": {
         "react-hooks/immutability": 2
-      }
-    },
-    "src/services/network/index.ts": {
-      "errors": 0,
-      "warnings": 3,
-      "rules": {
-        "import/no-named-as-default": 3
-      }
-    },
-    "src/services/secure/keyManager.ts": {
-      "errors": 0,
-      "warnings": 1,
-      "rules": {
-        "import/no-named-as-default": 1
-      }
-    },
-    "src/services/secure/simplifiedKeyManager.ts": {
-      "errors": 0,
-      "warnings": 1,
-      "rules": {
-        "import/no-named-as-default": 1
-      }
-    },
-    "src/services/swap/index.ts": {
-      "errors": 0,
-      "warnings": 1,
-      "rules": {
-        "import/no-named-as-default": 1
-      }
-    },
-    "src/services/transactions/arc200.ts": {
-      "errors": 0,
-      "warnings": 1,
-      "rules": {
-        "import/no-named-as-default": 1
-      }
-    },
-    "src/services/transactions/arc72.ts": {
-      "errors": 0,
-      "warnings": 1,
-      "rules": {
-        "import/no-named-as-default": 1
-      }
-    },
-    "src/services/walletconnect/client.ts": {
-      "errors": 0,
-      "warnings": 1,
-      "rules": {
-        "import/no-named-as-default": 1
-      }
-    },
-    "src/store/claimableStore.ts": {
-      "errors": 0,
-      "warnings": 2,
-      "rules": {
-        "import/no-named-as-default": 2
-      }
-    },
-    "src/store/friendsStore.ts": {
-      "errors": 0,
-      "warnings": 1,
-      "rules": {
-        "import/no-named-as-default": 1
-      }
-    },
-    "src/store/messagesStore.ts": {
-      "errors": 0,
-      "warnings": 1,
-      "rules": {
-        "import/no-named-as-default": 1
-      }
-    },
-    "src/store/walletStore.ts": {
-      "errors": 0,
-      "warnings": 1,
-      "rules": {
-        "import/no-named-as-default": 1
-      }
-    },
-    "src/utils/address.ts": {
-      "errors": 0,
-      "warnings": 1,
-      "rules": {
-        "import/no-named-as-default": 1
       }
     },
     "src/utils/animations.ts": {

--- a/package.json
+++ b/package.json
@@ -7,7 +7,7 @@
     "android": "expo run:android",
     "ios": "expo run:ios",
     "web": "expo start --web",
-    "lint": "eslint src/ --max-warnings 188",
+    "lint": "eslint src/ --max-warnings 158",
     "lint:fix": "eslint src/ --fix",
     "lint:baseline": "node scripts/lint-baseline.mjs --write",
     "lint:baseline:check": "node scripts/lint-baseline.mjs --check",


### PR DESCRIPTION
Final PR of **PLAN-229** (Wave 5, DR-7) — the post-soak rule-promotion + floor-finalization. **Config + comments + ratchet artifact only. No source `.ts`/`.tsx` behavior change** (only `eslint.config.js`, `package.json`, `lint-baseline.json`).

## What changed

### 1. Promote `react-hooks/purity` and `react-hooks/refs` → `error` (DR-7)
Both were cleared to **0** by TASK-242 and have soaked on main. Five documented inline disables keep the reported counts at 0, so `npm run lint` stays green with the rules at `error`:
- **refs (2):** `AuthContext.tsx:204` (render-body ref mirror — the inactivity-lock source of truth; deferring into an effect reopens a suspend-before-commit lock-bypass window) and `VerifyBackupScreen.tsx:80` (account-guard write-then-read latch, backed by a test).
- **purity (3):** `SignerAuthModal.tsx:182` (`Date.now()` in an async submit handler, not render), `FriendListItem.tsx:32` and `MessagesInboxScreen.tsx:305` (intentional coarse relative-time reads in list-row renders).

### 2. Retire `import/no-named-as-default` (30 → 0)
Re-measured after TASK-253 (**PR #166**) renamed the one genuine ambiguity (`services/network` default-exported an *instance* while aliasing the *class* as `VoiNetworkService`, imported inconsistently by `utils/address.ts` vs `store/walletStore.ts`) — that hit is gone from the report. The **30** residual production hits are all the idiomatic default-export pattern this rule false-positives on:
- **11** `export default SomeClass.getInstance()` singletons (mimir, messaging, price, algorand-price, snowball, rekeyManager, auth-account-discovery).
- **19** where the default *is* the named binding (envoi; components DeviceDiscovery / AccountImport / AirgapVerificationFlow; third-party `@walletconnect/universal-provider`, whose named `UniversalProvider` is a `typeof` alias of its default).

None is a real named-vs-default mix-up, so the rule is turned **OFF** with a documented rationale (and the now-redundant test-scoped override removed). Re-confirm command reports 32 (30 production + 2 benign test jest-mock imports).

### 3. Rewrite the `eslint.config.js` rationale — every number regenerable
Struck the **unverifiable** `185/185 components (react-compiler-healthcheck)` claim (that tool is in neither `package.json` nor `node_modules`; no script runs it). Replaced with the measured structural categories, each regenerable from `lint-baseline.json` (`npm run lint:baseline`), sub-splits recoverable from `npx eslint src/ -f json` message text:
- `react-hooks/immutability` = **96** = 58 Reanimated `useSharedValue().value =` writes + 38 forward-referenced deferred helper consts (no TDZ).
- `react-hooks/set-state-in-effect` = **37** = effect-driven setState (async-loaders + synchronous initialize/reset-on-transition effects), none a correctness bug. (This category was the exit-gate reconciliation correction, absent from the plan's original ~128 estimate.)
- `react-hooks/preserve-manual-memoization` = **25** = React Compiler bail-outs (compiler skipped optimizing; emits source unchanged, manual memo survives).

### 4. Final `--max-warnings` floor = 158
`96 + 37 + 25 = 158`, with `no-named-as-default` now 0 and `purity`/`refs` at 0/`error`. Lowered from 188; `lint-baseline.json` re-committed. `npm run lint:baseline:check` passes.

## Acceptance (exit gate)
1. **All six debt rules at 0:** no-unused-vars, no-require-imports, no-named-as-default (via rule-off), no-redeclare, purity, refs.
2. purity + refs at `error`; `npm run lint` green (0 errors, 158 warnings ≤ pin).
3. `--max-warnings` at the residual floor **158**; every remaining warning attributable to a documented structural cause in `eslint.config.js`.
4. `npx tsc --noEmit` 0 · `npm test -- --ci` green (**105 suites / 1553 tests**) · no source `.ts`/`.tsx` behavior change.
5. Every rationale number regenerable from `lint-baseline.json` / `npm run lint:baseline`; the unverifiable react-compiler-healthcheck claim struck.

## Codex review
CLEAN (after four rounds resolving comment-accuracy findings: set-state-in-effect category description, disable count/lines, and the 30-vs-32 residual reconciliation).

https://claude.ai/code/session_01AL4EmUSYAiVXEstBgKqDmv