### PR TITLE
fix(walletconnect): ARC-0001 null semantics + session/chain binding at the signer (TASK-256 PR 1, TASK-251)

### DIFF
--- a/src/navigation/AppNavigator.tsx
+++ b/src/navigation/AppNavigator.tsx
@@ -68,6 +68,8 @@ import { AuthProvider, useAuth } from '@/contexts/AuthContext';
 import { useNetworkStore } from '@/store/networkStore';
 import { NetworkId } from '@/types/network';
 import { TransactionInfo, WalletAccount } from '@/types/wallet';
+import type { WalletTransaction } from '@/services/walletconnect/types';
+import type { WalletConnectSessionBinding } from '@/services/transactions/unifiedSigner';
 import { ScannedAccount } from '@/utils/accountQRParser';
 import { NFTToken, ARC72Collection } from '@/types/nft';
 import { SerializableClaimableItem } from '@/types/claimable';
@@ -235,6 +237,18 @@ export type RootStackParamList = {
     title?: string;
     networkId?: NetworkId;
     chainId?: string;
+    /**
+     * DR-15 — the dApp handoff. Present ONLY for a WalletConnect request, and
+     * it carries what the signer legally needs: the full ARC-0001 entries
+     * (`signers` / `authAddr` / `msig`, which `transactions: string[]` cannot
+     * express) plus the session + chain the request must be bound to.
+     *
+     * Its absence means "in-app batch", i.e. a group this wallet built itself.
+     */
+    walletConnect?: {
+      transactions: WalletTransaction[];
+      binding: WalletConnectSessionBinding;
+    };
   };
   QRScanner: undefined;
   QRAccountImport: undefined;

