### PR TITLE
chore(scripts): add worktree janitor for leaked agent worktrees and refs

### DIFF
--- a/package.json
+++ b/package.json
@@ -14,6 +14,8 @@
     "format": "prettier --write src/",
     "typecheck": "tsc --noEmit",
     "eas-build-pre-install": "node scripts/eas-build-pre-install.js",
+    "worktree:check": "node scripts/worktree-janitor.mjs",
+    "worktree:clean": "node scripts/worktree-janitor.mjs --apply",
     "build:android:dev": "GOOGLE_SERVICES_DEV_JSON_BASE64=$(base64 -i ./google-services-dev.json) eas build --platform android --profile development --local",
     "build:android:preview": "GOOGLE_SERVICES_JSON_BASE64=$(base64 -i ./google-services.json) eas build --platform android --profile preview --local",
     "build:android:production": "GOOGLE_SERVICES_JSON_BASE64=$(base64 -i ./google-services.json) eas build --platform android --profile production --local",

--- a/scripts/worktree-janitor.mjs
+++ b/scripts/worktree-janitor.mjs
@@ -1,0 +1,211 @@
+#!/usr/bin/env node
+/**
+ * Reaps the worktrees and branch refs that agent tooling leaves behind.
+ *
+ * Claude Code's worktree isolation creates a worktree under .claude/worktrees/
+ * plus a `worktree-<id>` branch ref, and never cleans either one up. They
+ * accumulate: a single sweep in Aug 2026 found 14 stale worktrees (2.8 GB) and
+ * 40 orphaned `worktree-*` refs, none of which held unmerged work.
+ *
+ * This repo squash-merges, so `git merge-base --is-ancestor <branch> main`
+ * reports NO for branches that are fully merged. Ancestry alone would refuse to
+ * clean anything. We check three ways and accept any one of them:
+ *
+ *   1. the branch tip is a literal ancestor of main
+ *   2. the tip equals (or is an ancestor of) a MERGED PR's headRefOid
+ *   3. every file the branch added is already present in main
+ *
+ * Refuses to touch main, the current branch, or anything with an OPEN PR.
+ * Dry-run unless --apply is passed.
+ *
+ * Usage:
+ *   node scripts/worktree-janitor.mjs                # report only
+ *   node scripts/worktree-janitor.mjs --apply        # actually delete
+ *   node scripts/worktree-janitor.mjs --all-merged   # widen past worktree-* refs
+ */
+
+import { execFileSync } from 'node:child_process';
+
+const args = new Set(process.argv.slice(2));
+const APPLY = args.has('--apply');
+const ALL_MERGED = args.has('--all-merged');
+const BASE = 'origin/main';
+const WORKTREE_REF = /^worktree-/;
+
+if (args.has('--help') || args.has('-h')) {
+  console.log(
+    [
+      'worktree-janitor — remove merged agent worktrees and their branch refs',
+      '',
+      '  --apply        perform deletions (default: dry run)',
+      '  --all-merged   also consider non-worktree-* branches',
+      '  --help         this message',
+    ].join('\n')
+  );
+  process.exit(0);
+}
+
+const git = (...a) => execFileSync('git', a, { encoding: 'utf8' }).trim();
+const gitOk = (...a) => {
+  try {
+    execFileSync('git', a, { stdio: 'ignore' });
+    return true;
+  } catch {
+    return false;
+  }
+};
+
+/** PR metadata by branch name. Empty when gh is unavailable — we degrade to ancestry only. */
+function prsFor(branch) {
+  try {
+    const out = execFileSync(
+      'gh',
+      [
+        'pr',
+        'list',
+        '--state',
+        'all',
+        '--head',
+        branch,
+        '--limit',
+        '10',
+        '--json',
+        'number,state,headRefOid',
+      ],
+      { encoding: 'utf8', stdio: ['ignore', 'pipe', 'ignore'] }
+    );
+    return JSON.parse(out);
+  } catch {
+    return [];
+  }
+}
+
+/**
+ * Why this branch is safe to delete, or null to keep it.
+ * An OPEN PR is an absolute veto regardless of what the other checks say.
+ */
+function mergedReason(branch, sha) {
+  const prs = prsFor(branch);
+  if (prs.some((p) => p.state === 'OPEN')) return null;
+
+  if (gitOk('merge-base', '--is-ancestor', sha, BASE))
+    return 'ancestor-of-main';
+
+  for (const pr of prs) {
+    if (pr.state !== 'MERGED') continue;
+    if (pr.headRefOid === sha) return `PR#${pr.number} head`;
+    if (gitOk('merge-base', '--is-ancestor', sha, pr.headRefOid))
+      return `PR#${pr.number} ancestor`;
+  }
+
+  // Squash-merged and the PR lookup missed it (agent refs carry a different name
+  // than the PR's head branch). Fall back to content: nothing new means nothing lost.
+  const mergeBase = git('merge-base', BASE, sha);
+  const added = git('diff', '--diff-filter=A', '--name-only', mergeBase, sha)
+    .split('\n')
+    .filter((f) => f && !f.startsWith('node_modules'));
+  if (
+    added.length &&
+    added.every((f) => gitOk('cat-file', '-e', `${BASE}:${f}`))
+  ) {
+    return 'content-in-main';
+  }
+  return null;
+}
+
+/** node_modules is gitignored; its presence is not real work. Anything else is. */
+function realChanges(dir) {
+  try {
+    return execFileSync('git', ['-C', dir, 'status', '--porcelain'], {
+      encoding: 'utf8',
+    })
+      .split('\n')
+      .filter((l) => l.trim() && !l.includes('node_modules'));
+  } catch {
+    return [];
+  }
+}
+
+git('fetch', 'origin', '--quiet');
+const currentBranch = git('rev-parse', '--abbrev-ref', 'HEAD');
+const mainRoot = git('rev-parse', '--show-toplevel');
+
+// ---- worktrees ----------------------------------------------------------
+const worktrees = git('worktree', 'list', '--porcelain')
+  .split('\n\n')
+  .map((block) => {
+    const path = block.match(/^worktree (.+)$/m)?.[1];
+    const branch = block.match(/^branch refs\/heads\/(.+)$/m)?.[1];
+    return path && path !== mainRoot ? { path, branch } : null;
+  })
+  .filter(Boolean);
+
+const wtRemove = [];
+for (const wt of worktrees) {
+  const dirty = realChanges(wt.path);
+  if (dirty.length) {
+    console.log(
+      `KEEP     ${wt.path}  — uncommitted work:\n         ${dirty.join('\n         ')}`
+    );
+    continue;
+  }
+  const sha = git('-C', wt.path, 'rev-parse', 'HEAD');
+  const why = wt.branch ? mergedReason(wt.branch, sha) : 'detached';
+  if (why) wtRemove.push({ ...wt, why });
+  else console.log(`KEEP     ${wt.path}  — branch ${wt.branch} is not merged`);
+}
+
+for (const wt of wtRemove) {
+  console.log(`${APPLY ? 'REMOVE  ' : 'would rm'} ${wt.path}  [${wt.why}]`);
+  if (APPLY) git('worktree', 'remove', '--force', wt.path);
+}
+if (APPLY && wtRemove.length) git('worktree', 'prune');
+
+// ---- branches -----------------------------------------------------------
+// A branch still checked out in a surviving worktree cannot be deleted — git
+// refuses, and we kept that worktree on purpose (dirty or unmerged). Only
+// branches whose worktree we just removed, or that never had one, are eligible.
+const removedPaths = new Set(wtRemove.map((w) => w.path));
+const stillAttached = new Set(
+  worktrees
+    .filter((w) => w.branch && !removedPaths.has(w.path))
+    .map((w) => w.branch)
+);
+
+const branches = git(
+  'for-each-ref',
+  '--format=%(refname:short) %(objectname)',
+  'refs/heads/'
+)
+  .split('\n')
+  .filter(Boolean)
+  .map((l) => {
+    const [name, sha] = l.split(' ');
+    return { name, sha };
+  })
+  .filter((b) => b.name !== 'main' && b.name !== currentBranch)
+  .filter((b) => !stillAttached.has(b.name))
+  .filter((b) => ALL_MERGED || WORKTREE_REF.test(b.name));
+
+let deleted = 0;
+let kept = 0;
+for (const b of branches) {
+  const why = mergedReason(b.name, b.sha);
+  if (!why) {
+    console.log(`KEEP     ${b.name}  — unmerged or has an open PR`);
+    kept += 1;
+    continue;
+  }
+  console.log(
+    `${APPLY ? 'DELETE  ' : 'would rm'} ${b.name}  ${b.sha.slice(0, 9)}  [${why}]`
+  );
+  if (APPLY) git('branch', '-D', b.name);
+  deleted += 1;
+}
+
+console.log(
+  `\n${APPLY ? 'removed' : 'would remove'}: ${wtRemove.length} worktree(s), ${deleted} branch(es); kept ${kept}`
+);
+if (!APPLY && (wtRemove.length || deleted)) {
+  console.log('Dry run — re-run with --apply to delete.');
+}


