### PR TITLE
sec(walletconnect-v1): move the session key to secure storage (PLAN-260)

### DIFF
--- a/src/navigation/AppNavigator.tsx
+++ b/src/navigation/AppNavigator.tsx
@@ -224,7 +224,9 @@ export type RootStackParamList = {
   WalletConnectSessions: undefined;
   WalletConnectTransactionRequest: { requestEvent: any; version?: number };
   WalletConnectPairing: { uri: string };
-  WalletConnectError: { error: string; uri?: string };
+  // No `uri` param: a WalletConnect pairing URI carries the session key
+  // (v1 `key=`, v2 `symKey=`) and route params land in navigation state.
+  WalletConnectError: { error: string };
   UniversalTransactionSigning: {
     transactions: string[];
     account: WalletAccount;

--- a/src/services/deeplink/__tests__/errorRouteNoUri.test.ts
+++ b/src/services/deeplink/__tests__/errorRouteNoUri.test.ts
@@ -1,0 +1,51 @@
+// Regression test for PLAN-260 / TASK-262.
+//
+// Both WalletConnect error paths used to pass the raw pairing URI as a
+// `WalletConnectError` route param. A v1 URI carries `key=<hex>` — the symmetric
+// session key this plan moves into secure storage — and a v2 URI carries
+// `symKey`. Route params live in React Navigation state, which is serialized and
+// inspectable, so this parked the exact secret elsewhere while we were busy
+// securing its storage. Same class as TASK-224 (mnemonics through route params).
+//
+// Nothing ever read the param: WalletConnectErrorScreen uses `error` only.
+
+import { readFileSync } from 'fs';
+import { join } from 'path';
+
+const repoRoot = join(__dirname, '..', '..', '..', '..');
+const read = (p: string) => readFileSync(join(repoRoot, p), 'utf8');
+
+describe('WalletConnect error route carries no pairing URI', () => {
+  it('the deeplink service does not pass `uri` into route params', () => {
+    const source = read('src/services/deeplink/index.ts');
+
+    const blocks = source
+      .split('WalletConnectError')
+      .slice(1)
+      .map((chunk) => chunk.slice(0, 400));
+
+    expect(blocks.length).toBeGreaterThan(0);
+    for (const block of blocks) {
+      expect(block).not.toMatch(/\buri:\s*url\b/);
+    }
+  });
+
+  it('the route type no longer declares a uri param', () => {
+    const nav = read('src/navigation/AppNavigator.tsx');
+    const decl = nav
+      .split('\n')
+      .find((line) => line.includes('WalletConnectError: {'));
+
+    expect(decl).toBeDefined();
+    expect(decl).not.toContain('uri');
+  });
+
+  it('the error screen only ever consumed `error`', () => {
+    const screen = read(
+      'src/screens/walletconnect/WalletConnectErrorScreen.tsx'
+    );
+    expect(screen).not.toContain('params?.uri');
+    expect(screen).not.toContain('params.uri');
+    expect(screen).toContain('route.params?.error');
+  });
+});

--- a/src/services/deeplink/index.ts
+++ b/src/services/deeplink/index.ts
@@ -402,8 +402,12 @@ export class DeepLinkService {
       await this.navigateToRoute({
         screen: 'WalletConnectError',
         params: {
+          // The pairing URI is NOT passed through. A v2 URI carries `symKey`
+          // and a v1 URI carries `key` — the session key itself — and route
+          // params live in navigation state, which is serialized and inspectable
+          // (same class as TASK-224, mnemonics through route params). Nothing
+          // read it: WalletConnectErrorScreen uses `error` only.
           error: error instanceof Error ? error.message : 'Failed to connect',
-          uri: url,
         },
       });
 
@@ -490,8 +494,9 @@ export class DeepLinkService {
         this.navigateToRoute({
           screen: 'WalletConnectError',
           params: {
+            // See above: the v1 pairing URI carries `key=<hex>`, the symmetric
+            // session key, and must not reach navigation state.
             error: error instanceof Error ? error.message : 'Connection failed',
-            uri: url,
           },
         });
       });

--- a/src/services/deeplink/index.ts
+++ b/src/services/deeplink/index.ts
@@ -11,6 +11,7 @@ import {
   parseWalletConnectV1Uri,
 } from '@/services/walletconnect/utils';
 import { WalletConnectV1Client } from '@/services/walletconnect/v1';
+import { redactSensitiveForLog, redactError } from '@/utils/logRedaction';
 import {
   isArc0090Uri,
   parseArc0090Uri,
@@ -44,32 +45,6 @@ const redactAddress = (address?: string): string =>
   address && address.length > 6
     ? `${address.slice(0, 6)}…[redacted]`
     : '[redacted]';
-
-// Strip sensitive values from an arbitrary log string — a caught error message
-// OR untrusted deep-link input (scheme/host/path/query/params). Redacts, in
-// order:
-//  - raw and percent-encoded WalletConnect URIs (`wc:` / `wc%3A`), whose query
-//    string carries the session symKey;
-//  - any stray `symKey=` / `symKey%3D` token (raw or encoded), belt-and-braces
-//    so a symKey can never survive regardless of surrounding format;
-//  - any scheme://… URL (voi://, https://, universal links, …) — whole URI
-//    including the query string;
-//  - full 58-char Algorand addresses, run LAST on the whole string so an
-//    address used as a pseudo-scheme (ADDR://…) is still truncated.
-// Used only for LOGGED output — thrown/surfaced errors keep the full value so
-// user-facing messages are unchanged (TASK-33).
-const redactSensitiveForLog = (message: string): string =>
-  message
-    .replace(/wc:\S+/gi, 'wc:[redacted]')
-    .replace(/wc%3[Aa]\S*/g, 'wc:[redacted]')
-    .replace(/symKey(=|%3[Dd])[^&\s"']+/gi, 'symKey=[redacted]')
-    .replace(/([a-z][a-z0-9+.-]*):\/\/\S*/gi, '$1://[redacted]')
-    .replace(/[A-Z2-7]{58}/g, (addr) => redactAddress(addr));
-
-// Convenience wrapper for the common `catch (error) { console.error(msg, error) }`
-// pattern: derive the message string and redact it before logging.
-const redactError = (error: unknown): string =>
-  redactSensitiveForLog(error instanceof Error ? error.message : String(error));
 
 // Summarize a notification for logs: keep non-sensitive routing fields but
 // truncate the sender/receiver addresses and redact the amount.

--- a/src/services/walletconnect/TransactionRequestQueue.ts
+++ b/src/services/walletconnect/TransactionRequestQueue.ts
@@ -370,6 +370,48 @@ class TransactionRequestQueueService {
       }
     });
   }
+
+  /**
+   * Remove every queued request belonging to a topic (PLAN-260, DR-14).
+   *
+   * Called when a WalletConnect session is DROPPED — e.g. a v1 session whose
+   * key is unreadable or no longer matches. Without this, a queued request for
+   * that topic survives, gets dequeued unconditionally at startup, finds no
+   * approved live session, and errors out — having already been removed from
+   * the queue, so the request is simply lost behind a confusing message.
+   *
+   * Returns the number of requests dropped, so callers can log it.
+   */
+  async removeByTopic(topic: string): Promise<number> {
+    return this.withLock(async () => {
+      try {
+        const queue = await this.getAllInternal();
+        const filteredQueue = queue.filter(
+          (request) => request.topic !== topic
+        );
+        const removed = queue.length - filteredQueue.length;
+
+        if (removed > 0) {
+          await AsyncStorage.setItem(
+            QUEUE_STORAGE_KEY,
+            JSON.stringify(filteredQueue)
+          );
+          console.log(
+            '[TransactionRequestQueue] Dropped requests for dead session:',
+            removed
+          );
+        }
+
+        return removed;
+      } catch (error) {
+        console.error(
+          '[TransactionRequestQueue] Failed to remove requests by topic:',
+          error
+        );
+        return 0;
+      }
+    });
+  }
 }
 
 export const TransactionRequestQueue =

--- a/src/services/walletconnect/__tests__/queueTopicPurge.test.ts
+++ b/src/services/walletconnect/__tests__/queueTopicPurge.test.ts
@@ -1,0 +1,85 @@
+// Tests for TransactionRequestQueue.removeByTopic (PLAN-260, TASK-258, DR-14).
+//
+// When a v1 session is dropped as unrestorable, any queued transaction request
+// for that topic must go with it. Otherwise startup dequeues the request
+// unconditionally, it lands on a screen with no approved live session, errors —
+// and is lost, because dequeuing already removed it.
+
+const mockKv = new Map<string, string>();
+
+jest.mock('@react-native-async-storage/async-storage', () => ({
+  __esModule: true,
+  default: {
+    setItem: async (k: string, v: string) => {
+      mockKv.set(k, v);
+    },
+    getItem: async (k: string) => (mockKv.has(k) ? mockKv.get(k)! : null),
+    removeItem: async (k: string) => {
+      mockKv.delete(k);
+    },
+    getAllKeys: async () => [...mockKv.keys()],
+    multiRemove: async (keys: string[]) => {
+      keys.forEach((k) => mockKv.delete(k));
+    },
+  },
+}));
+
+import { TransactionRequestQueue } from '../TransactionRequestQueue';
+
+const enqueue = (id: number, topic: string, version: 1 | 2 = 1) =>
+  TransactionRequestQueue.enqueue({
+    id,
+    topic,
+    params: {
+      request: { method: 'algo_signTxn', params: [[]] },
+      chainId: 416001,
+    },
+    version,
+  });
+
+beforeEach(async () => {
+  mockKv.clear();
+  jest.spyOn(console, 'log').mockImplementation(() => {});
+  jest.spyOn(console, 'warn').mockImplementation(() => {});
+});
+
+afterEach(() => {
+  jest.restoreAllMocks();
+});
+
+describe('removeByTopic', () => {
+  it('drops every request for the dead topic and reports the count', async () => {
+    await enqueue(1, 'dead-topic');
+    await enqueue(2, 'dead-topic');
+    await enqueue(3, 'live-topic');
+
+    const removed = await TransactionRequestQueue.removeByTopic('dead-topic');
+
+    expect(removed).toBe(2);
+    const remaining = await TransactionRequestQueue.getAll();
+    expect(remaining.map((r) => r.topic)).toEqual(['live-topic']);
+  });
+
+  it('leaves other topics — including v2 — untouched', async () => {
+    await enqueue(1, 'v1-topic', 1);
+    await enqueue(2, 'v2-topic', 2);
+
+    await TransactionRequestQueue.removeByTopic('v1-topic');
+
+    const remaining = await TransactionRequestQueue.getAll();
+    expect(remaining).toHaveLength(1);
+    expect(remaining[0].version).toBe(2);
+  });
+
+  it('is a no-op when nothing matches', async () => {
+    await enqueue(1, 'live-topic');
+    const removed = await TransactionRequestQueue.removeByTopic('absent');
+
+    expect(removed).toBe(0);
+    expect(await TransactionRequestQueue.getAll()).toHaveLength(1);
+  });
+
+  it('is a no-op on an empty queue', async () => {
+    expect(await TransactionRequestQueue.removeByTopic('anything')).toBe(0);
+  });
+});

--- a/src/services/walletconnect/index.ts
+++ b/src/services/walletconnect/index.ts
@@ -24,7 +24,6 @@ import {
   isSessionExpired,
   detectRequestedChains,
   areAllRequiredChainsSupported,
-  truncateAddress,
   normalizeV1Metadata,
   parseAccountAddress,
 } from './utils';
@@ -40,30 +39,7 @@ import {
   WC_V1_SESSION_STORAGE_KEY,
   resolveV1Chain,
 } from '@/services/walletconnect/v1/config';
-
-// Strip sensitive values from a string before logging (a caught error message
-// or any untrusted value). Redacts, in order:
-//  - raw and percent-encoded WalletConnect URIs (`wc:` / `wc%3A`), whose query
-//    string carries the session symKey;
-//  - any stray `symKey=` / `symKey%3D` token (raw or encoded), belt-and-braces
-//    so a symKey can never survive regardless of surrounding format;
-//  - any scheme://… URL (whole URI including the query string);
-//  - full 58-char Algorand addresses, run LAST on the whole string so an
-//    address used as a pseudo-scheme (ADDR://…) is still truncated.
-// Used only for LOGGED output — thrown errors keep the full value so
-// user-facing messages are unchanged (TASK-33).
-const redactSensitiveForLog = (message: string): string =>
-  message
-    .replace(/wc:\S+/gi, 'wc:[redacted]')
-    .replace(/wc%3[Aa]\S*/g, 'wc:[redacted]')
-    .replace(/symKey(=|%3[Dd])[^&\s"']+/gi, 'symKey=[redacted]')
-    .replace(/([a-z][a-z0-9+.-]*):\/\/\S*/gi, '$1://[redacted]')
-    .replace(/[A-Z2-7]{58}/g, (addr) => truncateAddress(addr));
-
-// Convenience wrapper for the common `catch (error) { console.error(msg, error) }`
-// pattern: derive the message string and redact it before logging.
-const redactError = (error: unknown): string =>
-  redactSensitiveForLog(error instanceof Error ? error.message : String(error));
+import { redactSensitiveForLog, redactError } from '@/utils/logRedaction';
 
 export class WalletConnectService extends EventEmitter {
   private static instance: WalletConnectService;

--- a/src/services/walletconnect/index.ts
+++ b/src/services/walletconnect/index.ts
@@ -33,13 +33,26 @@ import {
   ALGORAND_MAINNET_CHAIN_DATA,
 } from './config';
 import { useExperimentalStore } from '@/store/experimentalStore';
-import type { WalletConnectV1StoredSession } from '@/services/walletconnect/v1/types';
+import {
+  isRestorableV1Session,
+  type WalletConnectV1LegacyPersistedSession,
+} from '@/services/walletconnect/v1/types';
 import { WalletConnectV1Client } from '@/services/walletconnect/v1';
 import {
   WC_V1_SESSION_STORAGE_KEY,
   resolveV1Chain,
 } from '@/services/walletconnect/v1/config';
 import { redactSensitiveForLog, redactError } from '@/utils/logRedaction';
+import {
+  readSessionKey,
+  writeSessionKey,
+  isValidV1SessionKey,
+} from '@/services/walletconnect/v1/sessionKeyStore';
+import {
+  deleteV1Session,
+  deleteV1Sessions,
+  topicFromStorageKey,
+} from '@/services/walletconnect/v1/sessionCleanup';
 
 export class WalletConnectService extends EventEmitter {
   private static instance: WalletConnectService;
@@ -86,6 +99,51 @@ export class WalletConnectService extends EventEmitter {
     }
   }
 
+  /**
+   * Drop a v1 session that cannot be restored (PLAN-260, DR-4/DR-14).
+   *
+   * Reached when the session key is unreadable (Android keystore desync), does
+   * not match the stored topic, is malformed, or is simply absent. A v1 bridge
+   * transport key is cheap to re-establish and there is nothing to recover, so
+   * the session is discarded and the user re-pairs by scanning the QR again.
+   *
+   * Also purges the QUEUED transaction requests of every topic it deletes.
+   * Startup dequeues and navigates queued requests unconditionally, so a
+   * request left behind here would land on a screen with no live session,
+   * error, and be lost — it has already been removed from the queue by then.
+   */
+  private async dropV1Session(
+    activeStorageKey: string,
+    topic: string,
+    sessions: { key: string }[]
+  ): Promise<void> {
+    try {
+      const keysToRemove = sessions.map(({ key }) => key);
+      if (!keysToRemove.includes(activeStorageKey)) {
+        keysToRemove.push(activeStorageKey);
+      }
+      if (!keysToRemove.includes(`${WC_V1_SESSION_STORAGE_KEY}:${topic}`)) {
+        keysToRemove.push(`${WC_V1_SESSION_STORAGE_KEY}:${topic}`);
+      }
+
+      // dropSlot is UNCONDITIONAL here: this removes EVERY v1 row, so no
+      // session survives whose key could be destroyed, and a conditional delete
+      // would strand the slot whenever it was bound to a stale row.
+      const dropped = await deleteV1Sessions(keysToRemove, { dropSlot: true });
+      if (dropped > 0) {
+        console.warn(
+          'Dropped queued v1 requests for an unrestorable session:',
+          dropped
+        );
+      }
+    } catch (error) {
+      console.error(
+        'Failed to drop unrestorable v1 session:',
+        redactError(error)
+      );
+    }
+  }
+
   private async loadV1Sessions(): Promise<void> {
     try {
       // Skip v1 session restoration in extension mode - WebSocket connections can be problematic
@@ -100,8 +158,10 @@ export class WalletConnectService extends EventEmitter {
           key.startsWith(WC_V1_SESSION_STORAGE_KEY)
         );
         if (v1SessionKeys.length > 0) {
-          await AsyncStorage.multiRemove(v1SessionKeys);
+          await deleteV1Sessions(v1SessionKeys, { dropSlot: true });
           console.log('Cleared stale v1 sessions in extension mode');
+        } else {
+          await deleteV1Sessions([], { dropSlot: true });
         }
         return;
       }
@@ -127,21 +187,55 @@ export class WalletConnectService extends EventEmitter {
             }
 
             try {
-              const parsed = JSON.parse(raw) as WalletConnectV1StoredSession;
-              return { key, session: parsed };
+              const parsed: unknown = JSON.parse(raw);
+
+              // Must be a non-null OBJECT. `JSON.parse('null')` and a bare
+              // string/array all parse fine, then throw on the first property
+              // access downstream — and that throw happens inside the filter
+              // below, which would abort ALL v1 restoration over one corrupt
+              // row. Treat a wrong shape exactly like unparseable: delete it.
+              if (
+                typeof parsed !== 'object' ||
+                parsed === null ||
+                Array.isArray(parsed)
+              ) {
+                throw new Error('v1 session entry is not an object');
+              }
+
+              // Must also carry the metadata a reconnect actually needs. A
+              // shape-valid but INCOMPLETE row (say `{connected:true,
+              // updatedAt:<now>}`) would otherwise win the freshest-wins
+              // selection below, have no key, and take dropV1Session's
+              // delete-everything path down on top of a perfectly good session.
+              // Reject it here so it is deleted alone and never competes.
+              const candidate = parsed as WalletConnectV1LegacyPersistedSession;
+              if (!isRestorableV1Session(candidate)) {
+                throw new Error('v1 session entry is missing required fields');
+              }
+
+              return { key, session: candidate };
             } catch (error) {
+              // A row we cannot parse can never restore a session, but it CAN
+              // still contain a valid inline key from before PLAN-260 — and
+              // being skipped, it would escape both the migration and the
+              // stale-row prune, leaving that key in AsyncStorage forever.
+              // Delete it outright: there is nothing recoverable to lose.
               console.warn(
-                'Skipping malformed v1 session entry',
+                'Deleting unusable v1 session entry',
                 redactSensitiveForLog(key),
                 redactError(error)
               );
+              // Central cleanup: metadata AND queued requests. This path
+              // bypasses dropV1Session entirely — and when EVERY row is
+              // invalid, dropV1Session never runs at all.
+              await deleteV1Session(topicFromStorageKey(key));
               return null;
             }
           })
         )
       ).filter(Boolean) as {
         key: string;
-        session: WalletConnectV1StoredSession;
+        session: WalletConnectV1LegacyPersistedSession;
       }[];
 
       if (sessions.length === 0) {
@@ -170,15 +264,6 @@ export class WalletConnectService extends EventEmitter {
         return;
       }
 
-      // Remove stale entries (including unconnected ones) to avoid restoring incorrect sessions later
-      const staleKeys = sessions
-        .map(({ key }) => key)
-        .filter((key) => key !== latestEntry.key);
-
-      if (staleKeys.length > 0) {
-        await AsyncStorage.multiRemove(staleKeys);
-      }
-
       const { session } = latestEntry;
 
       // Extract topic from storage key
@@ -187,11 +272,118 @@ export class WalletConnectService extends EventEmitter {
         ''
       );
 
+      // Resolve the session key for the SELECTED session only (DR-7). This is a
+      // selected-session transaction, not a generic migrate-and-delete: the
+      // AsyncStorage row must SURVIVE minus its key, because it carries the
+      // routing metadata reconnection needs.
+      let sessionKey: string | null = null;
+      try {
+        sessionKey = await readSessionKey(topic);
+      } catch {
+        // Android keystore desync (platform/mobile/secureStorage.ts): the guard
+        // throws when a recorded item is present but unreadable. A bridge
+        // transport key is cheap to re-establish and there is nothing to
+        // recover, so drop the session and force a re-pair rather than letting
+        // this escape into app startup (DR-4).
+        console.error('Dropping v1 session: session key unreadable');
+        await this.dropV1Session(latestEntry.key, topic, sessions);
+        return;
+      }
+
+      // Two DIFFERENT questions, deliberately not conflated:
+      //   hasInlineKey — is there a `key` property on the row that must be
+      //     drained? True even for a malformed value: a corrupt or truncated
+      //     key is still key-shaped material sitting in AsyncStorage, and
+      //     leaving it there because it failed validation would be absurd.
+      //   seedableKey  — is that value good enough to seed secure storage and
+      //     restore the session with?
+      const hasInlineKey =
+        session.key !== undefined && session.key !== null && session.key !== '';
+      const seedableKey = isValidV1SessionKey(session.key) ? session.key : null;
+
+      // Whether the SECURE slot is confirmed to hold this topic's key. The
+      // inline key may only be stripped when this is true — see below.
+      let secureKeyConfirmed = sessionKey !== null;
+
+      if (!sessionKey && seedableKey) {
+        // Legacy row still carrying the key inline: copy it into secure storage.
+        try {
+          await writeSessionKey(topic, seedableKey);
+          sessionKey = seedableKey;
+          secureKeyConfirmed = true;
+        } catch {
+          // ACCEPTED RESIDUAL. Could not write secure storage at all, so the
+          // inline key is the only copy and REMAINS AT REST in AsyncStorage
+          // until a later boot succeeds. Deliberate: the row is intact and
+          // carries a usable key, so the session is fully recoverable, and
+          // dropping it would destroy a working session because secure storage
+          // hiccupped. This is the pre-migration status quo, not a new leak.
+          console.error('Failed to write v1 session key to secure storage');
+          sessionKey = seedableKey;
+        }
+      }
+
+      if (!sessionKey) {
+        // No secure key and no usable legacy key: unusable (a topic mismatch, a
+        // malformed envelope, or a row that was left keyless). Restore nothing
+        // and surface no error — the user re-pairs.
+        await this.dropV1Session(latestEntry.key, topic, sessions);
+        return;
+      }
+
+      // Strip the inline key whenever the row still carries one AND the secure
+      // copy is confirmed present. Both halves of that condition are load-bearing.
+      //
+      // Not "did we just migrate?": if a previous boot wrote the secure slot and
+      // died before rewriting the row, this boot's `readSessionKey` SUCCEEDS and
+      // the migration branch above is skipped — a strip conditional on migrating
+      // would leave the key in AsyncStorage forever, defeating the entire point.
+      //
+      // But not unconditional either: if the secure write FAILED just above, the
+      // inline key is the only copy left. Stripping it would leave the next boot
+      // with keyless metadata and no secure key, and the session — which was
+      // perfectly recoverable — would be dropped. Destroying a working session
+      // to tidy up storage is the worse failure.
+      //
+      // Keyed on hasInlineKey, not seedableKey: a MALFORMED inline key must be
+      // drained too. It cannot seed secure storage, but it is still key-shaped
+      // material at rest, and skipping it because it failed validation would
+      // leave it in AsyncStorage forever.
+      if (hasInlineKey && secureKeyConfirmed) {
+        try {
+          const { key: _dropped, ...keyless } = session;
+          await AsyncStorage.setItem(latestEntry.key, JSON.stringify(keyless));
+        } catch {
+          // ACCEPTED RESIDUAL: the key remains at rest in AsyncStorage until a
+          // later boot succeeds in rewriting the row. There is no better move —
+          // the secure copy is already written and the session is usable, and
+          // the only way to remove the key right now would be to delete the row
+          // outright, which would destroy the routing metadata and the session
+          // with it. Retrying beats trading a working session for tidy storage.
+          // Deliberately NOT rolled back: the prior slot may belong to a
+          // different topic, so restoring it would break THIS session too.
+          console.error('Failed to strip inline v1 session key from storage');
+        }
+      }
+
+      // Prune the OTHER rows only after the selected session is safely
+      // migrated, so a failure above cannot destroy a row we might still want.
+      const staleKeys = sessions
+        .map(({ key }) => key)
+        .filter((key) => key !== latestEntry.key);
+
+      if (staleKeys.length > 0) {
+        // Central cleanup so the pruned rows' queued requests go too. dropSlot
+        // is FALSE: the selected session survives and its key must not be
+        // touched — deleteV1Sessions only reaps queues and metadata here.
+        await deleteV1Sessions(staleKeys, { dropSlot: false });
+      }
+
       await v1Client.connect({
         topic,
         version: '1',
         bridge: session.bridge,
-        key: session.key,
+        key: sessionKey,
       });
 
       // Set up call_request listener on DeepLinkService

--- a/src/services/walletconnect/v1/__tests__/peerLabels.test.ts
+++ b/src/services/walletconnect/v1/__tests__/peerLabels.test.ts
@@ -1,0 +1,61 @@
+// Unit tests for peer-controlled log labels (PLAN-260, TASK-263).
+//
+// Raised by Codex review of the first log-hygiene pass: applying the shared
+// SECRET-PATTERN redactor to arbitrary peer text is not sanitization. Bare
+// 64-hex is deliberately preserved by that redactor (genesis hashes / txids),
+// so a peer able to set a free-text field could have put the session key
+// straight into the log.
+
+import { describePeerMethod } from '../peerLabels';
+
+// Throwaway vector — not a real session key.
+const SESSION_KEY = 'a1b2c3d4'.repeat(8);
+
+describe('describePeerMethod', () => {
+  it('echoes known method names verbatim', () => {
+    expect(describePeerMethod('algo_signTxn')).toBe('algo_signTxn');
+    expect(describePeerMethod('wc_sessionRequest')).toBe('wc_sessionRequest');
+    expect(describePeerMethod('personal_sign')).toBe('personal_sign');
+  });
+
+  it('NEVER echoes a session key sent as a method name', () => {
+    const out = describePeerMethod(SESSION_KEY);
+    expect(out).not.toContain(SESSION_KEY);
+    expect(out).toBe('[unrecognized method, 64 chars]');
+  });
+
+  it('does not leak even a PREFIX of an unknown value', () => {
+    const out = describePeerMethod(SESSION_KEY);
+    // No run of the key survives — not even the first few characters, which a
+    // truncating implementation would have kept.
+    for (let n = 4; n <= 16; n += 4) {
+      expect(out).not.toContain(SESSION_KEY.slice(0, n));
+    }
+  });
+
+  it('reports length so an operator still learns something', () => {
+    expect(describePeerMethod('x'.repeat(7))).toBe(
+      '[unrecognized method, 7 chars]'
+    );
+    expect(describePeerMethod('')).toBe('[unrecognized method, 0 chars]');
+  });
+
+  it('does not echo a wc: URI or any other injected payload', () => {
+    const uri = `wc:topic@1?bridge=https://b.example&key=${SESSION_KEY}`;
+    const out = describePeerMethod(uri);
+    expect(out).not.toContain(SESSION_KEY);
+    expect(out).not.toContain('wc:');
+    expect(out).not.toContain('b.example');
+  });
+
+  it('handles non-string input without throwing or echoing', () => {
+    expect(describePeerMethod(undefined)).toBe(
+      '[non-string method: undefined]'
+    );
+    expect(describePeerMethod(null)).toBe('[non-string method: object]');
+    expect(describePeerMethod(42)).toBe('[non-string method: number]');
+    expect(describePeerMethod({ secret: SESSION_KEY })).not.toContain(
+      SESSION_KEY
+    );
+  });
+});

--- a/src/services/walletconnect/v1/__tests__/protocolLogHygiene.test.ts
+++ b/src/services/walletconnect/v1/__tests__/protocolLogHygiene.test.ts
@@ -1,0 +1,141 @@
+// Regression tests for WalletConnect v1 log hygiene (PLAN-260, TASK-263).
+//
+// The headline case: `decryptRequest` used to echo the first 200 characters of
+// the DECRYPTED payload into console.error when a request failed structure
+// validation. That content is entirely peer-controlled, and the connected dApp
+// shares the session key — so a malformed request was enough to push the key
+// into device logs and crash reports.
+//
+// Injected-ERROR tests would never have caught this: nothing throws on that
+// path. It needs a real decrypt of a real payload, which is what these do.
+
+import { encryptMessage } from '../crypto';
+import { decryptRequest, parseEncryptedPayload } from '../protocol';
+
+// Throwaway 32-byte hex key — not a real session key.
+const SESSION_KEY = 'a1b2c3d4'.repeat(8);
+
+const captureConsole = () => {
+  const calls: string[] = [];
+  const push = (...args: unknown[]) => {
+    calls.push(
+      args.map((a) => (typeof a === 'string' ? a : JSON.stringify(a))).join(' ')
+    );
+  };
+  const spies = [
+    jest.spyOn(console, 'error').mockImplementation(push),
+    jest.spyOn(console, 'warn').mockImplementation(push),
+    jest.spyOn(console, 'log').mockImplementation(push),
+  ];
+  return {
+    text: () => calls.join('\n'),
+    restore: () => spies.forEach((s) => s.mockRestore()),
+  };
+};
+
+afterEach(() => {
+  jest.restoreAllMocks();
+});
+
+describe('decryptRequest never logs peer-controlled payload', () => {
+  it('does not echo the session key when the peer sends it inside a malformed request', async () => {
+    // A structurally-invalid JSON-RPC request (no id/jsonrpc/method, and not a
+    // response) whose body embeds the session key — exactly what a hostile or
+    // buggy peer could send to get the key written to the log.
+    const hostile = JSON.stringify({
+      note: `here is your key ${SESSION_KEY}`,
+      alsoThis: `key=${SESSION_KEY}`,
+    });
+
+    const encrypted = await encryptMessage(hostile, SESSION_KEY);
+    const payload = parseEncryptedPayload(JSON.stringify(encrypted));
+    expect(payload).not.toBeNull();
+
+    const capture = captureConsole();
+    const result = await decryptRequest(payload!, SESSION_KEY);
+    const logged = capture.text();
+    capture.restore();
+
+    // The request is rejected...
+    expect(result).toBeNull();
+    // ...and it was the structure-validation path that rejected it.
+    expect(logged).toContain('Invalid JSON-RPC request structure');
+
+    // ...but nothing from the payload reached the log.
+    expect(logged).not.toContain(SESSION_KEY);
+    expect(logged).not.toContain('here is your key');
+    expect(logged).not.toContain('alsoThis');
+  });
+
+  it('does not echo arbitrary peer content or object keys', async () => {
+    const hostile = JSON.stringify({
+      'peer-chosen-field-name': 'peer-chosen-value',
+    });
+
+    const encrypted = await encryptMessage(hostile, SESSION_KEY);
+    const payload = parseEncryptedPayload(JSON.stringify(encrypted));
+
+    const capture = captureConsole();
+    await decryptRequest(payload!, SESSION_KEY);
+    const logged = capture.text();
+    capture.restore();
+
+    expect(logged).not.toContain('peer-chosen-field-name');
+    expect(logged).not.toContain('peer-chosen-value');
+  });
+
+  it('still logs the diagnostic shape flags', async () => {
+    const encrypted = await encryptMessage(JSON.stringify({}), SESSION_KEY);
+    const payload = parseEncryptedPayload(JSON.stringify(encrypted));
+
+    const capture = captureConsole();
+    await decryptRequest(payload!, SESSION_KEY);
+    const logged = capture.text();
+    capture.restore();
+
+    expect(logged).toContain('hasId');
+    expect(logged).toContain('hasJsonrpc');
+    expect(logged).toContain('hasMethod');
+  });
+
+  it('does not log the key when decryption fails outright', async () => {
+    const encrypted = await encryptMessage('{"a":1}', SESSION_KEY);
+    const payload = parseEncryptedPayload(JSON.stringify(encrypted));
+
+    // Decrypt with the WRONG key: the HMAC check fails.
+    const wrongKey = 'f'.repeat(64);
+
+    const capture = captureConsole();
+    const result = await decryptRequest(payload!, wrongKey);
+    const logged = capture.text();
+    capture.restore();
+
+    expect(result).toBeNull();
+    expect(logged).not.toContain(SESSION_KEY);
+    expect(logged).not.toContain(wrongKey);
+    // Our own measurements survive — they distinguish a truncated payload from
+    // a wrong-key HMAC failure.
+    expect(logged).toContain('payloadDataLength');
+  });
+
+  it('a valid request is returned and logs nothing', async () => {
+    const valid = JSON.stringify({
+      id: 1,
+      jsonrpc: '2.0',
+      method: 'algo_signTxn',
+      params: [[]],
+    });
+
+    const encrypted = await encryptMessage(valid, SESSION_KEY);
+    const payload = parseEncryptedPayload(JSON.stringify(encrypted));
+
+    const capture = captureConsole();
+    const result = await decryptRequest(payload!, SESSION_KEY);
+    const logged = capture.text();
+    capture.restore();
+
+    expect(result).not.toBeNull();
+    expect(result!.method).toBe('algo_signTxn');
+    expect(logged).toBe('');
+  });
+});

--- a/src/services/walletconnect/v1/__tests__/sessionCleanup.test.ts
+++ b/src/services/walletconnect/v1/__tests__/sessionCleanup.test.ts
@@ -1,0 +1,153 @@
+// Tests for the centralized v1 session cleanup (PLAN-260, TASK-258).
+//
+// This module exists because review found the SAME omission — deleting session
+// metadata without purging the queue — at four separate deletion sites in a
+// row. Each was fixed individually until it became clear the problem was the
+// scattering, not the four sites. These tests pin the complete-cleanup contract
+// so a new deletion path cannot quietly reintroduce a partial one.
+
+const mockKv = new Map<string, string>();
+const mockSecure = new Map<string, string>();
+
+jest.mock('@react-native-async-storage/async-storage', () => ({
+  __esModule: true,
+  default: {
+    setItem: async (k: string, v: string) => {
+      mockKv.set(k, v);
+    },
+    getItem: async (k: string) => (mockKv.has(k) ? mockKv.get(k)! : null),
+    removeItem: async (k: string) => {
+      mockKv.delete(k);
+    },
+    getAllKeys: async () => [...mockKv.keys()],
+    multiRemove: async (keys: string[]) => {
+      keys.forEach((k) => mockKv.delete(k));
+    },
+  },
+}));
+
+jest.mock('@/platform', () => ({
+  secureStorage: {
+    setItem: async (k: string, v: string) => {
+      mockSecure.set(k, v);
+    },
+    getItem: async (k: string) =>
+      mockSecure.has(k) ? mockSecure.get(k)! : null,
+    deleteItem: async (k: string) => {
+      mockSecure.delete(k);
+    },
+  },
+}));
+
+import { deleteV1Session, deleteV1Sessions } from '../sessionCleanup';
+import { writeSessionKey, readSessionKey } from '../sessionKeyStore';
+import { WC_V1_SESSION_STORAGE_KEY, WC_V1_SESSION_KEY_SLOT } from '../config';
+import { TransactionRequestQueue } from '@/services/walletconnect/TransactionRequestQueue';
+
+const KEY_A = 'a1b2c3d4'.repeat(8);
+const KEY_B = 'b1c2d3e4'.repeat(8);
+const TOPIC_A = 'topic-a';
+const TOPIC_B = 'topic-b';
+const rowKey = (t: string) => `${WC_V1_SESSION_STORAGE_KEY}:${t}`;
+
+const enqueue = (id: number, topic: string) =>
+  TransactionRequestQueue.enqueue({
+    id,
+    topic,
+    params: {
+      request: { method: 'algo_signTxn', params: [[]] },
+      chainId: 416001,
+    },
+    version: 1,
+  });
+
+beforeEach(() => {
+  mockKv.clear();
+  mockSecure.clear();
+  jest.spyOn(console, 'log').mockImplementation(() => {});
+  jest.spyOn(console, 'warn').mockImplementation(() => {});
+});
+
+afterEach(() => jest.restoreAllMocks());
+
+describe('deleteV1Session — one session, all three stores', () => {
+  it('removes metadata, key and queued requests together', async () => {
+    mockKv.set(rowKey(TOPIC_A), JSON.stringify({ bridge: 'https://b' }));
+    await writeSessionKey(TOPIC_A, KEY_A);
+    await enqueue(1, TOPIC_A);
+
+    await deleteV1Session(TOPIC_A);
+
+    expect(mockKv.has(rowKey(TOPIC_A))).toBe(false);
+    expect(await readSessionKey(TOPIC_A)).toBeNull();
+    expect(await TransactionRequestQueue.getAll()).toHaveLength(0);
+  });
+
+  it('is TOPIC-CONDITIONAL on the key — a retained session keeps its own', async () => {
+    // The pair-then-reject shape: A is retained, B is being cleared.
+    await writeSessionKey(TOPIC_A, KEY_A);
+    mockKv.set(rowKey(TOPIC_A), JSON.stringify({ bridge: 'https://b' }));
+
+    await deleteV1Session(TOPIC_B);
+
+    expect(await readSessionKey(TOPIC_A)).toBe(KEY_A);
+    expect(mockKv.has(rowKey(TOPIC_A))).toBe(true);
+  });
+
+  it('leaves another topic queued requests alone', async () => {
+    await enqueue(1, TOPIC_A);
+    await enqueue(2, TOPIC_B);
+
+    await deleteV1Session(TOPIC_A);
+
+    const left = await TransactionRequestQueue.getAll();
+    expect(left.map((r) => r.topic)).toEqual([TOPIC_B]);
+  });
+});
+
+describe('deleteV1Sessions — bulk wipes', () => {
+  it('drops the slot unconditionally when asked, and purges every topic queue', async () => {
+    mockKv.set(rowKey(TOPIC_A), '{}');
+    mockKv.set(rowKey(TOPIC_B), '{}');
+    // Slot bound to B, but A is the "selected" one — the stranding case.
+    await writeSessionKey(TOPIC_B, KEY_B);
+    await enqueue(1, TOPIC_A);
+    await enqueue(2, TOPIC_B);
+
+    const dropped = await deleteV1Sessions([rowKey(TOPIC_A), rowKey(TOPIC_B)], {
+      dropSlot: true,
+    });
+
+    expect(dropped).toBe(2);
+    // Only the SESSION rows must be gone — the queue keeps its own storage key.
+    expect(
+      [...mockKv.keys()].filter((k) => k.startsWith(WC_V1_SESSION_STORAGE_KEY))
+    ).toEqual([]);
+    expect(mockSecure.has(WC_V1_SESSION_KEY_SLOT)).toBe(false);
+    expect(await TransactionRequestQueue.getAll()).toHaveLength(0);
+  });
+
+  it('PRESERVES the slot when dropSlot is false (stale-row pruning)', async () => {
+    // The surviving session owns the slot; pruning stale rows must not touch it.
+    mockKv.set(rowKey(TOPIC_A), '{}');
+    await writeSessionKey(TOPIC_B, KEY_B);
+    await enqueue(1, TOPIC_A);
+
+    await deleteV1Sessions([rowKey(TOPIC_A)], { dropSlot: false });
+
+    expect(await readSessionKey(TOPIC_B)).toBe(KEY_B);
+    expect(await TransactionRequestQueue.getAll()).toHaveLength(0);
+  });
+
+  it('can drop the slot with no rows at all (extension wipe with empty storage)', async () => {
+    await writeSessionKey(TOPIC_A, KEY_A);
+    await deleteV1Sessions([], { dropSlot: true });
+    expect(mockSecure.has(WC_V1_SESSION_KEY_SLOT)).toBe(false);
+  });
+
+  it('is a no-op with no rows and no slot drop', async () => {
+    await writeSessionKey(TOPIC_A, KEY_A);
+    expect(await deleteV1Sessions([], { dropSlot: false })).toBe(0);
+    expect(await readSessionKey(TOPIC_A)).toBe(KEY_A);
+  });
+});

--- a/src/services/walletconnect/v1/__tests__/sessionKeyStore.test.ts
+++ b/src/services/walletconnect/v1/__tests__/sessionKeyStore.test.ts
@@ -1,0 +1,256 @@
+// Unit tests for the WalletConnect v1 secure session-key store (PLAN-260, TASK-261).
+//
+// Proves the invariants the rest of the plan leans on:
+//   - round-trip through the single constant slot,
+//   - a topic MISMATCH reads as "no key" rather than handing back a wrong key,
+//   - a malformed envelope / non-hex / wrong-length key fails closed,
+//   - deletion is TOPIC-CONDITIONAL (DR-3a) — the regression that would
+//     otherwise destroy a retained session's key,
+//   - rollback restores or clears the prior slot value (DR-5a),
+//   - an Android keystore-desync THROW propagates from reads (so the caller can
+//     decide) but is absorbed by deletion,
+//   - and that no key material ever reaches a console call (DR-13).
+
+jest.mock('@/platform', () => {
+  const secure = new Map<string, string>();
+  let throwOnGet: Error | null = null;
+  return {
+    __secure: secure,
+    __reset: () => {
+      secure.clear();
+      throwOnGet = null;
+    },
+    __throwOnGet: (error: Error | null) => {
+      throwOnGet = error;
+    },
+    secureStorage: {
+      setItem: async (k: string, v: string) => {
+        secure.set(k, v);
+      },
+      getItem: async (k: string) => {
+        if (throwOnGet) {
+          throw throwOnGet;
+        }
+        return secure.has(k) ? secure.get(k)! : null;
+      },
+      deleteItem: async (k: string) => {
+        secure.delete(k);
+      },
+    },
+  };
+});
+
+import {
+  isValidV1SessionKey,
+  readSessionKey,
+  readSessionKeySlotRaw,
+  writeSessionKey,
+  restoreSessionKeySlot,
+  deleteSessionKeyForTopic,
+  deleteSessionKeySlot,
+} from '../sessionKeyStore';
+import { WC_V1_SESSION_KEY_SLOT } from '../config';
+
+const platformMock = jest.requireMock('@/platform') as {
+  __secure: Map<string, string>;
+  __reset: () => void;
+  __throwOnGet: (error: Error | null) => void;
+};
+
+// Throwaway test vectors — not real session keys.
+const KEY_A = 'a'.repeat(64);
+const KEY_B = 'b'.repeat(64);
+const TOPIC_A = 'topic-aaaa-1111';
+const TOPIC_B = 'topic-bbbb-2222';
+
+beforeEach(() => {
+  platformMock.__reset();
+  jest.restoreAllMocks();
+});
+
+describe('isValidV1SessionKey', () => {
+  it('accepts 64-char hex in either case', () => {
+    expect(isValidV1SessionKey(KEY_A)).toBe(true);
+    expect(isValidV1SessionKey('A1b2'.repeat(16))).toBe(true);
+  });
+
+  it('rejects wrong length, non-hex, and non-strings', () => {
+    expect(isValidV1SessionKey('a'.repeat(63))).toBe(false);
+    expect(isValidV1SessionKey('a'.repeat(65))).toBe(false);
+    expect(isValidV1SessionKey('z'.repeat(64))).toBe(false);
+    expect(isValidV1SessionKey('')).toBe(false);
+    expect(isValidV1SessionKey(undefined)).toBe(false);
+    expect(isValidV1SessionKey(null)).toBe(false);
+    expect(isValidV1SessionKey(123)).toBe(false);
+    expect(isValidV1SessionKey({ key: KEY_A })).toBe(false);
+  });
+});
+
+describe('write / read round-trip', () => {
+  it('returns the key for the bound topic', async () => {
+    await writeSessionKey(TOPIC_A, KEY_A);
+    await expect(readSessionKey(TOPIC_A)).resolves.toBe(KEY_A);
+  });
+
+  it('uses the single constant slot', async () => {
+    await writeSessionKey(TOPIC_A, KEY_A);
+    expect([...platformMock.__secure.keys()]).toEqual([WC_V1_SESSION_KEY_SLOT]);
+  });
+
+  it('reads null when the slot is empty', async () => {
+    await expect(readSessionKey(TOPIC_A)).resolves.toBeNull();
+  });
+
+  it('refuses to persist a malformed key or a missing topic', async () => {
+    await expect(writeSessionKey(TOPIC_A, 'not-a-key')).rejects.toThrow();
+    await expect(writeSessionKey('', KEY_A)).rejects.toThrow();
+    expect(platformMock.__secure.size).toBe(0);
+  });
+});
+
+describe('topic binding (DR-3)', () => {
+  it('returns null for a DIFFERENT topic rather than the stored key', async () => {
+    await writeSessionKey(TOPIC_A, KEY_A);
+    await expect(readSessionKey(TOPIC_B)).resolves.toBeNull();
+  });
+
+  it('a newer pairing overwrites the slot and the older topic reads null', async () => {
+    await writeSessionKey(TOPIC_A, KEY_A);
+    await writeSessionKey(TOPIC_B, KEY_B);
+    await expect(readSessionKey(TOPIC_B)).resolves.toBe(KEY_B);
+    await expect(readSessionKey(TOPIC_A)).resolves.toBeNull();
+  });
+});
+
+describe('malformed envelopes fail closed (DR-10)', () => {
+  it.each([
+    ['not json at all', 'definitely-not-json'],
+    ['a json scalar', '"just-a-string"'],
+    ['null', 'null'],
+    ['missing topic', JSON.stringify({ key: KEY_A })],
+    ['blank topic', JSON.stringify({ topic: '', key: KEY_A })],
+    ['missing key', JSON.stringify({ topic: TOPIC_A })],
+    ['non-hex key', JSON.stringify({ topic: TOPIC_A, key: 'z'.repeat(64) })],
+    ['short key', JSON.stringify({ topic: TOPIC_A, key: 'a'.repeat(32) })],
+  ])('reads null for %s', async (_label, raw) => {
+    platformMock.__secure.set(WC_V1_SESSION_KEY_SLOT, raw);
+    await expect(readSessionKey(TOPIC_A)).resolves.toBeNull();
+  });
+});
+
+describe('topic-conditional deletion (DR-3a)', () => {
+  it('deletes the slot when it is bound to the given topic', async () => {
+    await writeSessionKey(TOPIC_A, KEY_A);
+    await deleteSessionKeyForTopic(TOPIC_A);
+    expect(platformMock.__secure.has(WC_V1_SESSION_KEY_SLOT)).toBe(false);
+  });
+
+  it('REGRESSION: leaves a slot bound to a different topic intact', async () => {
+    // The pair-then-reject sequence: session A is stored, B is being paired,
+    // B is rejected and clears "its" session. A's key must survive.
+    await writeSessionKey(TOPIC_A, KEY_A);
+    await deleteSessionKeyForTopic(TOPIC_B);
+    await expect(readSessionKey(TOPIC_A)).resolves.toBe(KEY_A);
+  });
+
+  it('clears an unparseable slot, which is useless to everyone', async () => {
+    platformMock.__secure.set(WC_V1_SESSION_KEY_SLOT, 'garbage');
+    await deleteSessionKeyForTopic(TOPIC_A);
+    expect(platformMock.__secure.has(WC_V1_SESSION_KEY_SLOT)).toBe(false);
+  });
+
+  it('is a no-op on an empty slot', async () => {
+    await expect(deleteSessionKeyForTopic(TOPIC_A)).resolves.toBeUndefined();
+  });
+
+  it('deleteSessionKeySlot clears regardless of binding', async () => {
+    await writeSessionKey(TOPIC_A, KEY_A);
+    await deleteSessionKeySlot();
+    expect(platformMock.__secure.has(WC_V1_SESSION_KEY_SLOT)).toBe(false);
+  });
+});
+
+describe('rollback (DR-5a)', () => {
+  it('restores the prior value after a failed paired write', async () => {
+    await writeSessionKey(TOPIC_A, KEY_A);
+    const prior = await readSessionKeySlotRaw();
+
+    // Session B takes the slot, then its metadata write fails.
+    await writeSessionKey(TOPIC_B, KEY_B);
+    await restoreSessionKeySlot(prior);
+
+    await expect(readSessionKey(TOPIC_A)).resolves.toBe(KEY_A);
+    await expect(readSessionKey(TOPIC_B)).resolves.toBeNull();
+  });
+
+  it('clears the slot when there was nothing there before', async () => {
+    const prior = await readSessionKeySlotRaw();
+    expect(prior).toBeNull();
+
+    await writeSessionKey(TOPIC_B, KEY_B);
+    await restoreSessionKeySlot(prior);
+
+    expect(platformMock.__secure.has(WC_V1_SESSION_KEY_SLOT)).toBe(false);
+  });
+});
+
+describe('Android keystore desync', () => {
+  const desync = new Error(
+    'Secure storage read failed: a stored item is present but unreadable'
+  );
+
+  it('propagates from reads so the caller can decide (DR-4)', async () => {
+    platformMock.__throwOnGet(desync);
+    await expect(readSessionKey(TOPIC_A)).rejects.toThrow(desync);
+    await expect(readSessionKeySlotRaw()).rejects.toThrow(desync);
+  });
+
+  it('is absorbed by deletion, which clears the unreadable entry', async () => {
+    platformMock.__secure.set(WC_V1_SESSION_KEY_SLOT, 'unreadable');
+    platformMock.__throwOnGet(desync);
+
+    await expect(deleteSessionKeyForTopic(TOPIC_A)).resolves.toBeUndefined();
+    expect(platformMock.__secure.has(WC_V1_SESSION_KEY_SLOT)).toBe(false);
+  });
+});
+
+describe('no key material reaches logs (DR-13)', () => {
+  it('logs a fixed message and never the payload when discarding a bad record', async () => {
+    const warn = jest.spyOn(console, 'warn').mockImplementation(() => {});
+    const error = jest.spyOn(console, 'error').mockImplementation(() => {});
+    const log = jest.spyOn(console, 'log').mockImplementation(() => {});
+
+    // A malformed payload that nonetheless embeds a key, in both the bare form
+    // and the `key=<hex>` URI form.
+    platformMock.__secure.set(
+      WC_V1_SESSION_KEY_SLOT,
+      `{ broken json, key=${KEY_A}, ${KEY_A} }`
+    );
+    await expect(readSessionKey(TOPIC_A)).resolves.toBeNull();
+
+    const logged = [...warn.mock.calls, ...error.mock.calls, ...log.mock.calls]
+      .flat()
+      .map((arg) => (typeof arg === 'string' ? arg : JSON.stringify(arg)))
+      .join(' ');
+
+    expect(logged).not.toContain(KEY_A);
+    expect(logged).not.toMatch(/[0-9a-f]{64}/i);
+    expect(warn).toHaveBeenCalledWith(
+      'WC v1 SessionKeyStore: discarding malformed stored record'
+    );
+  });
+
+  it('does not log the key on a successful round-trip', async () => {
+    const warn = jest.spyOn(console, 'warn').mockImplementation(() => {});
+    const error = jest.spyOn(console, 'error').mockImplementation(() => {});
+    const log = jest.spyOn(console, 'log').mockImplementation(() => {});
+
+    await writeSessionKey(TOPIC_A, KEY_A);
+    await readSessionKey(TOPIC_A);
+    await deleteSessionKeyForTopic(TOPIC_A);
+
+    expect(warn).not.toHaveBeenCalled();
+    expect(error).not.toHaveBeenCalled();
+    expect(log).not.toHaveBeenCalled();
+  });
+});

--- a/src/services/walletconnect/v1/__tests__/sessionPersistence.test.ts
+++ b/src/services/walletconnect/v1/__tests__/sessionPersistence.test.ts
@@ -1,0 +1,723 @@
+// Integration tests for v1 session persistence across the AsyncStorage /
+// SecureStore split (PLAN-260, TASK-258).
+//
+// Covers the four original acceptance criteria plus the failure modes the
+// Codex consensus loop surfaced:
+//   - no key material left in AsyncStorage after migration (AC1),
+//   - an EXISTING session still reconnects after upgrade (AC2) — migration, not
+//     just fresh pairings,
+//   - no key reaches logs on any path (AC3),
+//   - the migrate-then-rewrite sequence (AC4),
+//   - fault injection PER STORAGE OPERATION, not just crash-ordering (DR-5a),
+//   - "A stored -> pair/reject B -> A still restores" (DR-3a),
+//   - keyless metadata + empty slot restores nothing, quietly (DR-4/DR-15).
+
+const mockSecure = new Map<string, string>();
+const mockKv = new Map<string, string>();
+let mockSecureGetThrows: Error | null = null;
+let mockAsyncSetThrows: Error | null = null;
+let mockSecureSetThrows: Error | null = null;
+
+jest.mock('@/platform', () => ({
+  secureStorage: {
+    setItem: async (k: string, v: string) => {
+      if (mockSecureSetThrows) throw mockSecureSetThrows;
+      mockSecure.set(k, v);
+    },
+    getItem: async (k: string) => {
+      if (mockSecureGetThrows) throw mockSecureGetThrows;
+      return mockSecure.has(k) ? mockSecure.get(k)! : null;
+    },
+    deleteItem: async (k: string) => {
+      mockSecure.delete(k);
+    },
+  },
+}));
+
+jest.mock('@react-native-async-storage/async-storage', () => ({
+  __esModule: true,
+  default: {
+    setItem: async (k: string, v: string) => {
+      if (mockAsyncSetThrows) throw mockAsyncSetThrows;
+      mockKv.set(k, v);
+    },
+    getItem: async (k: string) => (mockKv.has(k) ? mockKv.get(k)! : null),
+    removeItem: async (k: string) => {
+      mockKv.delete(k);
+    },
+    getAllKeys: async () => [...mockKv.keys()],
+    multiRemove: async (keys: string[]) => {
+      keys.forEach((k) => mockKv.delete(k));
+    },
+  },
+}));
+
+import AsyncStorage from '@react-native-async-storage/async-storage';
+import {
+  isValidV1SessionKey,
+  readSessionKey,
+  readSessionKeySlotRaw,
+  writeSessionKey,
+  restoreSessionKeySlot,
+  deleteSessionKeyForTopic,
+  deleteSessionKeySlot,
+} from '../sessionKeyStore';
+import { WC_V1_SESSION_STORAGE_KEY, WC_V1_SESSION_KEY_SLOT } from '../config';
+import {
+  isRestorableV1Session,
+  type WalletConnectV1LegacyPersistedSession,
+} from '../types';
+
+// Throwaway vectors.
+const KEY_A = 'a1b2c3d4'.repeat(8);
+const KEY_B = 'b1c2d3e4'.repeat(8);
+const TOPIC_A = 'topic-a';
+const TOPIC_B = 'topic-b';
+
+const rowKey = (topic: string) => `${WC_V1_SESSION_STORAGE_KEY}:${topic}`;
+
+const legacyRow = (
+  topic: string,
+  key: string,
+  updatedAt = 1000
+): WalletConnectV1LegacyPersistedSession => ({
+  connected: true,
+  accounts: ['ACCOUNT'],
+  chainId: 416001,
+  bridge: 'https://bridge.example',
+  key,
+  clientId: `client-${topic}`,
+  clientMeta: null,
+  peerId: `peer-${topic}`,
+  peerMeta: null,
+  handshakeId: 1,
+  handshakeTopic: topic,
+  updatedAt,
+});
+
+beforeEach(() => {
+  mockSecure.clear();
+  mockKv.clear();
+  mockSecureGetThrows = null;
+  mockAsyncSetThrows = null;
+  mockSecureSetThrows = null;
+  jest.restoreAllMocks();
+});
+
+/**
+ * The migration step exactly as boot restore performs it (DR-7): write the
+ * mockSecure copy first, then rewrite the SAME row without `key`. The rewrite is
+ * the delete — the row must survive, because it carries routing metadata.
+ */
+async function migrateSelectedRow(topic: string): Promise<void> {
+  const raw = await AsyncStorage.getItem(rowKey(topic));
+  const row = JSON.parse(raw!) as WalletConnectV1LegacyPersistedSession;
+  await writeSessionKey(topic, row.key!);
+  const { key: _dropped, ...keyless } = row;
+  await AsyncStorage.setItem(rowKey(topic), JSON.stringify(keyless));
+}
+
+describe('AC1/AC4 — migrate-then-rewrite leaves no key in AsyncStorage', () => {
+  it('removes the inline key while KEEPING the routing metadata', async () => {
+    mockKv.set(rowKey(TOPIC_A), JSON.stringify(legacyRow(TOPIC_A, KEY_A)));
+
+    await migrateSelectedRow(TOPIC_A);
+
+    const after = JSON.parse(mockKv.get(rowKey(TOPIC_A))!);
+    expect(after.key).toBeUndefined();
+    // Routing metadata survives — this is what makes reconnection possible.
+    expect(after.bridge).toBe('https://bridge.example');
+    expect(after.handshakeTopic).toBe(TOPIC_A);
+    expect(after.accounts).toEqual(['ACCOUNT']);
+  });
+
+  it('leaves NO key material anywhere in AsyncStorage', async () => {
+    mockKv.set(rowKey(TOPIC_A), JSON.stringify(legacyRow(TOPIC_A, KEY_A)));
+    await migrateSelectedRow(TOPIC_A);
+
+    const everything = [...mockKv.values()].join('\n');
+    expect(everything).not.toContain(KEY_A);
+  });
+
+  it('puts the key in the secure slot, bound to its topic', async () => {
+    mockKv.set(rowKey(TOPIC_A), JSON.stringify(legacyRow(TOPIC_A, KEY_A)));
+    await migrateSelectedRow(TOPIC_A);
+
+    expect(await readSessionKey(TOPIC_A)).toBe(KEY_A);
+    expect([...mockSecure.keys()]).toEqual([WC_V1_SESSION_KEY_SLOT]);
+  });
+});
+
+describe('AC2 — an existing session still reconnects after upgrade', () => {
+  it('yields the same key and bridge a reconnect needs', async () => {
+    mockKv.set(rowKey(TOPIC_A), JSON.stringify(legacyRow(TOPIC_A, KEY_A)));
+    await migrateSelectedRow(TOPIC_A);
+
+    // What boot restore reassembles for v1Client.connect():
+    const row = JSON.parse(mockKv.get(rowKey(TOPIC_A))!);
+    const key = await readSessionKey(TOPIC_A);
+
+    expect(key).toBe(KEY_A);
+    expect(row.bridge).toBe('https://bridge.example');
+  });
+
+  it('is idempotent — a second boot does not re-migrate or lose the key', async () => {
+    mockKv.set(rowKey(TOPIC_A), JSON.stringify(legacyRow(TOPIC_A, KEY_A)));
+    await migrateSelectedRow(TOPIC_A);
+
+    // Second boot: the row is already keyless, the secure slot answers.
+    const row = JSON.parse(
+      mockKv.get(rowKey(TOPIC_A))!
+    ) as WalletConnectV1LegacyPersistedSession;
+    expect(row.key).toBeUndefined();
+    expect(await readSessionKey(TOPIC_A)).toBe(KEY_A);
+  });
+});
+
+describe('multiple legacy rows — freshest wins, others are dropped', () => {
+  it('migrates only the selected row and discards the rest with their keys', async () => {
+    mockKv.set(rowKey(TOPIC_A), JSON.stringify(legacyRow(TOPIC_A, KEY_A, 500)));
+    mockKv.set(
+      rowKey(TOPIC_B),
+      JSON.stringify(legacyRow(TOPIC_B, KEY_B, 9000))
+    );
+
+    // B is fresher, so it is the selected session.
+    await migrateSelectedRow(TOPIC_B);
+    await AsyncStorage.multiRemove([rowKey(TOPIC_A)]);
+
+    expect(await readSessionKey(TOPIC_B)).toBe(KEY_B);
+    const everything = [...mockKv.values()].join('\n');
+    expect(everything).not.toContain(KEY_A);
+    expect(everything).not.toContain(KEY_B);
+  });
+});
+
+describe('DR-5a — fault injection per storage operation', () => {
+  it('rolls back the secure write when the metadata write fails', async () => {
+    // Session A is fully persisted.
+    mockKv.set(rowKey(TOPIC_A), JSON.stringify(legacyRow(TOPIC_A, KEY_A)));
+    await migrateSelectedRow(TOPIC_A);
+
+    // Exactly what storeSession does: capture the prior slot, write, and on a
+    // metadata failure hand the captured value to the real rollback helper.
+    const priorSlot = await readSessionKeySlotRaw();
+
+    await writeSessionKey(TOPIC_B, KEY_B);
+    mockAsyncSetThrows = new Error('disk full');
+    await expect(AsyncStorage.setItem(rowKey(TOPIC_B), '{}')).rejects.toThrow();
+    mockAsyncSetThrows = null;
+
+    await restoreSessionKeySlot(priorSlot);
+
+    // A is intact and restorable — the whole point of the rollback.
+    expect(await readSessionKey(TOPIC_A)).toBe(KEY_A);
+    expect(await readSessionKey(TOPIC_B)).toBeNull();
+  });
+
+  it('a failed migration leaves the legacy row intact so it can retry', async () => {
+    mockKv.set(rowKey(TOPIC_A), JSON.stringify(legacyRow(TOPIC_A, KEY_A)));
+
+    await writeSessionKey(TOPIC_A, KEY_A);
+    mockAsyncSetThrows = new Error('write failed');
+    await expect(migrateSelectedRow(TOPIC_A)).rejects.toThrow();
+    mockAsyncSetThrows = null;
+
+    // The row still has its inline key, so the next boot can migrate again.
+    const row = JSON.parse(
+      mockKv.get(rowKey(TOPIC_A))!
+    ) as WalletConnectV1LegacyPersistedSession;
+    expect(row.key).toBe(KEY_A);
+  });
+});
+
+describe('DR-3a — pair-then-reject must not destroy the retained session', () => {
+  it('REGRESSION: A stored, B paired then rejected, A still restores', async () => {
+    // A is the live persisted session.
+    mockKv.set(rowKey(TOPIC_A), JSON.stringify(legacyRow(TOPIC_A, KEY_A)));
+    await migrateSelectedRow(TOPIC_A);
+
+    // B is being paired. connect() retains A's storage; config now points at B.
+    // B is rejected -> clearSession() runs with B's topic.
+    await AsyncStorage.removeItem(rowKey(TOPIC_B));
+    await deleteSessionKeyForTopic(TOPIC_B);
+
+    // A survives, key and metadata both.
+    expect(await readSessionKey(TOPIC_A)).toBe(KEY_A);
+    expect(mockKv.has(rowKey(TOPIC_A))).toBe(true);
+  });
+});
+
+describe('DR-4/DR-15 — unrestorable states fail closed and quietly', () => {
+  it('keyless metadata with an empty slot yields no key and no error', async () => {
+    const { key: _dropped, ...keyless } = legacyRow(TOPIC_A, KEY_A);
+    mockKv.set(rowKey(TOPIC_A), JSON.stringify(keyless));
+
+    const errorSpy = jest.spyOn(console, 'error').mockImplementation(() => {});
+    const key = await readSessionKey(TOPIC_A);
+
+    expect(key).toBeNull();
+    expect(errorSpy).not.toHaveBeenCalled();
+  });
+
+  it('a keystore desync surfaces as a throw the caller can catch', async () => {
+    mockKv.set(rowKey(TOPIC_A), JSON.stringify(legacyRow(TOPIC_A, KEY_A)));
+    await migrateSelectedRow(TOPIC_A);
+
+    mockSecureGetThrows = new Error('keystore desync');
+    await expect(readSessionKey(TOPIC_A)).rejects.toThrow('keystore desync');
+  });
+
+  it('a slot bound to another topic reads as no-key', async () => {
+    await writeSessionKey(TOPIC_B, KEY_B);
+    expect(await readSessionKey(TOPIC_A)).toBeNull();
+  });
+});
+
+describe('AC3 — no key reaches logs on any path', () => {
+  it('logs nothing containing the key across migrate, read and drop', async () => {
+    const calls: string[] = [];
+    const push = (...args: unknown[]) =>
+      calls.push(
+        args
+          .map((a) => (typeof a === 'string' ? a : JSON.stringify(a)))
+          .join(' ')
+      );
+    jest.spyOn(console, 'error').mockImplementation(push);
+    jest.spyOn(console, 'warn').mockImplementation(push);
+    jest.spyOn(console, 'log').mockImplementation(push);
+
+    mockKv.set(rowKey(TOPIC_A), JSON.stringify(legacyRow(TOPIC_A, KEY_A)));
+    await migrateSelectedRow(TOPIC_A);
+    await readSessionKey(TOPIC_A);
+    await deleteSessionKeyForTopic(TOPIC_A);
+
+    // Malformed slot, which is the path that DOES log.
+    mockSecure.set(WC_V1_SESSION_KEY_SLOT, `garbage ${KEY_A} key=${KEY_A}`);
+    await readSessionKey(TOPIC_A);
+
+    const logged = calls.join('\n');
+    expect(logged).not.toContain(KEY_A);
+  });
+});
+
+/**
+ * Mirrors the restore path's strip rule: the inline key is removed whenever
+ * the row still carries one, NOT only when a migration just happened.
+ */
+async function restoreStripRule(topic: string): Promise<string | null> {
+  const raw = await AsyncStorage.getItem(rowKey(topic));
+  const row = JSON.parse(raw!) as WalletConnectV1LegacyPersistedSession;
+
+  let sessionKey = await readSessionKey(topic);
+  const hasInlineKey =
+    row.key !== undefined && row.key !== null && row.key !== '';
+  const seedableKey = isValidV1SessionKey(row.key) ? row.key : null;
+  let secureKeyConfirmed = sessionKey !== null;
+
+  if (!sessionKey && seedableKey) {
+    try {
+      await writeSessionKey(topic, seedableKey);
+      secureKeyConfirmed = true;
+    } catch {
+      // Secure write failed; the inline key is the only copy left.
+    }
+    sessionKey = seedableKey;
+  }
+  if (!sessionKey) return null;
+
+  if (hasInlineKey && secureKeyConfirmed) {
+    const { key: _dropped, ...keyless } = row;
+    await AsyncStorage.setItem(rowKey(topic), JSON.stringify(keyless));
+  }
+  return sessionKey;
+}
+
+describe('crash windows in migration (Codex review of TASK-258)', () => {
+  it('strips the inline key even when the secure slot ALREADY has it', async () => {
+    // The crash window: a previous boot wrote the secure slot, then died before
+    // rewriting the row. readSessionKey now succeeds, so a strip conditional on
+    // "did we just migrate?" would leave the key in AsyncStorage forever.
+    mockKv.set(rowKey(TOPIC_A), JSON.stringify(legacyRow(TOPIC_A, KEY_A)));
+    await writeSessionKey(TOPIC_A, KEY_A);
+
+    const key = await restoreStripRule(TOPIC_A);
+
+    expect(key).toBe(KEY_A);
+    expect([...mockKv.values()].join('\n')).not.toContain(KEY_A);
+    const row = JSON.parse(mockKv.get(rowKey(TOPIC_A))!);
+    expect(row.key).toBeUndefined();
+    // Routing metadata still intact.
+    expect(row.bridge).toBe('https://bridge.example');
+  });
+
+  it('REGRESSION: a failed secure write must NOT strip the only remaining key', async () => {
+    // Codex round 2. The round-1 fix fell back to the inline key on a secure
+    // write failure but still stripped the row — leaving the NEXT boot with
+    // keyless metadata and no secure key, dropping a recoverable session.
+    mockKv.set(rowKey(TOPIC_A), JSON.stringify(legacyRow(TOPIC_A, KEY_A)));
+
+    mockSecureSetThrows = new Error('keystore unavailable');
+    const key = await restoreStripRule(TOPIC_A);
+    mockSecureSetThrows = null;
+
+    // The session still restores this boot...
+    expect(key).toBe(KEY_A);
+    // ...and the inline key SURVIVES, so the next boot can retry the migration
+    // instead of finding an unusable keyless row.
+    const row = JSON.parse(
+      mockKv.get(rowKey(TOPIC_A))!
+    ) as WalletConnectV1LegacyPersistedSession;
+    expect(row.key).toBe(KEY_A);
+
+    // And once secure storage recovers, the migration completes.
+    const key2 = await restoreStripRule(TOPIC_A);
+    expect(key2).toBe(KEY_A);
+    expect([...mockKv.values()].join('\n')).not.toContain(KEY_A);
+  });
+
+  it('a failed row rewrite leaves the session working and retries next boot', async () => {
+    mockKv.set(rowKey(TOPIC_A), JSON.stringify(legacyRow(TOPIC_A, KEY_A)));
+
+    await writeSessionKey(TOPIC_A, KEY_A);
+    mockAsyncSetThrows = new Error('write failed');
+    await expect(restoreStripRule(TOPIC_A)).rejects.toThrow();
+    mockAsyncSetThrows = null;
+
+    // Secure copy is present, row still has its key: session works either way.
+    expect(await readSessionKey(TOPIC_A)).toBe(KEY_A);
+
+    // Next boot completes the strip.
+    const key = await restoreStripRule(TOPIC_A);
+    expect(key).toBe(KEY_A);
+    expect([...mockKv.values()].join('\n')).not.toContain(KEY_A);
+  });
+});
+
+describe('dropping an unrestorable session cleans up ALL of it', () => {
+  /**
+   * Mirrors dropV1Session: every v1 row goes, so the slot delete is
+   * UNCONDITIONAL (nothing survives that could need its key) and queues are
+   * purged for every removed topic, not just the selected one.
+   */
+  async function dropAll(topics: string[]): Promise<void> {
+    await AsyncStorage.multiRemove(topics.map(rowKey));
+    await deleteSessionKeySlot();
+  }
+
+  it('REGRESSION: does not orphan a slot bound to a STALE row', async () => {
+    // Codex round 3. The selected-but-unrestorable row is A, while the slot
+    // happens to hold B's key. A topic-conditional delete keyed on A would have
+    // wiped both rows and left B's key stranded in a store with no enumeration.
+    mockKv.set(rowKey(TOPIC_A), JSON.stringify(legacyRow(TOPIC_A, KEY_A)));
+    mockKv.set(rowKey(TOPIC_B), JSON.stringify(legacyRow(TOPIC_B, KEY_B)));
+    await writeSessionKey(TOPIC_B, KEY_B);
+
+    await dropAll([TOPIC_A, TOPIC_B]);
+
+    expect(mockSecure.size).toBe(0);
+    expect(mockKv.size).toBe(0);
+    expect(await readSessionKey(TOPIC_B)).toBeNull();
+  });
+
+  it('leaves no key material anywhere afterwards', async () => {
+    mockKv.set(rowKey(TOPIC_A), JSON.stringify(legacyRow(TOPIC_A, KEY_A)));
+    await writeSessionKey(TOPIC_A, KEY_A);
+
+    await dropAll([TOPIC_A]);
+
+    const everything = [...mockKv.values(), ...mockSecure.values()].join('\n');
+    expect(everything).not.toContain(KEY_A);
+  });
+});
+
+describe('a MALFORMED inline key is drained too', () => {
+  it('REGRESSION: strips an invalid inline key when the secure copy is valid', async () => {
+    // Codex round 4. `inlineKey` used to conflate "is there a key to drain?"
+    // with "is it good enough to seed SecureStore?", so a corrupt or truncated
+    // key would sit in AsyncStorage forever once the secure slot was populated.
+    const malformed = 'not-a-valid-key';
+    const row = { ...legacyRow(TOPIC_A, KEY_A), key: malformed };
+    mockKv.set(rowKey(TOPIC_A), JSON.stringify(row));
+    await writeSessionKey(TOPIC_A, KEY_A);
+
+    const key = await restoreStripRule(TOPIC_A);
+
+    // Restores from the valid SECURE copy...
+    expect(key).toBe(KEY_A);
+    // ...and the malformed inline value is gone.
+    const after = JSON.parse(mockKv.get(rowKey(TOPIC_A))!);
+    expect(after.key).toBeUndefined();
+    expect([...mockKv.values()].join('\n')).not.toContain(malformed);
+  });
+
+  it('does not seed the secure slot from a malformed key', async () => {
+    const row = { ...legacyRow(TOPIC_A, KEY_A), key: 'zzzz' };
+    mockKv.set(rowKey(TOPIC_A), JSON.stringify(row));
+
+    // No secure copy and no seedable key: unrestorable.
+    expect(await restoreStripRule(TOPIC_A)).toBeNull();
+    expect(mockSecure.size).toBe(0);
+  });
+});
+
+describe('every path that reads a legacy row also drains it', () => {
+  // Codex round 5. loadSession() is reachable independently of boot restore —
+  // a v1 deep link connects through it, and boot restore may never run if
+  // WalletConnect initialization failed earlier — so leaving the drain solely
+  // to the restore path let a legacy key sit in AsyncStorage indefinitely.
+
+  it('an unparseable row is DELETED, not skipped', async () => {
+    // A truncated row can still contain a valid inline key. Skipped rows escape
+    // both the migration and the stale-row prune, so the key would survive
+    // forever. Nothing recoverable is lost by deleting it.
+    const truncated = `{"bridge":"https://b.example","key":"${KEY_A}"`;
+    mockKv.set(rowKey(TOPIC_A), truncated);
+
+    // What the restore path now does on a JSON.parse failure:
+    try {
+      JSON.parse(mockKv.get(rowKey(TOPIC_A))!);
+    } catch {
+      await AsyncStorage.removeItem(rowKey(TOPIC_A));
+    }
+
+    expect(mockKv.has(rowKey(TOPIC_A))).toBe(false);
+    expect([...mockKv.values()].join('\n')).not.toContain(KEY_A);
+  });
+
+  it('draining is idempotent across repeated reads', async () => {
+    mockKv.set(rowKey(TOPIC_A), JSON.stringify(legacyRow(TOPIC_A, KEY_A)));
+
+    await restoreStripRule(TOPIC_A);
+    await restoreStripRule(TOPIC_A);
+    const key = await restoreStripRule(TOPIC_A);
+
+    expect(key).toBe(KEY_A);
+    expect([...mockKv.values()].join('\n')).not.toContain(KEY_A);
+  });
+});
+
+describe('unusable rows are deleted, not retained (Codex round 7)', () => {
+  /**
+   * loadSession's rule for a parsable row with no usable key: delete it, the
+   * same as the restore path's dropV1Session. Covers valid JSON of the WRONG
+   * SHAPE, which slips past the parse guard while still possibly holding
+   * key-shaped text.
+   */
+  async function loadOrDelete(topic: string): Promise<string | null> {
+    const stored = await AsyncStorage.getItem(rowKey(topic));
+    if (!stored) return null;
+
+    let row: WalletConnectV1LegacyPersistedSession;
+    try {
+      row = JSON.parse(stored) as WalletConnectV1LegacyPersistedSession;
+    } catch {
+      await AsyncStorage.removeItem(rowKey(topic));
+      return null;
+    }
+
+    const sessionKey =
+      (await readSessionKey(topic)) ??
+      (isValidV1SessionKey(row?.key) ? row.key! : null);
+
+    if (!sessionKey) {
+      await AsyncStorage.removeItem(rowKey(topic));
+      return null;
+    }
+    return sessionKey;
+  }
+
+  it('deletes a parsable row that has no usable key anywhere', async () => {
+    const { key: _d, ...keyless } = legacyRow(TOPIC_A, KEY_A);
+    mockKv.set(rowKey(TOPIC_A), JSON.stringify(keyless));
+
+    expect(await loadOrDelete(TOPIC_A)).toBeNull();
+    expect(mockKv.has(rowKey(TOPIC_A))).toBe(false);
+  });
+
+  it('deletes valid JSON of the WRONG SHAPE that still holds key-shaped text', async () => {
+    // Parses fine, so the parse guard does not catch it — but it is unusable
+    // and would otherwise sit there with the key text inside.
+    mockKv.set(rowKey(TOPIC_A), JSON.stringify(`stray ${KEY_A}`));
+
+    expect(await loadOrDelete(TOPIC_A)).toBeNull();
+    expect(mockKv.has(rowKey(TOPIC_A))).toBe(false);
+    expect([...mockKv.values()].join('\n')).not.toContain(KEY_A);
+  });
+
+  it('keeps a row that IS usable', async () => {
+    mockKv.set(rowKey(TOPIC_A), JSON.stringify(legacyRow(TOPIC_A, KEY_A)));
+    expect(await loadOrDelete(TOPIC_A)).toBe(KEY_A);
+    expect(mockKv.has(rowKey(TOPIC_A))).toBe(true);
+  });
+});
+
+describe('wrong-shape rows cannot abort restoration (Codex round 8)', () => {
+  /** The restore path's per-row guard: non-null object, or the row is dropped. */
+  function parseRowOrNull(raw: string): object | null {
+    try {
+      const parsed: unknown = JSON.parse(raw);
+      if (typeof parsed !== 'object' || parsed === null) return null;
+      if (Array.isArray(parsed)) return null;
+      return parsed;
+    } catch {
+      return null;
+    }
+  }
+
+  it.each([
+    ['JSON null', 'null'],
+    ['a bare string', '"just-a-string"'],
+    ['a number', '42'],
+    ['unparseable', '{"truncated"'],
+  ])('rejects %s without throwing', (_label, raw) => {
+    expect(parseRowOrNull(raw)).toBeNull();
+  });
+
+  it('REGRESSION: one null row does not abort restoration of a VALID row', async () => {
+    // Previously `session.connected` on a null row threw inside the filter,
+    // taking down v1 restoration entirely — one corrupt row denied service to
+    // every good one.
+    mockKv.set(rowKey('corrupt'), 'null');
+    mockKv.set(rowKey(TOPIC_A), JSON.stringify(legacyRow(TOPIC_A, KEY_A)));
+
+    const rows = [...mockKv.entries()].map(([k, v]) => ({
+      key: k,
+      session: parseRowOrNull(v),
+    }));
+    const usable = rows.filter((r) => r.session !== null);
+
+    // The valid row survives selection.
+    expect(usable).toHaveLength(1);
+    expect(usable[0].key).toBe(rowKey(TOPIC_A));
+    // And filtering on a real field no longer throws.
+    expect(() =>
+      usable.filter((r) => (r.session as { connected?: boolean }).connected)
+    ).not.toThrow();
+  });
+
+  it('an array row is rejected too', () => {
+    expect(parseRowOrNull('[1,2,3]')).toBeNull();
+  });
+});
+
+describe('incomplete rows must not win selection (Codex round 9)', () => {
+  /** Restore's per-row admission rule: object shape AND a usable bridge. */
+  function admitRow(raw: string): WalletConnectV1LegacyPersistedSession | null {
+    try {
+      const parsed: unknown = JSON.parse(raw);
+      if (
+        typeof parsed !== 'object' ||
+        parsed === null ||
+        Array.isArray(parsed)
+      ) {
+        return null;
+      }
+      const candidate = parsed as WalletConnectV1LegacyPersistedSession;
+      if (
+        typeof candidate.bridge !== 'string' ||
+        candidate.bridge.length === 0
+      ) {
+        return null;
+      }
+      return candidate;
+    } catch {
+      return null;
+    }
+  }
+
+  it('REGRESSION: a fresh-but-incomplete row does not displace a valid session', async () => {
+    // The corrupt row has the newest updatedAt, so freshest-wins would have
+    // selected it. Having no key, it would then route into dropV1Session —
+    // which deletes EVERY v1 row and the secure slot, destroying the good
+    // session as collateral.
+    mockKv.set(
+      rowKey('corrupt'),
+      JSON.stringify({ connected: true, updatedAt: 999999 })
+    );
+    mockKv.set(rowKey(TOPIC_A), JSON.stringify(legacyRow(TOPIC_A, KEY_A, 100)));
+
+    const admitted = [...mockKv.entries()]
+      .map(([k, v]) => ({ key: k, session: admitRow(v) }))
+      .filter((r) => r.session !== null);
+
+    // Only the real session is a candidate at all.
+    expect(admitted).toHaveLength(1);
+    expect(admitted[0].key).toBe(rowKey(TOPIC_A));
+    expect(admitted[0].session!.bridge).toBe('https://bridge.example');
+  });
+
+  it.each([
+    ['no bridge', JSON.stringify({ connected: true })],
+    ['empty bridge', JSON.stringify({ bridge: '' })],
+    ['non-string bridge', JSON.stringify({ bridge: 42 })],
+  ])('rejects a row with %s', (_label, raw) => {
+    expect(admitRow(raw)).toBeNull();
+  });
+
+  it('admits a complete row', () => {
+    const ok = admitRow(JSON.stringify(legacyRow(TOPIC_A, KEY_A)));
+    expect(ok).not.toBeNull();
+  });
+});
+
+describe('isRestorableV1Session — full reconnect contract (Codex round 12)', () => {
+  it('accepts a complete row', () => {
+    expect(isRestorableV1Session(legacyRow(TOPIC_A, KEY_A))).toBe(true);
+  });
+
+  it('REGRESSION: rejects a row that passes a SHALLOW check but cannot reconnect', () => {
+    // bridge + handshakeTopic + accounts + chainId only. This used to be
+    // admitted, win freshest-wins selection, and restore with an undefined
+    // clientId onto a dead handshake topic — a session that looks live but is
+    // unusable, which is worse than deleting it and re-pairing.
+    expect(
+      isRestorableV1Session({
+        bridge: 'https://b.example',
+        handshakeTopic: TOPIC_A,
+        accounts: [],
+        chainId: 416001,
+      } as unknown as WalletConnectV1LegacyPersistedSession)
+    ).toBe(false);
+  });
+
+  it.each([
+    'connected',
+    'accounts',
+    'chainId',
+    'bridge',
+    'clientId',
+    'peerId',
+    'handshakeId',
+    'handshakeTopic',
+  ])('rejects a row missing %s', (field) => {
+    const row = { ...legacyRow(TOPIC_A, KEY_A) } as Record<string, unknown>;
+    delete row[field];
+    expect(
+      isRestorableV1Session(
+        row as unknown as WalletConnectV1LegacyPersistedSession
+      )
+    ).toBe(false);
+  });
+
+  it('rejects empty-string bridge, clientId, peerId and handshakeTopic', () => {
+    for (const field of ['bridge', 'clientId', 'peerId', 'handshakeTopic']) {
+      const row = { ...legacyRow(TOPIC_A, KEY_A), [field]: '' };
+      expect(
+        isRestorableV1Session(row as WalletConnectV1LegacyPersistedSession)
+      ).toBe(false);
+    }
+  });
+
+  it('rejects null and undefined', () => {
+    expect(isRestorableV1Session(null)).toBe(false);
+    expect(isRestorableV1Session(undefined)).toBe(false);
+  });
+
+  it('does NOT require `key` — it no longer lives on the row', () => {
+    const { key: _d, ...keyless } = legacyRow(TOPIC_A, KEY_A);
+    expect(
+      isRestorableV1Session(keyless as WalletConnectV1LegacyPersistedSession)
+    ).toBe(true);
+  });
+});

--- a/src/services/walletconnect/v1/client.ts
+++ b/src/services/walletconnect/v1/client.ts
@@ -11,7 +11,9 @@ import {
   WalletConnectV1SessionRequest,
   WalletConnectV1Event,
   AlgoSignTxnRequest,
-  WalletConnectV1StoredSession,
+  WalletConnectV1PersistedSession,
+  WalletConnectV1LegacyPersistedSession,
+  isRestorableV1Session,
 } from './types';
 import { WalletConnectV1WebSocket } from './websocket';
 import { generateClientId } from './crypto';
@@ -37,6 +39,16 @@ import {
 } from './config';
 import { redactError } from '@/utils/logRedaction';
 import { describePeerMethod } from './peerLabels';
+import {
+  readSessionKey,
+  readSessionKeySlotRaw,
+  writeSessionKey,
+  restoreSessionKeySlot,
+  deleteSessionKeyForTopic,
+  deleteSessionKeySlot,
+  isValidV1SessionKey,
+} from './sessionKeyStore';
+import { deleteV1Session, deleteV1Sessions } from './sessionCleanup';
 
 export class WalletConnectV1Client extends EventEmitter {
   private static instance: WalletConnectV1Client | null = null;
@@ -531,49 +543,102 @@ export class WalletConnectV1Client extends EventEmitter {
   }
 
   /**
-   * Store session in AsyncStorage
+   * Persist the session: routing metadata to AsyncStorage, the symmetric key to
+   * secure storage (PLAN-260).
+   *
+   * ORDERING IS LOAD-BEARING (DR-5/DR-5a). The secure key is written FIRST and
+   * the metadata SECOND, so the metadata row is the commit record — a crash
+   * between the two leaves an orphaned key with no pointer, never a pointer to a
+   * key that was never written.
+   *
+   * If the metadata write then FAILS, the secure write is ROLLED BACK to
+   * whatever was there before. Without that rollback this split would be
+   * strictly worse than the old single-blob write: storing session B while
+   * session A is persisted would leave the slot holding B and A's metadata
+   * intact, and A's topic check would then make A permanently unrestorable —
+   * whereas the old code left A fully recoverable with its inline key.
    */
   private async storeSession(): Promise<void> {
     if (!this.sessionData || !this.config) {
       return;
     }
 
-    try {
-      const storedSession: WalletConnectV1StoredSession = {
-        connected: this.sessionData.connected,
-        accounts: this.sessionData.accounts,
-        chainId: this.sessionData.chainId,
-        bridge: this.sessionData.bridge,
-        key: this.sessionData.key,
-        clientId: this.sessionData.clientId,
-        clientMeta: this.sessionData.clientMeta,
-        peerId: this.sessionData.peerId,
-        peerMeta: this.sessionData.peerMeta,
-        handshakeId: this.sessionData.handshakeId,
-        handshakeTopic: this.sessionData.handshakeTopic,
-        updatedAt: Date.now(),
-      };
+    // Capture identity BEFORE any await so a concurrent connect() cannot swap
+    // `this.config` underneath us and make us write one session's key against
+    // another session's topic (DR-12).
+    const topic = this.config.topic;
+    const sessionKey = this.sessionData.key;
 
-      const key = `${WC_V1_SESSION_STORAGE_KEY}:${this.config.topic}`;
-      await AsyncStorage.setItem(key, JSON.stringify(storedSession));
-      await this.removeStaleSessions(key);
-    } catch (error) {
+    const persisted: WalletConnectV1PersistedSession = {
+      connected: this.sessionData.connected,
+      accounts: this.sessionData.accounts,
+      chainId: this.sessionData.chainId,
+      bridge: this.sessionData.bridge,
+      clientId: this.sessionData.clientId,
+      clientMeta: this.sessionData.clientMeta,
+      peerId: this.sessionData.peerId,
+      peerMeta: this.sessionData.peerMeta,
+      handshakeId: this.sessionData.handshakeId,
+      handshakeTopic: this.sessionData.handshakeTopic,
+      updatedAt: Date.now(),
+    };
+
+    const storageKey = `${WC_V1_SESSION_STORAGE_KEY}:${topic}`;
+
+    let priorSlot: string | null = null;
+    let secureWritten = false;
+
+    try {
+      // Capture the prior slot for rollback. An unreadable slot (Android
+      // keystore desync) is treated as "nothing to roll back to" — it was
+      // already unusable.
+      try {
+        priorSlot = await readSessionKeySlotRaw();
+      } catch {
+        priorSlot = null;
+      }
+
+      await writeSessionKey(topic, sessionKey);
+      secureWritten = true;
+
+      await AsyncStorage.setItem(storageKey, JSON.stringify(persisted));
+      await this.removeStaleSessions(storageKey, topic);
+    } catch {
       console.error('WC v1 Client: Failed to store session');
+      if (secureWritten) {
+        try {
+          await restoreSessionKeySlot(priorSlot);
+        } catch {
+          console.error('WC v1 Client: Failed to roll back session key');
+        }
+      }
     }
   }
 
   /**
-   * Clear session from AsyncStorage
+   * Clear the session: metadata from AsyncStorage, key from secure storage.
+   *
+   * The secure delete is TOPIC-CONDITIONAL (DR-3a), and that is not a nicety.
+   * `connect()` deliberately RETAINS the previous session's persisted storage
+   * when replacing an active connection, but by then `this.config` already
+   * points at the NEW topic. So pairing session B while session A is stored and
+   * then rejecting B routes here with B's topic — an unconditional delete would
+   * destroy A's key while A's metadata survived, leaving A unrestorable.
+   *
+   * Metadata is removed FIRST so it stays the commit record: the worst case is
+   * an orphaned key with no pointer, which the constant slot self-heals on the
+   * next pairing.
    */
   private async clearSession(): Promise<void> {
     if (!this.config) {
       return;
     }
 
+    const topic = this.config.topic;
+
     try {
-      const key = `${WC_V1_SESSION_STORAGE_KEY}:${this.config.topic}`;
-      await AsyncStorage.removeItem(key);
-    } catch (error) {
+      await deleteV1Session(topic);
+    } catch {
       console.error('WC v1 Client: Failed to clear session');
     }
   }
@@ -583,16 +648,119 @@ export class WalletConnectV1Client extends EventEmitter {
    */
   async loadSession(topic: string): Promise<WalletConnectV1SessionData | null> {
     try {
-      const key = `${WC_V1_SESSION_STORAGE_KEY}:${topic}`;
-      const stored = await AsyncStorage.getItem(key);
+      const stored = await AsyncStorage.getItem(
+        `${WC_V1_SESSION_STORAGE_KEY}:${topic}`
+      );
 
       if (!stored) {
         return null;
       }
 
-      const sessionData = JSON.parse(stored) as WalletConnectV1StoredSession;
-      return sessionData;
-    } catch (error) {
+      const storageKey = `${WC_V1_SESSION_STORAGE_KEY}:${topic}`;
+
+      let persisted: WalletConnectV1LegacyPersistedSession;
+      try {
+        const parsed: unknown = JSON.parse(stored);
+        // Must be a non-null OBJECT: `JSON.parse('null')`, a bare string and an
+        // array all parse cleanly and then throw on the first property access.
+        if (
+          typeof parsed !== 'object' ||
+          parsed === null ||
+          Array.isArray(parsed)
+        ) {
+          throw new Error('v1 session entry is not an object');
+        }
+        const candidate = parsed as WalletConnectV1LegacyPersistedSession;
+        // Same admission rule as boot restore — shared so the two paths cannot
+        // drift apart (this one used to skip validation entirely).
+        if (!isRestorableV1Session(candidate)) {
+          throw new Error('v1 session entry is missing required fields');
+        }
+        persisted = candidate;
+      } catch {
+        // Unparseable rows can never restore a session but CAN still hold a
+        // pre-PLAN-260 inline key, so retaining one would leave that key at
+        // rest indefinitely. Delete it — nothing recoverable is lost. Mirrors
+        // the restore path.
+        console.warn('WC v1 Client: Deleting malformed session entry');
+        await deleteV1Session(topic);
+        return null;
+      }
+
+      // The key comes from secure storage. A legacy row may still carry it
+      // inline (pre-PLAN-260); prefer the secure copy and fall back to the
+      // legacy field so an un-migrated row still loads.
+      //
+      // This path MIGRATES AND DRAINS too, rather than leaving that to boot
+      // restore. It is reachable independently — a v1 deep link connects
+      // through here, and boot restore may never run if WalletConnect
+      // initialization failed earlier — so relying on the restore path alone
+      // would let a legacy key sit in AsyncStorage indefinitely.
+      let sessionKey: string | null = null;
+      try {
+        sessionKey = await readSessionKey(topic);
+      } catch {
+        // Android keystore desync: the key is unrecoverable, so the session is
+        // too. Fail closed to "no session" and let the user re-pair (DR-4), and
+        // DELETE the row — otherwise a legacy inline key would stay at rest
+        // forever on a path that can be reached without boot restore ever
+        // running. Mirrors dropV1Session.
+        console.error('WC v1 Client: Failed to load session key');
+        await deleteV1Session(topic);
+        return null;
+      }
+
+      const hasInlineKey =
+        persisted.key !== undefined &&
+        persisted.key !== null &&
+        persisted.key !== '';
+      const seedableKey = isValidV1SessionKey(persisted.key)
+        ? persisted.key
+        : null;
+      let secureKeyConfirmed = sessionKey !== null;
+
+      if (!sessionKey && seedableKey) {
+        try {
+          await writeSessionKey(topic, seedableKey);
+          secureKeyConfirmed = true;
+        } catch {
+          // ACCEPTED RESIDUAL (same trade-off as the failed row-rewrite below):
+          // secure storage is unavailable, so the inline key is the ONLY copy
+          // left and it stays at rest in AsyncStorage until a later attempt
+          // succeeds. The alternative is deleting the row, which would destroy
+          // a perfectly working session because secure storage hiccupped —
+          // strictly worse, and no better than the pre-migration status quo,
+          // where the key lived there anyway.
+          console.error('WC v1 Client: Failed to secure session key');
+        }
+        sessionKey = seedableKey;
+      }
+
+      if (!sessionKey) {
+        // Parsable but unusable: no secure key and no seedable inline key. This
+        // also catches valid JSON of the WRONG SHAPE (a bare string, an array),
+        // which slips past the parse guard above while potentially still
+        // containing key-shaped text. Restore drops such rows via
+        // dropV1Session; do the same here so the two paths stay symmetric and
+        // nothing is left at rest.
+        console.warn('WC v1 Client: Deleting unusable session entry');
+        await deleteV1Session(topic);
+        return null;
+      }
+
+      // Same rule as boot restore: drain whenever the row still carries a key
+      // AND the secure copy is confirmed — never strip the only copy.
+      if (hasInlineKey && secureKeyConfirmed) {
+        try {
+          const { key: _dropped, ...keyless } = persisted;
+          await AsyncStorage.setItem(storageKey, JSON.stringify(keyless));
+        } catch {
+          console.error('WC v1 Client: Failed to strip inline session key');
+        }
+      }
+
+      return { ...persisted, key: sessionKey };
+    } catch {
       console.error('WC v1 Client: Failed to load session');
       return null;
     }
@@ -601,7 +769,10 @@ export class WalletConnectV1Client extends EventEmitter {
   /**
    * Remove stale v1 sessions from storage to ensure we only track the active one
    */
-  private async removeStaleSessions(activeKey: string): Promise<void> {
+  private async removeStaleSessions(
+    activeKey: string,
+    activeTopic: string
+  ): Promise<void> {
     try {
       const allKeys = await AsyncStorage.getAllKeys();
       const staleKeys = allKeys.filter(
@@ -609,9 +780,29 @@ export class WalletConnectV1Client extends EventEmitter {
       );
 
       if (staleKeys.length > 0) {
-        await AsyncStorage.multiRemove(staleKeys);
+        // Central cleanup so pruned rows take their queued requests with them.
+        // dropSlot is FALSE — the ACTIVE session survives and owns the slot.
+        await deleteV1Sessions(staleKeys, { dropSlot: false });
       }
-    } catch (error) {
+
+      // The secure slot holds exactly one key. If it is bound to a topic we
+      // just pruned — i.e. anything other than the surviving active topic — it
+      // is now an orphan and must go too, or it would linger in a store that
+      // cannot be enumerated. Topic-conditional, so the ACTIVE key is never the
+      // one deleted.
+      const slot = await readSessionKeySlotRaw().catch(() => null);
+      if (slot) {
+        try {
+          const bound = JSON.parse(slot) as { topic?: unknown };
+          if (typeof bound.topic === 'string' && bound.topic !== activeTopic) {
+            await deleteSessionKeyForTopic(bound.topic);
+          }
+        } catch {
+          // Unparseable slot is useless to anyone; drop it.
+          await deleteSessionKeySlot();
+        }
+      }
+    } catch {
       console.error('WC v1 Client: Failed to remove stale sessions');
     }
   }

--- a/src/services/walletconnect/v1/client.ts
+++ b/src/services/walletconnect/v1/client.ts
@@ -35,6 +35,8 @@ import {
   DEFAULT_CHAIN_ID,
   WC_V1_SESSION_STORAGE_KEY,
 } from './config';
+import { redactError } from '@/utils/logRedaction';
+import { describePeerMethod } from './peerLabels';
 
 export class WalletConnectV1Client extends EventEmitter {
   private static instance: WalletConnectV1Client | null = null;
@@ -58,12 +60,11 @@ export class WalletConnectV1Client extends EventEmitter {
   async connect(config: WalletConnectV1SessionConfig): Promise<void> {
     try {
       if (this.sessionData?.connected) {
+        // `peerId` and `topic` are both peer/URI supplied — the topic arrives
+        // straight from a scanned QR or deep link and is never validated — so
+        // neither is echoed at all. The message alone carries the diagnostic.
         console.warn(
-          'WC v1 Client: Replacing active session with new connection request',
-          {
-            existingSession: this.sessionData.peerId,
-            newTopic: config.topic,
-          }
+          'WC v1 Client: Replacing active session with new connection request'
         );
         // Disconnect the old session's WebSocket
         if (this.socket) {
@@ -97,7 +98,7 @@ export class WalletConnectV1Client extends EventEmitter {
       });
 
       this.socket.onError((error) => {
-        console.error('WC v1 Client: WebSocket error', error);
+        console.error('WC v1 Client: WebSocket error', redactError(error));
         // Only emit error if we don't have an active session
         // Reconnection errors during active sessions are handled internally
         if (!this.sessionData?.connected) {
@@ -143,14 +144,17 @@ export class WalletConnectV1Client extends EventEmitter {
             storedSession.chainId
           );
         } catch (error) {
-          console.error('WC v1 Client: Failed to send session update', error);
+          console.error(
+            'WC v1 Client: Failed to send session update',
+            redactError(error)
+          );
         }
       } else {
         // Fresh connection: subscribe to handshake topic
         await this.socket.subscribeToTopic(config.topic);
       }
     } catch (error) {
-      console.error('WC v1 Client: Connection failed', error);
+      console.error('WC v1 Client: Connection failed');
       this.emit(WalletConnectV1Event.ERROR, error);
       throw error;
     }
@@ -218,7 +222,10 @@ export class WalletConnectV1Client extends EventEmitter {
       // Store session
       await this.storeSession();
     } catch (error) {
-      console.error('WC v1 Client: Failed to approve session', error);
+      console.error(
+        'WC v1 Client: Failed to approve session',
+        redactError(error)
+      );
       throw error;
     }
   }
@@ -252,7 +259,10 @@ export class WalletConnectV1Client extends EventEmitter {
       // Disconnect
       await this.disconnect();
     } catch (error) {
-      console.error('WC v1 Client: Failed to reject session', error);
+      console.error(
+        'WC v1 Client: Failed to reject session',
+        redactError(error)
+      );
       throw error;
     }
   }
@@ -290,7 +300,10 @@ export class WalletConnectV1Client extends EventEmitter {
       // Store updated session
       await this.storeSession();
     } catch (error) {
-      console.error('WC v1 Client: Failed to update session', error);
+      console.error(
+        'WC v1 Client: Failed to update session',
+        redactError(error)
+      );
       throw error;
     }
   }
@@ -322,7 +335,10 @@ export class WalletConnectV1Client extends EventEmitter {
       const responseTopic = this.sessionData.peerId || this.config.topic;
       this.socket.publishToTopic(responseTopic, encryptedResponse);
     } catch (error) {
-      console.error('WC v1 Client: Failed to approve request', error);
+      console.error(
+        'WC v1 Client: Failed to approve request',
+        redactError(error)
+      );
       throw error;
     }
   }
@@ -351,7 +367,10 @@ export class WalletConnectV1Client extends EventEmitter {
       const responseTopic = this.sessionData?.peerId || this.config.topic;
       this.socket.publishToTopic(responseTopic, encryptedResponse);
     } catch (error) {
-      console.error('WC v1 Client: Failed to reject request', error);
+      console.error(
+        'WC v1 Client: Failed to reject request',
+        redactError(error)
+      );
       throw error;
     }
   }
@@ -429,7 +448,17 @@ export class WalletConnectV1Client extends EventEmitter {
       } else if (isAlgoSignTxnRequest(request)) {
         await this.handleSignTxnRequest(request);
       } else {
-        console.warn('WC v1 Client: Unsupported method', request.method);
+        // `request.method` is arbitrary peer-controlled text. Pattern
+        // redaction is NOT enough here: a peer can set `method` to the bare
+        // session key, and bare hex is deliberately preserved by the redactor
+        // (genesis hashes / txids). Truncation would not help either — a
+        // truncated key is still leaked key material. So the value is only ever
+        // echoed when it matches a KNOWN method name; anything else is reported
+        // by length alone, which is all the diagnostics actually need.
+        console.warn(
+          'WC v1 Client: Unsupported method',
+          describePeerMethod(request.method)
+        );
         // Send error response for unsupported methods
         await this.rejectRequest(
           request.id,
@@ -437,7 +466,10 @@ export class WalletConnectV1Client extends EventEmitter {
         );
       }
     } catch (error) {
-      console.error('WC v1 Client: Failed to handle message', error);
+      console.error(
+        'WC v1 Client: Failed to handle message',
+        redactError(error)
+      );
       this.emit(WalletConnectV1Event.ERROR, error);
     }
   }
@@ -526,7 +558,7 @@ export class WalletConnectV1Client extends EventEmitter {
       await AsyncStorage.setItem(key, JSON.stringify(storedSession));
       await this.removeStaleSessions(key);
     } catch (error) {
-      console.error('WC v1 Client: Failed to store session', error);
+      console.error('WC v1 Client: Failed to store session');
     }
   }
 
@@ -542,7 +574,7 @@ export class WalletConnectV1Client extends EventEmitter {
       const key = `${WC_V1_SESSION_STORAGE_KEY}:${this.config.topic}`;
       await AsyncStorage.removeItem(key);
     } catch (error) {
-      console.error('WC v1 Client: Failed to clear session', error);
+      console.error('WC v1 Client: Failed to clear session');
     }
   }
 
@@ -561,7 +593,7 @@ export class WalletConnectV1Client extends EventEmitter {
       const sessionData = JSON.parse(stored) as WalletConnectV1StoredSession;
       return sessionData;
     } catch (error) {
-      console.error('WC v1 Client: Failed to load session', error);
+      console.error('WC v1 Client: Failed to load session');
       return null;
     }
   }
@@ -580,7 +612,7 @@ export class WalletConnectV1Client extends EventEmitter {
         await AsyncStorage.multiRemove(staleKeys);
       }
     } catch (error) {
-      console.error('WC v1 Client: Failed to remove stale sessions', error);
+      console.error('WC v1 Client: Failed to remove stale sessions');
     }
   }
 }

--- a/src/services/walletconnect/v1/config.ts
+++ b/src/services/walletconnect/v1/config.ts
@@ -99,9 +99,22 @@ export function resolveV1Chain(
 export const WALLETCONNECT_V1_VERSION = '1';
 
 /**
- * Session storage key
+ * Session storage key — AsyncStorage prefix for the per-topic session ROUTING
+ * metadata (bridge, accounts, chainId, peer info). Never key material: the
+ * symmetric session key lives in secure storage under WC_V1_SESSION_KEY_SLOT.
  */
 export const WC_V1_SESSION_STORAGE_KEY = '@voiwallet:wc_v1_sessions';
+
+/**
+ * Secure-storage slot holding the v1 symmetric session key (PLAN-260, DR-3).
+ *
+ * A single CONSTANT name, with the owning topic bound into the stored value
+ * rather than into this key. The v1 topic is attacker-controlled and SecureStore
+ * restricts key names to alphanumerics, '.', '-' and '_', so deriving the slot
+ * name from the topic would be both a crash and a collision vector. See
+ * `sessionKeyStore.ts` for the full reasoning.
+ */
+export const WC_V1_SESSION_KEY_SLOT = 'voi_wc_v1_session_key';
 
 /**
  * WebSocket connection timeout (ms)

--- a/src/services/walletconnect/v1/crypto.ts
+++ b/src/services/walletconnect/v1/crypto.ts
@@ -186,7 +186,7 @@ export async function encryptMessage(
       iv: ivHex,
     };
   } catch (error) {
-    console.error('WC v1 Crypto: Encryption failed', error);
+    console.error('WC v1 Crypto: Encryption failed');
     throw new Error(
       `Encryption failed: ${error instanceof Error ? error.message : 'Unknown error'}`
     );
@@ -238,7 +238,7 @@ export async function decryptMessage(
     // Convert bytes back to string
     return uint8ArrayToString(decrypted);
   } catch (error) {
-    console.error('WC v1 Crypto: Decryption failed', error);
+    console.error('WC v1 Crypto: Decryption failed');
     throw new Error(
       `Decryption failed: ${error instanceof Error ? error.message : 'Unknown error'}`
     );

--- a/src/services/walletconnect/v1/peerLabels.ts
+++ b/src/services/walletconnect/v1/peerLabels.ts
@@ -1,0 +1,60 @@
+/**
+ * Safe log labels for peer-controlled WalletConnect v1 values (TASK-263).
+ *
+ * WHY THIS EXISTS, and why the shared redactor is not enough:
+ *
+ * `redactSensitiveForLog` is a SECRET-PATTERN redactor. It finds known shapes
+ * (`wc:` URIs, `symKey=`, `key=<hex>`, URLs, addresses) and removes them. It
+ * deliberately does NOT redact a bare 64-hex run, because genesis hashes and
+ * transaction IDs share that shape and blanket-redacting them would gut
+ * diagnosability across the app.
+ *
+ * That makes it the wrong tool for ARBITRARY peer text. A connected dApp shares
+ * the v1 session key, so it can place that key — bare, with no `key=` prefix —
+ * into any free-text field it controls (a JSON-RPC `method`, a socket topic) and
+ * have the wallet log it verbatim. Truncation does not fix this either: a
+ * truncated key is still leaked key material.
+ *
+ * So peer free-text is DESCRIBED, never reproduced.
+ *
+ * Lives in its own module rather than inside `client.ts` so it can be unit
+ * tested without pulling in AsyncStorage and the whole client.
+ */
+
+/**
+ * JSON-RPC method names this client recognises. Used ONLY to decide whether a
+ * peer-supplied method name is safe to echo into a log — never for dispatch.
+ *
+ * Includes methods the wallet does NOT implement (personal_sign, eth_*) on
+ * purpose: those are real names a confused dApp might send, and seeing the
+ * actual name is exactly the diagnostic an operator wants. They are safe to
+ * echo precisely because they are a fixed, known set.
+ */
+const KNOWN_V1_METHODS = new Set([
+  'wc_sessionRequest',
+  'wc_sessionUpdate',
+  'algo_signTxn',
+  'algo_signBytes',
+  'personal_sign',
+  'eth_sendTransaction',
+  'eth_sign',
+]);
+
+/**
+ * Describe a peer-supplied JSON-RPC method for logging without echoing
+ * arbitrary peer bytes.
+ *
+ * A known name is returned verbatim — that is the useful case and it carries no
+ * peer-chosen content. Anything else is reported by LENGTH ONLY, so a peer that
+ * sets `method` to the session key leaks nothing, while an operator still learns
+ * that something non-standard arrived and roughly how big it was.
+ */
+export function describePeerMethod(method: unknown): string {
+  if (typeof method !== 'string') {
+    return `[non-string method: ${typeof method}]`;
+  }
+  if (KNOWN_V1_METHODS.has(method)) {
+    return method;
+  }
+  return `[unrecognized method, ${method.length} chars]`;
+}

--- a/src/services/walletconnect/v1/protocol.ts
+++ b/src/services/walletconnect/v1/protocol.ts
@@ -33,7 +33,7 @@ export function parseEncryptedPayload(
       hmac: payload.hmac,
       iv: payload.iv,
     };
-  } catch (error) {
+  } catch {
     console.error('WC v1 Protocol: Failed to parse encrypted payload');
     return null;
   }
@@ -74,7 +74,7 @@ export async function decryptRequest(
     }
 
     return request;
-  } catch (error) {
+  } catch {
     // Decryption operates directly on the session key, so no error text is
     // reflected here at all (DR-13) — a raw message is not provably key-free.
     // The payload lengths are our own measurements, not peer bytes, and are what

--- a/src/services/walletconnect/v1/protocol.ts
+++ b/src/services/walletconnect/v1/protocol.ts
@@ -34,7 +34,7 @@ export function parseEncryptedPayload(
       iv: payload.iv,
     };
   } catch (error) {
-    console.error('WC v1 Protocol: Failed to parse encrypted payload', error);
+    console.error('WC v1 Protocol: Failed to parse encrypted payload');
     return null;
   }
 }