--- a/src/screens/wallet/ClaimAllConfirmationScreen.tsx
+++ b/src/screens/wallet/ClaimAllConfirmationScreen.tsx
@@ -371,8 +371,18 @@ export default function ClaimAllConfirmationScreen() {
           try {
             const networkService = NetworkService.getInstance(CLAIM_NETWORK_ID);
             const algodClient = networkService.getAlgodClient();
-            const signedTxns = result.signedTransactions.map(
-              (txn: string) => new Uint8Array(Buffer.from(txn, 'base64'))
+            // DR-1: a `null` slot means the signer DECLINED that entry
+            // (ARC-0001). `Buffer.from(null, 'base64')` would throw a bare
+            // TypeError here; submitting a hole would corrupt the group. Fail
+            // with an explicit, debuggable message instead.
+            const rawSigned = result.signedTransactions as (string | null)[];
+            if (rawSigned.some((txn) => txn === null || txn === undefined)) {
+              throw new Error(
+                'The wallet declined to sign part of this claim group, so nothing was submitted.'
+              );
+            }
+            const signedTxns = rawSigned.map(
+              (txn) => new Uint8Array(Buffer.from(txn as string, 'base64'))
             );
             await algodClient.sendRawTransaction(signedTxns).do();
 

--- a/src/screens/wallet/ClaimTokenScreen.tsx
+++ b/src/screens/wallet/ClaimTokenScreen.tsx
@@ -352,8 +352,18 @@ export default function ClaimTokenScreen() {
           try {
             const networkService = NetworkService.getInstance(CLAIM_NETWORK_ID);
             const algodClient = networkService.getAlgodClient();
-            const signedTxns = result.signedTransactions.map(
-              (txn: string) => new Uint8Array(Buffer.from(txn, 'base64'))
+            // DR-1: a `null` slot means the signer DECLINED that entry
+            // (ARC-0001). `Buffer.from(null, 'base64')` would throw a bare
+            // TypeError here; submitting a hole would corrupt the group. Fail
+            // with an explicit, debuggable message instead.
+            const rawSigned = result.signedTransactions as (string | null)[];
+            if (rawSigned.some((txn) => txn === null || txn === undefined)) {
+              throw new Error(
+                'The wallet declined to sign part of this claim group, so nothing was submitted.'
+              );
+            }
+            const signedTxns = rawSigned.map(
+              (txn) => new Uint8Array(Buffer.from(txn as string, 'base64'))
             );
 
             await algodClient.sendRawTransaction(signedTxns).do();

--- a/src/screens/wallet/SwapScreen.tsx
+++ b/src/screens/wallet/SwapScreen.tsx
@@ -719,15 +719,28 @@ export default function SwapScreen() {
         // Standard flow - need to submit signed transactions
         const networkService = NetworkService.getInstance(selectedNetwork);
 
+        // DR-1: the signer returns ARC-0001 `null` for any entry it DECLINED to
+        // sign. Submitting a group with a hole (or, as before this contract
+        // existed, with raw unsigned bytes in that slot) is what produced the
+        // `apaa` msgpack decode failure at algod. Fail loudly instead.
+        const rawSigned = result.signedTransactions as (
+          | string
+          | Uint8Array
+          | null
+        )[];
+        if (rawSigned.some((txn) => txn === null || txn === undefined)) {
+          throw new Error(
+            'The wallet declined to sign part of this swap group, so nothing was submitted.'
+          );
+        }
+
         // Convert signed transactions from base64 strings to Uint8Array if needed
-        const signedTxns = result.signedTransactions.map(
-          (txn: string | Uint8Array) => {
-            if (typeof txn === 'string') {
-              return new Uint8Array(Buffer.from(txn, 'base64'));
-            }
-            return txn;
+        const signedTxns = rawSigned.map((txn: string | Uint8Array | null) => {
+          if (typeof txn === 'string') {
+            return new Uint8Array(Buffer.from(txn, 'base64'));
           }
-        );
+          return txn as Uint8Array;
+        });
 
         // Submit transaction group
         const submitRes = await networkService.submitTransaction(signedTxns);

--- a/src/screens/wallet/UniversalTransactionSigningScreen.tsx
+++ b/src/screens/wallet/UniversalTransactionSigningScreen.tsx
@@ -76,7 +76,21 @@ export default function UniversalTransactionSigningScreen({
     title = 'Sign Transaction',
     networkId,
     chainId,
+    walletConnect,
   } = route.params;
+
+  // DR-15 — the ARC-0001 entries are the single source of truth for a dApp
+  // request: the wallet must review and sign exactly the bytes the dApp sent,
+  // with its `signers`/`authAddr` intact. `transactions` (bare base64) remains
+  // the shape the in-app callers (swap / claim) use.
+  const walletTransactions = useMemo(
+    () => walletConnect?.transactions ?? transactions.map((txn) => ({ txn })),
+    [walletConnect, transactions]
+  );
+  const transactionBytes = useMemo(
+    () => walletTransactions.map((wtxn) => wtxn.txn),
+    [walletTransactions]
+  );
   // The route param is typed `WalletAccount` (legacy), but callers always pass a
   // full `AccountMetadata` at runtime (see SwapScreen/Claim screens which cast the
   // other direction). Coerce to the real shape so display fields (color/label) and
@@ -142,7 +156,7 @@ export default function UniversalTransactionSigningScreen({
       const parsed: ParsedTransaction[] = [];
       const decoded: algosdk.Transaction[] = [];
 
-      for (const txnBase64 of transactions) {
+      for (const txnBase64 of transactionBytes) {
         try {
           const txnBytes = Buffer.from(txnBase64, 'base64');
           let txn: algosdk.Transaction;
@@ -269,13 +283,12 @@ export default function UniversalTransactionSigningScreen({
       return;
     }
 
-    // Build the transaction list
-    const allTransactions = transactions.map((txn) => ({
-      txn,
-      signers: [account.address],
-    }));
+    // Hand the signer the REAL entries. This screen used to fabricate
+    // `signers: [account.address]` for every transaction, which destroyed the
+    // dApp's own instructions — including `signers: []`, i.e. "do not sign
+    // this one" — before the signer ever saw them.
     const allDecodedTransactions =
-      decodedTransactions.length === transactions.length
+      decodedTransactions.length === walletTransactions.length
         ? [...decodedTransactions]
         : undefined;
 
@@ -283,10 +296,14 @@ export default function UniversalTransactionSigningScreen({
     const request: UnifiedTransactionRequest = {
       type: 'batch_transaction',
       account,
+      networkId: walletConnect?.binding.networkId ?? networkId,
       walletConnectParams: {
-        transactions: allTransactions,
+        transactions: walletTransactions,
         accountAddress: account.address,
         decodedTransactions: allDecodedTransactions,
+        // DR-15: bind a dApp request to its session + chain; `null` declares an
+        // in-app batch the wallet built itself.
+        sessionBinding: walletConnect?.binding ?? null,
       },
     };
 

--- a/src/screens/walletconnect/TransactionRequestScreen.tsx
+++ b/src/screens/walletconnect/TransactionRequestScreen.tsx
@@ -21,16 +21,22 @@ import {
 } from '@/services/walletconnect';
 import { MultiAccountWalletService } from '@/services/wallet';
 import { AccountMetadata, WalletAccount } from '@/types/wallet';
+import { NetworkId } from '@/types/network';
 import UniversalHeader from '@/components/common/UniversalHeader';
 import UnifiedTransactionAuthModal from '@/components/UnifiedTransactionAuthModal';
 import { useTransactionAuthController } from '@/services/auth/transactionAuthController';
-import { UnifiedTransactionRequest } from '@/services/transactions/unifiedSigner';
+import {
+  UnifiedTransactionRequest,
+  WalletConnectSessionBinding,
+} from '@/services/transactions/unifiedSigner';
 import {
   truncateAddress,
   getNetworkNameByChainId,
   getNetworkCurrencyByChainId,
-  getChainIdByGenesisHash,
+  getNetworkByChainId,
+  formatAccountAddress,
 } from '@/services/walletconnect/utils';
+import { resolveV1Chain } from '@/services/walletconnect/v1/config';
 import { WalletConnectV1Client } from '@/services/walletconnect/v1';
 import { useTheme } from '@/contexts/ThemeContext';
 import { useThemedStyles } from '@/hooks/useThemedStyles';
@@ -73,6 +79,8 @@ export default function TransactionRequestScreen({ navigation, route }: Props) {
     useState<AccountMetadata | null>(null);
   const [networkName, setNetworkName] = useState<string>('Unknown Network');
   const [networkCurrency, setNetworkCurrency] = useState<string>('TOKEN');
+  const [sessionBinding, setSessionBinding] =
+    useState<WalletConnectSessionBinding | null>(null);
   const [dangerAcknowledged, setDangerAcknowledged] = useState(false);
 
   // Use the unified auth controller
@@ -125,9 +133,7 @@ export default function TransactionRequestScreen({ navigation, route }: Props) {
       }
 
       const paramsWrapper = eventParams;
-      const initialChainId = paramsWrapper.chainId as string | undefined;
       const { request } = paramsWrapper;
-      let derivedChainId: string | null = null;
 
       if (request.method === 'algo_signTxn') {
         // Support both WC param shapes: { txn: WalletTransaction[] } or [ WalletTransaction[] ]
@@ -142,103 +148,122 @@ export default function TransactionRequestScreen({ navigation, route }: Props) {
           throw new Error('Malformed request: missing transactions array');
         }
 
-        // Extract chainId from first transaction for network detection
-        if (txns.length > 0) {
-          try {
-            const txnBytes = Buffer.from(txns[0].txn, 'base64');
-            const txn = algosdk.decodeUnsignedTransaction(txnBytes);
-            const txnAny = txn as any;
-            const genesisSource =
-              txnAny.genesisHash || txnAny.gh || txn?.genesisHash;
-            const chainIdFromGenesis = getChainIdByGenesisHash(genesisSource);
-            if (chainIdFromGenesis) {
-              derivedChainId = chainIdFromGenesis;
-            }
-          } catch (error) {
-            console.error('Failed to extract chainId from transaction:', error);
-          }
-        }
-
         setTransactions(txns);
 
-        // Set default account (first account that can sign for the first transaction)
-        if (txns.length > 0) {
-          try {
-            const txnBytes = Buffer.from(txns[0].txn, 'base64');
-            const txn = algosdk.decodeUnsignedTransaction(txnBytes);
-            const txnAny = txn as any;
-            let fromAddress = 'N/A';
-            if (txnAny.sender && txnAny.sender.publicKey) {
-              fromAddress = algosdk.encodeAddress(txnAny.sender.publicKey);
-            }
-            const account = allAccounts.find(
-              (acc) => acc.address === fromAddress
+        // DR-7 / DR-11 / DR-14 — resolve the chain the REQUEST is scoped to.
+        // This is deliberately the chain the dApp/session declares, never one
+        // derived from the transaction bytes: deriving it from the bytes would
+        // make the binding circular, and the signer's job is to verify that the
+        // bytes match this chain.
+        const requestChainId = paramsWrapper.chainId;
+        let chainId: string;
+        let chainNetworkId: NetworkId;
+
+        if (version === 1) {
+          const resolved = resolveV1Chain(Number(requestChainId));
+          if (!resolved) {
+            throw new Error(
+              'This WalletConnect v1 session uses a network this wallet cannot ' +
+                'identify (v1 sessions carry an ambiguous numeric chain id). ' +
+                'Please reconnect the dApp using WalletConnect v2.'
             );
-            if (account) {
-              setSelectedAccount(account);
-            }
-          } catch (error) {
-            console.error('Failed to determine signing account:', error);
           }
-        }
-
-        // Determine effective chainId and navigate to UniversalTransactionSigning
-        const effectiveChainId = derivedChainId || initialChainId;
-        if (effectiveChainId) {
-          setNetworkName(getNetworkNameByChainId(effectiveChainId));
-          setNetworkCurrency(getNetworkCurrencyByChainId(effectiveChainId));
-          // effectiveChainId is passed explicitly to UniversalTransactionSigning
-          // below (navigation param); do NOT mutate the incoming WalletConnect
-          // request's params object in place (Rules of React + shared-object safety).
-        }
-
-        // Navigate to UniversalTransactionSigning screen
-        // Decode the first transaction to get the sender address (signer)
-        let signingAccount = allAccounts[0]; // Default to first account
-        if (txns.length > 0) {
-          try {
-            const txnBytes = Buffer.from(txns[0].txn, 'base64');
-            const txn = algosdk.decodeUnsignedTransaction(txnBytes);
-            const txnAny = txn as any;
-            let senderAddress: string | null = null;
-
-            // Extract sender address from decoded transaction
-            if (txnAny.sender && txnAny.sender.publicKey) {
-              senderAddress = algosdk.encodeAddress(txnAny.sender.publicKey);
-            }
-
-            // Try to find account by sender address, or fall back to signers array if provided
-            if (senderAddress) {
-              signingAccount =
-                allAccounts.find((acc) => acc.address === senderAddress) ||
-                allAccounts[0];
-            } else if (txns[0].signers?.[0]) {
-              signingAccount =
-                allAccounts.find(
-                  (acc) => acc.address === txns[0].signers?.[0]
-                ) || allAccounts[0];
-            }
-          } catch (error) {
-            console.error(
-              'Failed to decode transaction for signing account:',
-              error
+          chainId = resolved.chainId;
+          chainNetworkId = resolved.networkId;
+        } else {
+          if (typeof requestChainId !== 'string' || !requestChainId) {
+            throw new Error('Malformed request: missing chain id');
+          }
+          const resolved = getNetworkByChainId(requestChainId);
+          if (!resolved) {
+            throw new Error(
+              'This request targets a network this wallet does not support.'
             );
-            // Fall back to signers array if decoding fails
-            if (txns[0].signers?.[0]) {
-              signingAccount =
-                allAccounts.find(
-                  (acc) => acc.address === txns[0].signers?.[0]
-                ) || allAccounts[0];
+          }
+          chainId = requestChainId;
+          chainNetworkId = resolved;
+        }
+
+        setNetworkName(getNetworkNameByChainId(chainId));
+        setNetworkCurrency(getNetworkCurrencyByChainId(chainId));
+
+        // DR-5 / DR-14 — the accounts the LIVE session approved for THIS chain,
+        // as full CAIP-10 strings. Empty means absent / expired / disconnected /
+        // topic-mismatched, which is a rejection: local accounts are never
+        // substituted for the session's.
+        const requestTopic = (requestEvent as any).topic as string | undefined;
+        const approvedAccounts = requestTopic
+          ? WalletConnectService.getInstance().getApprovedAccountsForChain(
+              requestTopic,
+              chainId
+            )
+          : [];
+
+        if (approvedAccounts.length === 0) {
+          throw new Error(
+            'This dApp session has no approved account on ' +
+              `${getNetworkNameByChainId(chainId)}. Reconnect the session and try again.`
+          );
+        }
+
+        const binding: WalletConnectSessionBinding = {
+          topic: requestTopic!,
+          chainId,
+          networkId: chainNetworkId,
+          approvedAccounts,
+        };
+        setSessionBinding(binding);
+
+        // Choose the account to review. DR-13 keeps signing eligibility narrow —
+        // only the REVIEWED account signs — so this must pick an account that is
+        // both ours and session-approved for this chain, rather than defaulting
+        // to `allAccounts[0]` (which would review one account and then decline
+        // every entry). The first eligible sender in the group wins; a group
+        // whose first entry is a pool/logic-sig transaction still resolves to
+        // the user's own account further down the list.
+        let signingAccount: AccountMetadata | undefined;
+        for (const wtxn of txns) {
+          let senderAddress: string | null = null;
+          try {
+            const txn = algosdk.decodeUnsignedTransaction(
+              Buffer.from(wtxn.txn, 'base64')
+            );
+            if (txn.sender?.publicKey) {
+              senderAddress = algosdk.encodeAddress(txn.sender.publicKey);
             }
+          } catch {
+            // Pre-signed / undecodable entry — it names no signer of ours.
+            continue;
+          }
+
+          if (!senderAddress) {
+            continue;
+          }
+          if (
+            !approvedAccounts.includes(
+              formatAccountAddress(chainId, senderAddress)
+            )
+          ) {
+            continue;
+          }
+          const match = allAccounts.find(
+            (acc) => acc.address === senderAddress
+          );
+          if (match) {
+            signingAccount = match;
+            break;
           }
         }
 
         if (!signingAccount) {
-          // No account is available to sign this request (e.g. every account was
-          // removed after the session was approved). Surface an explicit error
-          // rather than stranding the user on an empty review screen.
+          // No account this session approved on this chain is available to sign
+          // (e.g. every account was removed after the session was approved).
+          // Surface an explicit error rather than stranding the user on an
+          // empty review screen or reviewing an account that cannot sign.
           throw new Error('No account available to sign this request');
         }
+
+        setSelectedAccount(signingAccount);
 
         // Register callbacks in the callback registry to avoid serialization warnings
         const callbackId = registerNavigationCallbacks({
@@ -251,14 +276,20 @@ export default function TransactionRequestScreen({ navigation, route }: Props) {
         });
 
         navigation.replace('UniversalTransactionSigning', {
+          // Display bytes. `walletConnect.transactions` below is the authority
+          // for both review and signing; this stays index-aligned with it.
           transactions: txns.map((wtxn) => wtxn.txn),
           // Nav param is typed WalletAccount (legacy); the screen coerces it back
           // to AccountMetadata at runtime. Matches the existing cast pattern used
           // by the other callers of this route (e.g. SwapScreen).
           account: signingAccount as unknown as WalletAccount,
-          chainId: effectiveChainId,
+          chainId,
+          networkId: chainNetworkId,
           title: 'WalletConnect Request',
           callbackId,
+          // DR-15: the real ARC-0001 entries (signers / authAddr / msig) plus
+          // the session + chain the signer must bind every entry to.
+          walletConnect: { transactions: txns, binding },
         });
       } else {
         // The normal path (algo_signTxn) always navigates away to
@@ -292,13 +323,25 @@ export default function TransactionRequestScreen({ navigation, route }: Props) {
       return;
     }
 
+    if (!sessionBinding) {
+      // Fail closed: without a resolved session + chain there is nothing to bind
+      // the signature to, so there is no safe way to sign here.
+      Alert.alert(
+        'Error',
+        'This request is not bound to an active session. Reconnect the dApp and try again.'
+      );
+      return;
+    }
+
     // Create unified transaction request for WalletConnect batch
     const request: UnifiedTransactionRequest = {
       type: 'walletconnect_batch',
       account: selectedAccount,
+      networkId: sessionBinding.networkId,
       walletConnectParams: {
         transactions,
         accountAddress: selectedAccount.address,
+        sessionBinding,
       },
     };
 

--- a/src/services/transactions/__tests__/unifiedSigner.test.ts
+++ b/src/services/transactions/__tests__/unifiedSigner.test.ts
@@ -29,6 +29,10 @@ import { Buffer } from 'buffer';
 
 import { makeAccount, paymentTxn } from '@/__tests__/fixtures/algorand';
 import { AccountType } from '@/types/wallet';
+import { NetworkId } from '@/types/network';
+import { NETWORK_CONFIGURATIONS } from '@/services/network/config';
+import { resolveV1Chain } from '@/services/walletconnect/v1/config';
+import { createSignTxnResponse } from '@/services/walletconnect/v1/protocol';
 
 // ---------------------------------------------------------------------------
 // Leaf-transport mocks (see DR-3 note above). Declared before importing the
@@ -67,6 +71,7 @@ import {
   RemoteSignerRequiredError,
   UnifiedSigningCallbacks,
   UnifiedTransactionRequest,
+  WalletConnectSessionBinding,
 } from '../unifiedSigner';
 import { TransactionService } from '@/services/transactions';
 import { SecureKeyManager } from '@/services/secure/keyManager';
@@ -129,6 +134,61 @@ function accountOf(
 /** base64 of an unsigned transaction (the WalletConnect wire shape). */
 function unsignedB64(txn: algosdk.Transaction): string {
   return Buffer.from(algosdk.encodeUnsignedTransaction(txn)).toString('base64');
+}
+
+// ---------------------------------------------------------------------------
+// Chain-binding helpers (DR-7 / DR-14).
+//
+// The shared fixtures deliberately use an all-zero, obviously-fake genesis hash,
+// which algosdk omits from the canonical encoding entirely — so a fixture txn
+// decodes with `genesisHash: undefined` and belongs to no network. That is
+// exactly right for the UNBOUND (in-app) tests, and exactly wrong for the bound
+// ones, which need REAL network identities. These builders read them from
+// `NETWORK_CONFIGURATIONS`, the same source the signer binds against.
+// ---------------------------------------------------------------------------
+
+function paramsFor(networkId: NetworkId): algosdk.SuggestedParams {
+  const config = NETWORK_CONFIGURATIONS[networkId];
+  return {
+    fee: 1000,
+    firstValid: 1,
+    lastValid: 1001,
+    genesisID: config.genesisId,
+    genesisHash: new Uint8Array(Buffer.from(config.genesisHash, 'base64')),
+    flatFee: true,
+    minFee: 1000,
+  };
+}
+
+/** Payment transaction carrying a REAL network identity. */
+function payOn(
+  networkId: NetworkId,
+  sender: string,
+  amount: number
+): algosdk.Transaction {
+  return algosdk.makePaymentTxnWithSuggestedParamsFromObject({
+    sender,
+    receiver: sender,
+    amount,
+    suggestedParams: paramsFor(networkId),
+  });
+}
+
+const chainIdOf = (networkId: NetworkId): string =>
+  NETWORK_CONFIGURATIONS[networkId].chainId;
+
+/** A session binding approving `addresses` on `networkId`'s chain (CAIP-10). */
+function bindingFor(
+  networkId: NetworkId,
+  addresses: string[]
+): WalletConnectSessionBinding {
+  const chainId = chainIdOf(networkId);
+  return {
+    topic: 'topic-under-test',
+    chainId,
+    networkId,
+    approvedAccounts: addresses.map((address) => `${chainId}:${address}`),
+  };
 }
 
 /** Drain the microtask queue (and one macrotask tick) so awaited work settles. */
@@ -475,6 +535,7 @@ describe('signTransaction — batch routing (local vs ledger)', () => {
         walletConnectParams: {
           transactions: txns.map((t) => ({ txn: unsignedB64(t) })),
           accountAddress: account.address,
+          sessionBinding: null,
         },
       },
       cb
@@ -534,6 +595,7 @@ describe('signTransaction — batch routing (local vs ledger)', () => {
         walletConnectParams: {
           transactions: txns.map((t) => ({ txn: unsignedB64(t) })),
           accountAddress: account.address,
+          sessionBinding: null,
         },
       },
       cb
@@ -595,40 +657,48 @@ describe('signTransaction — batch routing (local vs ledger)', () => {
     });
   });
 
-  it('passes through a transaction whose sender is NOT our signer (unsigned)', async () => {
+  // DR-1 — THE REGRESSION TEST FOR THE ORIGINAL `apaa` BUG.
+  //
+  // This slot used to come back holding the RAW UNSIGNED wire bytes. The dApp
+  // reassembled its group from the response array, found a bare `Transaction`
+  // where a `SignedTxn` belongs, submitted it, and algod died on the first
+  // Transaction-only key — `apaa` (ApplicationArgs). ARC-0001 says a declined
+  // entry is `null`. Note the assertion is on the exact POSITIONAL value, not
+  // on array length: a length-only assertion passes for both behaviours and
+  // would not catch the regression.
+  it('returns null (never the unsigned bytes) for a transaction whose sender is NOT our signer', async () => {
     const account = accountOf('batch-owner', AccountType.STANDARD);
     const foreign = makeAccount('batch-foreign').addr;
     const foreignTxn = paymentTxn(foreign, { amount: 5 });
     const wireTxn = unsignedB64(foreignTxn);
 
-    // Our signer is `account`, but the txn's sender is `foreign` and no
-    // signers/authAddr override points back at `foreign` — so the entry does
-    // NOT match our signer and must be passed through unsigned.
     const result = await signer.signTransaction({
       type: 'batch_transaction',
       account,
       walletConnectParams: {
         transactions: [{ txn: wireTxn }],
         accountAddress: account.address,
+        sessionBinding: null,
       },
     });
 
     expect(result.success).toBe(true);
-    // Passed through verbatim (still the unsigned wire bytes) and never signed.
-    expect((result.signedTransactions as string[])[0]).toBe(wireTxn);
+    const signed = result.signedTransactions as (string | null)[];
+    expect(signed).toHaveLength(1);
+    expect(signed[0]).toBeNull();
+    expect(signed[0]).not.toBe(wireTxn);
     expect(mockSignTransaction).not.toHaveBeenCalled();
   });
 
-  // Characterization of the caller-controlled signer-selection branch
-  // (unifiedSigner.ts ~L493): `wtxn.signers[0]` OVERRIDES the request's
-  // `accountAddress`. So a batch whose request is scoped to account A, but whose
-  // entry declares `signers: [B]` for a B-sender txn, is signed with B's key
-  // (whenever B is resolvable in the wallet) — NOT skipped. This pins that
-  // routing precisely: a regression that ignored `signers` would sign as A (and
-  // fail sender-match → pass through), flipping these assertions.
-  it('honors the wtxn.signers[0] override to select the signing key', async () => {
-    const selected = accountOf('wc-selected', AccountType.STANDARD); // A (request)
-    const signerB = accountOf('wc-signer-b', AccountType.STANDARD); // B (override)
+  // DR-13 — eligibility must not outrun the UI. The review screen names exactly
+  // ONE account, so a `signers: [B]` entry whose sender is B is DECLINED when
+  // the reviewed account is A. Previously `signers[0]` overrode the request's
+  // account and B's key signed while the screen said "Sign with Account A".
+  // TASK-259 widens this to true multi-account signing together with the
+  // signer-list display; until then the honest answer is `null`.
+  it('declines an entry whose sender is not the REVIEWED account, even when signers names it', async () => {
+    const selected = accountOf('wc-selected', AccountType.STANDARD); // A (reviewed)
+    const signerB = accountOf('wc-signer-b', AccountType.STANDARD); // B
     const txnFromB = paymentTxn(signerB.address, { amount: 7 });
 
     const result = await signer.signTransaction({
@@ -640,21 +710,14 @@ describe('signTransaction — batch routing (local vs ledger)', () => {
           { txn: unsignedB64(txnFromB), signers: [signerB.address] },
         ],
         accountAddress: selected.address,
+        sessionBinding: null,
       },
     });
 
     expect(result.success).toBe(true);
-    // The leaf was invoked as B (the override), not A (the request account).
-    expect(mockSignTransaction).toHaveBeenCalledTimes(1);
-    expect(mockSignTransaction.mock.calls[0][1]).toBe(signerB.address);
-    // And the produced blob is a real signature by B over B's transaction.
-    const blob = new Uint8Array(
-      Buffer.from((result.signedTransactions as string[])[0], 'base64')
-    );
-    expect(blobIsSignedBy(blob, signerB.address)).toBe(true);
-    expect(algosdk.decodeSignedTransaction(blob).txn.txID()).toBe(
-      txnFromB.txID()
-    );
+    expect((result.signedTransactions as (string | null)[])[0]).toBeNull();
+    // B's key was never touched.
+    expect(mockSignTransaction).not.toHaveBeenCalled();
   });
 
   // FIXED (TASK-163): a rekeyed account's WalletConnect txn carrying `authAddr`
@@ -681,6 +744,7 @@ describe('signTransaction — batch routing (local vs ledger)', () => {
       walletConnectParams: {
         transactions: [{ txn: unsignedB64(txn), authAddr: authority.address }],
         accountAddress: rekeyed,
+        sessionBinding: null,
       },
     });
 
@@ -722,6 +786,7 @@ describe('signTransaction — batch routing (local vs ledger)', () => {
           },
         ],
         accountAddress: rekeyed,
+        sessionBinding: null,
       },
     });
 
@@ -753,6 +818,7 @@ describe('signTransaction — batch routing (local vs ledger)', () => {
           },
         ],
         accountAddress: rekeyed,
+        sessionBinding: null,
       },
     });
 
@@ -765,7 +831,12 @@ describe('signTransaction — batch routing (local vs ledger)', () => {
     expect(blobIsSignedBy(blob, authority.address)).toBe(true);
   });
 
-  it('passes through an already-signed / undecodable entry unchanged', async () => {
+  // DR-8 — REVERSED BEHAVIOUR. This used to assert that four arbitrary bytes
+  // passed through unchanged, i.e. that the wallet would hand garbage back to a
+  // dApp for it to submit. Classification now happens BEFORE pass-through:
+  // only a genuine, validly-authorized signed transaction is echoed, and
+  // undecodable bytes fail the whole request.
+  it('REJECTS undecodable bytes instead of echoing them back (DR-8)', async () => {
     const account = accountOf('batch-logicsig', AccountType.STANDARD);
     // Bytes that are NOT a decodable unsigned transaction.
     const opaque = Buffer.from([0x01, 0x02, 0x03, 0x04]).toString('base64');
@@ -776,12 +847,54 @@ describe('signTransaction — batch routing (local vs ledger)', () => {
       walletConnectParams: {
         transactions: [{ txn: opaque }],
         accountAddress: account.address,
+        sessionBinding: null,
+      },
+    });
+
+    expect(result.success).toBe(false);
+    expect(result.error?.message).toMatch(
+      /neither a valid unsigned transaction nor a valid signed transaction/i
+    );
+    expect(result.signedTransactions).toBeUndefined();
+    expect(mockSignTransaction).not.toHaveBeenCalled();
+  });
+
+  it('passes through a GENUINELY pre-signed entry unchanged', async () => {
+    const account = accountOf('batch-presigned-owner', AccountType.STANDARD);
+    const other = accountOf('batch-presigned-other', AccountType.STANDARD);
+    const mine = paymentTxn(account.address, { amount: 1 });
+    // A real, fully-signed transaction by a third party (real Ed25519 bytes —
+    // nothing fabricated), of the kind an atomic group legitimately carries.
+    const preSignedBlob = realSign(
+      paymentTxn(other.address, { amount: 2 }),
+      other.address
+    );
+    const preSigned = Buffer.from(preSignedBlob).toString('base64');
+
+    const result = await signer.signTransaction({
+      type: 'batch_transaction',
+      account,
+      pin: '1234',
+      walletConnectParams: {
+        transactions: [{ txn: preSigned }, { txn: unsignedB64(mine) }],
+        accountAddress: account.address,
+        sessionBinding: null,
       },
     });
 
     expect(result.success).toBe(true);
-    expect((result.signedTransactions as string[])[0]).toBe(opaque);
-    expect(mockSignTransaction).not.toHaveBeenCalled();
+    const signed = result.signedTransactions as (string | null)[];
+    expect(signed).toHaveLength(2);
+    // Slot 0 is echoed byte-for-byte; slot 1 is really signed by us.
+    expect(signed[0]).toBe(preSigned);
+    expect(
+      blobIsSignedBy(
+        new Uint8Array(Buffer.from(signed[1] as string, 'base64')),
+        account.address
+      )
+    ).toBe(true);
+    // Only OUR entry reached the key manager.
+    expect(mockSignTransaction).toHaveBeenCalledTimes(1);
   });
 
   it('reports a Ledger signing failure via onLedgerRejected and clears the cache', async () => {
@@ -798,6 +911,7 @@ describe('signTransaction — batch routing (local vs ledger)', () => {
         walletConnectParams: {
           transactions: [{ txn: unsignedB64(txn) }],
           accountAddress: account.address,
+          sessionBinding: null,
         },
       },
       cb
@@ -810,6 +924,426 @@ describe('signTransaction — batch routing (local vs ledger)', () => {
     expect(rejCtx.error).toBeInstanceOf(Error);
     // Cache is cleared on the error path too.
     expect(mockClearCache).toHaveBeenCalled();
+  });
+});
+
+// ===========================================================================
+// WalletConnect batch — ARC-0001 response contract, session binding (DR-5 /
+// DR-14), chain binding (DR-7), signers semantics (DR-2) and the DR-13 narrow
+// eligibility rule. Every test in this block goes through a SESSION-BOUND
+// request, i.e. the real dApp path.
+// ===========================================================================
+
+describe('signWalletConnectBatch — session + chain binding', () => {
+  const VOI = NetworkId.VOI_MAINNET;
+  const ALGO = NetworkId.ALGORAND_MAINNET;
+
+  it('returns positional null for the foreign slots of a mixed-sender group', async () => {
+    const mine = accountOf('bind-mine', AccountType.STANDARD);
+    const theirs = accountOf('bind-theirs', AccountType.STANDARD);
+
+    const txnA = payOn(VOI, mine.address, 1);
+    const txnB = payOn(VOI, theirs.address, 2);
+    const txnC = payOn(VOI, mine.address, 3);
+    const wireB = unsignedB64(txnB);
+
+    const result = await signer.signTransaction({
+      type: 'batch_transaction',
+      account: mine,
+      pin: '1234',
+      walletConnectParams: {
+        transactions: [txnA, txnB, txnC].map((t) => ({ txn: unsignedB64(t) })),
+        accountAddress: mine.address,
+        // BOTH accounts are session-approved; only the reviewed one may sign.
+        sessionBinding: bindingFor(VOI, [mine.address, theirs.address]),
+      },
+    });
+
+    expect(result.success).toBe(true);
+    const signed = result.signedTransactions as (string | null)[];
+
+    // Response length is invariant with the request...
+    expect(signed).toHaveLength(3);
+    // ...and the DECLINED slot holds exactly `null` — not the unsigned bytes,
+    // which is the original apaa defect.
+    expect(signed[1]).toBeNull();
+    expect(signed[1]).not.toBe(wireB);
+
+    // The two slots that ARE ours carry genuine signatures over the matching
+    // transactions, still at the matching indexes.
+    [0, 2].forEach((i) => {
+      const blob = new Uint8Array(Buffer.from(signed[i] as string, 'base64'));
+      expect(blobIsSignedBy(blob, mine.address)).toBe(true);
+      expect(algosdk.decodeSignedTransaction(blob).txn.txID()).toBe(
+        [txnA, txnB, txnC][i].txID()
+      );
+    });
+
+    expect(mockSignTransaction).toHaveBeenCalledTimes(2);
+  });
+
+  it('never signs an entry marked `signers: []` (explicit do-not-sign)', async () => {
+    const account = accountOf('bind-empty-signers', AccountType.STANDARD);
+    const txn = payOn(VOI, account.address, 1);
+
+    const result = await signer.signTransaction({
+      type: 'batch_transaction',
+      account,
+      pin: '1234',
+      walletConnectParams: {
+        transactions: [{ txn: unsignedB64(txn), signers: [] }],
+        accountAddress: account.address,
+        sessionBinding: bindingFor(VOI, [account.address]),
+      },
+    });
+
+    expect(result.success).toBe(true);
+    expect((result.signedTransactions as (string | null)[])[0]).toBeNull();
+    expect(mockSignTransaction).not.toHaveBeenCalled();
+  });
+
+  it('signs when `signers` is undefined and the sender is the reviewed account', async () => {
+    const account = accountOf('bind-no-signers', AccountType.STANDARD);
+    const txn = payOn(VOI, account.address, 1);
+
+    const result = await signer.signTransaction({
+      type: 'batch_transaction',
+      account,
+      pin: '1234',
+      walletConnectParams: {
+        transactions: [{ txn: unsignedB64(txn) }],
+        accountAddress: account.address,
+        sessionBinding: bindingFor(VOI, [account.address]),
+      },
+    });
+
+    expect(result.success).toBe(true);
+    const blob = new Uint8Array(
+      Buffer.from((result.signedTransactions as string[])[0], 'base64')
+    );
+    expect(blobIsSignedBy(blob, account.address)).toBe(true);
+  });
+
+  it('declines an entry whose `signers` list excludes the sender', async () => {
+    const account = accountOf('bind-excluded', AccountType.STANDARD);
+    const someoneElse = makeAccount('bind-excluded-other').addr;
+    const txn = payOn(VOI, account.address, 1);
+
+    const result = await signer.signTransaction({
+      type: 'batch_transaction',
+      account,
+      pin: '1234',
+      walletConnectParams: {
+        transactions: [{ txn: unsignedB64(txn), signers: [someoneElse] }],
+        accountAddress: account.address,
+        sessionBinding: bindingFor(VOI, [account.address]),
+      },
+    });
+
+    expect(result.success).toBe(true);
+    expect((result.signedTransactions as (string | null)[])[0]).toBeNull();
+    expect(mockSignTransaction).not.toHaveBeenCalled();
+  });
+
+  // DR-5: a dApp used to be able to harvest a signature from ANY locally
+  // controlled account simply by naming it. Eligibility is now anchored in what
+  // the SESSION approved, and the wallet's own account list is never a
+  // substitute for it.
+  it('declines a locally-controlled sender the SESSION never approved', async () => {
+    const account = accountOf('bind-unapproved', AccountType.STANDARD);
+    const txn = payOn(VOI, account.address, 1);
+
+    const result = await signer.signTransaction({
+      type: 'batch_transaction',
+      account,
+      pin: '1234',
+      walletConnectParams: {
+        transactions: [{ txn: unsignedB64(txn) }],
+        accountAddress: account.address,
+        // Session approved a DIFFERENT account on this chain.
+        sessionBinding: bindingFor(VOI, [makeAccount('bind-other').addr]),
+      },
+    });
+
+    expect(result.success).toBe(true);
+    expect((result.signedTransactions as (string | null)[])[0]).toBeNull();
+    expect(mockSignTransaction).not.toHaveBeenCalled();
+  });
+
+  // DR-14: authorization is CHAIN-SCOPED. A session may approve address A on
+  // Voi and not on Algorand; reducing the session to a bare address set would
+  // let the Voi approval authorize an Algorand transaction from A.
+  it('declines a sender approved on a DIFFERENT chain than the request', async () => {
+    const account = accountOf('bind-wrong-chain', AccountType.STANDARD);
+    const txn = payOn(ALGO, account.address, 1);
+
+    // Request is on Algorand; the approved CAIP account is the Voi one.
+    const binding = bindingFor(ALGO, []);
+    binding.approvedAccounts = [`${chainIdOf(VOI)}:${account.address}`];
+
+    const result = await signer.signTransaction({
+      type: 'batch_transaction',
+      account,
+      pin: '1234',
+      walletConnectParams: {
+        transactions: [{ txn: unsignedB64(txn) }],
+        accountAddress: account.address,
+        sessionBinding: binding,
+      },
+    });
+
+    expect(result.success).toBe(true);
+    expect((result.signedTransactions as (string | null)[])[0]).toBeNull();
+    expect(mockSignTransaction).not.toHaveBeenCalled();
+  });
+
+  it('rejects the whole request when the session approved nothing on this chain', async () => {
+    const account = accountOf('bind-empty-session', AccountType.STANDARD);
+    const txn = payOn(VOI, account.address, 1);
+
+    const result = await signer.signTransaction({
+      type: 'batch_transaction',
+      account,
+      pin: '1234',
+      walletConnectParams: {
+        transactions: [{ txn: unsignedB64(txn) }],
+        accountAddress: account.address,
+        sessionBinding: bindingFor(VOI, []),
+      },
+    });
+
+    expect(result.success).toBe(false);
+    expect(result.error?.message).toMatch(/no approved account/i);
+    expect(mockSignTransaction).not.toHaveBeenCalled();
+  });
+
+  // DR-7 (TASK-251). A single mismatched entry fails the WHOLE batch: a
+  // partially-signed group returned to a dApp is its own failure mode.
+  it('fails the WHOLE batch on a genesis mismatch and never calls the signer', async () => {
+    const account = accountOf('bind-genesis-mismatch', AccountType.STANDARD);
+    const good = payOn(VOI, account.address, 1);
+    const wrongChain = payOn(ALGO, account.address, 2);
+
+    const result = await signer.signTransaction({
+      type: 'batch_transaction',
+      account,
+      pin: '1234',
+      walletConnectParams: {
+        transactions: [good, wrongChain].map((t) => ({ txn: unsignedB64(t) })),
+        accountAddress: account.address,
+        sessionBinding: bindingFor(VOI, [account.address]),
+      },
+    });
+
+    expect(result.success).toBe(false);
+    expect(result.error?.message).toMatch(/mixed or invalid network batch/i);
+    // The decisive assertion: NO key was used for ANY entry, not even the
+    // well-formed first one.
+    expect(mockSignTransaction).not.toHaveBeenCalled();
+    expect(result.signedTransactions).toBeUndefined();
+  });
+
+  it('rejects a transaction carrying no recognized network identity', async () => {
+    const account = accountOf('bind-no-genesis', AccountType.STANDARD);
+    // The shared fixture's genesis hash is all-zero, which algosdk omits from
+    // the encoding entirely — the decoded txn belongs to no known chain.
+    const txn = paymentTxn(account.address, { amount: 1 });
+
+    const result = await signer.signTransaction({
+      type: 'batch_transaction',
+      account,
+      pin: '1234',
+      walletConnectParams: {
+        transactions: [{ txn: unsignedB64(txn) }],
+        accountAddress: account.address,
+        sessionBinding: bindingFor(VOI, [account.address]),
+      },
+    });
+
+    expect(result.success).toBe(false);
+    expect(result.error?.message).toMatch(
+      /no recognized network identity|mixed or invalid network batch/i
+    );
+    expect(mockSignTransaction).not.toHaveBeenCalled();
+  });
+
+  it('rejects a transaction whose genesisID contradicts its chain', async () => {
+    const account = accountOf('bind-genesis-id', AccountType.STANDARD);
+    const params = paramsFor(VOI);
+    const txn = algosdk.makePaymentTxnWithSuggestedParamsFromObject({
+      sender: account.address,
+      receiver: account.address,
+      amount: 1,
+      suggestedParams: { ...params, genesisID: 'not-voimain-v1.0' },
+    });
+
+    const result = await signer.signTransaction({
+      type: 'batch_transaction',
+      account,
+      pin: '1234',
+      walletConnectParams: {
+        transactions: [{ txn: unsignedB64(txn) }],
+        accountAddress: account.address,
+        sessionBinding: bindingFor(VOI, [account.address]),
+      },
+    });
+
+    expect(result.success).toBe(false);
+    expect(result.error?.message).toMatch(/genesis id/i);
+    expect(mockSignTransaction).not.toHaveBeenCalled();
+  });
+
+  // DR-7: the resolved NetworkId must reach SecureKeyManager, which otherwise
+  // defaults to the ACTIVE network — so a Voi-active app reviewing an Algorand
+  // rekeyed account would resolve the wrong signing authority.
+  it('threads the resolved NetworkId into SecureKeyManager.signTransaction', async () => {
+    const account = accountOf('bind-network-thread', AccountType.STANDARD);
+    const txn = payOn(ALGO, account.address, 1);
+
+    await signer.signTransaction({
+      type: 'batch_transaction',
+      account,
+      pin: '1234',
+      walletConnectParams: {
+        transactions: [{ txn: unsignedB64(txn) }],
+        accountAddress: account.address,
+        sessionBinding: bindingFor(ALGO, [account.address]),
+      },
+    });
+
+    expect(mockSignTransaction).toHaveBeenCalledTimes(1);
+    expect(mockSignTransaction.mock.calls[0][3]).toBe(ALGO);
+  });
+
+  // DR-16: `decodeSignedTransaction` only proves a msgpack wrapper parsed. A
+  // wrapper with a corrupted signature would still have "passed through" as an
+  // invalid SignedTxn for the dApp to submit.
+  it('rejects a pre-signed blob whose signature does not verify (DR-16)', async () => {
+    const account = accountOf('bind-badsig-owner', AccountType.STANDARD);
+    const other = accountOf('bind-badsig-other', AccountType.STANDARD);
+    const blob = realSign(payOn(VOI, other.address, 2), other.address);
+    // Corrupt one byte of the signature (the txn itself is untouched, so it
+    // still decodes cleanly as a SignedTransaction).
+    const decoded = algosdk.decodeSignedTransaction(blob);
+    const tampered = new algosdk.SignedTransaction({
+      txn: decoded.txn,
+      sig: Uint8Array.from(decoded.sig!, (b, i) => (i === 0 ? b ^ 0xff : b)),
+    });
+    const tamperedB64 = Buffer.from(algosdk.encodeMsgpack(tampered)).toString(
+      'base64'
+    );
+
+    const result = await signer.signTransaction({
+      type: 'batch_transaction',
+      account,
+      pin: '1234',
+      walletConnectParams: {
+        transactions: [{ txn: tamperedB64 }],
+        accountAddress: account.address,
+        sessionBinding: bindingFor(VOI, [account.address]),
+      },
+    });
+
+    expect(result.success).toBe(false);
+    expect(result.error?.message).toMatch(/signature does not verify/i);
+    expect(mockSignTransaction).not.toHaveBeenCalled();
+  });
+
+  it('accepts a genuinely pre-signed group member on the session-bound path', async () => {
+    const account = accountOf('bind-presigned-owner', AccountType.STANDARD);
+    const other = accountOf('bind-presigned-other', AccountType.STANDARD);
+    const preSigned = Buffer.from(
+      realSign(payOn(VOI, other.address, 2), other.address)
+    ).toString('base64');
+    const mine = payOn(VOI, account.address, 1);
+
+    const result = await signer.signTransaction({
+      type: 'batch_transaction',
+      account,
+      pin: '1234',
+      walletConnectParams: {
+        transactions: [{ txn: preSigned }, { txn: unsignedB64(mine) }],
+        accountAddress: account.address,
+        sessionBinding: bindingFor(VOI, [account.address]),
+      },
+    });
+
+    expect(result.success).toBe(true);
+    const signed = result.signedTransactions as (string | null)[];
+    expect(signed).toHaveLength(2);
+    expect(signed[0]).toBe(preSigned);
+    expect(signed[1]).not.toBeNull();
+  });
+
+  it('preserves response length and positions on a Ledger (sequential) batch', async () => {
+    const account = accountOf('bind-ledger', AccountType.LEDGER);
+    const foreign = makeAccount('bind-ledger-foreign').addr;
+    const txns = [
+      payOn(VOI, account.address, 1),
+      payOn(VOI, foreign, 2),
+      payOn(VOI, account.address, 3),
+    ];
+
+    const result = await signer.signTransaction({
+      type: 'batch_transaction',
+      account,
+      walletConnectParams: {
+        transactions: txns.map((t) => ({ txn: unsignedB64(t) })),
+        accountAddress: account.address,
+        sessionBinding: bindingFor(VOI, [account.address]),
+      },
+    });
+
+    expect(result.success).toBe(true);
+    const signed = result.signedTransactions as (string | null)[];
+    expect(signed).toHaveLength(3);
+    expect(signed[1]).toBeNull();
+    expect(signed[0]).not.toBeNull();
+    expect(signed[2]).not.toBeNull();
+    expect(mockSignTransaction).toHaveBeenCalledTimes(2);
+  });
+});
+
+// ===========================================================================
+// WalletConnect v1 boundary — DR-11 chain mapping, DR-12 null threading
+// ===========================================================================
+
+describe('WalletConnect v1 boundary', () => {
+  it('maps the Algorand mainnet v1 chain ids and rejects everything else (DR-11)', () => {
+    expect(resolveV1Chain(416001)).toEqual({
+      chainId: NETWORK_CONFIGURATIONS[NetworkId.ALGORAND_MAINNET].chainId,
+      networkId: NetworkId.ALGORAND_MAINNET,
+    });
+    expect(resolveV1Chain(4160)).toEqual({
+      chainId: NETWORK_CONFIGURATIONS[NetworkId.ALGORAND_MAINNET].chainId,
+      networkId: NetworkId.ALGORAND_MAINNET,
+    });
+
+    // Ambiguous / unsupported v1 chains resolve to nothing and must be
+    // rejected. `416001` is NOT allowed to silently mean Voi, which is the
+    // accepted v1-Voi session break.
+    expect(resolveV1Chain(416002)).toBeNull(); // Algorand testnet
+    expect(resolveV1Chain(416003)).toBeNull(); // Algorand betanet
+    expect(resolveV1Chain(0)).toBeNull();
+    expect(resolveV1Chain(undefined)).toBeNull();
+    expect(resolveV1Chain(null)).toBeNull();
+  });
+
+  // DR-12: the v1 response path is the one place a null could be silently
+  // filtered or stringified. It must survive encoding positionally.
+  it('carries a positional null through the v1 sign-txn response (DR-12)', () => {
+    const response = createSignTxnResponse(42, ['AAA', null, 'CCC']);
+
+    expect(response.result).toEqual(['AAA', null, 'CCC']);
+
+    // The wire form is JSON, which is where a filtered/stringified null would
+    // show up. Round-trip it the way the v1 encryptResponse path does.
+    const roundTripped = JSON.parse(JSON.stringify(response));
+    expect(roundTripped.result).toHaveLength(3);
+    expect(roundTripped.result[1]).toBeNull();
+    expect(roundTripped.result[1]).not.toBe('null');
+    expect(roundTripped.result[0]).toBe('AAA');
+    expect(roundTripped.result[2]).toBe('CCC');
   });
 });
 

--- a/src/services/transactions/__tests__/unifiedSigner.test.ts
+++ b/src/services/transactions/__tests__/unifiedSigner.test.ts
@@ -49,8 +49,15 @@ jest.mock('@/services/transactions', () => ({
   },
 }));
 
+// The live-session lookup the signer re-checks the binding against (DR-5). The
+// per-test approved set is driven through `liveApprovedAccounts` below.
+const mockGetApprovedAccountsForChain = jest.fn<string[], [string, string]>();
 jest.mock('@/services/walletconnect', () => ({
-  WalletConnectService: { getInstance: jest.fn(() => ({})) },
+  WalletConnectService: {
+    getInstance: jest.fn(() => ({
+      getApprovedAccountsForChain: mockGetApprovedAccountsForChain,
+    })),
+  },
 }));
 
 jest.mock('@/services/secure/keyManager', () => ({
@@ -177,17 +184,26 @@ function payOn(
 const chainIdOf = (networkId: NetworkId): string =>
   NETWORK_CONFIGURATIONS[networkId].chainId;
 
+/**
+ * What the LIVE session currently approves, as the signer's DR-5 revalidation
+ * would see it. `bindingFor` keeps it in step with the snapshot by default; a
+ * test that wants a session which changed mid-flow overwrites it afterwards.
+ */
+let liveApprovedAccounts: string[] = [];
+
 /** A session binding approving `addresses` on `networkId`'s chain (CAIP-10). */
 function bindingFor(
   networkId: NetworkId,
   addresses: string[]
 ): WalletConnectSessionBinding {
   const chainId = chainIdOf(networkId);
+  const approvedAccounts = addresses.map((address) => `${chainId}:${address}`);
+  liveApprovedAccounts = [...approvedAccounts];
   return {
     topic: 'topic-under-test',
     chainId,
     networkId,
-    approvedAccounts: addresses.map((address) => `${chainId}:${address}`),
+    approvedAccounts,
   };
 }
 
@@ -270,6 +286,10 @@ let signer: UnifiedTransactionSigner;
 beforeEach(() => {
   keyRegistry.clear();
   rekeyRegistry.clear();
+  liveApprovedAccounts = [];
+  mockGetApprovedAccountsForChain.mockImplementation(
+    () => liveApprovedAccounts
+  );
   signer = new UnifiedTransactionSigner();
 
   // Default happy-path leaf behaviour (clearMocks resets call data each test).
@@ -1077,9 +1097,11 @@ describe('signWalletConnectBatch — session + chain binding', () => {
     const account = accountOf('bind-wrong-chain', AccountType.STANDARD);
     const txn = payOn(ALGO, account.address, 1);
 
-    // Request is on Algorand; the approved CAIP account is the Voi one.
+    // Request is on Algorand; the approved CAIP account is the Voi one, so a
+    // bare-address comparison would wrongly authorize it.
     const binding = bindingFor(ALGO, []);
     binding.approvedAccounts = [`${chainIdOf(VOI)}:${account.address}`];
+    liveApprovedAccounts = [...binding.approvedAccounts];
 
     const result = await signer.signTransaction({
       type: 'batch_transaction',
@@ -1113,8 +1135,126 @@ describe('signWalletConnectBatch — session + chain binding', () => {
     });
 
     expect(result.success).toBe(false);
-    expect(result.error?.message).toMatch(/no approved account/i);
+    expect(result.error?.message).toMatch(/no longer approves an account/i);
     expect(mockSignTransaction).not.toHaveBeenCalled();
+  });
+
+  // DR-5 (Codex diff-review, round 1): the binding is snapshotted when the
+  // request screen loads, but the user then reviews and authenticates. If the
+  // session is disconnected/expires in that window, the snapshot alone would
+  // still authorize a signature the dApp no longer holds authorization for.
+  it('rejects when the session was disconnected between review and signing', async () => {
+    const account = accountOf('bind-stale-session', AccountType.STANDARD);
+    const txn = payOn(VOI, account.address, 1);
+    const binding = bindingFor(VOI, [account.address]);
+
+    // The live session is gone by the time signing starts.
+    liveApprovedAccounts = [];
+
+    const result = await signer.signTransaction({
+      type: 'batch_transaction',
+      account,
+      pin: '1234',
+      walletConnectParams: {
+        transactions: [{ txn: unsignedB64(txn) }],
+        accountAddress: account.address,
+        sessionBinding: binding,
+      },
+    });
+
+    expect(result.success).toBe(false);
+    expect(result.error?.message).toMatch(/no longer approves an account/i);
+    expect(mockSignTransaction).not.toHaveBeenCalled();
+    // It re-checked the LIVE session for this exact topic + chain.
+    expect(mockGetApprovedAccountsForChain).toHaveBeenCalledWith(
+      binding.topic,
+      binding.chainId
+    );
+  });
+
+  it('declines a sender the session dropped after the review started', async () => {
+    const mine = accountOf('bind-stale-mine', AccountType.STANDARD);
+    const other = accountOf('bind-stale-other', AccountType.STANDARD);
+    const binding = bindingFor(VOI, [mine.address, other.address]);
+
+    // `session_update` removed OUR account; the other one survives, so the
+    // request is not rejected outright — but our entry must not be signed.
+    liveApprovedAccounts = [`${chainIdOf(VOI)}:${other.address}`];
+
+    const result = await signer.signTransaction({
+      type: 'batch_transaction',
+      account: mine,
+      pin: '1234',
+      walletConnectParams: {
+        transactions: [{ txn: unsignedB64(payOn(VOI, mine.address, 1)) }],
+        accountAddress: mine.address,
+        sessionBinding: binding,
+      },
+    });
+
+    expect(result.success).toBe(true);
+    expect((result.signedTransactions as (string | null)[])[0]).toBeNull();
+    expect(mockSignTransaction).not.toHaveBeenCalled();
+  });
+
+  // Codex diff-review round 1 (medium): the pre-decoded cache is a display-side
+  // optimization. Trusting it on index alignment alone would let a caller show
+  // one transaction and have a DIFFERENT one signed. The signer only uses a
+  // cached entry when it re-encodes to exactly the wire bytes.
+  it('ignores a decoded cache that does not match the wire bytes', async () => {
+    const account = accountOf('bind-cache-swap', AccountType.STANDARD);
+    const shown = payOn(VOI, account.address, 1);
+    const swapped = payOn(VOI, account.address, 999_999);
+
+    const result = await signer.signTransaction({
+      type: 'batch_transaction',
+      account,
+      pin: '1234',
+      walletConnectParams: {
+        transactions: [{ txn: unsignedB64(shown) }],
+        accountAddress: account.address,
+        // Same length, but a completely different transaction.
+        decodedTransactions: [swapped],
+        sessionBinding: bindingFor(VOI, [account.address]),
+      },
+    });
+
+    expect(result.success).toBe(true);
+    const blob = new Uint8Array(
+      Buffer.from((result.signedTransactions as string[])[0], 'base64')
+    );
+    // The signature covers the transaction the WIRE bytes carried, not the
+    // cached substitute.
+    expect(algosdk.decodeSignedTransaction(blob).txn.txID()).toBe(shown.txID());
+    expect(algosdk.decodeSignedTransaction(blob).txn.txID()).not.toBe(
+      swapped.txID()
+    );
+    expect(mockSignTransaction.mock.calls[0][0].txID()).toBe(shown.txID());
+  });
+
+  it('uses a decoded cache that DOES match the wire bytes', async () => {
+    const account = accountOf('bind-cache-ok', AccountType.STANDARD);
+    const txn = payOn(VOI, account.address, 1);
+    const wire = unsignedB64(txn);
+    const cached = algosdk.decodeUnsignedTransaction(
+      new Uint8Array(Buffer.from(wire, 'base64'))
+    );
+
+    const result = await signer.signTransaction({
+      type: 'batch_transaction',
+      account,
+      pin: '1234',
+      walletConnectParams: {
+        transactions: [{ txn: wire }],
+        accountAddress: account.address,
+        decodedTransactions: [cached],
+        sessionBinding: bindingFor(VOI, [account.address]),
+      },
+    });
+
+    expect(result.success).toBe(true);
+    expect(mockSignTransaction).toHaveBeenCalledTimes(1);
+    expect(mockSignTransaction.mock.calls[0][0]).toBe(cached);
   });
 
   // DR-7 (TASK-251). A single mismatched entry fails the WHOLE batch: a

--- a/src/services/transactions/__tests__/unifiedSigner.test.ts
+++ b/src/services/transactions/__tests__/unifiedSigner.test.ts
@@ -1044,6 +1044,98 @@ describe('signWalletConnectBatch — session + chain binding', () => {
     expect(blobIsSignedBy(blob, account.address)).toBe(true);
   });
 
+  // Codex diff-review round 3 (P1): `signers` / `authAddr` are attacker-supplied
+  // strings. Unvalidated, a pair of matching junk values would satisfy the
+  // designation rule purely by matching each other.
+  it.each([
+    [
+      'signers',
+      { signers: ['not-an-address'] },
+      /invalid address in "signers"/i,
+    ],
+    [
+      'authAddr',
+      { signers: ['not-an-address'], authAddr: 'not-an-address' },
+      /invalid address in "signers"/i,
+    ],
+  ])(
+    'rejects the request when %s carries an invalid address',
+    async (_label, metadata, pattern) => {
+      const account = accountOf(
+        `bind-bad-meta-${_label}`,
+        AccountType.STANDARD
+      );
+      const txn = payOn(VOI, account.address, 1);
+
+      const result = await signer.signTransaction({
+        type: 'batch_transaction',
+        account,
+        pin: '1234',
+        walletConnectParams: {
+          transactions: [{ txn: unsignedB64(txn), ...metadata }],
+          accountAddress: account.address,
+          sessionBinding: bindingFor(VOI, [account.address]),
+        },
+      });
+
+      expect(result.success).toBe(false);
+      expect(result.error?.message).toMatch(pattern);
+      expect(mockSignTransaction).not.toHaveBeenCalled();
+    }
+  );
+
+  it('rejects the request when authAddr alone is an invalid address', async () => {
+    const account = accountOf('bind-bad-authaddr', AccountType.STANDARD);
+    const txn = payOn(VOI, account.address, 1);
+
+    const result = await signer.signTransaction({
+      type: 'batch_transaction',
+      account,
+      pin: '1234',
+      walletConnectParams: {
+        transactions: [{ txn: unsignedB64(txn), authAddr: 'nope' }],
+        accountAddress: account.address,
+        sessionBinding: bindingFor(VOI, [account.address]),
+      },
+    });
+
+    expect(result.success).toBe(false);
+    expect(result.error?.message).toMatch(/invalid "authAddr" address/i);
+    expect(mockSignTransaction).not.toHaveBeenCalled();
+  });
+
+  // Codex diff-review round 3 (P1): this wallet has no multisig signing path.
+  // Returning a single-key signature for an `msig` entry would hand the dApp
+  // bytes that can never validate on chain; `null` is the honest answer.
+  it('declines an entry that requests a multisig signature', async () => {
+    const account = accountOf('bind-msig', AccountType.STANDARD);
+    const txn = payOn(VOI, account.address, 1);
+
+    const result = await signer.signTransaction({
+      type: 'batch_transaction',
+      account,
+      pin: '1234',
+      walletConnectParams: {
+        transactions: [
+          {
+            txn: unsignedB64(txn),
+            msig: {
+              subsig: [{ pk: 'AAAA' }, { pk: 'BBBB' }],
+              thr: 2,
+              v: 1,
+            },
+          },
+        ],
+        accountAddress: account.address,
+        sessionBinding: bindingFor(VOI, [account.address]),
+      },
+    });
+
+    expect(result.success).toBe(true);
+    expect((result.signedTransactions as (string | null)[])[0]).toBeNull();
+    expect(mockSignTransaction).not.toHaveBeenCalled();
+  });
+
   it('declines an entry whose `signers` list excludes the sender', async () => {
     const account = accountOf('bind-excluded', AccountType.STANDARD);
     const someoneElse = makeAccount('bind-excluded-other').addr;

--- a/src/services/transactions/unifiedSigner.ts
+++ b/src/services/transactions/unifiedSigner.ts
@@ -656,6 +656,11 @@ export class UnifiedTransactionSigner {
   ): BatchEntryPlan {
     const txnBytes = Buffer.from(wtxn.txn, 'base64');
 
+    // ARC-0001 metadata must be well formed before it is allowed to influence
+    // anything. A malformed `signers` / `authAddr` is invalid input, and invalid
+    // input fails the request rather than being interpreted charitably.
+    this.assertWellFormedEntryMetadata(wtxn, index);
+
     // Reuse the caller's pre-decoded transactions ONLY when the cached entry
     // re-encodes to exactly the wire bytes of this entry. The cache is a
     // display-side optimization; an index-alignment check alone would let a
@@ -710,6 +715,47 @@ export class UnifiedTransactionSigner {
     }
 
     return { action: 'sign', txn, sender: txnSender };
+  }
+
+  /**
+   * Validate the ARC-0001 metadata on one entry before it can influence
+   * eligibility (Codex diff-review round 3).
+   *
+   * `signers` and `authAddr` are attacker-supplied strings. Left unvalidated,
+   * `signers: ["not-an-address"], authAddr: "not-an-address"` would satisfy the
+   * designation rule below purely because the two junk values match each other.
+   * ARC-0001 treats invalid addresses as invalid input, so this fails the whole
+   * request rather than interpreting nonsense charitably.
+   */
+  private assertWellFormedEntryMetadata(
+    wtxn: WalletTransaction,
+    index: number
+  ): void {
+    if (wtxn.signers !== undefined) {
+      if (!Array.isArray(wtxn.signers)) {
+        throw new Error(
+          `Transaction ${index + 1} has a malformed "signers" field.`
+        );
+      }
+      for (const signer of wtxn.signers) {
+        if (typeof signer !== 'string' || !algosdk.isValidAddress(signer)) {
+          throw new Error(
+            `Transaction ${index + 1} lists an invalid address in "signers".`
+          );
+        }
+      }
+    }
+
+    if (wtxn.authAddr !== undefined) {
+      if (
+        typeof wtxn.authAddr !== 'string' ||
+        !algosdk.isValidAddress(wtxn.authAddr)
+      ) {
+        throw new Error(
+          `Transaction ${index + 1} has an invalid "authAddr" address.`
+        );
+      }
+    }
   }
 
   /**
@@ -785,6 +831,16 @@ export class UnifiedTransactionSigner {
    * are assembled by our own aggregator integrations and may legitimately carry
    * delegated logic-sigs that `LogicSig.verify` cannot validate offline (it does
    * not track the delegating public key when the sender differs).
+   *
+   * DELIBERATE DEVIATION FROM ARC-0001, per DR-8. The standard says `txn` MUST
+   * hold canonical UNSIGNED bytes and that an already-signed companion belongs
+   * in a separate `stxn` field paired with `signers: []`. In practice both our
+   * own aggregator groups (`services/deflex/index.ts` puts logic-sig blobs
+   * straight into `txn`) and a number of dApps use the `txn` slot for a
+   * pre-signed group member and expect it echoed. Rejecting those outright
+   * would break real groups, so the leniency stays — but it is gated on the
+   * blob being a genuinely, verifiably authorized transaction rather than on it
+   * merely failing to decode as unsigned, which is what used to happen.
    */
   private assertGenuinePreSigned(
     txnBytes: Uint8Array,
@@ -873,6 +929,15 @@ export class UnifiedTransactionSigner {
     wtxn: WalletTransaction,
     binding: WalletConnectSessionBinding | null
   ): boolean {
+    // 0. This wallet has no multisig signing path — SecureKeyManager only ever
+    //    produces a single-key signature. An entry carrying `msig` is asking for
+    //    a partial multisig signature we cannot produce, so the honest ARC-0001
+    //    answer is `null`. Silently returning a single-key signature for it
+    //    would hand the dApp bytes that can never validate on chain.
+    if (wtxn.msig) {
+      return false;
+    }
+
     // 1. Session authorization, chain-scoped (DR-5 / DR-14).
     if (binding) {
       const caipAccount = `${binding.chainId}:${txnSender}`;

--- a/src/services/transactions/unifiedSigner.ts
+++ b/src/services/transactions/unifiedSigner.ts
@@ -464,12 +464,12 @@ export class UnifiedTransactionSigner {
       // mismatched session resolves to an EMPTY approved set. Reject the whole
       // request rather than silently declining every entry — and never
       // substitute the wallet's local accounts for the session's.
-      if (binding && binding.approvedAccounts.length === 0) {
-        throw new Error(
-          'This dApp session has no approved account on the requested network. ' +
-            'Reconnect the session and try again.'
-        );
-      }
+      const effectiveBinding = binding
+        ? {
+            ...binding,
+            approvedAccounts: await this.revalidateBinding(binding),
+          }
+        : null;
 
       // ---------------------------------------------------------------------
       // PREFLIGHT (DR-2/5/7/8/13/14/16). Runs to completion BEFORE a single key
@@ -477,7 +477,13 @@ export class UnifiedTransactionSigner {
       // signatures and no partially-signed response handed back to a dApp.
       // ---------------------------------------------------------------------
       const plans = params.transactions.map((wtxn, index) =>
-        this.planBatchEntry(wtxn, index, params, binding, boundNetworkId)
+        this.planBatchEntry(
+          wtxn,
+          index,
+          params,
+          effectiveBinding,
+          boundNetworkId
+        )
       );
 
       // Track signing progress for each transaction. `null` = declined (DR-1).
@@ -596,6 +602,48 @@ export class UnifiedTransactionSigner {
   }
 
   /**
+   * DR-5 — re-resolve the session's approved accounts against the LIVE session,
+   * immediately before preflight.
+   *
+   * The binding is snapshotted when the request screen loads, but the user then
+   * reviews the group and authenticates, which can take minutes. In that window
+   * the session can be disconnected, expire, or drop an account via
+   * `session_update`. Trusting the snapshot would let the wallet sign against
+   * authorization the dApp no longer holds.
+   *
+   * The result is the INTERSECTION of the snapshot and the live set, so it can
+   * only ever shrink: an account the session gained after the review started was
+   * never reviewed and must not become signable here either. An empty
+   * intersection is a rejection of the whole request.
+   */
+  private async revalidateBinding(
+    binding: WalletConnectSessionBinding
+  ): Promise<string[]> {
+    // Lazy import: keeps the in-app batch path free of the WalletConnect module
+    // graph, and mirrors the existing dynamic-import pattern in this file.
+    const { WalletConnectService } = await import('@/services/walletconnect');
+    const service = WalletConnectService.getInstance();
+
+    const live = service.getApprovedAccountsForChain(
+      binding.topic,
+      binding.chainId
+    );
+
+    const stillApproved = binding.approvedAccounts.filter((caipAccount) =>
+      live.includes(caipAccount)
+    );
+
+    if (stillApproved.length === 0) {
+      throw new Error(
+        'This dApp session no longer approves an account on the requested ' +
+          'network. Reconnect the session and try again.'
+      );
+    }
+
+    return stillApproved;
+  }
+
+  /**
    * Preflight ONE batch entry. Never touches a key; either returns a plan or
    * THROWS, and a throw fails the entire batch (DR-7/DR-8).
    */
@@ -608,16 +656,28 @@ export class UnifiedTransactionSigner {
   ): BatchEntryPlan {
     const txnBytes = Buffer.from(wtxn.txn, 'base64');
 
-    // Reuse the caller's pre-decoded transactions only when the cache is
-    // index-aligned with the request (same fail-closed length check as before).
+    // Reuse the caller's pre-decoded transactions ONLY when the cached entry
+    // re-encodes to exactly the wire bytes of this entry. The cache is a
+    // display-side optimization; an index-alignment check alone would let a
+    // caller show one transaction and get a different one signed, so the bytes
+    // that were reviewed and the object that gets signed are proven identical.
     const cache = params.decodedTransactions;
-    const cacheAligned =
-      !!cache && cache.length === params.transactions.length && !!cache[index];
-
     let txn: algosdk.Transaction | null = null;
-    if (cacheAligned) {
-      txn = cache![index];
-    } else {
+
+    if (cache && cache.length === params.transactions.length && cache[index]) {
+      try {
+        const reEncoded = Buffer.from(
+          algosdk.encodeUnsignedTransaction(cache[index])
+        );
+        if (reEncoded.equals(txnBytes)) {
+          txn = cache[index];
+        }
+      } catch {
+        txn = null;
+      }
+    }
+
+    if (!txn) {
       try {
         txn = algosdk.decodeUnsignedTransaction(txnBytes);
       } catch {

--- a/src/services/transactions/unifiedSigner.ts
+++ b/src/services/transactions/unifiedSigner.ts
@@ -1,6 +1,7 @@
 import algosdk from 'algosdk';
+import nacl from 'tweetnacl';
 import { TransactionService, TransactionParams } from '@/services/transactions';
-import { WalletTransaction } from '@/services/walletconnect';
+import type { WalletTransaction } from '@/services/walletconnect/types';
 import {
   WalletAccount,
   AccountMetadata,
@@ -12,6 +13,7 @@ import {
   RemoteSignerRequiredError,
 } from '@/types/wallet';
 import { NetworkId } from '@/types/network';
+import { NETWORK_CONFIGURATIONS } from '@/services/network/config';
 import { SecureKeyManager } from '@/services/secure/keyManager';
 
 /**
@@ -23,6 +25,81 @@ import { SecureKeyManager } from '@/services/secure/keyManager';
  * Re-exported so existing import paths keep working.
  */
 export { RemoteSignerRequiredError };
+
+/**
+ * Genesis hash (lowercase hex) -> NetworkId, derived from the single source of
+ * truth in `NETWORK_CONFIGURATIONS` rather than a second hand-maintained table.
+ * Used by the DR-7 sign-time chain binding below.
+ */
+const GENESIS_HASH_HEX_TO_NETWORK: ReadonlyMap<string, NetworkId> = new Map(
+  (
+    Object.values(NETWORK_CONFIGURATIONS) as {
+      id: NetworkId;
+      genesisHash: string;
+    }[]
+  ).map(
+    (config) =>
+      [
+        Buffer.from(config.genesisHash, 'base64').toString('hex').toLowerCase(),
+        config.id,
+      ] as const
+  )
+);
+
+/**
+ * Resolve the network a DECODED transaction belongs to from its genesis hash.
+ * Returns `null` for an absent, malformed, or unsupported genesis hash — the
+ * caller must treat that as a rejection, never as "assume the active network".
+ */
+function networkFromGenesisHash(
+  genesisHash: Uint8Array | undefined
+): NetworkId | null {
+  if (!genesisHash || genesisHash.length === 0) {
+    return null;
+  }
+  const hex = Buffer.from(genesisHash).toString('hex').toLowerCase();
+  return GENESIS_HASH_HEX_TO_NETWORK.get(hex) ?? null;
+}
+
+/**
+ * DR-5 / DR-7 / DR-14 — the WalletConnect session an incoming dApp batch is
+ * bound to.
+ *
+ * Resolved once at the request boundary (`TransactionRequestScreen`) and
+ * threaded through navigation to the signer, which re-checks EVERY entry
+ * against it before a key is touched. Authorization is chain-scoped (DR-14): a
+ * session may approve address A on Voi but not on Algorand, so membership is
+ * tested on the full CAIP-10 string, never on the bare address.
+ */
+export interface WalletConnectSessionBinding {
+  /** Session topic the request arrived on. */
+  topic: string;
+  /** CAIP-2 chain the request is scoped to, e.g. `algorand:<32-char gh>`. */
+  chainId: string;
+  /**
+   * NetworkId resolved from `chainId` at the boundary. Threaded into
+   * `SecureKeyManager.signTransaction` so rekey authority is resolved against
+   * the TRANSACTION's network rather than the app's active one.
+   */
+  networkId: NetworkId;
+  /**
+   * Full CAIP-10 accounts (`algorand:<chain>:<address>`) the live session
+   * approved FOR `chainId`. Never substituted with local accounts: an absent,
+   * disconnected, topic-mismatched or empty set is a rejection.
+   */
+  approvedAccounts: string[];
+}
+
+/**
+ * Preflight decision for one batch entry, computed BEFORE any key is touched.
+ *  - `sign`        — eligible; hand the decoded txn to SecureKeyManager.
+ *  - `decline`     — ARC-0001 says return `null` in this slot (DR-1).
+ *  - `passthrough` — a genuine, validly-authorized pre-signed blob (DR-8/DR-16).
+ */
+type BatchEntryPlan =
+  | { action: 'sign'; txn: algosdk.Transaction; sender: string }
+  | { action: 'decline' }
+  | { action: 'passthrough'; value: string };
 
 /**
  * Unified callback interface for ALL signing operations
@@ -67,7 +144,15 @@ export interface UnifiedSigningResult {
    */
   confirmed?: boolean;
   error?: Error;
-  signedTransactions?: Uint8Array | Uint8Array[] | string[];
+  /**
+   * DR-1 — ARC-0001 response array. For a batch, this is index-aligned with the
+   * request and a `null` element means "the wallet DECLINED to sign this entry",
+   * which is exactly what the standard requires. It is NOT a placeholder for the
+   * unsigned bytes: returning raw unsigned bytes where a `SignedTxn` belongs is
+   * the original `apaa` msgpack-decode failure this contract exists to prevent.
+   * Every consumer that submits must guard the `null`s rather than submit them.
+   */
+  signedTransactions?: Uint8Array | Uint8Array[] | (string | null)[];
 }
 
 /**
@@ -114,9 +199,25 @@ export interface UnifiedTransactionRequest {
   // For WalletConnect batch signing
   walletConnectParams?: {
     transactions: WalletTransaction[];
+    /**
+     * The account the user actually reviewed and consented to sign with.
+     * DR-13: eligibility never outruns the UI — an entry is only signed when the
+     * DECODED sender IS this account.
+     */
     accountAddress: string;
     // Optional: Pre-decoded transactions to avoid double-parsing
     decodedTransactions?: algosdk.Transaction[];
+    /**
+     * REQUIRED, deliberately with NO default.
+     *
+     * `null` declares an IN-APP batch that the wallet itself built (swap /
+     * claim): there is no dApp session to bind to. A value binds the batch to a
+     * WalletConnect session + chain and turns on the DR-5/DR-7/DR-14 checks.
+     *
+     * Making it required means a caller that forgets to thread the session
+     * fails to COMPILE rather than silently getting the unbound path.
+     */
+    sessionBinding: WalletConnectSessionBinding | null;
   };
 
   // For key registration (go online/offline)
@@ -347,17 +448,40 @@ export class UnifiedTransactionSigner {
       throw new Error('WalletConnect parameters required for batch signing');
     }
 
+    const params = request.walletConnectParams;
+
     try {
-      const total = request.walletConnectParams.transactions.length;
+      const total = params.transactions.length;
+      const binding = params.sessionBinding;
 
-      // Track signing progress for each transaction
-      const signedTxns: string[] = [];
+      // The network the batch is bound to. For a dApp request this is resolved
+      // from the SESSION's chain; for an in-app batch it is the network the
+      // caller built the group on. Threaded into SecureKeyManager so rekey
+      // authority is resolved on the transaction's chain, not the active one.
+      const boundNetworkId = binding?.networkId ?? request.networkId;
 
-      // Use pre-decoded transactions if available to avoid double-parsing
-      const useDecodedCache =
-        request.walletConnectParams.decodedTransactions &&
-        request.walletConnectParams.decodedTransactions.length ===
-          request.walletConnectParams.transactions.length;
+      // DR-5/DR-14 fail-closed guard: an absent / disconnected / topic-
+      // mismatched session resolves to an EMPTY approved set. Reject the whole
+      // request rather than silently declining every entry — and never
+      // substitute the wallet's local accounts for the session's.
+      if (binding && binding.approvedAccounts.length === 0) {
+        throw new Error(
+          'This dApp session has no approved account on the requested network. ' +
+            'Reconnect the session and try again.'
+        );
+      }
+
+      // ---------------------------------------------------------------------
+      // PREFLIGHT (DR-2/5/7/8/13/14/16). Runs to completion BEFORE a single key
+      // is touched, so one bad entry fails the WHOLE batch with no partial
+      // signatures and no partially-signed response handed back to a dApp.
+      // ---------------------------------------------------------------------
+      const plans = params.transactions.map((wtxn, index) =>
+        this.planBatchEntry(wtxn, index, params, binding, boundNetworkId)
+      );
+
+      // Track signing progress for each transaction. `null` = declined (DR-1).
+      const signedTxns: (string | null)[] = [];
 
       // Detect if this is a Ledger account - Ledger requires sequential signing due to hardware constraints
       const isLedgerAccount = request.account.type === AccountType.LEDGER;
@@ -366,73 +490,31 @@ export class UnifiedTransactionSigner {
       // For standard accounts: sign in parallel for better performance
       if (isLedgerAccount) {
         // Sequential signing for Ledger
-        for (
-          let i = 0;
-          i < request.walletConnectParams.transactions.length;
-          i++
-        ) {
+        for (let i = 0; i < plans.length; i++) {
           callbacks?.onLedgerPrompt?.({ index: i + 1, total });
 
-          // Sign individual transaction
-          const wtxn = request.walletConnectParams.transactions[i];
+          const plan = plans[i];
+
+          if (plan.action !== 'sign') {
+            // Declined -> ARC-0001 `null`; genuine pre-signed -> verbatim.
+            signedTxns.push(plan.action === 'passthrough' ? plan.value : null);
+            callbacks?.onLedgerSigned?.({ index: i + 1, total });
+            continue;
+          }
 
           try {
-            const txnBytes = Buffer.from(wtxn.txn, 'base64');
-
-            // Try to decode as unsigned transaction
-            // If it fails, the transaction is already signed (e.g., logic sig) - pass through
-            let txn: algosdk.Transaction;
-            try {
-              if (
-                useDecodedCache &&
-                request.walletConnectParams.decodedTransactions?.[i]
-              ) {
-                txn = request.walletConnectParams.decodedTransactions[i];
-              } else {
-                txn = algosdk.decodeUnsignedTransaction(txnBytes);
-              }
-            } catch {
-              // Transaction is already signed (logic sig, etc.) - pass through as-is
-              signedTxns.push(wtxn.txn);
-              callbacks?.onLedgerSigned?.({ index: i + 1, total });
-              continue;
-            }
-
-            // Verify we have a valid transaction with sender info
-            if (!txn || !txn.sender || !txn.sender.publicKey) {
-              // Invalid or already-signed transaction - pass through
-              signedTxns.push(wtxn.txn);
-              callbacks?.onLedgerSigned?.({ index: i + 1, total });
-              continue;
-            }
-
-            // Get the transaction sender address
-            const txnSender = algosdk.encodeAddress(txn.sender.publicKey);
-
-            // Decide whether this batch entry is one we should sign, then sign
-            // it with the SENDER's key. The dApp-supplied `authAddr`/`signers`
+            // Sign with the SENDER's key. The dApp-supplied `authAddr`/`signers`
             // are advisory hints for ELIGIBILITY only — never key selection: a
             // dApp must not be able to direct which of our keys signs, and rekey
             // authority is resolved from on-chain state, not from the request
-            // (TASK-163). SecureKeyManager.signTransaction(txn, txnSender)
+            // (TASK-163). SecureKeyManager.signTransaction(txn, sender)
             // resolves any current rekey authority itself and signs with it
             // (emitting the correct sgnr) — identical to the non-rekeyed path.
-            if (
-              !this.shouldSignBatchEntry(
-                txnSender,
-                request.walletConnectParams!.accountAddress,
-                wtxn
-              )
-            ) {
-              signedTxns.push(wtxn.txn);
-              callbacks?.onLedgerSigned?.({ index: i + 1, total });
-              continue;
-            }
-
             const signedTxnBlob = await SecureKeyManager.signTransaction(
-              txn,
-              txnSender,
-              request.pin // optional; controller supplies for software keys, undefined for Ledger
+              plan.txn,
+              plan.sender,
+              request.pin, // optional; controller supplies for software keys, undefined for Ledger
+              boundNetworkId
             );
 
             signedTxns.push(Buffer.from(signedTxnBlob).toString('base64'));
@@ -451,60 +533,20 @@ export class UnifiedTransactionSigner {
         // Parallel signing for standard accounts (much faster!)
         callbacks?.onLedgerPrompt?.({ index: 1, total });
 
-        const signingPromises = request.walletConnectParams!.transactions.map(
-          async (wtxn, i) => {
+        const signingPromises = plans.map(
+          async (plan, i): Promise<string | null> => {
+            if (plan.action !== 'sign') {
+              return plan.action === 'passthrough' ? plan.value : null;
+            }
+
             try {
-              const txnBytes = Buffer.from(wtxn.txn, 'base64');
-
-              // Try to decode as unsigned transaction
-              // If it fails, the transaction is already signed (e.g., logic sig) - pass through
-              let txn: algosdk.Transaction;
-              try {
-                if (
-                  useDecodedCache &&
-                  request.walletConnectParams!.decodedTransactions?.[i]
-                ) {
-                  txn = request.walletConnectParams!.decodedTransactions[i];
-                } else {
-                  txn = algosdk.decodeUnsignedTransaction(txnBytes);
-                }
-              } catch {
-                // Transaction is already signed (logic sig, etc.) - pass through as-is
-                return wtxn.txn;
-              }
-
-              // Verify we have a valid transaction with sender info
-              if (!txn || !txn.sender || !txn.sender.publicKey) {
-                // Invalid or already-signed transaction - pass through
-                return wtxn.txn;
-              }
-
-              // Get the transaction sender address
-              const txnSender = algosdk.encodeAddress(txn.sender.publicKey);
-
-              // Decide whether this batch entry is one we should sign, then sign
-              // it with the SENDER's key. The dApp-supplied `authAddr`/`signers`
-              // are advisory hints for ELIGIBILITY only — never key selection: a
-              // dApp must not be able to direct which of our keys signs, and
-              // rekey authority is resolved from on-chain state, not from the
-              // request (TASK-163). SecureKeyManager.signTransaction(txn,
-              // txnSender) resolves any current rekey authority itself and signs
-              // with it (emitting the correct sgnr) — same as the non-rekeyed
-              // path.
-              if (
-                !this.shouldSignBatchEntry(
-                  txnSender,
-                  request.walletConnectParams!.accountAddress,
-                  wtxn
-                )
-              ) {
-                return wtxn.txn;
-              }
-
+              // See the TASK-163 note on the Ledger branch above: the SENDER is
+              // always the address handed to SecureKeyManager.
               const signedTxnBlob = await SecureKeyManager.signTransaction(
-                txn,
-                txnSender,
-                request.pin
+                plan.txn,
+                plan.sender,
+                request.pin,
+                boundNetworkId
               );
 
               return Buffer.from(signedTxnBlob).toString('base64');
@@ -554,28 +596,246 @@ export class UnifiedTransactionSigner {
   }
 
   /**
+   * Preflight ONE batch entry. Never touches a key; either returns a plan or
+   * THROWS, and a throw fails the entire batch (DR-7/DR-8).
+   */
+  private planBatchEntry(
+    wtxn: WalletTransaction,
+    index: number,
+    params: NonNullable<UnifiedTransactionRequest['walletConnectParams']>,
+    binding: WalletConnectSessionBinding | null,
+    boundNetworkId: NetworkId | undefined
+  ): BatchEntryPlan {
+    const txnBytes = Buffer.from(wtxn.txn, 'base64');
+
+    // Reuse the caller's pre-decoded transactions only when the cache is
+    // index-aligned with the request (same fail-closed length check as before).
+    const cache = params.decodedTransactions;
+    const cacheAligned =
+      !!cache && cache.length === params.transactions.length && !!cache[index];
+
+    let txn: algosdk.Transaction | null = null;
+    if (cacheAligned) {
+      txn = cache![index];
+    } else {
+      try {
+        txn = algosdk.decodeUnsignedTransaction(txnBytes);
+      } catch {
+        txn = null;
+      }
+    }
+
+    if (!txn || !txn.sender || !txn.sender.publicKey) {
+      // Not a decodable unsigned transaction. DR-8/DR-16: ONLY a genuine,
+      // validly-authorized pre-signed blob passes through unchanged. Malformed
+      // bytes are rejected, never echoed back to the dApp.
+      this.assertGenuinePreSigned(txnBytes, index, binding, boundNetworkId);
+      return { action: 'passthrough', value: wtxn.txn };
+    }
+
+    // DR-7 (absorbs TASK-251): bind the bytes to a chain before anything else.
+    this.assertChainBinding(txn, index, binding, boundNetworkId);
+
+    const txnSender = algosdk.encodeAddress(txn.sender.publicKey);
+
+    if (
+      !this.isEligibleBatchEntry(
+        txnSender,
+        params.accountAddress,
+        wtxn,
+        binding
+      )
+    ) {
+      return { action: 'decline' };
+    }
+
+    return { action: 'sign', txn, sender: txnSender };
+  }
+
+  /**
+   * DR-7 / TASK-251 — sign-time chain binding.
+   *
+   * Nothing between "a dApp handed us bytes" and `SecureKeyManager` used to
+   * establish which chain those bytes were for. This asserts that the decoded
+   * transaction's own genesis identity matches the network the batch is bound
+   * to. An unmapped or absent genesis hash is a rejection, never a default to
+   * the app's active network. One mismatched entry fails the WHOLE batch: a
+   * partially-signed group returned to a dApp is its own failure mode.
+   *
+   * For an in-app batch with no declared network there is nothing to bind to
+   * (the wallet built the group itself), so the check is skipped.
+   */
+  private assertChainBinding(
+    txn: algosdk.Transaction,
+    index: number,
+    binding: WalletConnectSessionBinding | null,
+    boundNetworkId: NetworkId | undefined
+  ): void {
+    if (!boundNetworkId) {
+      return;
+    }
+
+    const expected = NETWORK_CONFIGURATIONS[boundNetworkId];
+    if (!expected) {
+      throw new Error(
+        'Mixed or invalid network batch: this request targets a network this wallet does not support.'
+      );
+    }
+
+    if (binding && expected.chainId !== binding.chainId) {
+      // Defence in depth: the boundary is supposed to derive networkId FROM
+      // chainId, so a disagreement means the handoff was tampered with.
+      throw new Error(
+        'Mixed or invalid network batch: the session chain and resolved network disagree.'
+      );
+    }
+
+    const actual = networkFromGenesisHash(txn.genesisHash);
+    if (!actual) {
+      throw new Error(
+        `Mixed or invalid network batch: transaction ${index + 1} carries no recognized network identity.`
+      );
+    }
+    if (actual !== boundNetworkId) {
+      throw new Error(
+        `Mixed or invalid network batch: transaction ${index + 1} is for ` +
+          `${NETWORK_CONFIGURATIONS[actual].name}, but this request is for ${expected.name}.`
+      );
+    }
+    if (txn.genesisID && txn.genesisID !== expected.genesisId) {
+      throw new Error(
+        `Mixed or invalid network batch: transaction ${index + 1} declares genesis ID ` +
+          `"${txn.genesisID}", which is not ${expected.name}.`
+      );
+    }
+  }
+
+  /**
+   * DR-8 / DR-16 — classify before pass-through.
+   *
+   * `decodeSignedTransaction` only proves a msgpack wrapper parsed; it does not
+   * prove a usable authorization exists. Require exactly one authorization form
+   * and, for dApp-supplied bytes, verify it cryptographically against
+   * `sgnr ?? sender`. Anything else is REJECTED rather than echoed back — an
+   * echoed blob is submitted by the dApp and fails at algod, which is precisely
+   * the class of bug this change exists to remove.
+   *
+   * The cryptographic verification is applied to SESSION-BOUND (dApp) bytes.
+   * An in-app batch (swap / claim) gets the structural check only: those groups
+   * are assembled by our own aggregator integrations and may legitimately carry
+   * delegated logic-sigs that `LogicSig.verify` cannot validate offline (it does
+   * not track the delegating public key when the sender differs).
+   */
+  private assertGenuinePreSigned(
+    txnBytes: Uint8Array,
+    index: number,
+    binding: WalletConnectSessionBinding | null,
+    boundNetworkId: NetworkId | undefined
+  ): void {
+    let stxn: algosdk.SignedTransaction;
+    try {
+      stxn = algosdk.decodeSignedTransaction(txnBytes);
+    } catch {
+      throw new Error(
+        `Transaction ${index + 1} is neither a valid unsigned transaction nor a valid signed transaction.`
+      );
+    }
+
+    // A pre-signed group member is still part of THIS request's chain.
+    this.assertChainBinding(stxn.txn, index, binding, boundNetworkId);
+
+    const forms = [stxn.sig, stxn.msig, stxn.lsig].filter(Boolean).length;
+    if (forms !== 1) {
+      throw new Error(
+        `Transaction ${index + 1} claims to be pre-signed but carries no single valid authorization.`
+      );
+    }
+
+    if (!binding) {
+      return;
+    }
+
+    const authorizer = stxn.sgnr ?? stxn.txn.sender;
+    let authorized: boolean;
+    try {
+      if (stxn.lsig) {
+        authorized = stxn.lsig.verify(authorizer.publicKey);
+      } else if (stxn.msig) {
+        authorized = algosdk.verifyMultisig(
+          stxn.txn.bytesToSign(),
+          stxn.msig,
+          authorizer.publicKey
+        );
+      } else {
+        authorized = nacl.sign.detached.verify(
+          stxn.txn.bytesToSign(),
+          stxn.sig!,
+          authorizer.publicKey
+        );
+      }
+    } catch {
+      authorized = false;
+    }
+
+    if (!authorized) {
+      throw new Error(
+        `Transaction ${index + 1} claims to be pre-signed but its signature does not verify.`
+      );
+    }
+  }
+
+  /**
    * Decide whether a WalletConnect batch entry should be signed by this wallet.
    *
    * The signing KEY is always the transaction sender's — SecureKeyManager
    * resolves any on-chain rekey authority itself. This gates ELIGIBILITY only,
-   * from the DECODED sender and the dApp's advisory `signers` hint; it never
-   * lets request metadata (`authAddr`/`signers`) select which key signs
-   * (TASK-163). We sign when:
-   *  - the sender is our WC session account (covers normal AND rekeyed senders —
-   *    a rekey does not change the transaction sender), or
-   *  - the dApp's `signers` hint designates the sender and we control it
-   *    (multi-account atomic groups; preserves the pre-existing `signers`
-   *    behavior, minus the ability to point at a different key than the sender).
+   * from the DECODED sender plus the session's approved accounts and the dApp's
+   * advisory `signers` hint; it never lets request metadata (`authAddr` /
+   * `signers`) select which key signs (TASK-163).
+   *
+   * Evaluated in order, all must pass (DR-2 / DR-5 / DR-13 / DR-14):
+   *  1. the sender is authorized by the SESSION for THIS chain. Membership is
+   *     tested on the full CAIP-10 string, so a Voi-only approval for A cannot
+   *     authorize an Algorand transaction from A.
+   *  2. `signers: []` is an explicit do-not-sign instruction — never signed.
+   *  3. a non-empty `signers` must designate this entry as ours. ARC-0001
+   *     encodes a REKEYED sender as `signers: [authAddr]`, so the entry's own
+   *     advisory `authAddr` also satisfies the designation. That stays advisory:
+   *     the key still comes from the sender via on-chain rekey resolution.
+   *  4. DR-13 — the sender must be the account the user actually reviewed. The
+   *     review screen can only name ONE account, so signing on behalf of any
+   *     other approved account would mean "UI says A, signs B". Widening to true
+   *     multi-account signing lands with the signer-list UI (TASK-259).
    */
-  private shouldSignBatchEntry(
+  private isEligibleBatchEntry(
     txnSender: string,
-    sessionAccount: string,
-    wtxn: WalletTransaction
+    reviewedAccount: string,
+    wtxn: WalletTransaction,
+    binding: WalletConnectSessionBinding | null
   ): boolean {
-    if (txnSender === sessionAccount) {
-      return true;
+    // 1. Session authorization, chain-scoped (DR-5 / DR-14).
+    if (binding) {
+      const caipAccount = `${binding.chainId}:${txnSender}`;
+      if (!binding.approvedAccounts.includes(caipAccount)) {
+        return false;
+      }
     }
-    return wtxn.signers?.includes(txnSender) ?? false;
+
+    // 2/3. ARC-0001 `signers` semantics (DR-2).
+    if (Array.isArray(wtxn.signers)) {
+      if (wtxn.signers.length === 0) {
+        return false;
+      }
+      const designatesSender =
+        wtxn.signers.includes(txnSender) ||
+        (!!wtxn.authAddr && wtxn.signers.includes(wtxn.authAddr));
+      if (!designatesSender) {
+        return false;
+      }
+    }
+
+    // 4. The reviewed account, and only the reviewed account (DR-13).
+    return txnSender === reviewedAccount;
   }
 
   /**

--- a/src/services/walletconnect/index.ts
+++ b/src/services/walletconnect/index.ts
@@ -26,6 +26,7 @@ import {
   areAllRequiredChainsSupported,
   truncateAddress,
   normalizeV1Metadata,
+  parseAccountAddress,
 } from './utils';
 import {
   DEFAULT_NAMESPACES,
@@ -35,7 +36,10 @@ import {
 import { useExperimentalStore } from '@/store/experimentalStore';
 import type { WalletConnectV1StoredSession } from '@/services/walletconnect/v1/types';
 import { WalletConnectV1Client } from '@/services/walletconnect/v1';
-import { WC_V1_SESSION_STORAGE_KEY } from '@/services/walletconnect/v1/config';
+import {
+  WC_V1_SESSION_STORAGE_KEY,
+  resolveV1Chain,
+} from '@/services/walletconnect/v1/config';
 
 // Strip sensitive values from a string before logging (a caught error message
 // or any untrusted value). Redacts, in order:
@@ -574,6 +578,65 @@ export class WalletConnectService extends EventEmitter {
 
   getSession(topic: string): WalletConnectSession | undefined {
     return this.activeSessions.get(topic);
+  }
+
+  /**
+   * DR-5 / DR-14 — the CAIP-10 accounts a LIVE session approved for one
+   * specific chain, used to bind signing to the session that asked.
+   *
+   * Authorization is chain-scoped, not topic-wide: a session can approve
+   * address A on Voi but not on Algorand, so the full
+   * `algorand:<chain>:<address>` strings are returned and callers must compare
+   * whole strings rather than reducing to a bare address set.
+   *
+   * Returns an EMPTY array when the session is absent, expired, disconnected,
+   * topic-mismatched, or simply approved nothing on `chainId`. Callers must
+   * treat empty as a rejection — the wallet's local accounts are never
+   * substituted for the session's.
+   */
+  getApprovedAccountsForChain(topic: string, chainId: string): string[] {
+    if (!topic || !chainId) {
+      return [];
+    }
+
+    try {
+      // v1 first: it keeps a single session whose accounts were retained at
+      // approval time. Its numeric chain id must resolve to the SAME CAIP-2
+      // chain the caller is asking about (DR-11), otherwise it authorizes
+      // nothing here.
+      const v1SessionData =
+        WalletConnectV1Client.getInstance().getSessionData();
+      if (
+        v1SessionData &&
+        v1SessionData.connected &&
+        v1SessionData.handshakeTopic === topic
+      ) {
+        const resolved = resolveV1Chain(v1SessionData.chainId);
+        if (!resolved || resolved.chainId !== chainId) {
+          return [];
+        }
+        return v1SessionData.accounts.map((address) =>
+          formatAccountAddress(chainId, address)
+        );
+      }
+
+      const session = this.activeSessions.get(topic);
+      if (!session || isSessionExpired(session)) {
+        return [];
+      }
+
+      const accounts = session.namespaces?.algorand?.accounts ?? [];
+      return accounts.filter((caipAccount) => {
+        const parsed = parseAccountAddress(caipAccount);
+        return parsed?.chainId === chainId;
+      });
+    } catch (error) {
+      console.error(
+        'Failed to resolve session-approved accounts:',
+        redactError(error)
+      );
+      return [];
+    }
   }
 
   async getSignableAccounts(): Promise<AccountMetadata[]> {

--- a/src/services/walletconnect/v1/client.ts
+++ b/src/services/walletconnect/v1/client.ts
@@ -296,9 +296,17 @@ export class WalletConnectV1Client extends EventEmitter {
   }
 
   /**
-   * Approve transaction signing request
+   * Approve transaction signing request.
+   *
+   * DR-12: `signedTxns` is the ARC-0001 response array and admits `null` in the
+   * slots the wallet declined to sign. Pass it straight through — filtering or
+   * stringifying a null would break the dApp's positional reassembly of the
+   * group (and reintroduce the `apaa` class of failure).
    */
-  async approveRequest(requestId: number, signedTxns: string[]): Promise<void> {
+  async approveRequest(
+    requestId: number,
+    signedTxns: (string | null)[]
+  ): Promise<void> {
     if (!this.config || !this.socket || !this.sessionData) {
       throw new Error('Client not connected');
     }

--- a/src/services/walletconnect/v1/config.ts
+++ b/src/services/walletconnect/v1/config.ts
@@ -1,4 +1,6 @@
 import { WalletConnectV1PeerMeta } from './types';
+import { NetworkId } from '@/types/network';
+import { ALGORAND_MAINNET_CHAIN_DATA } from '../config';
 
 /**
  * PeraWallet peer metadata for v1 compatibility
@@ -48,10 +50,48 @@ export const ALGORAND_CHAIN_IDS = {
 } as const;
 
 /**
- * Default chain ID (Algorand mainnet)
- * Voi Network also uses mainnet ID as it's Algorand-compatible
+ * Default chain ID (Algorand mainnet).
+ *
+ * DR-11: this is Algorand mainnet and ONLY Algorand mainnet. The previous note
+ * here claimed Voi "also uses" the same numeric id because it is
+ * Algorand-compatible — that is exactly the ambiguity that makes a v1 session
+ * impossible to bind securely, so it no longer holds. See `resolveV1Chain`.
  */
 export const DEFAULT_CHAIN_ID = ALGORAND_CHAIN_IDS.MAINNET;
+
+/**
+ * DR-11 — resolve a WalletConnect **v1** numeric chain id to the CAIP-2 chain
+ * and `NetworkId` the wallet will bind signing to.
+ *
+ * v1 carries a numeric chain id while every other layer of this wallet speaks
+ * CAIP-2 (`getNetworkByChainId` only accepts `algorand:<hash>` strings). The
+ * numeric space is also ambiguous: `416001` was historically treated as usable
+ * for BOTH Algorand and Voi, so a v1 session cannot securely identify a Voi
+ * chain at all.
+ *
+ * The mapping is therefore explicit and fail-closed: `416001` / `4160` mean
+ * Algorand mainnet, and everything else — including any v1 request that is
+ * really meant for Voi — resolves to `null` and must be rejected. This keeps
+ * normal Pera v1 `algo_signTxn` interop working while refusing to guess.
+ *
+ * ACCEPTED USER-VISIBLE CONSEQUENCE: a live v1 **Voi** session breaks on
+ * upgrade and must be reconnected. Silently treating it as Algorand would be
+ * the alternative, and that is not an acceptable trade at a signing boundary.
+ */
+export function resolveV1Chain(
+  chainId: number | undefined | null
+): { chainId: string; networkId: NetworkId } | null {
+  if (
+    chainId === ALGORAND_CHAIN_IDS.MAINNET ||
+    chainId === ALGORAND_CHAIN_IDS.MAINNET_LEGACY
+  ) {
+    return {
+      chainId: ALGORAND_MAINNET_CHAIN_DATA.chainId,
+      networkId: NetworkId.ALGORAND_MAINNET,
+    };
+  }
+  return null;
+}
 
 /**
  * WalletConnect v1 protocol version

--- a/src/services/walletconnect/v1/protocol.ts
+++ b/src/services/walletconnect/v1/protocol.ts
@@ -167,11 +167,16 @@ export function createSessionUpdateMessage(
 }
 
 /**
- * Create transaction signing response
+ * Create transaction signing response.
+ *
+ * DR-12: the array is index-aligned with the request and admits `null` for the
+ * entries the wallet DECLINED to sign, exactly as ARC-0001 requires. Nulls must
+ * be neither filtered nor stringified — `JSON.stringify` preserves them, and the
+ * dApp reassembles its group positionally.
  */
 export function createSignTxnResponse(
   requestId: number,
-  signedTxns: string[]
+  signedTxns: (string | null)[]
 ): WalletConnectV1Response {
   return {
     id: requestId,


### PR DESCRIPTION
PR 1 of the WalletConnect signing-path rewrite: the **signer boundary** only.
All display work (ASA symbol/decimals, bigint formatting, the multi-account
signer list, the unknown-chain warning, the decoded-cache restructure, deleting
`TransactionPreview.tsx`) stays in the dependent TASK-259. Implements TASK-256
PR 1 and absorbs TASK-251.

## Root cause of the original `apaa` failure

A Folks Finance deposit on Algorand mainnet produced:

```
400 … msgpack decode error [pos 1185]: no matching struct field found
when decoding stream map with key apaa
```

`signWalletConnectBatch` returned the **raw UNSIGNED transaction bytes** for
every entry it decided not to sign (`unifiedSigner.ts:396,404,428` on the Ledger
path and `:473,479,501` on the parallel path), where ARC-0001 requires `null`.
The dApp reassembled its group from our response array positionally, found a
bare `Transaction` where a `SignedTxn` belongs, and submitted it. algod decoded
it as a `SignedTxn` and tripped on the first Transaction-only key — `apaa`
(ApplicationArgs), which a Folks Finance deposit group is full of.

Two upstream defects widened the blast radius and are fixed here too:

* `TransactionRequestScreen.tsx:254` navigated with `txns.map(w => w.txn)`,
  discarding the dApp's `signers` / `authAddr` / `msig` entirely.
* `UniversalTransactionSigningScreen.tsx:273-276` then fabricated
  `signers: [account.address]` for **every** transaction, so `signers: []`
  ("do not sign this one") was silently signed anyway.

## What changed

### `src/services/transactions/unifiedSigner.ts` (the substance)

A **preflight** pass now runs to completion before a single key is touched, so
one bad entry fails the whole batch with no partial signatures and no
partially-signed response handed back to a dApp. Each entry resolves to
`sign` / `decline` / `passthrough`.

* **DR-1** — `null` for declined entries on BOTH the Ledger sequential and
  parallel paths. `UnifiedSigningResult.signedTransactions` is now
  `Uint8Array | Uint8Array[] | (string | null)[]`.
* **DR-2** — strict ARC-0001 `signers`: `[]` never signs; a non-empty list must
  designate the sender. ARC-0001 encodes a *rekeyed* sender as
  `signers: [authAddr]`, so the entry's own advisory `authAddr` also satisfies
  designation — that keeps TASK-163 correct without letting request metadata
  select a key.
* **DR-5 / DR-14** — eligibility is anchored in what the **session** approved,
  compared on the full CAIP-10 string (`algorand:<chain>:<address>`), never a
  bare address. A Voi-only approval for A cannot authorize an Algorand
  transaction from A. Absent / expired / disconnected / topic-mismatched /
  empty is a rejection; the wallet's local account list is never a substitute.
* **DR-7 (absorbs TASK-251)** — sign-time chain binding. Every decoded
  transaction's `genesisHash` (and `genesisID` where present) must match the
  bound network; an unmapped or absent genesis hash is rejected rather than
  defaulting to the active network. One mismatch fails the whole batch with a
  single explicit "mixed or invalid network batch" rejection. The resolved
  `NetworkId` is threaded into `SecureKeyManager.signTransaction`, which
  previously defaulted to the **active** network (`keyManager.ts:97-105`) — so a
  Voi-active app reviewing an Algorand rekeyed account could resolve the wrong
  signing authority.
* **DR-8 / DR-16** — classify before pass-through. Only a genuine, validly
  authorized pre-signed blob is echoed: it must decode as a `SignedTransaction`,
  carry exactly one authorization form, and (on the dApp path) verify
  cryptographically against `sgnr ?? sender` — standard signature via Ed25519,
  multisig via `algosdk.verifyMultisig`, logic-sig via `LogicSig.verify`.
  Malformed bytes are REJECTED, not echoed.
* **DR-13** — eligibility does not outrun the UI: the sender must be the
  account the user actually reviewed. The review screen can name only one
  account today, so signing on behalf of another approved account would mean
  "UI says A, signs B". TASK-259 widens this together with the signer-list
  display.

`walletConnectParams.sessionBinding` is **required with no default** (`null`
declares an in-app batch). A caller that forgets to thread the session fails to
compile rather than silently getting the unbound path.

Key selection still derives from the **decoded sender only**;
`authAddr` / `signers` remain advisory and never select a key (TASK-163
preserved — its tests are untouched and still pass).

### Boundary and plumbing

* `walletconnect/index.ts` — new `getApprovedAccountsForChain(topic, chainId)`,
  returning the live session's CAIP-10 accounts for one chain (v2 via the
  namespace accounts, v1 via `getSessionData`), and `[]` when there is no live
  authorization.
* **DR-11** — `v1/config.ts` gains `resolveV1Chain`: `416001` / `4160` map to
  **Algorand mainnet only**; every other numeric v1 chain is rejected. The stale
  "Voi Network also uses mainnet ID" comment is gone.
* **DR-12** — `v1/client.ts` `approveRequest` and `v1/protocol.ts`
  `createSignTxnResponse` widen to `(string | null)[]`. Nulls are neither
  filtered nor stringified.
* **DR-15** — `RootStackParamList.UniversalTransactionSigning` gains an optional
  `walletConnect: { transactions: WalletTransaction[]; binding }`. Without this
  the signer physically could not receive the real `signers` / `authAddr`,
  session-approved accounts, or a resolved `NetworkId`. `TransactionRequestScreen` resolves the
  chain from what the **session/dApp declares** (never from the transaction
  bytes, which would make the binding circular), resolves the approved accounts,
  and picks a reviewed account that is both ours and session-approved instead of
  falling back to `allAccounts[0]`. `UniversalTransactionSigningScreen` is
  touched only as far as the handoff requires — it stops fabricating `signers`
  and passes the entries and binding through.
* Guards in `SwapScreen.tsx`, `ClaimAllConfirmationScreen.tsx` and
  `ClaimTokenScreen.tsx`: all three shared the same latent defect (they would
  have submitted a declined entry, and the two claim screens would have thrown a
  bare `TypeError` from `Buffer.from(null, 'base64')`). They now throw an
  explicit, debuggable error and submit nothing.

### Folded in from the Codex diff review (round 3)

* **P1** — `signers` / `authAddr` were used unvalidated, so
  `signers: ["not-an-address"], authAddr: "not-an-address"` satisfied the
  designation rule purely by matching each other. Both are now checked with
  `algosdk.isValidAddress`, and invalid metadata fails the request.
* **P1** — an entry carrying `msig` asks for a partial multisig signature this
  wallet has no path to produce (`SecureKeyManager` only ever emits a single-key
  signature). Such entries are now **declined** — ARC-0001 `null` — rather than
  answered with bytes that could never validate on chain. Declining rather than
  failing the batch keeps the rest of the group signable.
* **P2, documented not changed** — accepting a pre-signed blob in the `txn` slot
  is a **deliberate deviation** from ARC-0001, which reserves `txn` for canonical
  unsigned bytes and puts a signed companion in `stxn` alongside `signers: []`
  (our `WalletTransaction` type has no `stxn` field). This is DR-8's settled
  behaviour: our own aggregator groups (`services/deflex/index.ts` puts logic-sig
  blobs straight into `txn`) and a number of dApps rely on it, so rejecting them
  would break real groups. The leniency is now gated on the blob being a
  genuinely, verifiably authorized transaction; the rationale is recorded at the
  call site.

### Folded in from the Codex diff review (round 1)

* **HIGH** — the binding was snapshotted when the request screen loaded, then
  trusted minutes later after review + authentication. The signer now
  re-resolves the approved accounts against the **live** session immediately
  before preflight and uses the intersection with the snapshot, so the set can
  only shrink; an empty intersection rejects the request.
* **MEDIUM** — `decodedTransactions` was trusted on index alignment alone and
  then signed, so a caller could show one transaction and get a different one
  signed. A cached entry is now used only when it re-encodes to exactly the wire
  bytes.

## Accepted user-visible consequence (DR-11)

A live WalletConnect **v1 Voi** session breaks on upgrade and must be
reconnected. v1 persists only a numeric chain id and `416001` was treated as
valid for both ecosystems, so a v1 Voi session cannot be securely identified.
Such a session now gets an explicit unsupported/ambiguous-chain rejection rather
than silently becoming Algorand. Normal Pera v1 `algo_signTxn` interop on
Algorand mainnet is unaffected. See TASK-258 on retiring the v1 path.

## Tests

`src/services/transactions/__tests__/unifiedSigner.test.ts` — 66 tests (was 48).
Every signature asserted is real Ed25519 produced from the deterministic
fixtures; nothing about the crypto is mocked beyond the secure-storage leaf.

Changed:
* `:598-620` now asserts the exact **positional** `null` (and explicitly
  `not.toBe(wireTxn)`) — a length-only assertion passes for both behaviours and
  would not catch a regression of the `apaa` bug.
* the `signers[0]` override characterization is inverted per DR-13: the entry is
  declined and the key is never touched.
* `:768-785` (4 arbitrary bytes pass through) is inverted per DR-8: undecodable
  bytes are rejected, not echoed.

Added:
* mixed-sender group — positional `null` in the foreign slot, real signatures at
  the matching indexes, response length invariant with the request;
* `signers: []` never signs; `signers` undefined signs the reviewed sender;
  `signers` excluding the sender declines;
* a locally-controlled sender the session never approved is declined;
* chain-scoped CAIP authorization (approved on Voi, request on Algorand →
  declined);
* session approved nothing / session disconnected mid-flow → whole request
  rejected; account dropped by `session_update` → that entry declined;
* genesis mismatch fails the whole batch and **never calls the signing spy**;
  unrecognized genesis rejected; contradictory `genesisID` rejected;
* the resolved `NetworkId` reaches `SecureKeyManager.signTransaction`;
* genuine pre-signed blob passes through on both paths; a tampered signature is
  rejected (DR-16);
* decoded cache that diverges from the wire bytes is ignored (the wire
  transaction is what gets signed); a matching cache is used;
* Ledger (sequential) batch preserves length and positions;
* DR-11 v1 chain mapping (416001/4160 → Algorand mainnet; 416002/416003/0/
  undefined/null → rejected);
* invalid `signers` / `authAddr` addresses fail the request; an `msig` entry is
  declined without touching a key;
* DR-12 positional `null` survives the v1 response path through `JSON.stringify`.

## Gates

* `npm run typecheck` — 0 errors (whole-project baseline held)
* `npm run lint` — 0 errors, 158 warnings (the documented ratcheted floor)
* `npm test -- --ci` — 105 suites, 1578 tests, all passing
* Codex review of the diff — 3 rounds. Rounds 1 and 3 raised findings, all
  folded in above except the ARC-0001 `stxn` deviation, which is DR-8 and is now
  documented. Codex runs read-only, so its verdict covers logic only and never
  substitutes for the gates above.

## Not merged

Security-critical signing rewrite — held for human review. Device verification
(connect a real dApp, approve a session, sign one request end-to-end) is still
outstanding per HT-218.
