### PR TITLE
fix(realtime): make disabled realtime inert; batch notification subscribes (PLAN-275)

### DIFF
--- a/src/navigation/__tests__/serviceBootstrap.test.ts
+++ b/src/navigation/__tests__/serviceBootstrap.test.ts
@@ -22,6 +22,7 @@
  */
 
 import { initializeServices } from '../serviceBootstrap';
+import { isAccountSubscribeTokenCurrent } from '@/services/notifications/subscribePass';
 
 // --- Mock leaves (all prefixed `mock` so jest can hoist them into factories) ---
 const mockWcService = {
@@ -41,7 +42,9 @@ const mockExtensionDeepLinkHandler = {
 const mockNotificationService = {
   initialize: jest.fn(async () => {}),
   registerPushToken: jest.fn(async () => null as string | null),
-  subscribeAllAccounts: jest.fn(async () => {}),
+  subscribeAllAccounts: jest.fn(
+    async (_accounts: unknown[], _subscribeToken?: number) => {}
+  ),
   cleanup: jest.fn(),
 };
 const mockTxnQueue = {
@@ -94,8 +97,14 @@ jest.mock('@/services/notifications', () => ({
   },
 }));
 
+const mockGetCurrentWallet = jest.fn(
+  async (): Promise<{ accounts: unknown[] } | null> => null
+);
+
 jest.mock('@/services/wallet', () => ({
-  MultiAccountWalletService: { getCurrentWallet: jest.fn(async () => null) },
+  MultiAccountWalletService: {
+    getCurrentWallet: () => mockGetCurrentWallet(),
+  },
 }));
 
 jest.mock('@/services/ledger/transport', () => ({
@@ -120,9 +129,11 @@ const makeCleanupRef = () => ({
 
 describe('serviceBootstrap.initializeServices — TASK-243 teardown wiring', () => {
   beforeEach(() => {
-    // jest.config `clearMocks: true` resets call history; only the mutable app
-    // mode needs resetting.
+    // jest.config `clearMocks: true` resets call history but NOT implementations
+    // (mockResolvedValue survives), so restore the defaults the boot path reads.
     mockAppMode = 'user';
+    mockGetCurrentWallet.mockResolvedValue(null);
+    mockNotificationService.registerPushToken.mockResolvedValue(null);
   });
 
   it('captures a teardown that unregisters BOTH WalletConnect handlers and cleans up deep-link + notifications on unmount', async () => {
@@ -248,5 +259,96 @@ describe('serviceBootstrap.initializeServices — TASK-243 teardown wiring', () 
     expect(mockWcService.off).not.toHaveBeenCalled();
     expect(mockExtensionDeepLinkHandler.cleanup).not.toHaveBeenCalled();
     expect(mockNotificationService.cleanup).not.toHaveBeenCalled();
+  });
+});
+
+/**
+ * TASK-192. The deferred per-account subscribe is fire-and-forget over a wallet
+ * snapshot, and since it now ends in ONE batched write the gap between snapshot
+ * and write is a real window. Teardown must be able to cancel it — teardown
+ * removes listeners, it does not await or abort this work, so without the token
+ * an unmounted session would still write. This spec pins the boot side: a token
+ * is taken and handed to the pass, and the captured teardown invalidates it.
+ */
+describe('serviceBootstrap.initializeServices — deferred subscribe abort token (TASK-192)', () => {
+  const flush = () => new Promise((resolve) => setTimeout(resolve, 0));
+
+  beforeEach(() => {
+    mockAppMode = 'user';
+    mockGetCurrentWallet.mockResolvedValue({ accounts: [{ id: 'acct-1' }] });
+    mockNotificationService.registerPushToken.mockResolvedValue('expo-token');
+  });
+
+  it('hands the deferred subscribe a live token, which the teardown then invalidates', async () => {
+    const cleanupRef = makeCleanupRef();
+
+    await initializeServices({
+      navigationRef: { current: null },
+      initializeNetwork: jest.fn(async () => {}),
+      cleanupRef,
+    });
+    await flush();
+
+    expect(mockNotificationService.subscribeAllAccounts).toHaveBeenCalledTimes(
+      1
+    );
+    const [, subscribeToken] =
+      mockNotificationService.subscribeAllAccounts.mock.calls[0];
+    expect(typeof subscribeToken).toBe('number');
+
+    // Still mounted: the pass is allowed to write.
+    expect(isAccountSubscribeTokenCurrent(subscribeToken!)).toBe(true);
+
+    // Unmount. The pass may still be in flight; its token must now be stale.
+    cleanupRef.current!();
+
+    expect(isAccountSubscribeTokenCurrent(subscribeToken!)).toBe(false);
+  });
+
+  it('takes the token BEFORE the deferred pass awaits the wallet, so a teardown during that await still cancels it', async () => {
+    // The token must be taken synchronously at launch. Taken one await later —
+    // after getCurrentWallet() resolves — it would be minted AFTER an unmount
+    // that happened in the meantime, and would therefore still look current:
+    // the pass would go on to write for a dead session. Pin the ordering by
+    // holding the deferred wallet read open across the teardown.
+    const wallet = { accounts: [{ id: 'acct-1' }] };
+    let releaseDeferredWallet!: () => void;
+    mockGetCurrentWallet
+      // Boot-time read (decides shouldSubscribeAccounts) resolves normally...
+      .mockImplementationOnce(async () => wallet)
+      // ...the deferred pass's re-read hangs until the test releases it.
+      .mockImplementationOnce(
+        () =>
+          new Promise((resolve) => {
+            releaseDeferredWallet = () => resolve(wallet);
+          })
+      );
+
+    const cleanupRef = makeCleanupRef();
+
+    await initializeServices({
+      navigationRef: { current: null },
+      initializeNetwork: jest.fn(async () => {}),
+      cleanupRef,
+    });
+    await flush();
+
+    // The pass is parked on the wallet read; nothing has been subscribed yet.
+    expect(mockNotificationService.subscribeAllAccounts).not.toHaveBeenCalled();
+
+    // Unmount WHILE the read is still outstanding.
+    cleanupRef.current!();
+
+    releaseDeferredWallet();
+    await flush();
+
+    // The pass resumed and called through — with the token it minted at
+    // launch, which the teardown has already invalidated.
+    expect(mockNotificationService.subscribeAllAccounts).toHaveBeenCalledTimes(
+      1
+    );
+    const [, subscribeToken] =
+      mockNotificationService.subscribeAllAccounts.mock.calls[0];
+    expect(isAccountSubscribeTokenCurrent(subscribeToken!)).toBe(false);
   });
 });

--- a/src/navigation/serviceBootstrap.ts
+++ b/src/navigation/serviceBootstrap.ts
@@ -11,6 +11,10 @@ import { DeepLinkService } from '@/services/deeplink';
 import { extensionDeepLinkHandler } from '@/services/deeplink/extensionHandler';
 import { isWalletConnectUri } from '@/services/walletconnect/utils';
 import { notificationService } from '@/services/notifications';
+import {
+  takeAccountSubscribeToken,
+  invalidateAccountSubscribePasses,
+} from '@/services/notifications/subscribePass';
 import { MultiAccountWalletService } from '@/services/wallet';
 import { ledgerTransportService } from '@/services/ledger/transport';
 import { TransactionRequestQueue } from '@/services/walletconnect/TransactionRequestQueue';
@@ -240,9 +244,10 @@ export const initializeServices = async ({
             // Register push token if permissions granted
             const token = await notificationService.registerPushToken();
             if (token) {
-              // Defer the expensive per-account subscribe (N sequential
-              // Supabase round-trips) off the critical path; it re-reads the
-              // wallet at run time so startup-created accounts are included.
+              // Defer the per-account subscribe off the critical path; it
+              // re-reads the wallet at run time so startup-created accounts
+              // are included. TASK-192 collapsed it to two Supabase round
+              // trips (one read, one write) regardless of account count.
               shouldSubscribeAccounts = true;
             }
           }
@@ -330,18 +335,23 @@ export const initializeServices = async ({
     // included (constraint: defer only AFTER re-reading the wallet). This is
     // fire-and-forget so it never delays time-to-interactive.
     if (shouldSubscribeAccounts) {
+      // Abort token, taken SYNCHRONOUSLY at launch so it covers the whole
+      // window. The pass below works from a wallet snapshot and, since
+      // TASK-192, defers to a single batched write at the end — so an unmount
+      // or an account deletion in the meantime must be able to drop that
+      // write. The teardown assigned just below and the account-deletion paths
+      // both invalidate it; re-checked immediately before the write.
+      const subscribeToken = takeAccountSubscribeToken();
       void (async () => {
         try {
           const wallet = await MultiAccountWalletService.getCurrentWallet();
           if (wallet && wallet.accounts.length > 0) {
             // Subscribe ALL accounts to notifications (not just active one)
             // Watch accounts will have message notifications disabled by default
-            await notificationService.subscribeAllAccounts(wallet.accounts);
-
-            // TODO: Re-enable realtime subscription when needed
-            // Currently disabled to reduce server load - using polling instead
-            // const allAddresses = wallet.accounts.map(a => a.address);
-            // await realtimeService.subscribeToAddresses(allAddresses);
+            await notificationService.subscribeAllAccounts(
+              wallet.accounts,
+              subscribeToken
+            );
           }
         } catch (error) {
           console.warn('Failed to subscribe accounts to notifications:', error);
@@ -355,6 +365,11 @@ export const initializeServices = async ({
     // defect), so no teardown ever ran.
     cleanupRef.current = () => {
       try {
+        // FIRST, and unconditionally: cancel any in-flight deferred subscribe
+        // pass. It holds a wallet snapshot from this (now dead) session and
+        // would otherwise still perform its batched write. Done ahead of the
+        // unregister calls so a throw there cannot skip it.
+        invalidateAccountSubscribePasses();
         if (wcService && onProposal) {
           wcService.off?.('session_proposal', onProposal);
         }
@@ -365,7 +380,6 @@ export const initializeServices = async ({
           extensionDeepLinkHandler.cleanup();
           notificationService.cleanup();
         }
-        // realtimeService.cleanup(); // Disabled - realtime subscription not active
       } catch {}
     };
 

--- a/src/services/notifications/__tests__/subscribeAllAccounts.test.ts
+++ b/src/services/notifications/__tests__/subscribeAllAccounts.test.ts
@@ -1,0 +1,517 @@
+/**
+ * TASK-192 / F-37: `subscribeAllAccounts` used to issue two Supabase round
+ * trips PER ACCOUNT (a `.single()` read, then an upsert) on every cold start.
+ * Batching it is trivial; batching it WITHOUT regressing the four behaviours the
+ * sequential loop got for free is not. These specs pin those behaviours first
+ * and the round-trip count last, deliberately in that order:
+ *
+ *   - Accounts that already have preferences never enter the payload. A blanket
+ *     upsert of defaults would silently reset every user's notification
+ *     settings on the next app start.
+ *   - `messages` is decided PER ACCOUNT (watch accounts cannot decrypt), not
+ *     once for the batch.
+ *   - The batch read fails CLOSED. One `.select()` cannot report which account
+ *     failed, so a partial result is not a thing: a read error aborts the pass
+ *     and writes nothing rather than overwriting real settings with defaults.
+ *   - The write is insert-if-absent (ON CONFLICT DO NOTHING), so a row created
+ *     or edited on another device between the read and the write survives.
+ *
+ * Plus the abort token: the pass is launched fire-and-forget over a wallet
+ * snapshot, so an unmount or an account deletion mid-flight must drop the
+ * write.
+ *
+ * Supabase is faked rather than mocked call-by-call: the fake owns a row store
+ * and implements ON CONFLICT DO NOTHING for real, so "existing preferences
+ * survive" is an assertion about stored state, not about arguments.
+ */
+
+import algosdk from 'algosdk';
+
+import { AccountMetadata, AccountType } from '@/types/wallet';
+
+const DEVICE_ID = 'test-device-id';
+
+// --- Fake Supabase -------------------------------------------------------
+
+type SubscriptionRow = Record<string, unknown>;
+
+interface SelectResult {
+  data: { account_address: string }[] | null;
+  error: unknown;
+}
+
+interface SelectCall {
+  columns: string;
+  deviceId?: string;
+  addresses?: string[];
+}
+
+interface UpsertCall {
+  rows: SubscriptionRow[];
+  options: Record<string, unknown> | undefined;
+}
+
+interface FakeDb {
+  /** account_address -> stored row. */
+  rows: Map<string, SubscriptionRow>;
+  selectCalls: SelectCall[];
+  upsertCalls: UpsertCall[];
+  /** When set, the batch read resolves with this error and no data. */
+  selectError: unknown;
+  /** Runs after the read resolves and before the write — the race window. */
+  betweenReadAndWrite: (() => void) | null;
+}
+
+const mockDb: FakeDb = {
+  rows: new Map(),
+  selectCalls: [],
+  upsertCalls: [],
+  selectError: null,
+  betweenReadAndWrite: null,
+};
+
+interface SelectQuery {
+  eq(column: string, value: string): SelectQuery;
+  in(column: string, values: string[]): SelectQuery;
+  then<TResult1 = SelectResult, TResult2 = never>(
+    onfulfilled?:
+      | ((value: SelectResult) => TResult1 | PromiseLike<TResult1>)
+      | null,
+    onrejected?: ((reason: unknown) => TResult2 | PromiseLike<TResult2>) | null
+  ): PromiseLike<TResult1 | TResult2>;
+}
+
+const mockMakeSelectQuery = (columns: string): SelectQuery => {
+  const call: SelectCall = { columns };
+
+  const run = async (): Promise<SelectResult> => {
+    mockDb.selectCalls.push(call);
+
+    if (mockDb.selectError) {
+      // Read failed wholesale — the caller cannot know which account this
+      // covered, which is exactly why it must abort.
+      mockDb.betweenReadAndWrite?.();
+      return { data: null, error: mockDb.selectError };
+    }
+
+    const scope = call.addresses ?? Array.from(mockDb.rows.keys());
+    const data = scope
+      .filter((address) => mockDb.rows.has(address))
+      .map((address) => ({ account_address: address }));
+
+    mockDb.betweenReadAndWrite?.();
+    return { data, error: null };
+  };
+
+  const query: SelectQuery = {
+    eq(column, value) {
+      if (column === 'device_id') call.deviceId = value;
+      return query;
+    },
+    in(column, values) {
+      if (column === 'account_address') call.addresses = values;
+      return query;
+    },
+    then: (onfulfilled, onrejected) => run().then(onfulfilled, onrejected),
+  };
+
+  return query;
+};
+
+const mockSupabaseClient = {
+  schema: (schemaName: string) => ({
+    from: (table: string) => ({
+      select: (columns: string) => {
+        if (schemaName !== 'voiwallet' || table !== 'account_subscriptions') {
+          throw new Error(`Unexpected read of ${schemaName}.${table}`);
+        }
+        return mockMakeSelectQuery(columns);
+      },
+      upsert: async (
+        rows: SubscriptionRow | SubscriptionRow[],
+        options?: Record<string, unknown>
+      ) => {
+        const list = Array.isArray(rows) ? rows : [rows];
+        mockDb.upsertCalls.push({ rows: list, options });
+
+        for (const row of list) {
+          const address = row.account_address as string;
+          const existing = mockDb.rows.get(address);
+          // ON CONFLICT DO NOTHING when ignoreDuplicates is set; otherwise the
+          // row is overwritten (which is what must NOT happen here).
+          if (existing && options?.ignoreDuplicates) continue;
+          mockDb.rows.set(address, { ...(existing ?? {}), ...row });
+        }
+
+        return { error: null };
+      },
+    }),
+  }),
+};
+
+jest.mock('../../supabase', () => ({
+  getSupabaseClient: () => mockSupabaseClient,
+  isSupabaseConfigured: () => true,
+  setDeviceId: jest.fn(),
+}));
+
+// The service reaches for these at import/init time only; none of them carry
+// behaviour these specs depend on.
+jest.mock('expo-notifications', () => ({
+  setNotificationHandler: jest.fn(),
+  addNotificationReceivedListener: jest.fn(() => ({ remove: jest.fn() })),
+  addNotificationResponseReceivedListener: jest.fn(() => ({
+    remove: jest.fn(),
+  })),
+  getLastNotificationResponseAsync: jest.fn(async () => null),
+  getPermissionsAsync: jest.fn(async () => ({ status: 'granted' })),
+  requestPermissionsAsync: jest.fn(async () => ({ status: 'granted' })),
+  getExpoPushTokenAsync: jest.fn(async () => ({ data: 'token' })),
+  setBadgeCountAsync: jest.fn(async () => {}),
+  setNotificationChannelAsync: jest.fn(async () => {}),
+  AndroidImportance: { HIGH: 4, DEFAULT: 3 },
+}));
+
+jest.mock('expo-device', () => ({ isDevice: true }));
+
+jest.mock('react-native-toast-message', () => ({
+  __esModule: true,
+  default: { show: jest.fn(), hide: jest.fn() },
+}));
+
+jest.mock('@react-native-async-storage/async-storage', () => ({
+  __esModule: true,
+  default: {
+    getItem: jest.fn(async () => null),
+    setItem: jest.fn(async () => {}),
+    removeItem: jest.fn(async () => {}),
+  },
+}));
+
+jest.mock('../../../platform', () => ({
+  deviceId: { getDeviceId: jest.fn(async () => DEVICE_ID) },
+}));
+
+import { notificationService } from '../index';
+import { DEFAULT_NOTIFICATION_PREFERENCES } from '../types';
+import {
+  invalidateAccountSubscribePasses,
+  takeAccountSubscribeToken,
+} from '../subscribePass';
+
+// --- Fixtures ------------------------------------------------------------
+
+/** A real, checksum-valid Algorand address (deterministic per seed byte). */
+const address = (seed: number): string =>
+  algosdk.encodeAddress(new Uint8Array(32).fill(seed));
+
+const STANDARD_A = address(1);
+const STANDARD_B = address(2);
+const WATCH_A = address(3);
+const EXISTING_A = address(4);
+const LEDGER_A = address(5);
+
+const account = (
+  addr: string,
+  type: AccountType = AccountType.STANDARD
+): AccountMetadata =>
+  ({
+    id: `id-${addr.slice(0, 6)}`,
+    address: addr,
+    publicKey: '00',
+    type,
+  }) as AccountMetadata;
+
+/** Seed a row as if this account had been subscribed on a previous run. */
+const seedExisting = (addr: string, overrides: SubscriptionRow = {}): void => {
+  mockDb.rows.set(addr, {
+    device_id: DEVICE_ID,
+    account_address: addr,
+    notify_messages: false,
+    notify_voi_payments: false,
+    notify_arc200_transfers: false,
+    notify_arc72_transfers: false,
+    notify_outgoing_confirmations: false,
+    notify_price_alerts: false,
+    min_voi_amount: 42,
+    min_arc200_amount: 7,
+    price_alert_threshold_percent: 99,
+    ...overrides,
+  });
+};
+
+const writtenAddresses = (): string[] =>
+  mockDb.upsertCalls.flatMap((call) =>
+    call.rows.map((row) => row.account_address as string)
+  );
+
+const writtenRow = (addr: string): SubscriptionRow | undefined =>
+  mockDb.upsertCalls
+    .flatMap((call) => call.rows)
+    .find((row) => row.account_address === addr);
+
+// The device ID is normally assigned by initialize(); the specs only need it
+// present, and driving the full Expo init would add nothing they assert on.
+beforeAll(() => {
+  (notificationService as unknown as { deviceId: string | null }).deviceId =
+    DEVICE_ID;
+});
+
+beforeEach(() => {
+  mockDb.rows.clear();
+  mockDb.selectCalls = [];
+  mockDb.upsertCalls = [];
+  mockDb.selectError = null;
+  mockDb.betweenReadAndWrite = null;
+});
+
+describe('subscribeAllAccounts — existing preferences are never overwritten', () => {
+  it('excludes accounts that already have preferences from the payload entirely', async () => {
+    seedExisting(EXISTING_A);
+
+    await notificationService.subscribeAllAccounts([
+      account(EXISTING_A),
+      account(STANDARD_A),
+    ]);
+
+    expect(writtenAddresses()).toEqual([STANDARD_A]);
+    expect(writtenRow(EXISTING_A)).toBeUndefined();
+  });
+
+  it('leaves the stored preferences of an already-subscribed account byte-for-byte unchanged', async () => {
+    seedExisting(EXISTING_A);
+    const before = { ...mockDb.rows.get(EXISTING_A) };
+
+    await notificationService.subscribeAllAccounts([
+      account(EXISTING_A),
+      account(STANDARD_A),
+    ]);
+
+    expect(mockDb.rows.get(EXISTING_A)).toEqual(before);
+  });
+
+  it('writes nothing at all when every account is already subscribed', async () => {
+    seedExisting(EXISTING_A);
+    seedExisting(STANDARD_A);
+
+    await notificationService.subscribeAllAccounts([
+      account(EXISTING_A),
+      account(STANDARD_A),
+    ]);
+
+    expect(mockDb.upsertCalls).toHaveLength(0);
+  });
+});
+
+describe('subscribeAllAccounts — defaults are decided per account', () => {
+  it('disables messages for watch accounts and enables them for every other type', async () => {
+    await notificationService.subscribeAllAccounts([
+      account(STANDARD_A, AccountType.STANDARD),
+      account(WATCH_A, AccountType.WATCH),
+      account(LEDGER_A, AccountType.LEDGER),
+    ]);
+
+    expect(writtenRow(STANDARD_A)?.notify_messages).toBe(true);
+    expect(writtenRow(WATCH_A)?.notify_messages).toBe(false);
+    expect(writtenRow(LEDGER_A)?.notify_messages).toBe(true);
+  });
+
+  it('produces exactly the right payload for a mixed batch (existing + new + watch + non-watch)', async () => {
+    seedExisting(EXISTING_A);
+
+    await notificationService.subscribeAllAccounts([
+      account(EXISTING_A, AccountType.STANDARD),
+      account(STANDARD_A, AccountType.STANDARD),
+      account(WATCH_A, AccountType.WATCH),
+      account(STANDARD_B, AccountType.REKEYED),
+    ]);
+
+    expect(mockDb.upsertCalls).toHaveLength(1);
+    expect(mockDb.upsertCalls[0].rows).toHaveLength(3);
+    expect(writtenAddresses()).toEqual([STANDARD_A, WATCH_A, STANDARD_B]);
+
+    expect(writtenRow(STANDARD_A)).toMatchObject({
+      device_id: DEVICE_ID,
+      account_address: STANDARD_A,
+      notify_messages: true,
+      notify_voi_payments: DEFAULT_NOTIFICATION_PREFERENCES.voiPayments,
+      notify_price_alerts: DEFAULT_NOTIFICATION_PREFERENCES.priceAlerts,
+      price_alert_threshold_percent:
+        DEFAULT_NOTIFICATION_PREFERENCES.priceAlertThreshold,
+    });
+    expect(writtenRow(WATCH_A)).toMatchObject({
+      account_address: WATCH_A,
+      notify_messages: false,
+      // Only `messages` differs for a watch account; the rest are defaults.
+      notify_voi_payments: DEFAULT_NOTIFICATION_PREFERENCES.voiPayments,
+    });
+    expect(writtenRow(STANDARD_B)?.notify_messages).toBe(true);
+  });
+});
+
+describe('subscribeAllAccounts — the batch read fails CLOSED', () => {
+  it('aborts the whole pass and writes nothing when the batch read errors', async () => {
+    mockDb.selectError = { message: 'network down' };
+
+    await notificationService.subscribeAllAccounts([
+      account(STANDARD_A),
+      account(WATCH_A, AccountType.WATCH),
+      account(EXISTING_A),
+    ]);
+
+    expect(mockDb.upsertCalls).toHaveLength(0);
+  });
+
+  it('leaves every account’s stored preferences unchanged when the read errors', async () => {
+    seedExisting(EXISTING_A);
+    seedExisting(WATCH_A, { notify_messages: true });
+    const snapshot = new Map(
+      Array.from(mockDb.rows, ([key, row]) => [key, { ...row }])
+    );
+    mockDb.selectError = { message: 'network down' };
+
+    await notificationService.subscribeAllAccounts([
+      account(EXISTING_A),
+      account(WATCH_A, AccountType.WATCH),
+      account(STANDARD_A),
+    ]);
+
+    expect(mockDb.rows.size).toBe(snapshot.size);
+    for (const [addr, row] of snapshot) {
+      expect(mockDb.rows.get(addr)).toEqual(row);
+    }
+  });
+});
+
+describe('subscribeAllAccounts — writes are insert-if-absent', () => {
+  it('does not clobber a preference changed on another device between the read and the write', async () => {
+    // STANDARD_A is absent when the batch read runs, so it lands in the
+    // payload; another device then subscribes it with messages OFF.
+    mockDb.betweenReadAndWrite = () => {
+      seedExisting(STANDARD_A, { notify_messages: false, min_voi_amount: 123 });
+    };
+
+    await notificationService.subscribeAllAccounts([account(STANDARD_A)]);
+
+    // The write went out (the pass could not have known) but resolved to
+    // ON CONFLICT DO NOTHING, so the other device's values survive.
+    expect(mockDb.upsertCalls).toHaveLength(1);
+    expect(mockDb.upsertCalls[0].options).toMatchObject({
+      onConflict: 'device_id,account_address',
+      ignoreDuplicates: true,
+    });
+    expect(mockDb.rows.get(STANDARD_A)).toMatchObject({
+      notify_messages: false,
+      min_voi_amount: 123,
+    });
+  });
+});
+
+describe('subscribeAllAccounts — the abort token drops stale writes', () => {
+  it('performs no write when a teardown invalidates the pass mid-flight', async () => {
+    // Exactly what serviceBootstrap's unmount teardown calls.
+    mockDb.betweenReadAndWrite = () => invalidateAccountSubscribePasses();
+
+    await notificationService.subscribeAllAccounts([
+      account(STANDARD_A),
+      account(WATCH_A, AccountType.WATCH),
+    ]);
+
+    expect(mockDb.upsertCalls).toHaveLength(0);
+    expect(mockDb.rows.size).toBe(0);
+  });
+
+  it('performs no write when an account is deleted mid-flight (session still mounted)', async () => {
+    // Distinct path from teardown: walletStore.deleteAccount invalidates while
+    // the session is very much alive, because the snapshot below still names
+    // the account being removed.
+    const snapshot = [account(STANDARD_A), account(STANDARD_B)];
+    mockDb.betweenReadAndWrite = () => {
+      // The account is gone from storage; the snapshot is now a lie.
+      invalidateAccountSubscribePasses();
+    };
+
+    await notificationService.subscribeAllAccounts(snapshot);
+
+    expect(mockDb.upsertCalls).toHaveLength(0);
+    expect(mockDb.rows.has(STANDARD_B)).toBe(false);
+  });
+
+  it('honours a token taken at launch rather than at entry', async () => {
+    // serviceBootstrap takes the token synchronously at launch and passes it
+    // in; an invalidation before subscribeAllAccounts is even entered must
+    // still drop the write.
+    const launchToken = takeAccountSubscribeToken();
+    invalidateAccountSubscribePasses();
+
+    await notificationService.subscribeAllAccounts(
+      [account(STANDARD_A)],
+      launchToken
+    );
+
+    expect(mockDb.upsertCalls).toHaveLength(0);
+  });
+
+  it('still writes when nothing invalidated the pass', async () => {
+    await notificationService.subscribeAllAccounts([account(STANDARD_A)]);
+
+    expect(mockDb.upsertCalls).toHaveLength(1);
+  });
+});
+
+describe('subscribeAllAccounts — address validation is a real checksum check', () => {
+  it('rejects a 58-character string that fails the checksum before the payload is built', async () => {
+    // 58 chars of valid base32 — the old length-only check accepted this.
+    const bogus = 'A'.repeat(58);
+    expect(bogus).toHaveLength(58);
+    expect(algosdk.isValidAddress(bogus)).toBe(false);
+
+    await notificationService.subscribeAllAccounts([
+      account(bogus),
+      account(STANDARD_A),
+    ]);
+
+    expect(writtenAddresses()).toEqual([STANDARD_A]);
+    // ...and it was never even asked about in the read.
+    expect(mockDb.selectCalls[0].addresses).toEqual([STANDARD_A]);
+  });
+
+  it('writes nothing and issues no query when every address is invalid', async () => {
+    await notificationService.subscribeAllAccounts([
+      account('A'.repeat(58)),
+      account('not-an-address'),
+    ]);
+
+    expect(mockDb.selectCalls).toHaveLength(0);
+    expect(mockDb.upsertCalls).toHaveLength(0);
+  });
+});
+
+describe('subscribeAllAccounts — round-trip count', () => {
+  it('issues exactly one read and one write for N accounts', async () => {
+    const accounts = [
+      account(STANDARD_A),
+      account(STANDARD_B),
+      account(WATCH_A, AccountType.WATCH),
+      account(LEDGER_A, AccountType.LEDGER),
+      account(EXISTING_A),
+    ];
+
+    await notificationService.subscribeAllAccounts(accounts);
+
+    expect(mockDb.selectCalls).toHaveLength(1);
+    expect(mockDb.upsertCalls).toHaveLength(1);
+    expect(mockDb.selectCalls[0]).toMatchObject({
+      deviceId: DEVICE_ID,
+      addresses: accounts.map((a) => a.address),
+    });
+    expect(mockDb.upsertCalls[0].rows).toHaveLength(accounts.length);
+  });
+
+  it('issues no query at all for an empty account list', async () => {
+    await notificationService.subscribeAllAccounts([]);
+
+    expect(mockDb.selectCalls).toHaveLength(0);
+    expect(mockDb.upsertCalls).toHaveLength(0);
+  });
+});

--- a/src/services/notifications/__tests__/subscribeAllAccounts.test.ts
+++ b/src/services/notifications/__tests__/subscribeAllAccounts.test.ts
@@ -515,3 +515,49 @@ describe('subscribeAllAccounts — round-trip count', () => {
     expect(mockDb.upsertCalls).toHaveLength(0);
   });
 });
+
+// Found by the full-diff Codex pass over PLAN-275. `.in()` is serialised into
+// the request URL, so a single unbounded read grows with wallet size and a
+// large wallet can exceed PostgREST/proxy URL limits. Combined with the
+// fail-closed rule that is not a degraded read — it is a wallet that never
+// subscribes anything, on every launch. The per-account loop this replaced had
+// no aggregate limit, so an unchunked read would have been a regression.
+describe('subscribeAllAccounts — the read is chunked', () => {
+  it('splits a large wallet across several reads instead of one huge one', async () => {
+    const many = Array.from({ length: 120 }, () =>
+      account(algosdk.generateAccount().addr.toString())
+    );
+
+    await notificationService.subscribeAllAccounts(many);
+
+    // 120 accounts at a chunk size of 50 → 3 reads. Emphatically not 1 (the
+    // unbounded URL) and not 120 (the round-trip cost this task removed).
+    expect(mockDb.selectCalls).toHaveLength(3);
+    expect(mockDb.selectCalls[0].addresses).toHaveLength(50);
+    expect(mockDb.selectCalls[2].addresses).toHaveLength(20);
+
+    // Every address is still covered exactly once.
+    const queried = mockDb.selectCalls.flatMap((c) => c.addresses);
+    expect(new Set(queried).size).toBe(120);
+  });
+
+  it('still aborts the WHOLE pass when a later chunk fails', async () => {
+    const many = Array.from({ length: 120 }, () =>
+      account(algosdk.generateAccount().addr.toString())
+    );
+    // Fail only AFTER the first chunk has already succeeded, using the
+    // existing between-read hook — the point is that a partial success must
+    // not be treated as a complete read.
+    mockDb.betweenReadAndWrite = () => {
+      if (mockDb.selectCalls.length === 1) {
+        mockDb.selectError = { message: 'url too long' };
+      }
+    };
+
+    await notificationService.subscribeAllAccounts(many);
+
+    // A partially-read pass cannot tell "absent" from "unread" for the chunks
+    // it never got, so it must write nothing at all.
+    expect(mockDb.upsertCalls).toHaveLength(0);
+  });
+});

--- a/src/services/notifications/index.ts
+++ b/src/services/notifications/index.ts
@@ -413,23 +413,41 @@ class NotificationService {
 
     const addresses = Array.from(pending.keys());
 
-    // --- ONE read for N accounts ---
-    const { data, error } = await supabase
-      .schema('voiwallet')
-      .from('account_subscriptions')
-      .select('account_address')
-      .eq('device_id', deviceId)
-      .in('account_address', addresses);
+    // --- Chunked read: one query per CHUNK, not per account ---
+    // `.in()` is serialised into the request URL, so an unbounded list grows
+    // with wallet size and a large wallet can blow past PostgREST/proxy URL
+    // limits. Combined with the fail-closed rule below that is not a degraded
+    // read — it is a wallet that never subscribes anything, on every launch.
+    // The old per-account loop had no aggregate limit; chunking keeps the
+    // round-trip saving (N accounts -> ceil(N/50) reads, not N) without
+    // reintroducing one.
+    const READ_CHUNK_SIZE = 50;
+    const existingRows: { account_address: string }[] = [];
 
-    // Fail CLOSED: writing defaults over accounts whose real preferences could
-    // not be read is the one outcome the user cannot recover from.
-    if (error || !data) {
-      console.error(
-        '[NotificationService] Aborting subscribe pass: failed to read existing subscriptions',
-        error
-      );
-      return;
+    for (let i = 0; i < addresses.length; i += READ_CHUNK_SIZE) {
+      const chunk = addresses.slice(i, i + READ_CHUNK_SIZE);
+      const { data, error } = await supabase
+        .schema('voiwallet')
+        .from('account_subscriptions')
+        .select('account_address')
+        .eq('device_id', deviceId)
+        .in('account_address', chunk);
+
+      // Fail CLOSED, and abort the WHOLE pass on any chunk failing. Writing
+      // defaults over accounts whose real preferences could not be read is the
+      // one outcome the user cannot recover from, and a partially-read pass
+      // cannot tell "absent" from "unread" for the chunks it never got.
+      if (error || !data) {
+        console.error(
+          '[NotificationService] Aborting subscribe pass: failed to read existing subscriptions',
+          error
+        );
+        return;
+      }
+      existingRows.push(...data);
     }
+
+    const data = existingRows;
 
     const alreadySubscribed = new Set(
       (data as { account_address: string }[]).map((row) => row.account_address)

--- a/src/services/notifications/index.ts
+++ b/src/services/notifications/index.ts
@@ -10,6 +10,7 @@ import * as Device from 'expo-device';
 import { Platform, AppState, AppStateStatus } from 'react-native';
 import Constants from 'expo-constants';
 import AsyncStorage from '@react-native-async-storage/async-storage';
+import algosdk from 'algosdk';
 import {
   getSupabaseClient,
   isSupabaseConfigured,
@@ -20,6 +21,10 @@ import {
   DEFAULT_NOTIFICATION_PREFERENCES,
   NotificationData,
 } from './types';
+import {
+  takeAccountSubscribeToken,
+  isAccountSubscribeTokenCurrent,
+} from './subscribePass';
 import Toast from 'react-native-toast-message';
 import { AccountMetadata, AccountType } from '@/types/wallet';
 import { deviceId } from '../../platform';
@@ -318,20 +323,7 @@ class NotificationService {
       .schema('voiwallet')
       .from('account_subscriptions')
       .upsert(
-        {
-          device_id: this.deviceId,
-          account_address: validatedAddress,
-          notify_messages: prefs.messages,
-          notify_voi_payments: prefs.voiPayments,
-          notify_arc200_transfers: prefs.arc200Transfers,
-          notify_arc72_transfers: prefs.arc72Transfers,
-          notify_outgoing_confirmations: prefs.outgoingConfirmations,
-          notify_price_alerts: prefs.priceAlerts,
-          min_voi_amount: prefs.minVoiAmount,
-          min_arc200_amount: prefs.minArc200Amount,
-          price_alert_threshold_percent: prefs.priceAlertThreshold,
-          updated_at: new Date().toISOString(),
-        },
+        this.buildSubscriptionRow(this.deviceId, validatedAddress, prefs),
         {
           onConflict: 'device_id,account_address',
         }
@@ -347,30 +339,148 @@ class NotificationService {
   }
 
   /**
-   * Subscribe all wallet accounts to notifications
-   * Called on app startup and when new accounts are added.
-   * Only subscribes accounts that don't already have preferences (preserves existing settings).
-   * Watch accounts have message notifications disabled by default since they can't decrypt.
+   * Subscribe all wallet accounts to notifications.
+   *
+   * Called on app startup (deferred, fire-and-forget) and when new accounts are
+   * added. TASK-192 collapsed the former per-account loop — one `.single()`
+   * read plus one upsert per account — into exactly ONE read and ONE write for
+   * N accounts. The batching is subordinate to four correctness rules the old
+   * loop got for free, and which a naive batch upsert would each destroy:
+   *
+   * 1. Accounts that ALREADY have preferences are excluded from the payload
+   *    entirely. A blanket upsert of defaults would silently reset every user's
+   *    notification settings on the next app start.
+   * 2. Defaults are per account, not per batch: watch accounts cannot decrypt,
+   *    so they get `messages: false` while every other type gets `true`.
+   * 3. FAIL CLOSED on the read. A single batch `.select()` succeeds or fails
+   *    wholesale — it cannot say which account failed — so per-account error
+   *    tolerance is incoherent here. If the read fails we abort the whole pass
+   *    and write nothing, retrying on the next app start. (The old loop was
+   *    fail-OPEN: `getPreferences` returns null for both "absent" and "query
+   *    failed", which under a batch would make an errored account look brand
+   *    new and overwrite its real settings.) Aborting resolves that ambiguity
+   *    by removing the path where it matters: absent from a SUCCESSFUL batch
+   *    read means genuinely absent.
+   * 4. Insert-if-absent (`ignoreDuplicates`), not a blanket upsert, so a
+   *    preference changed on another device between the read and the write is
+   *    not clobbered.
+   *
+   * @param accounts - Wallet accounts to subscribe.
+   * @param subscribeToken - Abort token taken at launch (see `subscribePass`).
+   *   Re-checked immediately before the write; a teardown or account deletion
+   *   in between drops the write. Defaults to a token taken on entry, which is
+   *   correct for synchronous callers that are not working from a snapshot.
    */
-  async subscribeAllAccounts(accounts: AccountMetadata[]): Promise<void> {
-    for (const account of accounts) {
-      // Check if already subscribed - if so, don't overwrite existing preferences
-      const existing = await this.getPreferences(account.address);
-      if (existing) {
-        console.log('Account already subscribed, skipping:', account.address);
-        continue;
-      }
+  async subscribeAllAccounts(
+    accounts: AccountMetadata[],
+    subscribeToken: number = takeAccountSubscribeToken()
+  ): Promise<void> {
+    if (accounts.length === 0) return;
 
-      // Determine default preferences based on account type
-      const isWatchAccount = account.type === AccountType.WATCH;
-      const preferences: Partial<NotificationPreferences> = {
-        ...DEFAULT_NOTIFICATION_PREFERENCES,
-        // Watch accounts can't decrypt messages, so disable by default
-        messages: !isWatchAccount,
-      };
-
-      await this.subscribeAccount(account.address, preferences);
+    const supabase = getSupabaseClient();
+    const deviceId = this.deviceId;
+    if (!supabase || !deviceId) {
+      console.warn(
+        'Cannot subscribe accounts: Supabase or device ID not available'
+      );
+      return;
     }
+
+    // Validate (checksum, not just length) BEFORE anything reaches the payload.
+    // A batch write amplifies bad data, so a single malformed address must be
+    // dropped here rather than corrupting a row. Deduplicate by address at the
+    // same time: the table is keyed (device_id, account_address), so two wallet
+    // entries sharing an address are one subscription. If any of them can
+    // decrypt, the device can decrypt, so `messages` ORs across duplicates.
+    const pending = new Map<string, { messages: boolean }>();
+    for (const account of accounts) {
+      const address = this.validateAddress(
+        account.address,
+        'subscribeAllAccounts'
+      );
+      if (!address) continue;
+
+      const canDecryptMessages = account.type !== AccountType.WATCH;
+      const existing = pending.get(address);
+      if (existing) {
+        existing.messages = existing.messages || canDecryptMessages;
+      } else {
+        pending.set(address, { messages: canDecryptMessages });
+      }
+    }
+
+    if (pending.size === 0) return;
+
+    const addresses = Array.from(pending.keys());
+
+    // --- ONE read for N accounts ---
+    const { data, error } = await supabase
+      .schema('voiwallet')
+      .from('account_subscriptions')
+      .select('account_address')
+      .eq('device_id', deviceId)
+      .in('account_address', addresses);
+
+    // Fail CLOSED: writing defaults over accounts whose real preferences could
+    // not be read is the one outcome the user cannot recover from.
+    if (error || !data) {
+      console.error(
+        '[NotificationService] Aborting subscribe pass: failed to read existing subscriptions',
+        error
+      );
+      return;
+    }
+
+    const alreadySubscribed = new Set(
+      (data as { account_address: string }[]).map((row) => row.account_address)
+    );
+
+    const rows = addresses
+      .filter((address) => !alreadySubscribed.has(address))
+      .map((address) =>
+        this.buildSubscriptionRow(deviceId, address, {
+          ...DEFAULT_NOTIFICATION_PREFERENCES,
+          // Watch accounts can't decrypt messages, so disable by default.
+          messages: pending.get(address)!.messages,
+        })
+      );
+
+    if (rows.length === 0) {
+      console.log(
+        '[NotificationService] All accounts already subscribed, nothing to write'
+      );
+      return;
+    }
+
+    // Re-check the abort token as late as possible: the accounts array is a
+    // snapshot taken before the read above, and an unmount or a deleteAccount
+    // since then means this write would resurrect a subscription.
+    if (!isAccountSubscribeTokenCurrent(subscribeToken)) {
+      console.log(
+        '[NotificationService] Subscribe pass superseded (teardown or account deletion); skipping write'
+      );
+      return;
+    }
+
+    // --- ONE write for N accounts ---
+    // ignoreDuplicates => ON CONFLICT DO NOTHING: insert-if-absent, so a row
+    // created or edited on another device between the read and here survives.
+    const { error: writeError } = await supabase
+      .schema('voiwallet')
+      .from('account_subscriptions')
+      .upsert(rows, {
+        onConflict: 'device_id,account_address',
+        ignoreDuplicates: true,
+      });
+
+    if (writeError) {
+      console.error('Failed to subscribe accounts:', writeError);
+      return;
+    }
+
+    console.log(
+      `[NotificationService] Subscribed ${rows.length} account(s) to notifications`
+    );
   }
 
   /**
@@ -543,15 +653,47 @@ class NotificationService {
   // Private methods
 
   /**
+   * Build one `account_subscriptions` row. Shared by the single-account
+   * subscribe and the batch pass so both write an identical column set.
+   */
+  private buildSubscriptionRow(
+    deviceId: string,
+    address: string,
+    prefs: NotificationPreferences
+  ): Record<string, unknown> {
+    return {
+      device_id: deviceId,
+      account_address: address,
+      notify_messages: prefs.messages,
+      notify_voi_payments: prefs.voiPayments,
+      notify_arc200_transfers: prefs.arc200Transfers,
+      notify_arc72_transfers: prefs.arc72Transfers,
+      notify_outgoing_confirmations: prefs.outgoingConfirmations,
+      notify_price_alerts: prefs.priceAlerts,
+      min_voi_amount: prefs.minVoiAmount,
+      min_arc200_amount: prefs.minArc200Amount,
+      price_alert_threshold_percent: prefs.priceAlertThreshold,
+      updated_at: new Date().toISOString(),
+    };
+  }
+
+  /**
    * Validate and normalize an address parameter.
    * Logs a warning and attempts recovery if an object is passed instead of a string.
+   *
+   * TASK-192: this used to accept ANY 58-character string — no checksum, no
+   * decode — so a truncated or corrupted address passed the gate and was
+   * written verbatim. It now runs the real checksum check (`isValidAddress`,
+   * as `services/envoi` does), because the batch subscribe amplifies bad data
+   * across a whole wallet in one write.
+   *
    * @param address - The address parameter to validate
    * @param context - Method name for logging context
    * @returns Validated address string, or null if invalid
    */
   private validateAddress(address: unknown, context: string): string | null {
     // Already a valid address string
-    if (typeof address === 'string' && address.length === 58) {
+    if (typeof address === 'string' && algosdk.isValidAddress(address)) {
       return address;
     }
 
@@ -574,7 +716,7 @@ class NotificationService {
       if (
         'address' in obj &&
         typeof obj.address === 'string' &&
-        obj.address.length === 58
+        algosdk.isValidAddress(obj.address)
       ) {
         console.warn(
           `[NotificationService] ${context}: Recovered address from object:`,

--- a/src/services/notifications/subscribePass.ts
+++ b/src/services/notifications/subscribePass.ts
@@ -1,0 +1,61 @@
+/**
+ * Generation token for the deferred per-account notification subscribe pass
+ * (TASK-192).
+ *
+ * `subscribeAllAccounts` is launched fire-and-forget from the service boot
+ * (`navigation/serviceBootstrap.ts`) over a `wallet.accounts` snapshot captured
+ * at launch. Nothing cancels that in-flight work: the mount effect's teardown
+ * only removes listeners, and an account deleted mid-window is already gone
+ * from storage by the time the pass writes. Batching the pass into a single
+ * write makes that window materially larger — one delayed write instead of N
+ * small independent ones — so the pass needs an abort token rather than luck.
+ *
+ * Contract: take a token at launch, re-check it immediately before the write,
+ * and drop the write if it is stale. Both invalidation paths matter and they
+ * are distinct:
+ *   - teardown (unmount / disposal) — the session that launched the pass is
+ *     gone;
+ *   - account deletion — the session is alive and never unmounted, but the
+ *     snapshot now names an account that no longer exists. Invalidated both in
+ *     `walletStore.deleteAccount` (earliest point, before it even reads the
+ *     account) and in `MultiAccountWalletService.deleteAccount` (the chokepoint
+ *     every deletion funnels through, including callers that bypass the store —
+ *     e.g. the watch→standard upgrade in AccountImportPreviewScreen).
+ *
+ * This lives in its own leaf module (no imports) so `walletStore` and
+ * `serviceBootstrap` can invalidate without pulling in the notification
+ * service's Expo/Supabase module graph, and without an import cycle.
+ */
+
+/**
+ * Monotonic counter. A token is "current" only while it equals this value, so
+ * any invalidation between take and check stales every token taken before it.
+ */
+let generation = 0;
+
+/**
+ * Take a token for a subscribe pass about to be launched. Call this
+ * SYNCHRONOUSLY at launch — a token taken later would not cover the window it
+ * is supposed to guard.
+ */
+export function takeAccountSubscribeToken(): number {
+  return generation;
+}
+
+/**
+ * Invalidate every in-flight subscribe pass. Called by the service-boot
+ * teardown and by both deletion entry points. Cheap and idempotent-ish
+ * (repeated calls simply advance the counter); it never blocks a future pass,
+ * which takes a fresh token at its own launch.
+ */
+export function invalidateAccountSubscribePasses(): void {
+  generation += 1;
+}
+
+/**
+ * True if `token` still refers to the current generation, i.e. no teardown or
+ * account deletion has happened since it was taken.
+ */
+export function isAccountSubscribeTokenCurrent(token: number): boolean {
+  return token === generation;
+}

--- a/src/services/realtime/__tests__/realtimeInert.test.ts
+++ b/src/services/realtime/__tests__/realtimeInert.test.ts
@@ -1,0 +1,477 @@
+// TASK-190 / F-26: Supabase realtime is intended to be OFF, but it was only
+// "off" by convention — nothing calls subscribeToAddresses, yet the singleton
+// was constructed at module import time and its constructor registered a
+// permanent AppState listener. walletStore.addAddress() (account create /
+// import / watch / rekey / remote-signer add) then populated the address set,
+// and the next background→foreground transition opened a real, unfiltered
+// WebSocket with no handlers attached.
+//
+// These specs pin the two halves of the fix:
+//   1. INERTNESS — importing the module, and adding addresses to it, opens
+//      nothing. Asserted against a fake Supabase client, not eyeballed.
+//   2. CHANNEL LIFECYCLE — for when realtime is re-enabled: concurrent installs
+//      leave exactly one live channel, a channel is always removed through the
+//      client that CREATED it (setDeviceId replaces the client), and emptying
+//      the address set tears the channel down.
+//
+// Supabase is faked rather than mocked ad hoc so each client carries its own
+// channel registry — "no orphan" is then a real assertion about what is still
+// live on a client, which is exactly what leaked in production.
+
+type StatusCallback = (status: string, err?: Error) => void;
+type EventCallback = (payload: { new: Record<string, unknown> }) => void;
+
+interface FakeChannel {
+  topic: string;
+  on: jest.Mock;
+  subscribe: jest.Mock;
+  /** Drive the realtime status callback the service registered. */
+  emit: (status: string, err?: Error) => void;
+  /** Deliver a postgres_changes INSERT to the handler the service registered. */
+  emitEvent: (row: Record<string, unknown>) => void;
+}
+
+interface FakeClient {
+  id: string;
+  /** Channels currently in this client's registry. */
+  live: FakeChannel[];
+  /** Every channel this client ever created, in order. */
+  created: FakeChannel[];
+  /** Channels handed to removeChannel(). */
+  removed: FakeChannel[];
+  channel: jest.Mock;
+  removeChannel: jest.Mock;
+}
+
+let mockClientSeq = 0;
+
+const mockCreateClient = (): FakeClient => {
+  mockClientSeq += 1;
+  const client: FakeClient = {
+    id: `client-${mockClientSeq}`,
+    live: [],
+    created: [],
+    removed: [],
+    channel: jest.fn(),
+    removeChannel: jest.fn(),
+  };
+
+  client.channel.mockImplementation((topic: string) => {
+    let statusCallback: StatusCallback | null = null;
+    let eventCallback: EventCallback | null = null;
+    const channel: FakeChannel = {
+      topic,
+      on: jest.fn((_event: string, _filter: unknown, cb: EventCallback) => {
+        eventCallback = cb;
+        return channel;
+      }),
+      subscribe: jest.fn((cb: StatusCallback) => {
+        statusCallback = cb;
+        return channel;
+      }),
+      emit: (status, err) => statusCallback?.(status, err),
+      emitEvent: (row) => eventCallback?.({ new: row }),
+    };
+    client.created.push(channel);
+    client.live.push(channel);
+    return channel;
+  });
+
+  client.removeChannel.mockImplementation(async (channel: FakeChannel) => {
+    client.removed.push(channel);
+    const index = client.live.indexOf(channel);
+    if (index >= 0) client.live.splice(index, 1);
+    return 'ok';
+  });
+
+  return client;
+};
+
+let mockCurrentClient: FakeClient | null = null;
+
+jest.mock('../../supabase', () => ({
+  getSupabaseClient: () => mockCurrentClient,
+  isSupabaseConfigured: () => mockCurrentClient !== null,
+  // Mirrors services/supabase/index.ts setDeviceId(): it RECREATES the client
+  // to change the x-device-id header, so any channel created before the call
+  // stays bound to the previous instance.
+  setDeviceId: () => {
+    mockCurrentClient = mockCreateClient();
+  },
+}));
+
+type AppStateHandler = (status: string) => unknown;
+
+const mockAppStateHandlers: AppStateHandler[] = [];
+
+const mockAddEventListener = jest.fn(
+  (_event: string, handler: AppStateHandler) => {
+    mockAppStateHandlers.push(handler);
+    return {
+      remove: () => {
+        const index = mockAppStateHandlers.indexOf(handler);
+        if (index >= 0) mockAppStateHandlers.splice(index, 1);
+      },
+    };
+  }
+);
+
+// The module under test only reaches for AppState; replacing react-native
+// wholesale keeps the fake listener registry authoritative.
+jest.mock('react-native', () => ({
+  AppState: {
+    addEventListener: (event: string, handler: AppStateHandler) =>
+      mockAddEventListener(event, handler),
+  },
+}));
+
+type RealtimeModule = typeof import('../index');
+type RealtimeInstance = ReturnType<RealtimeModule['getRealtimeService']>;
+
+/** Reaches the private members the lifecycle assertions need. */
+interface RealtimeInternals {
+  resubscribe(): Promise<boolean>;
+  installed: { channel: FakeChannel } | null;
+}
+
+const internals = (service: RealtimeInstance): RealtimeInternals =>
+  service as unknown as RealtimeInternals;
+
+/** Load the module in a fresh registry so each spec gets a fresh singleton. */
+const loadModule = (): RealtimeModule => {
+  let mod!: RealtimeModule;
+  jest.isolateModules(() => {
+    mod = require('../index');
+  });
+  return mod;
+};
+
+/** Let queued microtasks and zero-delay work settle (real timers only). */
+const flush = (): Promise<void> =>
+  new Promise((resolve) => setTimeout(resolve, 0));
+
+/** Deliver an AppState transition to every listener the service registered. */
+const fireAppState = async (status: string): Promise<void> => {
+  for (const handler of [...mockAppStateHandlers]) {
+    await handler(status);
+  }
+  await flush();
+};
+
+const ADDRESS_A = 'A'.repeat(58);
+const ADDRESS_B = 'B'.repeat(58);
+
+/** The service's currently installed channel, if any. */
+const installedChannel = (service: RealtimeInstance): FakeChannel | null =>
+  internals(service).installed?.channel ?? null;
+
+describe('realtime service — inertness while realtime is off', () => {
+  beforeEach(() => {
+    mockAppStateHandlers.length = 0;
+    mockCurrentClient = mockCreateClient();
+  });
+
+  it('registers no AppState listener at module import time', () => {
+    loadModule();
+
+    expect(mockAddEventListener).not.toHaveBeenCalled();
+  });
+
+  it('opens zero realtime connections after an account is added and the app is backgrounded/foregrounded', async () => {
+    const client = mockCurrentClient!;
+    const { realtimeService } = loadModule();
+
+    // Exactly what walletStore does on account create/import/watch/rekey/
+    // remote-signer add.
+    realtimeService.addAddress(ADDRESS_A);
+    realtimeService.addAddress(ADDRESS_B);
+
+    expect(mockAddEventListener).not.toHaveBeenCalled();
+
+    // Background → foreground. Nothing is listening, and even if something
+    // were, no connection may be opened.
+    await fireAppState('background');
+    await fireAppState('active');
+
+    expect(client.channel).not.toHaveBeenCalled();
+    expect(client.created).toHaveLength(0);
+    expect(client.live).toHaveLength(0);
+    expect(realtimeService.isRealtimeConnected()).toBe(false);
+  });
+
+  it('arms the AppState listener only on a genuine subscribe, and drops it on unsubscribe', async () => {
+    const { getRealtimeService } = loadModule();
+    const service = getRealtimeService();
+
+    service.addAddress(ADDRESS_A);
+    expect(mockAddEventListener).not.toHaveBeenCalled();
+
+    await service.subscribeToAddresses([ADDRESS_A]);
+    expect(mockAddEventListener).toHaveBeenCalledTimes(1);
+    expect(mockAppStateHandlers).toHaveLength(1);
+
+    await service.unsubscribe();
+    expect(mockAppStateHandlers).toHaveLength(0);
+
+    // And a foreground after the stop reopens nothing.
+    const client = mockCurrentClient!;
+    const createdBefore = client.created.length;
+    await fireAppState('active');
+    expect(client.created).toHaveLength(createdBefore);
+  });
+});
+
+describe('realtime service — channel lifecycle', () => {
+  beforeEach(() => {
+    mockAppStateHandlers.length = 0;
+    mockCurrentClient = mockCreateClient();
+  });
+
+  it('leaves exactly one channel and no orphan when three resubscribes race', async () => {
+    const client = mockCurrentClient!;
+    const { getRealtimeService } = loadModule();
+    const service = getRealtimeService();
+    service.addAddress(ADDRESS_A);
+
+    await Promise.all([
+      internals(service).resubscribe(),
+      internals(service).resubscribe(),
+      internals(service).resubscribe(),
+    ]);
+
+    expect(client.live).toHaveLength(1);
+    // The one live channel is the one the service holds — no channel is live
+    // in the registry that the service has forgotten about.
+    expect(client.live[0]).toBe(installedChannel(service));
+    // Anything else that got created was explicitly removed.
+    expect(client.created.length - client.removed.length).toBe(1);
+  });
+
+  it('leaves exactly one channel when an explicit subscribe races a resubscribe', async () => {
+    const client = mockCurrentClient!;
+    const { getRealtimeService } = loadModule();
+    const service = getRealtimeService();
+
+    await Promise.all([
+      service.subscribeToAddresses([ADDRESS_A]),
+      internals(service).resubscribe(),
+    ]);
+
+    expect(client.live).toHaveLength(1);
+    expect(client.live[0]).toBe(installedChannel(service));
+    expect(client.created.length - client.removed.length).toBe(1);
+  });
+
+  it('leaves exactly one channel when a resubscribe races an explicit subscribe (reverse order)', async () => {
+    const client = mockCurrentClient!;
+    const { getRealtimeService } = loadModule();
+    const service = getRealtimeService();
+    service.addAddress(ADDRESS_A);
+
+    await Promise.all([
+      internals(service).resubscribe(),
+      service.subscribeToAddresses([ADDRESS_B]),
+    ]);
+
+    expect(client.live).toHaveLength(1);
+    expect(client.live[0]).toBe(installedChannel(service));
+    expect(client.created.length - client.removed.length).toBe(1);
+  });
+
+  it('removes the channel from the client that created it after setDeviceId swaps the client', async () => {
+    const clientA = mockCurrentClient!;
+    const { getRealtimeService } = loadModule();
+    const { setDeviceId } = require('../../supabase');
+    const service = getRealtimeService();
+
+    await service.subscribeToAddresses([ADDRESS_A]);
+    expect(clientA.live).toHaveLength(1);
+
+    // setDeviceId replaces the Supabase singleton; the live channel is still
+    // bound to clientA.
+    setDeviceId('device-2');
+    const clientB = mockCurrentClient!;
+    expect(clientB).not.toBe(clientA);
+    expect(clientB.live).toHaveLength(0);
+
+    await service.unsubscribe();
+
+    // No channel remains on EITHER client.
+    expect(clientA.live).toHaveLength(0);
+    expect(clientB.live).toHaveLength(0);
+    expect(clientA.removeChannel).toHaveBeenCalledTimes(1);
+    expect(clientB.removeChannel).not.toHaveBeenCalled();
+    expect(installedChannel(service)).toBeNull();
+  });
+
+  it('tears the channel down through the old client when a reinstall lands after setDeviceId', async () => {
+    const clientA = mockCurrentClient!;
+    const { getRealtimeService } = loadModule();
+    const { setDeviceId } = require('../../supabase');
+    const service = getRealtimeService();
+
+    await service.subscribeToAddresses([ADDRESS_A]);
+    setDeviceId('device-2');
+    const clientB = mockCurrentClient!;
+
+    await internals(service).resubscribe();
+
+    expect(clientA.live).toHaveLength(0);
+    expect(clientB.live).toHaveLength(1);
+    expect(clientB.live[0]).toBe(installedChannel(service));
+  });
+
+  it('tears the channel down when the subscribed-address set becomes empty', async () => {
+    const client = mockCurrentClient!;
+    const { getRealtimeService } = loadModule();
+    const service = getRealtimeService();
+
+    await service.subscribeToAddresses([ADDRESS_A, ADDRESS_B]);
+    expect(client.live).toHaveLength(1);
+
+    // One address left: the subscription must survive.
+    service.removeAddress(ADDRESS_A);
+    await flush();
+    expect(client.live).toHaveLength(1);
+
+    // Last address gone: nothing to receive events for.
+    service.removeAddress(ADDRESS_B);
+    await flush();
+    expect(client.live).toHaveLength(0);
+    expect(installedChannel(service)).toBeNull();
+    expect(mockAppStateHandlers).toHaveLength(0);
+  });
+
+  it('does not accumulate channels across the reconnect backoff loop', async () => {
+    jest.useFakeTimers();
+    try {
+      const client = mockCurrentClient!;
+      const { getRealtimeService } = loadModule();
+      const service = getRealtimeService();
+
+      await service.subscribeToAddresses([ADDRESS_A]);
+      expect(client.live).toHaveLength(1);
+
+      // Five CHANNEL_ERROR → scheduleReconnect cycles: the pre-fix code pushed
+      // one un-removed RealtimeChannel into the registry per cycle.
+      for (let attempt = 0; attempt < 5; attempt++) {
+        client.live[0].emit('CHANNEL_ERROR');
+        await jest.advanceTimersByTimeAsync(60_000);
+      }
+
+      expect(client.created.length).toBeGreaterThan(1);
+      expect(client.live).toHaveLength(1);
+      expect(client.live[0]).toBe(installedChannel(service));
+      expect(client.removed).toHaveLength(client.created.length - 1);
+    } finally {
+      jest.useRealTimers();
+    }
+  });
+
+  it('ignores status callbacks from a superseded channel', async () => {
+    const client = mockCurrentClient!;
+    const onConnectionChange = jest.fn();
+    const { getRealtimeService } = loadModule();
+    const service = getRealtimeService();
+    service.setHandlers({ onConnectionChange });
+
+    await service.subscribeToAddresses([ADDRESS_A]);
+    const stale = client.created[0];
+
+    await internals(service).resubscribe();
+    onConnectionChange.mockClear();
+
+    // The stale channel was removed; its late status updates must not touch
+    // shared state or schedule a reconnect.
+    stale.emit('SUBSCRIBED');
+    stale.emit('CHANNEL_ERROR');
+    await flush();
+
+    expect(onConnectionChange).not.toHaveBeenCalled();
+    expect(service.isRealtimeConnected()).toBe(false);
+    expect(client.live).toHaveLength(1);
+    expect(client.live[0]).toBe(installedChannel(service));
+  });
+
+  it('drops wallet events that arrive on a superseded channel', async () => {
+    const client = mockCurrentClient!;
+    const onAnyEvent = jest.fn();
+    const { getRealtimeService } = loadModule();
+    const service = getRealtimeService();
+    service.setHandlers({ onAnyEvent });
+
+    await service.subscribeToAddresses([ADDRESS_A]);
+    const stale = client.created[0];
+
+    await internals(service).resubscribe();
+
+    const row = {
+      id: 1,
+      event_type: 'voi_payment',
+      sender: ADDRESS_B,
+      receiver: ADDRESS_A,
+    };
+
+    // In flight on the channel that was just torn down: delivering it would
+    // double-fire the handlers (or fire them after an unsubscribe).
+    stale.emitEvent(row);
+    expect(onAnyEvent).not.toHaveBeenCalled();
+
+    // The current channel still delivers — the guard must not over-block.
+    client.live[0].emitEvent(row);
+    expect(onAnyEvent).toHaveBeenCalledTimes(1);
+
+    // And nothing is delivered after an explicit stop.
+    const current = client.live[0];
+    await service.unsubscribe();
+    current.emitEvent(row);
+    expect(onAnyEvent).toHaveBeenCalledTimes(1);
+  });
+
+  it('retries removal when the client reports an error, so nothing is orphaned', async () => {
+    const client = mockCurrentClient!;
+    const { getRealtimeService } = loadModule();
+    const service = getRealtimeService();
+
+    await service.subscribeToAddresses([ADDRESS_A]);
+
+    // realtime-js resolves 'error' WITHOUT running the channel's close hook,
+    // so RealtimeClient._remove() never runs and the channel stays registered.
+    // The retry hits the `leaving` state and resolves locally.
+    let attempts = 0;
+    client.removeChannel.mockImplementation(async (channel: FakeChannel) => {
+      attempts += 1;
+      if (attempts === 1) return 'error';
+      client.removed.push(channel);
+      const index = client.live.indexOf(channel);
+      if (index >= 0) client.live.splice(index, 1);
+      return 'ok';
+    });
+
+    await service.unsubscribe();
+
+    expect(attempts).toBe(2);
+    expect(client.live).toHaveLength(0);
+    expect(installedChannel(service)).toBeNull();
+  });
+
+  it('cleanup leaves no channel, no listener and no addresses', async () => {
+    const client = mockCurrentClient!;
+    const { getRealtimeService } = loadModule();
+    const service = getRealtimeService();
+
+    await service.subscribeToAddresses([ADDRESS_A]);
+    expect(client.live).toHaveLength(1);
+    expect(mockAppStateHandlers).toHaveLength(1);
+
+    await service.cleanup();
+
+    expect(client.live).toHaveLength(0);
+    expect(mockAppStateHandlers).toHaveLength(0);
+    expect(installedChannel(service)).toBeNull();
+
+    // Address set cleared, so a foreground cannot resurrect anything.
+    await fireAppState('active');
+    expect(client.created).toHaveLength(1);
+  });
+});

--- a/src/services/realtime/__tests__/realtimeInert.test.ts
+++ b/src/services/realtime/__tests__/realtimeInert.test.ts
@@ -475,3 +475,30 @@ describe('realtime service — channel lifecycle', () => {
     expect(client.created).toHaveLength(1);
   });
 });
+
+// Round 3 of the full-diff Codex pass over PLAN-275. cleanup() awaited
+// unsubscribe() and cleared state only afterwards, so an install that completed
+// DURING that await survived: its channel stayed live while the addresses,
+// handlers and AppState listener were wiped out from under it — a channel
+// nothing would ever tear down. The generation bump does not cover this, because
+// such an install starts AFTER the bump and is therefore the newest.
+describe('cleanup() racing a concurrent subscribe (TASK-190)', () => {
+  it('leaves no channel behind when a subscribe lands mid-cleanup', async () => {
+    const client = mockCurrentClient!;
+    const { getRealtimeService } = loadModule();
+    const service = getRealtimeService();
+
+    await service.subscribeToAddresses([ADDRESS_A]);
+    expect(client.live).toHaveLength(1);
+
+    // Race an explicit subscribe into cleanup's teardown await.
+    const cleaning = service.cleanup();
+    const racing = service.subscribeToAddresses([ADDRESS_B]);
+    await Promise.all([cleaning, racing]);
+    await flush();
+
+    expect(client.live).toHaveLength(0);
+    expect(installedChannel(service)).toBeNull();
+    expect(client.created.length - client.removed.length).toBe(0);
+  });
+});

--- a/src/services/realtime/index.ts
+++ b/src/services/realtime/index.ts
@@ -2,16 +2,46 @@
  * Realtime Service
  *
  * Manages Supabase Realtime subscriptions for instant wallet event updates.
- * Replaces polling with WebSocket-based real-time updates.
+ *
+ * REALTIME IS CURRENTLY OFF (TASK-190). Nothing in the app calls
+ * `setHandlers`/`subscribeToAddresses` — the only references left are
+ * commented-out code in `navigation/serviceBootstrap.ts`. This module must
+ * therefore stay completely INERT until something performs a real subscribe:
+ *
+ *  - The singleton is NOT constructed at module import time. Importing this
+ *    module (as `walletStore` does) must have no side effects.
+ *  - The constructor registers nothing. The `AppState` listener is installed
+ *    only when a channel is actually installed, and removed again when the
+ *    subscription stops.
+ *  - `addAddress`/`removeAddress` are pure bookkeeping. They exist so the
+ *    address set is warm if realtime is ever re-enabled; they must never open
+ *    a socket. Previously `addAddress` (called on every account create /
+ *    import / watch / rekey / remote-signer add) armed the always-registered
+ *    `AppState` listener, so the next foreground opened a WebSocket nobody had
+ *    asked for.
+ *
+ * Channel lifecycle rules, so that re-enabling realtime later is safe:
+ *  - `installChannel` is the ONLY path that creates a channel. Explicit
+ *    subscribes, the foreground handler and the backoff timer all funnel
+ *    through it, behind a single-flight chain plus a generation token
+ *    (same idiom as `isLatestMultiNetworkRequest` in `store/walletStore.ts`).
+ *    An install that is no longer the newest DISCARDS its channel instead of
+ *    installing it.
+ *  - Every install tears the previous channel down first. `resubscribe` used
+ *    to overwrite `this.channel` without removing it, leaking one live
+ *    `RealtimeChannel` per reconnect for the lifetime of the app.
+ *  - A channel is always removed through the client that CREATED it — see
+ *    `InstalledChannel` below.
  */
 
-import {
+import type {
   RealtimeChannel,
   RealtimePostgresChangesPayload,
+  SupabaseClient,
 } from '@supabase/supabase-js';
 import { AppState, AppStateStatus } from 'react-native';
 import { getSupabaseClient, isSupabaseConfigured } from '../supabase';
-import { WalletEvent } from '../notifications/types';
+import type { WalletEvent } from '../notifications/types';
 
 /**
  * Event handlers for different wallet event types
@@ -27,15 +57,37 @@ export interface RealtimeEventHandlers {
 }
 
 /**
+ * A live channel together with the client it was created on.
+ *
+ * `setDeviceId()` REPLACES the Supabase singleton (`services/supabase/index.ts`
+ * recreates the client to change the `x-device-id` header), so resolving the
+ * client again at teardown time can hand back a different instance — one whose
+ * registry never held this channel. The removal would then silently no-op and
+ * the channel would stay live on the previous client forever. Always tear down
+ * through the client that created the channel.
+ */
+interface InstalledChannel {
+  channel: RealtimeChannel;
+  client: SupabaseClient;
+}
+
+/**
  * Realtime Service
  * Singleton service for managing Supabase Realtime subscriptions
  */
-class RealtimeService {
-  private static instance: RealtimeService;
-  private channel: RealtimeChannel | null = null;
+export class RealtimeService {
+  private static instance: RealtimeService | null = null;
+
+  private installed: InstalledChannel | null = null;
   private subscribedAddresses: Set<string> = new Set(); // Algorand addresses (58-char)
   private handlers: RealtimeEventHandlers = {};
   private isConnected: boolean = false;
+  /**
+   * True only while a channel has genuinely been installed. Gates the
+   * foreground reconnect and the backoff timer so bookkeeping alone can never
+   * bring the service to life.
+   */
+  private isActive: boolean = false;
   private reconnectAttempts: number = 0;
   private maxReconnectAttempts: number = 5;
   private reconnectTimeout: ReturnType<typeof setTimeout> | null = null;
@@ -43,31 +95,42 @@ class RealtimeService {
     typeof AppState.addEventListener
   > | null = null;
 
+  /** Monotonic token; only the newest install may install its channel. */
+  private installGeneration: number = 0;
+  /** Single-flight chain: installs never interleave. Never rejects. */
+  private installChain: Promise<unknown> = Promise.resolve();
+
   private constructor() {
-    // Private constructor for singleton
-    // Set up app state listener to handle foreground/background transitions
-    this.appStateSubscription = AppState.addEventListener(
-      'change',
-      this.handleAppStateChange
-    );
+    // Private constructor for the singleton. Deliberately registers NOTHING —
+    // see the module header. The AppState listener is attached lazily by
+    // `ensureAppStateSubscription`, on a real channel install only.
   }
 
   private handleAppStateChange = async (
     nextAppState: AppStateStatus
   ): Promise<void> => {
-    if (nextAppState === 'active') {
-      // App came to foreground - reset reconnect attempts and try to reconnect if needed
-      this.reconnectAttempts = 0;
+    if (nextAppState !== 'active') return;
 
-      if (!this.isConnected && this.subscribedAddresses.size > 0) {
-        console.log('App foregrounded, attempting to reconnect realtime...');
-        await this.resubscribe();
-      }
+    // App came to foreground - reset reconnect attempts and try to reconnect
+    // if needed. `isActive` is belt-and-braces: this listener only exists
+    // while a subscription is active.
+    this.reconnectAttempts = 0;
+
+    if (
+      this.isActive &&
+      !this.isConnected &&
+      this.subscribedAddresses.size > 0
+    ) {
+      console.log('App foregrounded, attempting to reconnect realtime...');
+      await this.resubscribe();
     }
   };
 
   /**
-   * Get the singleton instance
+   * Get the singleton instance.
+   *
+   * Constructing it is inert, so callers may do this freely — but the instance
+   * is still created lazily so that merely importing this module does nothing.
    */
   static getInstance(): RealtimeService {
     if (!RealtimeService.instance) {
@@ -98,12 +161,17 @@ class RealtimeService {
   }
 
   /**
-   * Subscribe to wallet events for specific addresses
+   * Subscribe to wallet events for specific addresses.
+   *
+   * This is the only public entry point that opens a connection.
+   *
    * @param addresses - Array of Algorand addresses to subscribe to (58-char format)
+   * @returns `true` when THIS call installed the channel. `false` when it could
+   *   not (Supabase unconfigured, no valid addresses) or when a newer install
+   *   superseded it — in the latter case the newer install owns the channel.
    */
   async subscribeToAddresses(addresses: string[]): Promise<boolean> {
-    const supabase = getSupabaseClient();
-    if (!supabase) {
+    if (!getSupabaseClient()) {
       console.warn('Supabase not configured, cannot subscribe to realtime');
       return false;
     }
@@ -119,14 +187,127 @@ class RealtimeService {
     // Store subscribed addresses
     validAddresses.forEach((addr) => this.subscribedAddresses.add(addr));
 
-    // Unsubscribe from existing channel if any
-    await this.unsubscribe();
+    return this.installChannel();
+  }
 
-    // Create new channel with unique name
-    const channelName = `wallet-events-${Date.now()}`;
+  /**
+   * Add an address to the subscription set.
+   *
+   * PURE BOOKKEEPING — this must never open a connection or register a
+   * listener. Realtime only starts from an explicit `subscribeToAddresses`.
+   *
+   * @param address - Algorand address to add (58-char format)
+   */
+  addAddress(address: string): void {
+    if (address.length === 58) {
+      this.subscribedAddresses.add(address);
+    }
+  }
+
+  /**
+   * Remove an address from the subscription set.
+   *
+   * When the last address goes the channel is torn down: a live socket bound
+   * to an empty address set can only deliver events we would immediately drop.
+   *
+   * @param address - Algorand address to remove (58-char format)
+   */
+  removeAddress(address: string): void {
+    if (!this.subscribedAddresses.delete(address)) return;
+
+    if (this.subscribedAddresses.size === 0) {
+      void this.unsubscribe().catch((error) => {
+        console.warn(
+          'Failed to tear down realtime after the last address was removed:',
+          error
+        );
+      });
+    }
+  }
+
+  /**
+   * Unsubscribe from all wallet events.
+   *
+   * Cancels any install still in flight, drops the AppState listener and
+   * returns the service to its inert state. The address set is preserved so a
+   * later `subscribeToAddresses` can pick it up again.
+   */
+  async unsubscribe(): Promise<void> {
+    // Supersede in-flight installs so a late one cannot resurrect a channel
+    // after an explicit stop.
+    this.installGeneration++;
+    this.isActive = false;
+    this.removeAppStateSubscription();
+    await this.teardownChannel();
+  }
+
+  /**
+   * Clear all subscriptions and handlers
+   */
+  async cleanup(): Promise<void> {
+    await this.unsubscribe();
+    this.subscribedAddresses.clear();
+    this.handlers = {};
+    this.removeAppStateSubscription();
+  }
+
+  // Private methods
+
+  private ensureAppStateSubscription(): void {
+    if (this.appStateSubscription) return;
+    this.appStateSubscription = AppState.addEventListener(
+      'change',
+      this.handleAppStateChange
+    );
+  }
+
+  private removeAppStateSubscription(): void {
+    if (!this.appStateSubscription) return;
+    this.appStateSubscription.remove();
+    this.appStateSubscription = null;
+  }
+
+  /**
+   * Queue a channel install. Every install path goes through here.
+   *
+   * The generation is taken SYNCHRONOUSLY, so concurrent callers are ordered
+   * the moment they arrive; the chain then runs them one at a time and every
+   * one but the newest drops out. Never rejects.
+   */
+  private installChannel(): Promise<boolean> {
+    const generation = ++this.installGeneration;
+
+    const settled: Promise<boolean> = this.installChain
+      .then(() => this.performInstall(generation))
+      .catch((error) => {
+        console.warn('Realtime channel install failed:', error);
+        return false;
+      });
+
+    // The chain itself can never reject, so the next install always runs.
+    this.installChain = settled;
+
+    return settled;
+  }
+
+  private async performInstall(generation: number): Promise<boolean> {
+    // Superseded before this install ever got its turn.
+    if (generation !== this.installGeneration) return false;
+
+    const supabase = getSupabaseClient();
+    if (!supabase || this.subscribedAddresses.size === 0) return false;
+
+    // Remove the previous channel BEFORE creating the next one, through the
+    // client that owns it.
+    await this.teardownChannel();
+    if (generation !== this.installGeneration) return false;
+
+    // Unique per install: realtime-js dedupes channels by topic only, and two
+    // installs can land inside the same millisecond.
+    const channelName = `wallet-events-${Date.now()}-${generation}`;
 
     // Subscribe to voiwallet.wallet_events (note: schema specified explicitly)
-    this.channel = supabase
+    const channel = supabase
       .channel(channelName)
       .on(
         'postgres_changes',
@@ -136,10 +317,20 @@ class RealtimeService {
           table: 'wallet_events',
         },
         (payload: RealtimePostgresChangesPayload<WalletEvent>) => {
+          // Same rule as the status callback below: a superseded channel is
+          // being (or has been) removed, and an event still in flight on it
+          // would otherwise be delivered to the handlers a second time, or
+          // after an explicit unsubscribe.
+          if (generation !== this.installGeneration) return;
           this.handleWalletEvent(payload.new as WalletEvent);
         }
       )
       .subscribe((status, err) => {
+        // A superseded (or discarded) channel must not touch shared state or
+        // schedule reconnects — its status updates describe a socket nobody
+        // owns any more.
+        if (generation !== this.installGeneration) return;
+
         if (status === 'SUBSCRIBED') {
           console.log('Realtime subscription active');
           this.isConnected = true;
@@ -159,61 +350,75 @@ class RealtimeService {
         }
       });
 
+    if (generation !== this.installGeneration) {
+      // A newer install (or an explicit unsubscribe) landed while this channel
+      // was being created. Discard it rather than install it — otherwise it is
+      // an orphan nobody will ever remove.
+      await this.removeChannelSafely(supabase, channel);
+      return false;
+    }
+
+    this.installed = { channel, client: supabase };
+    this.isActive = true;
+    this.ensureAppStateSubscription();
+
     return true;
   }
 
   /**
-   * Add an address to the subscription
-   * @param address - Algorand address to add (58-char format)
+   * Remove the installed channel, if any. Does NOT bump the generation, so it
+   * is safe to call from inside an install.
    */
-  addAddress(address: string): void {
-    if (address.length === 58) {
-      this.subscribedAddresses.add(address);
-    }
-  }
-
-  /**
-   * Remove an address from the subscription
-   * @param address - Algorand address to remove (58-char format)
-   */
-  removeAddress(address: string): void {
-    this.subscribedAddresses.delete(address);
-  }
-
-  /**
-   * Unsubscribe from all wallet events
-   */
-  async unsubscribe(): Promise<void> {
+  private async teardownChannel(): Promise<void> {
     if (this.reconnectTimeout) {
       clearTimeout(this.reconnectTimeout);
       this.reconnectTimeout = null;
     }
 
-    if (this.channel) {
-      const supabase = getSupabaseClient();
-      if (supabase) {
-        await supabase.removeChannel(this.channel);
-      }
-      this.channel = null;
-    }
-
+    const installed = this.installed;
+    // Clear first: teardown awaits, and nothing may observe a half-removed
+    // channel in the meantime.
+    this.installed = null;
     this.isConnected = false;
+
+    if (installed) {
+      await this.removeChannelSafely(installed.client, installed.channel);
+    }
   }
 
   /**
-   * Clear all subscriptions and handlers
+   * Remove a channel from its client. Teardown must never throw — it runs on
+   * cleanup paths.
+   *
+   * `removeChannel` RESOLVES with 'ok' | 'timed out' | 'error'; it does not
+   * reject. On 'error' realtime-js resolves without running the channel's
+   * close hook, so `RealtimeClient._remove()` never runs and the channel stays
+   * in the client's registry — precisely the orphan this task exists to
+   * prevent, and invisible if the status is ignored. The channel is left in
+   * the `leaving` state by that first attempt, which makes `_canPush()` false,
+   * so a second `unsubscribe` resolves 'ok' locally and does remove it.
    */
-  async cleanup(): Promise<void> {
-    await this.unsubscribe();
-    this.subscribedAddresses.clear();
-    this.handlers = {};
-    if (this.appStateSubscription) {
-      this.appStateSubscription.remove();
-      this.appStateSubscription = null;
+  private async removeChannelSafely(
+    client: SupabaseClient,
+    channel: RealtimeChannel
+  ): Promise<void> {
+    try {
+      const status = await client.removeChannel(channel);
+      if (status === 'ok') return;
+
+      console.warn(
+        `Realtime channel removal returned "${status}", retrying once`
+      );
+      const retryStatus = await client.removeChannel(channel);
+      if (retryStatus !== 'ok') {
+        console.warn(
+          `Realtime channel removal still "${retryStatus}" after retry; it may remain registered on the client`
+        );
+      }
+    } catch (error) {
+      console.warn('Failed to remove realtime channel:', error);
     }
   }
-
-  // Private methods
 
   private handleWalletEvent(event: WalletEvent): void {
     // Check if this event is relevant to our subscribed addresses
@@ -253,6 +458,9 @@ class RealtimeService {
   }
 
   private scheduleReconnect(): void {
+    // An explicit unsubscribe/cleanup stops the backoff loop dead.
+    if (!this.isActive) return;
+
     if (this.reconnectAttempts >= this.maxReconnectAttempts) {
       console.warn(
         'Max reconnect attempts reached, will retry on next app foreground'
@@ -270,9 +478,10 @@ class RealtimeService {
       `Scheduling reconnect attempt ${this.reconnectAttempts} in ${delay}ms`
     );
 
-    this.reconnectTimeout = setTimeout(async () => {
-      if (this.subscribedAddresses.size > 0) {
-        await this.resubscribe();
+    this.reconnectTimeout = setTimeout(() => {
+      this.reconnectTimeout = null;
+      if (this.isActive && this.subscribedAddresses.size > 0) {
+        void this.resubscribe();
       }
     }, delay);
   }
@@ -285,43 +494,48 @@ class RealtimeService {
     this.reconnectAttempts = 0;
   }
 
-  private async resubscribe(): Promise<void> {
-    const supabase = getSupabaseClient();
-    if (!supabase || this.subscribedAddresses.size === 0) return;
-
-    // Create new channel
-    const channelName = `wallet-events-${Date.now()}`;
-
-    // Resubscribe to voiwallet.wallet_events
-    this.channel = supabase
-      .channel(channelName)
-      .on(
-        'postgres_changes',
-        {
-          event: 'INSERT',
-          schema: 'voiwallet',
-          table: 'wallet_events',
-        },
-        (payload: RealtimePostgresChangesPayload<WalletEvent>) => {
-          this.handleWalletEvent(payload.new as WalletEvent);
-        }
-      )
-      .subscribe((status, err) => {
-        if (status === 'SUBSCRIBED') {
-          console.log('Realtime reconnection successful');
-          this.isConnected = true;
-          this.reconnectAttempts = 0;
-          this.handlers.onConnectionChange?.('connected');
-        } else if (status === 'CHANNEL_ERROR' || status === 'TIMED_OUT') {
-          console.warn(
-            `Realtime reconnection ${status.toLowerCase()}${err ? `: ${err.message || err}` : ''}`
-          );
-          this.isConnected = false;
-          this.scheduleReconnect();
-        }
-      });
+  private resubscribe(): Promise<boolean> {
+    return this.installChannel();
   }
 }
 
-// Export singleton getter
-export const realtimeService = RealtimeService.getInstance();
+/**
+ * Lazily resolve the singleton. Importing this module must not construct it —
+ * see the module header.
+ */
+export function getRealtimeService(): RealtimeService {
+  return RealtimeService.getInstance();
+}
+
+/** Public surface of the realtime service. */
+export type RealtimeServiceApi = Pick<
+  RealtimeService,
+  | 'isAvailable'
+  | 'isRealtimeConnected'
+  | 'setHandlers'
+  | 'subscribeToAddresses'
+  | 'addAddress'
+  | 'removeAddress'
+  | 'unsubscribe'
+  | 'cleanup'
+  | 'resetReconnectAttempts'
+>;
+
+/**
+ * Singleton facade. Kept as a value export so existing call sites (and the
+ * `jest.mock(... , { realtimeService: {} })` stubs in the store specs) are
+ * unchanged, but every method resolves the instance on demand rather than at
+ * import time.
+ */
+export const realtimeService: RealtimeServiceApi = {
+  isAvailable: () => getRealtimeService().isAvailable(),
+  isRealtimeConnected: () => getRealtimeService().isRealtimeConnected(),
+  setHandlers: (handlers) => getRealtimeService().setHandlers(handlers),
+  subscribeToAddresses: (addresses) =>
+    getRealtimeService().subscribeToAddresses(addresses),
+  addAddress: (address) => getRealtimeService().addAddress(address),
+  removeAddress: (address) => getRealtimeService().removeAddress(address),
+  unsubscribe: () => getRealtimeService().unsubscribe(),
+  cleanup: () => getRealtimeService().cleanup(),
+  resetReconnectAttempts: () => getRealtimeService().resetReconnectAttempts(),
+};

--- a/src/services/realtime/index.ts
+++ b/src/services/realtime/index.ts
@@ -97,6 +97,13 @@ export class RealtimeService {
 
   /** Monotonic token; only the newest install may install its channel. */
   private installGeneration: number = 0;
+  // Defence in depth against an install completing after cleanup's final sweep.
+  // NOTE: the cleanup-race test below is satisfied by the synchronous clear +
+  // sweep alone — this flag is NOT isolated by any test, because the fake
+  // client installs too promptly to open the window it guards. Kept because a
+  // real Supabase install has genuine async gaps the fake does not model, and
+  // the cost is one boolean. Do not read its presence as tested behaviour.
+  private shuttingDown: boolean = false;
   /** Single-flight chain: installs never interleave. Never rejects. */
   private installChain: Promise<unknown> = Promise.resolve();
 
@@ -171,6 +178,8 @@ export class RealtimeService {
    *   superseded it — in the latter case the newer install owns the channel.
    */
   async subscribeToAddresses(addresses: string[]): Promise<boolean> {
+    // Explicit intent to start again clears the cleanup latch.
+    this.shuttingDown = false;
     if (!getSupabaseClient()) {
       console.warn('Supabase not configured, cannot subscribe to realtime');
       return false;
@@ -245,10 +254,22 @@ export class RealtimeService {
    * Clear all subscriptions and handlers
    */
   async cleanup(): Promise<void> {
-    await this.unsubscribe();
+    // Latch and clear SYNCHRONOUSLY, before any await. This previously awaited
+    // unsubscribe() and cleared afterwards, so an install completing during
+    // that await survived: its channel stayed live while the addresses,
+    // handlers and AppState listener were wiped from under it, leaving a
+    // channel nothing would ever tear down. The generation bump inside
+    // unsubscribe() does not cover that case — such an install starts after
+    // the bump and is therefore the newest.
+    this.shuttingDown = true;
     this.subscribedAddresses.clear();
     this.handlers = {};
     this.removeAppStateSubscription();
+
+    await this.unsubscribe();
+
+    // Sweep anything that landed between the latch and here.
+    await this.teardownChannel();
   }
 
   // Private methods
@@ -293,6 +314,8 @@ export class RealtimeService {
   private async performInstall(generation: number): Promise<boolean> {
     // Superseded before this install ever got its turn.
     if (generation !== this.installGeneration) return false;
+    // cleanup() is tearing the service down; do not resurrect a channel.
+    if (this.shuttingDown) return false;
 
     const supabase = getSupabaseClient();
     if (!supabase || this.subscribedAddresses.size === 0) return false;

--- a/src/services/secure/AccountSecureStorage.ts
+++ b/src/services/secure/AccountSecureStorage.ts
@@ -48,6 +48,7 @@ import { SessionKeyVault, VaultLockedError } from './SessionKeyVault';
 import type { SecretSource } from './SessionKeyVault';
 import { clearPinSetupPending } from './pinSetupPending';
 import { SECURITY_CONFIG } from '../../config/security';
+import { invalidateAccountSubscribePasses } from '@/services/notifications/subscribePass';
 
 // ─────────────────────────────────────────────────────────────────────────────
 // PIN THROTTLE — THREAT MODEL (DOC-137 §8 / TASK-26). READ BEFORE CHANGING.
@@ -3693,6 +3694,15 @@ export class AccountSecureStorage {
     // reliably aborted, even if the mutex is momentarily busy). Mirrors
     // clearAllWallets bumping walletResetEpoch at its entry (TASK-212).
     this.secureResetGeneration += 1;
+    // TASK-192: cancel any in-flight deferred notification subscribe pass, here
+    // rather than only in clearAllWallets. Every reset path awaits THIS method
+    // first and reaches clearAllWallets second (LockScreen.performReset,
+    // SecureStorageUnavailableScreen, backup restorers.clearAllData,
+    // keyManager), so invalidating downstream leaves a window the length of a
+    // full secure-storage wipe in which the boot-time batch can still write
+    // subscriptions for accounts being erased. Synchronous and before the mutex,
+    // for the same reason the generation bump above is.
+    invalidateAccountSubscribePasses();
     // TASK-220: zero the in-memory private-key cache NOW (synchronously) so a full
     // wipe can't leave a decrypted key readable from cache after the persisted
     // secret is gone. Paired with the generation guard on the cache write in

--- a/src/services/secure/__tests__/clearAllSubscribePass.test.ts
+++ b/src/services/secure/__tests__/clearAllSubscribePass.test.ts
@@ -1,0 +1,56 @@
+// TASK-192 — round 2 of the full-diff Codex pass over PLAN-275.
+//
+// The clearAllWallets() guard was still too late. EVERY reset path awaits
+// AccountSecureStorage.clearAll() FIRST and reaches clearAllWallets second:
+// LockScreen.performReset (:284), SecureStorageUnavailableScreen (:165),
+// backup restorers.clearAllData (:92), and keyManager (:667). That left the
+// deferred notification subscribe pass a window the length of a full
+// secure-storage wipe in which to complete and batch-write subscriptions for
+// accounts the user was erasing.
+//
+// Guarding at this chokepoint closes it for all four callers at once, and a
+// fifth reset path added later inherits it rather than reintroducing the bug.
+//
+// SECURITY NOTE: no static or committed secret material in this file.
+
+jest.mock('@/platform', () => ({
+  storage: {
+    getItem: jest.fn(async () => null),
+    setItem: jest.fn(async () => {}),
+    removeItem: jest.fn(async () => {}),
+    getAllKeys: jest.fn(async () => []),
+    multiRemove: jest.fn(async () => {}),
+  },
+  secureStorage: {
+    getItem: jest.fn(async () => null),
+    setItem: jest.fn(async () => {}),
+    deleteItem: jest.fn(async () => {}),
+  },
+}));
+
+import { AccountSecureStorage } from '../AccountSecureStorage';
+import {
+  isAccountSubscribeTokenCurrent,
+  takeAccountSubscribeToken,
+} from '@/services/notifications/subscribePass';
+
+describe('AccountSecureStorage.clearAll — cancels the deferred subscribe pass (TASK-192)', () => {
+  it('invalidates synchronously at entry, before the wipe is awaited', async () => {
+    const inFlightToken = takeAccountSubscribeToken();
+    expect(isAccountSubscribeTokenCurrent(inFlightToken)).toBe(true);
+
+    // Deliberately not awaited. The point is that the token dies on the
+    // synchronous prefix — asserting after the wipe resolves would also pass
+    // for the too-late implementation this replaces.
+    const pending = AccountSecureStorage.clearAll();
+    expect(isAccountSubscribeTokenCurrent(inFlightToken)).toBe(false);
+
+    await pending.catch(() => {});
+  });
+
+  it('leaves a token taken after the wipe current', async () => {
+    await AccountSecureStorage.clearAll().catch(() => {});
+    const freshToken = takeAccountSubscribeToken();
+    expect(isAccountSubscribeTokenCurrent(freshToken)).toBe(true);
+  });
+});

--- a/src/services/wallet/__tests__/deleteAccountSubscribePass.test.ts
+++ b/src/services/wallet/__tests__/deleteAccountSubscribePass.test.ts
@@ -118,3 +118,46 @@ describe('MultiAccountWalletService.deleteAccount — cancels the deferred subsc
     expect(isAccountSubscribeTokenCurrent(inFlightToken)).toBe(false);
   });
 });
+
+// Found by the full-diff Codex pass over PLAN-275, not by either task's own
+// review — a gap that only exists BETWEEN the two tasks. TASK-192 invalidated
+// the pass on single-account deletion, but clearAllWallets() is a different
+// wallet-replacement path: it is the canonical metadata wipe behind
+// LockScreen.performReset(), the secure-storage-unavailable reset, and backup
+// restore. A wipe is the widest form of the same race — every account in the
+// boot snapshot is stale, not just one — so an in-flight pass could batch-write
+// subscriptions for a wallet the user just erased.
+describe('MultiAccountWalletService.clearAllWallets — cancels the deferred subscribe pass (TASK-192)', () => {
+  beforeEach(() => {
+    mockStore = {};
+    mockSecureDeleteAccount.mockImplementation(async () => {});
+    seedWallet();
+  });
+
+  it('invalidates an in-flight subscribe token synchronously, before any await', async () => {
+    const inFlightToken = takeAccountSubscribeToken();
+    expect(isAccountSubscribeTokenCurrent(inFlightToken)).toBe(true);
+
+    // Do not await: assert on the synchronous prefix. The epoch bump this sits
+    // beside is documented as needing to happen before any await, and the same
+    // reasoning applies here — awaiting first would leave a window in which the
+    // batched write could still land.
+    const pending = MultiAccountWalletService.clearAllWallets();
+    expect(isAccountSubscribeTokenCurrent(inFlightToken)).toBe(false);
+
+    await pending;
+    expect(isAccountSubscribeTokenCurrent(inFlightToken)).toBe(false);
+  });
+
+  it('leaves a token taken AFTER the wipe current', async () => {
+    const staleToken = takeAccountSubscribeToken();
+    await MultiAccountWalletService.clearAllWallets();
+    expect(isAccountSubscribeTokenCurrent(staleToken)).toBe(false);
+
+    // A pass started after the reset describes the post-wipe wallet and must
+    // not be collateral damage — otherwise a restore flow could never
+    // re-subscribe.
+    const freshToken = takeAccountSubscribeToken();
+    expect(isAccountSubscribeTokenCurrent(freshToken)).toBe(true);
+  });
+});

--- a/src/services/wallet/__tests__/deleteAccountSubscribePass.test.ts
+++ b/src/services/wallet/__tests__/deleteAccountSubscribePass.test.ts
@@ -1,0 +1,120 @@
+// TASK-192: the deferred notification subscribe pass must be cancelled by ANY
+// account deletion, not just the one that goes through walletStore.
+//
+// The store-level guard alone has a hole: AccountImportPreviewScreen's
+// watch→standard upgrade calls MultiAccountWalletService.deleteAccount
+// directly, bypassing walletStore entirely. A boot-time subscribe pass in
+// flight at that moment holds a snapshot in which the address is still a WATCH
+// account, and its single batched write would land afterwards. Invalidating at
+// the service — the chokepoint every deletion path funnels through — closes it.
+//
+// SECURITY NOTE: no static/committed secret material. The account address here
+// is generated fresh in-process by algosdk.
+
+let mockStore: Record<string, string> = {};
+
+jest.mock('@/platform', () => ({
+  storage: {
+    getItem: jest.fn(async (k: string) =>
+      Object.prototype.hasOwnProperty.call(mockStore, k) ? mockStore[k] : null
+    ),
+    setItem: jest.fn(async (k: string, v: string) => {
+      mockStore[k] = v;
+    }),
+    removeItem: jest.fn(async (k: string) => {
+      delete mockStore[k];
+    }),
+  },
+  secureStorage: {
+    getItem: jest.fn(async () => null),
+    setItem: jest.fn(async () => {}),
+    deleteItem: jest.fn(async () => {}),
+  },
+}));
+
+// Heavy/native side of the dependency graph; deleteAccount itself only touches
+// storage + the secure-storage delete mocked below.
+jest.mock('@/services/ledger/transport', () => ({
+  ledgerTransportService: {},
+}));
+jest.mock('@/services/ledger/algorand', () => ({ ledgerAlgorandService: {} }));
+jest.mock('@/services/network', () => ({ NetworkService: {} }));
+
+const mockSecureDeleteAccount = jest.fn(async (_id: string) => {});
+
+jest.mock('../../secure/AccountSecureStorage', () => ({
+  AccountSecureStorage: {
+    deleteAccount: (id: string) => mockSecureDeleteAccount(id),
+  },
+}));
+
+import algosdk from 'algosdk';
+import { Buffer } from 'buffer';
+
+import { MultiAccountWalletService } from '../index';
+import {
+  isAccountSubscribeTokenCurrent,
+  takeAccountSubscribeToken,
+} from '@/services/notifications/subscribePass';
+
+const WALLET_KEY = 'voi_wallet_metadata';
+
+const seedWallet = (): void => {
+  const account = algosdk.generateAccount();
+  mockStore[WALLET_KEY] = JSON.stringify({
+    id: 'wallet-1',
+    version: '1.0',
+    createdAt: '2026-01-01T00:00:00.000Z',
+    activeAccountId: 'acc-1',
+    accounts: [
+      {
+        id: 'acc-1',
+        address: account.addr.toString(),
+        publicKey: Buffer.from(account.addr.publicKey).toString('hex'),
+        type: 'watch',
+        createdAt: '2026-01-01T00:00:00.000Z',
+      },
+    ],
+  });
+};
+
+describe('MultiAccountWalletService.deleteAccount — cancels the deferred subscribe pass (TASK-192)', () => {
+  beforeEach(() => {
+    mockStore = {};
+    mockSecureDeleteAccount.mockImplementation(async () => {});
+    seedWallet();
+  });
+
+  it('invalidates an in-flight subscribe token before it touches storage, even when called outside walletStore', async () => {
+    const inFlightToken = takeAccountSubscribeToken();
+    expect(isAccountSubscribeTokenCurrent(inFlightToken)).toBe(true);
+
+    // Sample liveness at the moment the secure delete runs. Asserting only
+    // after the call resolves would also pass for an implementation that
+    // invalidated last (or in a `finally`), leaving the deletion window open
+    // for the batched write to land.
+    let tokenLiveDuringDeletion: boolean | null = null;
+    mockSecureDeleteAccount.mockImplementation(async () => {
+      tokenLiveDuringDeletion = isAccountSubscribeTokenCurrent(inFlightToken);
+    });
+
+    // Exactly what AccountImportPreviewScreen's watch→standard upgrade does.
+    await MultiAccountWalletService.deleteAccount('acc-1');
+
+    expect(tokenLiveDuringDeletion).toBe(false);
+    expect(isAccountSubscribeTokenCurrent(inFlightToken)).toBe(false);
+  });
+
+  it('invalidates before the deletion can fail part-way through', async () => {
+    mockSecureDeleteAccount.mockImplementation(async () => {
+      throw new Error('secure delete failed');
+    });
+    const inFlightToken = takeAccountSubscribeToken();
+
+    await expect(
+      MultiAccountWalletService.deleteAccount('acc-1')
+    ).rejects.toThrow('secure delete failed');
+
+    expect(isAccountSubscribeTokenCurrent(inFlightToken)).toBe(false);
+  });
+});

--- a/src/services/wallet/index.ts
+++ b/src/services/wallet/index.ts
@@ -2241,6 +2241,11 @@ export class MultiAccountWalletService {
    */
   static async pruneStandardAccounts(ids: string[]): Promise<void> {
     if (ids.length === 0) return;
+    // TASK-192: this removes a SUBSET of accounts without going through
+    // deleteAccount or clearAllWallets, so neither of those guards covers it.
+    // A boot-time subscribe pass holding the pre-prune snapshot would otherwise
+    // batch-write a subscription for an account this call just removed.
+    invalidateAccountSubscribePasses();
     const readEpoch = walletResetEpoch;
     const wallet = await this.getCurrentWallet();
     if (!wallet) {

--- a/src/services/wallet/index.ts
+++ b/src/services/wallet/index.ts
@@ -33,6 +33,7 @@ import {
   withDefaultAuthLevel,
 } from '@/types/wallet';
 import { AccountSecureStorage } from '../secure/AccountSecureStorage';
+import { invalidateAccountSubscribePasses } from '@/services/notifications/subscribePass';
 import { ledgerTransportService } from '@/services/ledger/transport';
 import type { LedgerDeviceInfo } from '@/services/ledger/transport';
 import { ledgerAlgorandService } from '@/services/ledger/algorand';
@@ -1359,6 +1360,16 @@ export class MultiAccountWalletService {
   }
 
   static async deleteAccount(accountId: string): Promise<void> {
+    // TASK-192: cancel any in-flight deferred notification subscribe pass. That
+    // pass holds a wallet snapshot from app start and finishes with one batched
+    // write, so a deletion inside its window would otherwise let it write a
+    // subscription derived from an account record that no longer exists.
+    // Invalidating HERE (not only in walletStore.deleteAccount) covers the
+    // callers that reach this service directly — e.g. the watch→standard
+    // upgrade in AccountImportPreviewScreen, which deletes the watch record
+    // without going through the store. Inert when no pass is in flight.
+    invalidateAccountSubscribePasses();
+
     // TASK-212: guard the write against a reset racing this read.
     const readEpoch = walletResetEpoch;
     const wallet = await this.getCurrentWallet();

--- a/src/services/wallet/index.ts
+++ b/src/services/wallet/index.ts
@@ -1392,6 +1392,16 @@ export class MultiAccountWalletService {
   }
 
   static async clearAllWallets(): Promise<void> {
+    // TASK-192: cancel any in-flight deferred notification subscribe pass, for
+    // the same reason deleteAccount does — that pass holds a wallet snapshot
+    // from app start and finishes with one batched write, so a wipe inside its
+    // window would otherwise let it write subscriptions for accounts that no
+    // longer exist. A full wipe is the widest version of that race: EVERY
+    // account in the snapshot is stale, not just one. Must be synchronous and
+    // before any await, alongside the epoch bump below. Inert when no pass is
+    // in flight.
+    invalidateAccountSubscribePasses();
+
     // TASK-212: this is the canonical wallet-metadata wipe — restore
     // (backup/restorers.ts clearAllData) and LockScreen.performReset() both
     // funnel through it. Bump the reset epoch and bust the memo SYNCHRONOUSLY,

--- a/src/store/__tests__/deleteAccountSubscribePass.test.ts
+++ b/src/store/__tests__/deleteAccountSubscribePass.test.ts
@@ -1,0 +1,156 @@
+/**
+ * TASK-192: deleting an account must cancel any in-flight deferred notification
+ * subscribe pass.
+ *
+ * This is the path the service-boot teardown does NOT cover. That pass is
+ * launched fire-and-forget at app start over a `wallet.accounts` snapshot and,
+ * now that it ends in one batched write, finishes long after the snapshot was
+ * taken. Delete an account in that window and the session is still mounted —
+ * nothing unmounts, so no teardown fires — yet the pending write still names
+ * the deleted address and would re-create its subscription (and with it, push
+ * notifications for an account the user just removed).
+ *
+ * The heavy service graph is mocked exactly as the sibling walletStore specs do;
+ * only the deletion path carries behaviour here.
+ */
+
+const mockDeleteAccount = jest.fn(async (_id: string) => {});
+const mockGetCurrentWallet = jest.fn(async () => ({
+  id: 'wallet-1',
+  accounts: [] as unknown[],
+}));
+const mockUnsubscribeAccount = jest.fn(async (_address: string) => true);
+const mockGetDeviceId = jest.fn((): string | null => 'device-1');
+const mockRemoveAddress = jest.fn();
+
+jest.mock('@/services/network', () => ({
+  NetworkService: {
+    getInstance: () => ({
+      getCurrentNetworkId: () => 'voi-mainnet',
+    }),
+  },
+}));
+
+jest.mock('@/services/wallet', () => ({
+  MultiAccountWalletService: {
+    deleteAccount: (id: string) => mockDeleteAccount(id),
+    getCurrentWallet: () => mockGetCurrentWallet(),
+    getAccount: jest.fn(async () => null),
+    updateAccountMetadata: jest.fn(async () => {}),
+  },
+}));
+
+jest.mock('@/services/wallet/rekeyManager', () => ({
+  __esModule: true,
+  default: { updateAccountWithRekeyInfo: jest.fn() },
+}));
+
+jest.mock('@/services/envoi', () => ({ __esModule: true, default: {} }));
+jest.mock('@/services/mimir', () => ({ MimirApiService: {} }));
+jest.mock('@/services/token-mapping', () => ({
+  __esModule: true,
+  default: {},
+  TokenMappingService: {},
+}));
+jest.mock('@/services/network/multi-network', () => ({
+  MultiNetworkBalanceService: { getAggregatedBalance: jest.fn() },
+}));
+
+jest.mock('@/services/notifications', () => ({
+  notificationService: {
+    getDeviceId: () => mockGetDeviceId(),
+    unsubscribeAccount: (address: string) => mockUnsubscribeAccount(address),
+  },
+  DEFAULT_NOTIFICATION_PREFERENCES: {},
+}));
+
+jest.mock('@/services/realtime', () => ({
+  realtimeService: {
+    addAddress: jest.fn(),
+    removeAddress: (address: string) => mockRemoveAddress(address),
+  },
+}));
+
+jest.mock('@react-native-async-storage/async-storage', () => ({
+  __esModule: true,
+  default: {
+    getItem: jest.fn(async () => null),
+    setItem: jest.fn(async () => {}),
+    removeItem: jest.fn(async () => {}),
+    multiGet: jest.fn(async () => []),
+    multiSet: jest.fn(async () => {}),
+  },
+}));
+
+import { useWalletStore } from '../walletStore';
+import {
+  isAccountSubscribeTokenCurrent,
+  takeAccountSubscribeToken,
+} from '@/services/notifications/subscribePass';
+
+const ADDRESS = 'A'.repeat(58);
+
+describe('walletStore.deleteAccount — cancels the deferred subscribe pass (TASK-192)', () => {
+  beforeEach(() => {
+    mockDeleteAccount.mockImplementation(async () => {});
+    mockGetCurrentWallet.mockImplementation(async () => ({
+      id: 'wallet-1',
+      accounts: [],
+    }));
+    mockGetDeviceId.mockReturnValue('device-1');
+    useWalletStore.setState({
+      wallet: {
+        accounts: [{ id: 'acct-1', address: ADDRESS }],
+      } as never,
+      accountStates: {},
+    });
+  });
+
+  it('invalidates BEFORE the deletion starts, not merely by the time it finishes', async () => {
+    // The token a boot-time pass would be holding right now.
+    const inFlightToken = takeAccountSubscribeToken();
+    expect(isAccountSubscribeTokenCurrent(inFlightToken)).toBe(true);
+
+    // Sample the token's liveness at the instant the deletion begins. Asserting
+    // only after `deleteAccount` resolves would also pass for an implementation
+    // that invalidated in a `finally` — which would leave the whole deletion
+    // window open for the batched write to land.
+    let tokenLiveWhenDeletionStarted: boolean | null = null;
+    mockDeleteAccount.mockImplementation(async () => {
+      tokenLiveWhenDeletionStarted =
+        isAccountSubscribeTokenCurrent(inFlightToken);
+    });
+
+    await useWalletStore.getState().deleteAccount('acct-1');
+
+    expect(mockDeleteAccount).toHaveBeenCalledWith('acct-1');
+    expect(mockUnsubscribeAccount).toHaveBeenCalledWith(ADDRESS);
+    // Already stale when the deletion began...
+    expect(tokenLiveWhenDeletionStarted).toBe(false);
+    // ...and still stale afterwards.
+    expect(isAccountSubscribeTokenCurrent(inFlightToken)).toBe(false);
+  });
+
+  it('invalidates even when the deletion itself fails', async () => {
+    // Invalidation happens BEFORE the delete, so a failure part-way through
+    // cannot leave a stale pass armed against a half-removed account.
+    mockDeleteAccount.mockImplementation(async () => {
+      throw new Error('storage write failed');
+    });
+    const inFlightToken = takeAccountSubscribeToken();
+
+    await expect(
+      useWalletStore.getState().deleteAccount('acct-1')
+    ).rejects.toThrow('storage write failed');
+
+    expect(isAccountSubscribeTokenCurrent(inFlightToken)).toBe(false);
+  });
+
+  it('does not leave future passes permanently blocked', async () => {
+    await useWalletStore.getState().deleteAccount('acct-1');
+
+    // A pass launched after the deletion takes a fresh token and is live.
+    const nextToken = takeAccountSubscribeToken();
+    expect(isAccountSubscribeTokenCurrent(nextToken)).toBe(true);
+  });
+});

--- a/src/store/walletStore.ts
+++ b/src/store/walletStore.ts
@@ -43,6 +43,7 @@ import {
   notificationService,
   DEFAULT_NOTIFICATION_PREFERENCES,
 } from '@/services/notifications';
+import { invalidateAccountSubscribePasses } from '@/services/notifications/subscribePass';
 import { realtimeService } from '@/services/realtime';
 
 /**
@@ -965,6 +966,16 @@ export const useWalletStore = create<WalletState>()(
     deleteAccount: async (accountId: string) => {
       try {
         set({ isLoading: true, lastError: null });
+
+        // Cancel any in-flight deferred subscribe pass BEFORE the deletion
+        // starts. That pass holds a wallet snapshot taken at app start and
+        // finishes with one batched write; if it landed after this deletion it
+        // would re-create a subscription for the account being removed — in a
+        // session that never unmounted, so the teardown path never fires.
+        // MultiAccountWalletService.deleteAccount invalidates too (it is the
+        // chokepoint for callers that bypass this store); doing it here as well
+        // closes the window a few awaits earlier. (TASK-192.)
+        invalidateAccountSubscribePasses();
 
         // Get the account address before deletion for unsubscribing
         const { wallet: currentWallet } = get();


### PR DESCRIPTION
Implements **PLAN-275** (child of PLAN-183, Voi Wallet Audit II — Network & Data Efficiency).

Makes Supabase realtime genuinely inert — it was half-on and leaking — and collapses the per-account notification-subscribe fan-out into a bounded number of round trips.

## Tasks
- [x] **TASK-190** — realtime honors "off"; fix the channel leaks (`95c8aae`, `ece6284`)
- [x] **TASK-192** — batch notification subscription round trips (`3c647cf`, `833eaa7`, `85015cb`, `bff49e2`)

## Release vehicle
**OTA (JS-only).** No new flag in `app.config.js` (a module constant suffices), no config plugin, no native change. See #182 for the shared-channel publish note — these two coalesce into one bundle.

## Why realtime needed this
There is **no flag anywhere**. "Disabled" existed only as commented-out code, while an unintended path was fully live: `walletStore.addAddress` populated `subscribedAddresses`, and the `AppState 'active'` handler then called `resubscribe()`. After a user added, imported, watched, rekeyed or added a remote-signer account, the next foreground opened a WebSocket nobody asked for — the exact server load the polling migration was meant to remove.

The singleton was also constructed **at module import**, registering an `AppState` listener unconditionally. Import is now side-effect-free; the listener attaches only on a genuine install.

Two leaks fixed: `resubscribe()` installed without removing the previous channel, and `unsubscribe()` targeted whatever client was *current* — but `setDeviceId()` **replaces** the client, so cleanup could silently miss the channel bound to the old one. Every install path is now single-flight and generation-guarded, with teardown routed through the client that created the channel.

## Why the notification batch needed care
`subscribeAllAccounts` is not a blind loop. It deliberately **skips accounts that already have preferences** and sets `messages: !isWatchAccount`. A naive batch upsert would have **reset every user's notification settings on next app start** and enabled message notifications on watch accounts. `getPreferences` also returns `null` for both "absent" and "errored", so a transient read error would have overwritten real settings — the read now fails closed and writes nothing.

The read is **chunked at 50**: `.in()` serialises into the request URL, and an unbounded list on a large wallet could exceed proxy limits — which, combined with fail-closed, meant a wallet that never subscribes anything, on every launch.

## Test plan
`npm run typecheck` 0 errors · `npm run lint` 0 errors / 157 warnings (unchanged baseline) · `npm test -- --ci` **124 suites / 1807 tests** (main: 123 / 1796). Both required CI checks green.

New coverage in `services/realtime` and `services/notifications` — both had **zero** tests. Assertions include: zero connections opened after add + foreground; concurrent installs leaving exactly one channel and no orphan on *either* client across a `setDeviceId` swap; existing preferences absent from the write payload; per-account watch defaults; abort on teardown **and** on account deletion. Fixes were mutation-tested (revert the fix, confirm the test fails).

Device verification is batched before release, not per PR.

## Found by review, fixed here
The full-diff passes caught three gaps that existed only *between* the two tasks: `clearAllWallets()` didn't cancel the subscribe pass; guarding it was still too late because every reset awaits `AccountSecureStorage.clearAll()` first (now guarded at that chokepoint, covering all four reset callers); and `pruneStandardAccounts()` removed accounts without going through either path.

## Known gaps, filed not hidden
TASK-293 (server subscription rows are never reconciled with local accounts — after a reset the backend can keep pushing for erased accounts; pre-existing) · TASK-287 (`REMOTE_SIGNER` accounts get `notify_messages: true` from the batch backstop; pre-existing) · TASK-289 (unsubscribing can be undone by the next startup batch; pre-existing, needs a product call).

One review finding was **declined**: that `addAddress()` should reinstall a channel during teardown. `addAddress` is pure bookkeeping *by design* (DR-4) — making it install would reintroduce the exact bug this PR fixes. The legitimate kernel belongs to the realtime re-enable work.

🤖 Planned across 14 Codex review rounds; each task ran its own review loop, plus five full-diff passes over the integrated branch.