### PR DESCRIPTION
## Why

Agent worktree isolation creates a worktree under `.claude/worktrees/` **plus** a `worktree-<id>` branch ref, and never cleans up either one.

A sweep on 2026-08-01 found **14 stale worktrees (2.8 GB)** and **40 orphaned `worktree-*` refs**. None held unmerged work — every one was fully merged. Without a reaper the pile rebuilds itself every session.

## What

`scripts/worktree-janitor.mjs`, plus two npm scripts:

```bash
npm run worktree:check   # report only (default)
npm run worktree:clean   # actually delete
```

## The squash-merge wrinkle

This repo squash-merges, so `git merge-base --is-ancestor <branch> main` returns **NO for fully merged branches** — the naive check would refuse to clean anything, and reading it the other way round would suggest work is unmerged when it isn't.

The janitor accepts any one of three proofs:

1. tip is a literal ancestor of `main`
2. tip equals — or is an ancestor of — a MERGED PR's `headRefOid`
3. every file the branch added is already present in `main`

Tier 3 matters because agent refs carry a different name than the PR's head branch, so `gh pr list --head` misses them entirely.

## Safety

- **Dry run unless `--apply`**
- An **OPEN PR is an absolute veto**, regardless of other checks
- Worktrees with any non-gitignored change are **kept** (`node_modules` alone doesn't count as work)
- Branches still checked out in a surviving worktree are **skipped** — git refuses those, and they were kept deliberately
- `main` and the current branch are never touched
- **Never writes to a remote**

## Verification

Exercised against synthetic fixtures, each behaviour confirmed:

| Fixture | Expected | Result |
|---|---|---|
| clean + merged worktree | removed | removed |
| worktree w/ uncommitted file | kept | kept, file intact |
| branch w/ unmerged commit | kept | kept, commit intact |
| dry run | mutates nothing | confirmed inert |
| branch attached to kept worktree | skipped | skipped |

That last case was a real bug caught during testing — the branch was queued for deletion while its worktree was kept, which would have thrown on `--apply`.

Full suite green: **118 suites / 1758 tests**, `typecheck` clean, lint at baseline (157 warnings, 0 errors, unchanged).

## Related

`deleteBranchOnMerge` is now enabled on the repo, which stops the *remote* side accumulating. This script covers the local side, which that setting can't reach.

https://claude.ai/code/session_01T7N7iqGok5f6f9DKjKozS5