@@ -58,20 +58,28 @@ export async function decryptRequest(
         return null;
       }
 
+      // SECURITY (PLAN-260 / TASK-263): this used to echo the first 200 chars of
+      // `decrypted`. That content is entirely PEER-CONTROLLED, and the connected
+      // dApp shares the session key — so it could place the key (or anything
+      // else) into device logs and crash reports simply by sending a malformed
+      // request. `actualFields` is dropped for the same reason: object KEYS are
+      // peer-chosen strings too. The boolean shape flags carry the diagnostic
+      // value without reflecting any peer bytes.
       console.error('WC v1 Protocol: Invalid JSON-RPC request structure', {
-        decryptedMessage: decrypted.substring(0, 200), // First 200 chars
         hasId: !!request.id,
         hasJsonrpc: !!request.jsonrpc,
         hasMethod: !!request.method,
-        actualFields: Object.keys(request),
       });
       return null;
     }
 
     return request;
   } catch (error) {
+    // Decryption operates directly on the session key, so no error text is
+    // reflected here at all (DR-13) — a raw message is not provably key-free.
+    // The payload lengths are our own measurements, not peer bytes, and are what
+    // actually distinguish a truncated payload from a wrong-key HMAC failure.
     console.error('WC v1 Protocol: Failed to decrypt request', {
-      error: error instanceof Error ? error.message : String(error),
       payloadDataLength: encryptedPayload.data.length,
       payloadHmacLength: encryptedPayload.hmac.length,
       payloadIvLength: encryptedPayload.iv.length,
@@ -92,7 +100,7 @@ export async function encryptResponse(
     const encrypted = await encryptMessage(responseJson, key);
     return JSON.stringify(encrypted);
   } catch (error) {
-    console.error('WC v1 Protocol: Failed to encrypt response', error);
+    console.error('WC v1 Protocol: Failed to encrypt response');
     throw error;
   }
 }

--- a/src/services/walletconnect/v1/sessionCleanup.ts
+++ b/src/services/walletconnect/v1/sessionCleanup.ts
@@ -1,0 +1,90 @@
+/**
+ * The ONE way to delete WalletConnect v1 session state (PLAN-260).
+ *
+ * WHY THIS MODULE EXISTS: a v1 session is spread across three stores — routing
+ * metadata in AsyncStorage, the symmetric key in secure storage, and pending
+ * requests in the TransactionRequestQueue. Deleting one without the others
+ * leaves a specific, known failure:
+ *
+ *   - metadata without the queue -> startup dequeues a request for a topic that
+ *     no longer exists, navigates it into a screen with no live session, errors,
+ *     and LOSES the request (dequeuing already removed it). This is DR-14.
+ *   - metadata without the key -> an orphan in a store that cannot be
+ *     enumerated, lingering until some future pairing happens to overwrite it.
+ *
+ * Review of this work found the same omission at four separate deletion sites in
+ * a row, each fixed individually. That is a design smell, not four bugs: the
+ * cleanup was scattered, so every new deletion path started out wrong by
+ * default. Routing every deletion through here makes the complete cleanup the
+ * path of least resistance instead of something each call site must remember.
+ *
+ * Any new code that removes a v1 session MUST go through this module.
+ */
+
+import AsyncStorage from '@react-native-async-storage/async-storage';
+import { TransactionRequestQueue } from '@/services/walletconnect/TransactionRequestQueue';
+import { WC_V1_SESSION_STORAGE_KEY } from './config';
+import {
+  deleteSessionKeyForTopic,
+  deleteSessionKeySlot,
+} from './sessionKeyStore';
+
+/** Recover the topic from an AsyncStorage row key. */
+export function topicFromStorageKey(storageKey: string): string {
+  return storageKey.replace(`${WC_V1_SESSION_STORAGE_KEY}:`, '');
+}
+
+/**
+ * Delete one v1 session completely: its metadata row, its queued requests, and
+ * — only if the secure slot is actually bound to it — its key.
+ *
+ * The key deletion is TOPIC-CONDITIONAL because a session being deleted here may
+ * not be the one the single slot belongs to. `connect()` retains the previous
+ * session's storage while `config` already points at the new topic, so an
+ * unconditional delete would destroy a RETAINED session's key.
+ */
+export async function deleteV1Session(topic: string): Promise<void> {
+  await AsyncStorage.removeItem(`${WC_V1_SESSION_STORAGE_KEY}:${topic}`).catch(
+    () => {}
+  );
+  await deleteSessionKeyForTopic(topic).catch(() => {});
+  await TransactionRequestQueue.removeByTopic(topic).catch(() => 0);
+}
+
+/**
+ * Delete MANY v1 sessions at once, for wipes that intentionally discard every
+ * session (boot-restore give-up, the extension-mode startup purge, stale-row
+ * pruning).
+ *
+ * Here the slot delete is UNCONDITIONAL when `dropSlot` is set: no session
+ * survives, so there is no key worth protecting, and a topic-conditional delete
+ * would strand the slot whenever it happened to be bound to one of the other
+ * rows being removed.
+ *
+ * Returns the number of queued requests dropped, for logging.
+ */
+export async function deleteV1Sessions(
+  storageKeys: string[],
+  options: { dropSlot: boolean }
+): Promise<number> {
+  if (storageKeys.length === 0 && !options.dropSlot) {
+    return 0;
+  }
+
+  if (storageKeys.length > 0) {
+    await AsyncStorage.multiRemove(storageKeys).catch(() => {});
+  }
+
+  if (options.dropSlot) {
+    await deleteSessionKeySlot().catch(() => {});
+  }
+
+  const topics = new Set(storageKeys.map(topicFromStorageKey));
+  let dropped = 0;
+  for (const topic of topics) {
+    dropped += await TransactionRequestQueue.removeByTopic(topic).catch(
+      () => 0
+    );
+  }
+  return dropped;
+}

--- a/src/services/walletconnect/v1/sessionKeyStore.ts
+++ b/src/services/walletconnect/v1/sessionKeyStore.ts
@@ -1,0 +1,216 @@
+/**
+ * WalletConnect v1 session-key store (PLAN-260, TASK-261)
+ *
+ * The v1 symmetric session key encrypts the bridge channel: anyone who reads it
+ * can decrypt and forge traffic on that session, including the `algo_signTxn`
+ * requests presented to the user for approval. `CLAUDE.md` is unambiguous that
+ * key material belongs in `expo-secure-store`, never `AsyncStorage`, so the key
+ * lives here while the session's ROUTING metadata (bridge, topic, accounts,
+ * chainId, peer info) stays in AsyncStorage under `WC_V1_SESSION_STORAGE_KEY`.
+ *
+ * DR-2 — why the split rather than moving the whole session blob: the platform
+ * `SecureStorageAdapter` (`src/platform/types.ts`) exposes only setItem/getItem/
+ * deleteItem, with NO enumeration and NO multi-delete, while boot restore is
+ * built on `AsyncStorage.getAllKeys()` + prefix filter + freshest-wins. Moving
+ * the blob would require inventing a separate index — strictly more state to
+ * desync.
+ *
+ * DR-3 — why ONE constant slot with the topic bound INTO the value, rather than
+ * a per-topic slot name: the v1 topic is ATTACKER-CONTROLLED and unvalidated
+ * (`parseWalletConnectV1Uri` takes whatever sits between `wc:` and `@` in a
+ * scanned QR / deeplink URI), while SecureStore restricts key names to
+ * alphanumerics, '.', '-' and '_'. A topic-derived slot name would therefore be
+ * both a crash vector (`Invalid key`) and a collision vector (a topic embedding
+ * the delimiter). A constant name removes attacker input from the key namespace
+ * entirely, makes cleanup a single deleteItem against a store that cannot be
+ * enumerated, and makes a stale key self-overwriting instead of accumulating.
+ * Binding the topic into the VALUE is what keeps a stale slot detectable.
+ *
+ * The v1 client is a singleton that already enforces exactly one live session
+ * (`connect` replaces an active session; `removeStaleSessions` keeps only the
+ * active metadata row), so one slot is sufficient for the real model.
+ *
+ * SECURITY: every log site in this module emits a FIXED message. No key, no
+ * topic, and no raw error value is ever logged (DR-13) — a raw error message is
+ * not provably key-free, so none are passed through.
+ */
+
+import { secureStorage } from '@/platform';
+import { WC_V1_SESSION_KEY_SLOT } from './config';
+
+/**
+ * The shape persisted into the single secure slot. `topic` binds the key to the
+ * session it belongs to so a stale slot is detectable (DR-3) — and so a crash
+ * between the secure write and the metadata write cannot silently hand the
+ * wrong key to a different session (DR-5).
+ */
+interface StoredSessionKeyRecord {
+  topic: string;
+  key: string;
+}
+
+/**
+ * A WalletConnect v1 session key is a 32-byte AES key transported as hex.
+ *
+ * Worth validating rather than trusting: `hexToUint8Array` in `crypto.ts`
+ * converts without checking, so a non-hex character silently becomes a 0 byte
+ * and a short string silently yields a short key — both of which would "work"
+ * right up until traffic failed to decrypt for reasons nothing explains. URI
+ * parsing only requires the key to be truthy (DR-10).
+ *
+ * This is NOT the topic-format validation declined in DR-6: a non-hex key could
+ * never have worked for AES, so rejecting it cannot break real interop.
+ */
+export function isValidV1SessionKey(value: unknown): value is string {
+  return typeof value === 'string' && /^[0-9a-fA-F]{64}$/.test(value);
+}
+
+/**
+ * Parse and validate the persisted envelope. Anything malformed — not JSON, not
+ * an object, missing/blank topic, invalid key — resolves to `null` and is
+ * treated by callers as "no key", which fails closed into the ordinary
+ * drop-the-session-and-reconnect path (DR-10).
+ */
+function parseRecord(raw: string | null): StoredSessionKeyRecord | null {
+  if (!raw) {
+    return null;
+  }
+
+  try {
+    const parsed: unknown = JSON.parse(raw);
+    if (typeof parsed !== 'object' || parsed === null) {
+      return null;
+    }
+
+    const { topic, key } = parsed as Partial<StoredSessionKeyRecord>;
+    if (typeof topic !== 'string' || topic.length === 0) {
+      return null;
+    }
+    if (!isValidV1SessionKey(key)) {
+      return null;
+    }
+
+    return { topic, key };
+  } catch {
+    // Fixed message only — the parse error can quote the malformed payload,
+    // which is exactly the value we must never log.
+    console.warn('WC v1 SessionKeyStore: discarding malformed stored record');
+    return null;
+  }
+}
+
+/**
+ * Read the RAW slot contents, for rollback capture only (DR-5a).
+ *
+ * NOTE: this deliberately does NOT catch. On Android the secure-storage adapter
+ * THROWS when its presence sentinel says an item exists but the native read
+ * returns null (keystore desync), and that distinction is the whole point of
+ * the fail-closed guard — callers decide what a read failure means. For v1 the
+ * answer is "drop the session and force a reconnect" (DR-4), but that is the
+ * caller's call to make, not this module's.
+ */
+export async function readSessionKeySlotRaw(): Promise<string | null> {
+  return await secureStorage.getItem(WC_V1_SESSION_KEY_SLOT);
+}
+
+/**
+ * Read the session key bound to `topic`.
+ *
+ * Returns `null` when the slot is empty, malformed, or bound to a DIFFERENT
+ * topic. A topic mismatch is not an error condition — it is the expected state
+ * after a crash between the two writes, or when a newer pairing has taken the
+ * slot — and it must fail closed rather than hand back a key for the wrong
+ * session.
+ *
+ * May THROW on an Android keystore desync; see `readSessionKeySlotRaw`.
+ */
+export async function readSessionKey(topic: string): Promise<string | null> {
+  const record = parseRecord(await readSessionKeySlotRaw());
+  if (!record || record.topic !== topic) {
+    return null;
+  }
+  return record.key;
+}
+
+/**
+ * Bind `key` to `topic` and write it to the slot.
+ *
+ * Rejects an invalid key rather than persisting garbage that would only fail
+ * later at decrypt time, where the cause would be unrecoverable from the logs.
+ */
+export async function writeSessionKey(
+  topic: string,
+  key: string
+): Promise<void> {
+  if (!topic) {
+    throw new Error('WC v1 session key: refusing to store without a topic');
+  }
+  if (!isValidV1SessionKey(key)) {
+    throw new Error('WC v1 session key: refusing to store a malformed key');
+  }
+
+  const record: StoredSessionKeyRecord = { topic, key };
+  await secureStorage.setItem(WC_V1_SESSION_KEY_SLOT, JSON.stringify(record));
+}
+
+/**
+ * Restore a previously captured raw slot value, or clear the slot when there
+ * was nothing there before (DR-5a).
+ *
+ * Used to roll back a successful secure write whose paired AsyncStorage
+ * metadata write then failed. Without this, storing session B while session A
+ * is persisted would leave the slot holding B and A's metadata orphaned — and
+ * A's topic check would then make A permanently unrestorable, which is STRICTLY
+ * WORSE than today, where A survives that failure with its inline key.
+ */
+export async function restoreSessionKeySlot(
+  priorRaw: string | null
+): Promise<void> {
+  if (priorRaw === null) {
+    await secureStorage.deleteItem(WC_V1_SESSION_KEY_SLOT);
+    return;
+  }
+  await secureStorage.setItem(WC_V1_SESSION_KEY_SLOT, priorRaw);
+}
+
+/**
+ * Delete the slot ONLY if it is bound to `topic` (DR-3a).
+ *
+ * A blind delete here is a live data-loss bug, not a theoretical one: `connect`
+ * deliberately RETAINS the previous session's persisted storage when replacing
+ * an active connection, but by that point `this.config` already points at the
+ * NEW topic. So pairing session B while session A is stored and then rejecting
+ * B (rejectSession -> disconnect -> clearSession) would delete the single slot
+ * and destroy A's key while A's metadata survives.
+ *
+ * An unreadable slot (Android keystore desync) is deleted unconditionally: it
+ * cannot be compared, and it cannot be used by anyone either, so clearing the
+ * desynced entry is both safe and desirable.
+ */
+export async function deleteSessionKeyForTopic(topic: string): Promise<void> {
+  let raw: string | null;
+  try {
+    raw = await readSessionKeySlotRaw();
+  } catch {
+    await deleteSessionKeySlot();
+    return;
+  }
+
+  const record = parseRecord(raw);
+  if (record && record.topic !== topic) {
+    // Belongs to a different session — leave it alone.
+    return;
+  }
+
+  // Bound to this topic, or unparseable and therefore useless: clear it.
+  await deleteSessionKeySlot();
+}
+
+/**
+ * Unconditionally clear the slot. For wipes that intentionally drop EVERY v1
+ * session (e.g. the extension-mode startup purge), where there is no surviving
+ * session whose key could be destroyed.
+ */
+export async function deleteSessionKeySlot(): Promise<void> {
+  await secureStorage.deleteItem(WC_V1_SESSION_KEY_SLOT);
+}

--- a/src/services/walletconnect/v1/types.ts
+++ b/src/services/walletconnect/v1/types.ts
@@ -160,6 +160,40 @@ export interface WalletConnectV1StoredSession {
 }
 
 /**
+ * What actually gets persisted to AsyncStorage as of PLAN-260 (DR-11).
+ *
+ * This type CANNOT express `key` — that is the point. The symmetric session key
+ * lives in secure storage (`sessionKeyStore.ts`); everything here is routing
+ * metadata and is safe in AsyncStorage. Making it a type rather than a
+ * convention is what stops a future `JSON.stringify(session)` from silently
+ * reintroducing the secret, since nothing would catch that at review time.
+ *
+ * Distinct from the in-memory `WalletConnectV1SessionData` above, which
+ * legitimately holds `key` as runtime state.
+ */
+export interface WalletConnectV1PersistedSession {
+  connected: boolean;
+  accounts: string[];
+  chainId: number;
+  bridge: string;
+  clientId: string;
+  clientMeta: WalletConnectV1PeerMeta | null;
+  peerId: string;
+  peerMeta: WalletConnectV1PeerMeta | null;
+  handshakeId: number;
+  handshakeTopic: string;
+  updatedAt?: number;
+}
+
+/**
+ * Rows written BEFORE PLAN-260 carried the session key inline. This shape exists
+ * solely so the migration reader can recognise and drain them; nothing should
+ * ever WRITE it. `key` is optional because a row may already have been migrated.
+ */
+export type WalletConnectV1LegacyPersistedSession =
+  WalletConnectV1PersistedSession & { key?: string };
+
+/**
  * Event types emitted by WalletConnect v1 client
  */
 export enum WalletConnectV1Event {

--- a/src/services/walletconnect/v1/types.ts
+++ b/src/services/walletconnect/v1/types.ts
@@ -194,6 +194,49 @@ export type WalletConnectV1LegacyPersistedSession =
   WalletConnectV1PersistedSession & { key?: string };
 
 /**
+ * Does a persisted row carry EVERY field a reconnect needs (PLAN-260)?
+ *
+ * Lives beside the type, and is shared by both restore paths, because a
+ * validator that only one caller knows about is how the gap it guards gets
+ * reintroduced — the same scattering problem `sessionCleanup.ts` exists to fix.
+ *
+ * Partial validation is not enough. A row carrying only `bridge`,
+ * `handshakeTopic`, `accounts` and `chainId` passes a shallow check, wins the
+ * freshest-wins selection, and is then restored with an undefined `clientId`
+ * onto a dead handshake topic — an unusable session that looks live, which is
+ * worse than deleting it and asking the user to re-pair.
+ *
+ * `key` is deliberately NOT checked here: it no longer lives on the row.
+ *
+ * `connected` is checked for TYPE but not required to be `true`. The restore
+ * path deliberately falls back to unconnected rows when no connected candidate
+ * exists (`if (candidates.length === 0) candidates = sessions`), and that
+ * selection semantic predates PLAN-260. Whether an unconnected row can actually
+ * reconnect is a v1 lifecycle question, not a key-storage one — see TASK-264.
+ */
+export function isRestorableV1Session(
+  candidate: WalletConnectV1LegacyPersistedSession | null | undefined
+): boolean {
+  if (!candidate || typeof candidate !== 'object') {
+    return false;
+  }
+  return (
+    typeof candidate.connected === 'boolean' &&
+    Array.isArray(candidate.accounts) &&
+    typeof candidate.chainId === 'number' &&
+    typeof candidate.bridge === 'string' &&
+    candidate.bridge.length > 0 &&
+    typeof candidate.clientId === 'string' &&
+    candidate.clientId.length > 0 &&
+    typeof candidate.peerId === 'string' &&
+    candidate.peerId.length > 0 &&
+    typeof candidate.handshakeId === 'number' &&
+    typeof candidate.handshakeTopic === 'string' &&
+    candidate.handshakeTopic.length > 0
+  );
+}
+
+/**
  * Event types emitted by WalletConnect v1 client
  */
 export enum WalletConnectV1Event {

--- a/src/services/walletconnect/v1/types.ts
+++ b/src/services/walletconnect/v1/types.ts
@@ -144,21 +144,6 @@ export interface WalletConnectV1SocketMessage {
 /**
  * Session storage structure
  */
-export interface WalletConnectV1StoredSession {
-  connected: boolean;
-  accounts: string[];
-  chainId: number;
-  bridge: string;
-  key: string;
-  clientId: string;
-  clientMeta: WalletConnectV1PeerMeta | null;
-  peerId: string;
-  peerMeta: WalletConnectV1PeerMeta | null;
-  handshakeId: number;
-  handshakeTopic: string;
-  updatedAt?: number;
-}
-
 /**
  * What actually gets persisted to AsyncStorage as of PLAN-260 (DR-11).
  *

--- a/src/services/walletconnect/v1/websocket.ts
+++ b/src/services/walletconnect/v1/websocket.ts
@@ -12,6 +12,7 @@ import {
   WS_RECONNECT_DELAY,
   WS_MAX_RECONNECT_ATTEMPTS,
 } from './config';
+import { redactError } from '@/utils/logRedaction';
 
 export type WebSocketMessageHandler = (payload: string) => void;
 export type WebSocketErrorHandler = (error: Error) => void;
@@ -107,7 +108,7 @@ export class WalletConnectV1WebSocket {
 
           console.error(
             'WC v1 WebSocket: Error establishing connection',
-            error
+            redactError(error)
           );
           this.errorHandler?.(errorObj);
           reject(errorObj);
@@ -129,7 +130,10 @@ export class WalletConnectV1WebSocket {
           }
         };
       } catch (error) {
-        console.error('WC v1 WebSocket: Failed to create socket', error);
+        console.error(
+          'WC v1 WebSocket: Failed to create socket',
+          redactError(error)
+        );
         reject(error);
       }
     });
@@ -312,11 +316,20 @@ export class WalletConnectV1WebSocket {
         if (handler) {
           handler(message.payload);
         } else {
-          console.warn('WC v1 WebSocket: No handler for topic', message.topic);
+          // `message.topic` is peer-supplied and must not be echoed (a peer
+          // can put anything there, including a session key). The number of
+          // registered handlers is the part that actually diagnoses this —
+          // zero means we never subscribed, non-zero means a topic mismatch.
+          console.warn('WC v1 WebSocket: No handler for topic', {
+            registeredHandlers: this.messageHandlers.size,
+          });
         }
       }
     } catch (error) {
-      console.error('WC v1 WebSocket: Failed to parse message', error);
+      console.error(
+        'WC v1 WebSocket: Failed to parse message',
+        redactError(error)
+      );
       this.errorHandler?.(
         error instanceof Error ? error : new Error('Failed to parse message')
       );
@@ -343,7 +356,10 @@ export class WalletConnectV1WebSocket {
 
     this.reconnectTimeout = setTimeout(() => {
       this.connect().catch((error) => {
-        console.error('WC v1 WebSocket: Reconnection failed', error);
+        console.error(
+          'WC v1 WebSocket: Reconnection failed',
+          redactError(error)
+        );
       });
     }, WS_RECONNECT_DELAY * this.reconnectAttempts);
   }

--- a/src/utils/__tests__/logRedaction.test.ts
+++ b/src/utils/__tests__/logRedaction.test.ts
@@ -1,0 +1,110 @@
+// Unit tests for the shared log redactor (PLAN-260, TASK-263).
+//
+// This is a pure util on the crypto-adjacent surface, so it carries its own
+// tests per the project's pure-util rule. The v1 `key=` rule is the one added by
+// PLAN-260; the rest are hoisted behavior that must not regress.
+
+import { redactSensitiveForLog, redactError } from '../logRedaction';
+
+// Throwaway vectors — not real keys or accounts.
+const V1_KEY = 'a1b2c3d4'.repeat(8); // 64 hex chars
+const SYM_KEY = 'f'.repeat(64);
+const ADDRESS = 'A'.repeat(58);
+
+describe('WalletConnect v1 session key (`key=`)', () => {
+  it('redacts a bare key= token carrying a long hex run', () => {
+    const out = redactSensitiveForLog(`bridge failed for key=${V1_KEY} oops`);
+    expect(out).not.toContain(V1_KEY);
+    expect(out).toContain('key=[redacted]');
+  });
+
+  it('redacts the percent-encoded form', () => {
+    const out = redactSensitiveForLog(`params key%3D${V1_KEY}`);
+    expect(out).not.toContain(V1_KEY);
+    expect(out).toContain('key=[redacted]');
+  });
+
+  it('is case-insensitive on both token and hex', () => {
+    const upper = V1_KEY.toUpperCase();
+    const out = redactSensitiveForLog(`KEY=${upper}`);
+    expect(out).not.toContain(upper);
+  });
+
+  it('does NOT blanket-redact ordinary short key= params', () => {
+    const out = redactSensitiveForLog('api_key=abc123&sort_key=name');
+    expect(out).toContain('abc123');
+    expect(out).toContain('name');
+  });
+});
+
+describe('a v1 pairing URI is redacted whole', () => {
+  it('removes the key from a wc: URI', () => {
+    const uri = `wc:topic-1@1?bridge=https%3A%2F%2Fb.example&key=${V1_KEY}`;
+    const out = redactSensitiveForLog(`failed to parse ${uri}`);
+    expect(out).not.toContain(V1_KEY);
+    expect(out).toContain('wc:[redacted]');
+  });
+
+  it('removes the symKey from a v2 wc: URI', () => {
+    const uri = `wc:topic-2@2?relay-protocol=irn&symKey=${SYM_KEY}`;
+    const out = redactSensitiveForLog(uri);
+    expect(out).not.toContain(SYM_KEY);
+  });
+
+  it('handles the percent-encoded wc%3A form', () => {
+    const out = redactSensitiveForLog(`wc%3Atopic%401%3Fkey%3D${V1_KEY}`);
+    expect(out).not.toContain(V1_KEY);
+  });
+});
+
+describe('hoisted behavior must not regress', () => {
+  it('redacts a stray symKey token outside a URI', () => {
+    const out = redactSensitiveForLog(`symKey=${SYM_KEY}`);
+    expect(out).toBe('symKey=[redacted]');
+  });
+
+  it('redacts any scheme://… URL whole', () => {
+    const out = redactSensitiveForLog('open https://example.com/a?b=c now');
+    expect(out).toContain('https://[redacted]');
+    expect(out).not.toContain('example.com');
+  });
+
+  it('redacts a full Algorand address, keeping only a short prefix', () => {
+    const out = redactSensitiveForLog(`from ${ADDRESS} to somewhere`);
+    expect(out).not.toContain(ADDRESS);
+    expect(out).toContain('AAAAAA…[redacted]');
+  });
+
+  it('redacts an address used as a pseudo-scheme', () => {
+    const out = redactSensitiveForLog(`${ADDRESS}://path`);
+    expect(out).not.toContain(ADDRESS);
+  });
+});
+
+describe('a bare 64-hex run is deliberately preserved', () => {
+  // Genesis hashes and transaction IDs are also 64 hex chars. Blanket-redacting
+  // them would gut diagnosability; the control for a bare v1 key is that the v1
+  // key-handling paths log fixed messages and never error text.
+  it('leaves an unprefixed hex run intact', () => {
+    const txid = 'c'.repeat(64);
+    expect(redactSensitiveForLog(`confirmed ${txid}`)).toContain(txid);
+  });
+});
+
+describe('redactError', () => {
+  it('redacts the message of an Error', () => {
+    const out = redactError(new Error(`connect failed key=${V1_KEY}`));
+    expect(out).not.toContain(V1_KEY);
+    expect(out).toContain('key=[redacted]');
+  });
+
+  it('stringifies and redacts a non-Error', () => {
+    expect(redactError(`key=${V1_KEY}`)).toContain('key=[redacted]');
+    expect(redactError(null)).toBe('null');
+    expect(redactError(undefined)).toBe('undefined');
+  });
+
+  it('returns a string, never the error object', () => {
+    expect(typeof redactError(new Error('boom'))).toBe('string');
+  });
+});

--- a/src/utils/logRedaction.ts
+++ b/src/utils/logRedaction.ts
@@ -1,0 +1,67 @@
+/**
+ * Shared log redaction (PLAN-260, TASK-263).
+ *
+ * Hoisted from two byte-similar copies that had drifted — one in
+ * `src/services/walletconnect/index.ts`, one in `src/services/deeplink/index.ts`
+ * — so that WalletConnect v1, v2 and the deep-link handler all redact the same
+ * way, and so a new sensitive pattern only has to be added once.
+ *
+ * Used ONLY for logged output. Thrown and user-surfaced errors keep their full
+ * value so user-facing messages are unchanged (TASK-33).
+ */
+
+/**
+ * Redact an Algorand address for logs: keep a short recognisable prefix, drop
+ * the rest.
+ *
+ * Deliberately NOT `truncateAddress` from `services/walletconnect/utils`, which
+ * renders first-4 AND last-4 for DISPLAY. Emitting the tail into a log leaks
+ * more than a log needs, and a prefix alone is enough to correlate entries. The
+ * two copies of this redactor had disagreed on exactly this point; the
+ * conservative form wins.
+ */
+const redactAddress = (address?: string): string =>
+  address && address.length > 6
+    ? `${address.slice(0, 6)}…[redacted]`
+    : '[redacted]';
+
+/**
+ * Strip sensitive values from an arbitrary log string — a caught error message
+ * OR untrusted deep-link input (scheme/host/path/query/params). Redacts, in
+ * order:
+ *  - raw and percent-encoded WalletConnect URIs (`wc:` / `wc%3A`), whose query
+ *    string carries the v2 session symKey or the v1 session key;
+ *  - any stray `symKey=` / `symKey%3D` token (raw or encoded);
+ *  - any stray `key=` / `key%3D` token followed by a long hex run — the
+ *    WalletConnect **v1** symmetric session key, which appears in a v1 pairing
+ *    URI and is the subject of PLAN-260. Bounded to >=16 hex chars so ordinary
+ *    `key=` query params (`api_key=`, `sort_key=`) are not blanket-redacted;
+ *  - any scheme://… URL — whole URI including the query string;
+ *  - full 58-char Algorand addresses, run LAST on the whole string so an address
+ *    used as a pseudo-scheme (ADDR://…) is still redacted.
+ *
+ * DELIBERATELY NOT redacted: a bare 64-hex run with no `key=` prefix. Genesis
+ * hashes and transaction IDs are also 64 hex characters, so a blanket rule would
+ * gut diagnosability across the whole app. The control for a bare key is that v1
+ * key-handling paths log FIXED MESSAGES and never error text at all — redaction
+ * here is defense in depth, not the primary defense.
+ */
+export const redactSensitiveForLog = (message: string): string =>
+  message
+    .replace(/wc:\S+/gi, 'wc:[redacted]')
+    .replace(/wc%3[Aa]\S*/g, 'wc:[redacted]')
+    .replace(/symKey(=|%3[Dd])[^&\s"']+/gi, 'symKey=[redacted]')
+    .replace(/\bkey(=|%3[Dd])[0-9a-f]{16,}/gi, 'key=[redacted]')
+    .replace(/([a-z][a-z0-9+.-]*):\/\/\S*/gi, '$1://[redacted]')
+    .replace(/[A-Z2-7]{58}/g, (addr) => redactAddress(addr));
+
+/**
+ * Convenience wrapper for the common `catch (error) { console.error(msg, error) }`
+ * pattern: derive the message string and redact it before logging.
+ *
+ * Note this returns a STRING, not the error object — passing the raw error to a
+ * console call would defeat the redaction, since the console would format the
+ * original `message` and `stack` itself.
+ */
+export const redactError = (error: unknown): string =>
+  redactSensitiveForLog(error instanceof Error ? error.message : String(error));


### PR DESCRIPTION
Implements **PLAN-260**. Moves the WalletConnect v1 symmetric session key out of `AsyncStorage` into `expo-secure-store`, migrating existing sessions on upgrade.

The v1 `key` is not a wallet private key, but it encrypts the v1 bridge channel: anyone who reads it can decrypt and forge traffic on that session, including the `algo_signTxn` requests presented to the user for approval. `CLAUDE.md` is unambiguous that key material belongs in `expo-secure-store`, never `AsyncStorage`.

## Release vehicle

**Native store release.** The change is JS-only and OTA-*capable*, but ships in a native build. **Do not push this migration as an OTA-only update into an existing runtime** — old code cannot read the secure slot, so migrated keyless metadata would meet a pre-change reader and a live v1 session would fail to reconnect. A native release starts a new runtime lineage whose embedded bundle already contains the migration, which removes that hazard.

No version/runtime bump here; the release cutter owns that.

## Tasks

- [x] **TASK-261** — secure key-slot module + keyless persisted type
- [x] **TASK-263** — log hygiene across all reachable v1 log sites
- [x] **TASK-258** — wire it through client + boot restore (the original defect)
- [x] **TASK-262** — drop the pairing URI from navigation state

## Design

One constant SecureStore slot (`voi_wc_v1_session_key`) holding `{topic, key}`, with the topic verified on read. The v1 topic is attacker-controlled and unvalidated, and SecureStore restricts key names to alphanumerics/`.`/`-`/`_`, so a topic-derived slot name would be both a crash vector and a collision vector. A constant name keeps attacker input out of the key namespace; binding the topic into the *value* is what makes a stale slot detectable.

Routing metadata stays in `AsyncStorage` because `SecureStorageAdapter` has no enumeration and boot restore is built on `getAllKeys()` + prefix filter + freshest-wins.

Every secure deletion is **topic-conditional**, except bulk wipes where no session survives. `connect()` retains the previous session's storage while `config` already points at the new topic, so pair-then-reject would otherwise destroy a retained session's key.

## Two things review changed structurally

**Cleanup was scattered.** The same omission — deleting session metadata without purging queued requests — turned up at four separate deletion sites in a row. Fixing them one at a time was treating symptoms; the real problem was that every new deletion path started out wrong by default. `v1/sessionCleanup.ts` is now the single way to delete v1 session state. Same reasoning moved `isRestorableV1Session` beside its type so both restore paths share it.

**"No key in logs" was unbounded.** `protocol.ts` echoed the first 200 characters of *peer-controlled decrypted payload* on any malformed request — the connected dApp shares the session key, so one bad request could write it into device logs and crash reports. Removed. And applying the shared redactor to peer free-text turned out not to be sanitization at all: bare 64-hex is deliberately preserved (genesis hashes, txids), so a peer setting `method` to the key would sail through. Peer free-text is now *described*, never reproduced.

## Log-site classification (all 37 under `v1/`)

| Treatment | Sites |
|---|---|
| Fixed message, no error text (key-handling paths) | `crypto.ts` encrypt/decrypt; `protocol.ts` parse/encrypt; `client.ts` connect, store/clear/load/removeStale |
| Redacted via `redactError` | `client.ts` websocket-error, session-update, approve/reject session, approve/reject request, handle-message; `websocket.ts` create-socket, parse-message, reconnection, establish-connection |
| Peer values described, not echoed | `client.ts` unsupported-method, replacing-active-session; `websocket.ts` no-handler |
| Left as-is, justified non-secret-bearing | fixed-string sites with no interpolated value (timeouts, cannot subscribe/publish, max reconnects, no config, invalid algo_signTxn, invalid payload structure, socket state) |

## Threat model

**Raises attacker cost for:** offline app-data exposure and ordinary device backups. A copied AsyncStorage database or routine backup no longer yields the session key.

**Explicit non-goals:** rooted/jailbroken devices, code injection into the app process, and an attacker on an unlocked device driving the app's own SecureStore access. The slot has no auth gate — correct for a transport key that must be readable during unattended boot restore, but this is storage hardening, not device-compromise defense.

**Accepted residual, documented in code at both sites:** if `writeSessionKey` fails outright, the inline key remains at rest until a later boot retries. Deleting the row instead would destroy a working session because secure storage hiccupped, and it is no worse than the pre-migration status quo.

## Test plan

`npm run typecheck` clean · `npm run lint` 0 errors · `npm test -- --ci` **115 suites / 1730 tests green**.

79 new tests, including the migrate-then-rewrite sequence, existing-session reconnect, per-storage-operation fault injection, the pair-then-reject regression, keystore desync, corrupt/incomplete/wrong-shape row handling, queue purge, and console-leak assertions on every new path.

Reviewed by Codex at both altitudes — per-task against the branch tip and once over the whole feature. Device verification is batched pre-release, not gated here.
