### PR TITLE
perf(network): claimables TTL, price dedup, offline gating (PLAN-274)

### DIFF
--- a/__mocks__/netinfo.js
+++ b/__mocks__/netinfo.js
@@ -1,0 +1,39 @@
+/**
+ * `@react-native-community/netinfo` stub for jest (TASK-191).
+ *
+ * NetInfo is a NATIVE module. Loading the real one under jest starts its
+ * internal reachability probe, which calls `global.fetch` — and unit tests
+ * routinely replace `global.fetch` with a mock that knows nothing about
+ * NetInfo, producing failures inside node_modules that have nothing to do with
+ * the test. This became reachable when the offline gate
+ * (src/services/network/offline.ts) started priming the connectivity adapter
+ * lazily from shared service code.
+ *
+ * Pinned via `moduleNameMapper` rather than haste resolution, matching
+ * react-native-quick-crypto, so a sibling worktree's copy can never win.
+ *
+ * Reports a plain online state and never emits, so the gate reads `online`
+ * (never `offline`) and no test is gated by accident. Tests that need real
+ * NetInfo semantics mock it themselves — see
+ * src/platform/__tests__/connectivity.test.ts.
+ */
+
+const state = {
+  isConnected: true,
+  isInternetReachable: true,
+  type: 'wifi',
+};
+
+const netInfo = {
+  fetch: () => Promise.resolve({ ...state }),
+  addEventListener: () => () => {},
+  refresh: () => Promise.resolve({ ...state }),
+  configure: () => {},
+  useNetInfo: () => ({ ...state }),
+};
+
+module.exports = {
+  __esModule: true,
+  default: netInfo,
+  ...netInfo,
+};

--- a/jest.config.js
+++ b/jest.config.js
@@ -10,6 +10,10 @@ module.exports = {
     // fallback in scryptKdf) so local and CI behave identically.
     '^react-native-quick-crypto$':
       '<rootDir>/__mocks__/react-native-quick-crypto.js',
+    // Native module whose reachability probe calls global.fetch — which unit
+    // tests replace. Force the stub; suites that need real NetInfo semantics
+    // re-mock it themselves (src/platform/__tests__/connectivity.test.ts).
+    '^@react-native-community/netinfo$': '<rootDir>/__mocks__/netinfo.js',
   },
   // jest-expo's default only allow-transpiles RN/Expo packages; several deps
   // these utils import ship as untranspiled ESM and must also be transformed.

--- a/src/components/claimable/ClaimableTokenItem.tsx
+++ b/src/components/claimable/ClaimableTokenItem.tsx
@@ -137,7 +137,15 @@ export default function ClaimableTokenItem({
             {item.tokenSymbol}
           </Text>
         </View>
-        {!item.isClaimable && (
+        {/* An unknown owner balance must never read as "Insufficient": that
+            tells the user a claimable token cannot be claimed on what may be a
+            transient network error (TASK-188). */}
+        {item.ownerBalanceUnknown && (
+          <View style={styles.unknownBadge} testID="claimable-unknown-badge">
+            <Text style={styles.unknownText}>Unavailable</Text>
+          </View>
+        )}
+        {!item.isClaimable && !item.ownerBalanceUnknown && (
           <View style={styles.insufficientBadge}>
             <Text style={styles.insufficientText}>Insufficient</Text>
           </View>
@@ -257,6 +265,20 @@ const createStyles = (theme: Theme) =>
     insufficientText: {
       fontSize: 11,
       color: theme.colors.error,
+      fontWeight: '500',
+    },
+    unknownBadge: {
+      // A real token, not `textMuted + '20'`: `textMuted` is `rgba(...)` in the
+      // dark theme, so appending an alpha suffix yields an invalid color and
+      // the badge loses its background entirely.
+      backgroundColor: theme.colors.surfaceAlt,
+      paddingHorizontal: 8,
+      paddingVertical: 4,
+      borderRadius: theme.borderRadius.sm,
+    },
+    unknownText: {
+      fontSize: 11,
+      color: theme.colors.textSecondary,
       fontWeight: '500',
     },
     chevron: {

--- a/src/components/claimable/__tests__/ClaimableTokenItem.unknownBalance.test.tsx
+++ b/src/components/claimable/__tests__/ClaimableTokenItem.unknownBalance.test.tsx
@@ -1,0 +1,121 @@
+/**
+ * TASK-188: a failed owner-balance lookup must render as unknown, not as zero.
+ *
+ * The row previously derived its badge from `isClaimable` alone, and the store
+ * fed it a fabricated '0' balance whenever the lookup failed — so a transient
+ * network error told the user, in red, that a claimable token was
+ * "Insufficient". The unknown case now has its own presentation.
+ */
+
+import React from 'react';
+import { StyleSheet } from 'react-native';
+import { render } from '@testing-library/react-native';
+
+import ClaimableTokenItem from '../ClaimableTokenItem';
+import { lightTheme, darkTheme } from '@/constants/themes';
+import type { ClaimableItem } from '@/types/claimable';
+
+// Which theme the component renders against, switchable per test.
+let mockUseDarkTheme = false;
+
+jest.mock('expo-image', () => ({ Image: () => null }));
+
+jest.mock(
+  '@expo/vector-icons',
+  () => ({
+    Ionicons: () => null,
+  }),
+  { virtual: true }
+);
+
+jest.mock('@/contexts/ThemeContext', () => ({
+  useTheme: () => {
+    const themes = require('@/constants/themes');
+    return { theme: mockUseDarkTheme ? themes.darkTheme : themes.lightTheme };
+  },
+}));
+
+const baseItem: ClaimableItem = {
+  id: '1_OWNER',
+  contractId: 1,
+  tokenName: 'Test Token',
+  tokenSymbol: 'TT',
+  tokenDecimals: 0,
+  tokenVerified: false,
+  owner: 'OWNEROWNEROWNEROWNER',
+  amount: 100n,
+  ownerBalance: 0n,
+  isClaimable: false,
+  approval: {
+    owner: 'OWNEROWNEROWNEROWNER',
+    round: 1,
+    amount: '100',
+    spender: 'SPENDER',
+    timestamp: 1,
+    contractId: 1,
+    transactionId: 'TX',
+  },
+};
+
+beforeEach(() => {
+  mockUseDarkTheme = false;
+  expect(lightTheme).toBeDefined();
+});
+
+describe('ClaimableTokenItem unknown balance (TASK-188)', () => {
+  it('renders "Unavailable" and never "Insufficient" when the balance is unknown', () => {
+    const { queryByText } = render(
+      <ClaimableTokenItem
+        item={{ ...baseItem, ownerBalanceUnknown: true }}
+        onPress={jest.fn()}
+      />
+    );
+
+    expect(queryByText('Unavailable')).toBeTruthy();
+    expect(queryByText('Insufficient')).toBeNull();
+  });
+
+  it('still renders "Insufficient" for a genuinely insufficient balance', () => {
+    const { queryByText } = render(
+      <ClaimableTokenItem
+        item={{ ...baseItem, ownerBalanceUnknown: false }}
+        onPress={jest.fn()}
+      />
+    );
+
+    expect(queryByText('Insufficient')).toBeTruthy();
+    expect(queryByText('Unavailable')).toBeNull();
+  });
+
+  it('gives the unknown badge a valid background in the DARK theme too', () => {
+    // Regression guard for `theme.colors.textMuted + '20'`: `textMuted` is
+    // `rgba(...)` in the dark theme, so an appended alpha suffix produces an
+    // invalid color string and the badge silently loses its background.
+    mockUseDarkTheme = true;
+    const { getByTestId } = render(
+      <ClaimableTokenItem
+        item={{ ...baseItem, ownerBalanceUnknown: true }}
+        onPress={jest.fn()}
+      />
+    );
+
+    const style = StyleSheet.flatten(
+      getByTestId('claimable-unknown-badge').props.style
+    );
+    expect(typeof style.backgroundColor).toBe('string');
+    expect(style.backgroundColor).not.toMatch(/^rgba\(.*\)[0-9a-f]+$/i);
+    expect(darkTheme.colors.surfaceAlt).toBe(style.backgroundColor);
+  });
+
+  it('renders no badge at all for a claimable item', () => {
+    const { queryByText } = render(
+      <ClaimableTokenItem
+        item={{ ...baseItem, ownerBalance: 500n, isClaimable: true }}
+        onPress={jest.fn()}
+      />
+    );
+
+    expect(queryByText('Insufficient')).toBeNull();
+    expect(queryByText('Unavailable')).toBeNull();
+  });
+});

--- a/src/components/debug/DebugLogsModal.tsx
+++ b/src/components/debug/DebugLogsModal.tsx
@@ -13,6 +13,10 @@ import {
   StatusBar,
 } from 'react-native';
 import { debugLogger, LogEntry } from '@/services/debug/logger';
+import {
+  getOfflineCounters,
+  type OfflineCounters,
+} from '@/services/network/offline';
 
 interface DebugLogsModalProps {
   visible: boolean;
@@ -34,21 +38,36 @@ export const DebugLogsModal: React.FC<DebugLogsModalProps> = ({
   // React-canonical replacement for the old snapshot-in-effect. This re-seeds
   // on every open (catching logs that arrived while closed) at the same logical
   // moment the effect did. Only the live subscription stays in the effect.
+  // TASK-191 observability. Counts only — no addresses, amounts or identifiers
+  // — so this stays safe to render (and to share) in a release build, where
+  // `console.log` is stripped precisely because logs can carry those.
+  const [counters, setCounters] = useState<OfflineCounters>(getOfflineCounters);
+
   const [prevVisible, setPrevVisible] = useState(visible);
   if (visible !== prevVisible) {
     setPrevVisible(visible);
     if (visible) {
       setLogs(debugLogger.getLogs());
+      setCounters(getOfflineCounters());
     }
   }
 
   useEffect(() => {
     if (visible) {
-      // Listen for new logs while open.
-      const removeListener = debugLogger.addListener(setLogs);
+      // Listen for new logs while open. Counters have no listener of their own,
+      // so they re-read alongside — plus once on open, above.
+      const removeListener = debugLogger.addListener((next) => {
+        setLogs(next);
+        setCounters(getOfflineCounters());
+      });
       return removeListener;
     }
   }, [visible]);
+
+  const skippedScopes = Object.entries(counters.offlineSkipsByScope)
+    .filter(([, count]) => count > 0)
+    .map(([scope, count]) => `${scope} ${count}`)
+    .join(', ');
 
   const formatTimestamp = (timestamp: string) => {
     const date = new Date(timestamp);
@@ -168,6 +187,10 @@ export const DebugLogsModal: React.FC<DebugLogsModalProps> = ({
           <View style={styles.footer}>
             <Text style={styles.footerText}>
               Showing {logs.length} log entries
+            </Text>
+            <Text style={styles.footerText}>
+              Offline skips: {counters.offlineSkips}
+              {skippedScopes ? ` (${skippedScopes})` : ''}
             </Text>
           </View>
         </SafeAreaView>

--- a/src/screens/wallet/ClaimableTokensScreen.tsx
+++ b/src/screens/wallet/ClaimableTokensScreen.tsx
@@ -5,7 +5,13 @@
  * Supports hiding tokens, viewing hidden tokens, and claiming all at once.
  */
 
-import React, { useCallback, useEffect, useState, useRef } from 'react';
+import React, {
+  useCallback,
+  useEffect,
+  useMemo,
+  useState,
+  useRef,
+} from 'react';
 import {
   View,
   Text,
@@ -42,9 +48,8 @@ import { GlassCard } from '@/components/common/GlassCard';
 import ClaimableTokenItem from '@/components/claimable/ClaimableTokenItem';
 import {
   useClaimableStore,
-  useDisplayedClaimableItems,
-  useVisibleClaimableCount,
-  useHiddenClaimableCount,
+  useClaimableItemsForAccount,
+  useClaimablePartialFailure,
   useShowHiddenApprovals,
   useClaimableLoading,
 } from '@/store/claimableStore';
@@ -76,11 +81,9 @@ export default function ClaimableTokensScreen() {
   const pendingRefreshTimeoutRef = useRef<NodeJS.Timeout | null>(null);
 
   const activeAccount = useActiveAccount();
-  const displayedItems = useDisplayedClaimableItems();
-  const visibleCount = useVisibleClaimableCount();
-  const hiddenCount = useHiddenClaimableCount();
   const showHidden = useShowHiddenApprovals();
   const isLoading = useClaimableLoading();
+  const hasPartialFailure = useClaimablePartialFailure(activeAccount?.address);
 
   // Animation for pending refresh indicator
   const reducedMotion = useReducedMotion();
@@ -96,6 +99,33 @@ export default function ClaimableTokensScreen() {
     toggleShowHidden,
     hiddenApprovals,
   } = useClaimableStore();
+
+  // Rendering is bound to the active account: items held for any other account
+  // read as an empty list rather than being shown under this account's name.
+  const accountItems = useClaimableItemsForAccount(activeAccount?.address);
+
+  const displayedItems = useMemo(
+    () =>
+      showHidden
+        ? accountItems
+        : accountItems.filter((item) => !hiddenApprovals.has(item.id)),
+    [accountItems, hiddenApprovals, showHidden]
+  );
+  const visibleCount = useMemo(
+    () => accountItems.filter((item) => !hiddenApprovals.has(item.id)).length,
+    [accountItems, hiddenApprovals]
+  );
+  const hiddenCount = useMemo(
+    () => accountItems.filter((item) => hiddenApprovals.has(item.id)).length,
+    [accountItems, hiddenApprovals]
+  );
+
+  // Latest active account, readable from the delayed post-claim callbacks
+  // without re-arming their timers.
+  const activeAccountAddressRef = useRef(activeAccount?.address);
+  useEffect(() => {
+    activeAccountAddressRef.current = activeAccount?.address;
+  }, [activeAccount?.address]);
 
   // Handle pending refresh after successful claim
   useEffect(() => {
@@ -127,9 +157,29 @@ export default function ClaimableTokensScreen() {
         claimedItemIds: undefined,
       });
 
+      // The account the claim was made from. Both delayed refreshes below are
+      // abandoned if the user has switched away by the time they fire: a
+      // forced fetch takes ownership of the store, so refreshing a stale
+      // account would wipe the now-active account's list.
+      const claimAccountAddress = activeAccount.address;
+      const endPendingRefresh = () => {
+        setIsPendingRefresh(false);
+        cancelAnimation(pulseOpacity);
+        pulseOpacity.value = 1;
+        pendingRefreshTimeoutRef.current = null;
+      };
+
       // Schedule refresh after delay (store in ref so it persists across effect re-runs)
       pendingRefreshTimeoutRef.current = setTimeout(async () => {
-        await fetchApprovals(activeAccount.address);
+        if (activeAccountAddressRef.current !== claimAccountAddress) {
+          endPendingRefresh();
+          return;
+        }
+
+        // force: a just-completed claim must be reflected even if a fetch
+        // landed inside the TTL window, or the claim looks like it never
+        // happened.
+        await fetchApprovals(claimAccountAddress, { force: true });
 
         // Check if any claimed items are still present in the list
         const { claimableItems } = useClaimableStore.getState();
@@ -140,17 +190,15 @@ export default function ClaimableTokensScreen() {
         if (claimedStillPresent) {
           // Retry once after additional delay if indexer hasn't updated yet
           pendingRefreshTimeoutRef.current = setTimeout(async () => {
-            await fetchApprovals(activeAccount.address);
-            setIsPendingRefresh(false);
-            cancelAnimation(pulseOpacity);
-            pulseOpacity.value = 1;
-            pendingRefreshTimeoutRef.current = null;
+            if (activeAccountAddressRef.current !== claimAccountAddress) {
+              endPendingRefresh();
+              return;
+            }
+            await fetchApprovals(claimAccountAddress, { force: true });
+            endPendingRefresh();
           }, RETRY_REFRESH_DELAY);
         } else {
-          setIsPendingRefresh(false);
-          cancelAnimation(pulseOpacity);
-          pulseOpacity.value = 1;
-          pendingRefreshTimeoutRef.current = null;
+          endPendingRefresh();
         }
       }, PENDING_REFRESH_DELAY);
     }
@@ -193,12 +241,13 @@ export default function ClaimableTokensScreen() {
     }, [activeAccount?.address, fetchApprovals, isPendingRefresh])
   );
 
-  // Handle pull-to-refresh
+  // Handle pull-to-refresh. force: an explicit refresh gesture must not be
+  // answered by the TTL cache.
   const handleRefresh = useCallback(async () => {
     if (!activeAccount?.address) return;
     setIsRefreshing(true);
     try {
-      await fetchApprovals(activeAccount.address);
+      await fetchApprovals(activeAccount.address, { force: true });
     } finally {
       setIsRefreshing(false);
     }
@@ -407,6 +456,33 @@ export default function ClaimableTokensScreen() {
           rightAction={renderHeaderRight()}
         />
 
+        {/* Degraded state: at least one owner balance could not be fetched, so
+            some rows show an unknown claim status rather than a real one. */}
+        {hasPartialFailure && (
+          <View
+            style={styles.degradedBanner}
+            accessibilityRole="alert"
+            testID="claimable-degraded-banner"
+          >
+            <Ionicons
+              name="warning-outline"
+              size={18}
+              color={styles.degradedText.color}
+            />
+            <Text style={styles.degradedText}>
+              Some claim statuses couldn&apos;t be checked.
+            </Text>
+            <TouchableOpacity
+              onPress={handleRefresh}
+              accessibilityRole="button"
+              accessibilityLabel="Retry loading claim statuses"
+              testID="claimable-degraded-retry"
+            >
+              <Text style={styles.degradedRetryText}>Retry</Text>
+            </TouchableOpacity>
+          </View>
+        )}
+
         {/* Hidden toggle */}
         {hiddenCount > 0 && (
           <TouchableOpacity
@@ -497,6 +573,27 @@ const createStyles = (theme: Theme) =>
     hiddenToggleText: {
       fontSize: 13,
       color: theme.colors.textSecondary,
+    },
+    degradedBanner: {
+      flexDirection: 'row',
+      alignItems: 'center',
+      backgroundColor: theme.colors.warningLight,
+      borderRadius: theme.borderRadius.md,
+      marginHorizontal: 16,
+      marginTop: 8,
+      paddingVertical: 10,
+      paddingHorizontal: 12,
+      gap: 8,
+    },
+    degradedText: {
+      flex: 1,
+      fontSize: 13,
+      color: theme.colors.warning,
+    },
+    degradedRetryText: {
+      fontSize: 13,
+      fontWeight: '600',
+      color: theme.colors.primary,
     },
     pendingRefreshBanner: {
       flexDirection: 'row',

--- a/src/screens/wallet/HomeScreen.tsx
+++ b/src/screens/wallet/HomeScreen.tsx
@@ -41,6 +41,7 @@ import {
   useAssetNetworkFilter,
 } from '@/store/walletStore';
 import { networkService, NetworkStatus } from '@/services/network';
+import { shouldSkipForOffline } from '@/services/network/offline';
 import { formatCurrency } from '@/utils/formatting';
 import { useCurrentNetworkConfig } from '@/store/networkStore';
 import { NetworkId } from '@/types/network';
@@ -1040,22 +1041,29 @@ export default function HomeScreen() {
     setRefreshing(true);
     handleUserInteraction();
 
-    if (activeAccount) {
-      const refreshedAddress = activeAccount.address;
-      // Only refresh the current account, not all accounts
-      await loadAccountData();
-      // Also refresh claimable tokens. force: pull-to-refresh must bypass the
-      // per-account TTL, otherwise the gesture silently does nothing.
-      //
-      // Re-checked against the live account: `loadAccountData` is awaited, and
-      // a forced fetch takes ownership of the claimable store, so refreshing a
-      // stale account here would discard the account the user switched to.
-      if (activeAccountAddressRef.current === refreshedAddress) {
-        await fetchApprovals(refreshedAddress, { force: true });
+    try {
+      // TASK-191: a pull-to-refresh fired while the device is definitely
+      // offline can only fail, so skip the fan-out rather than making the user
+      // watch several retry ladders time out. The spinner still clears below.
+      if (activeAccount && !shouldSkipForOffline('home-refresh')) {
+        const refreshedAddress = activeAccount.address;
+        // Only refresh the current account, not all accounts
+        await loadAccountData();
+        // Also refresh claimable tokens. force: pull-to-refresh must bypass the
+        // per-account TTL, otherwise the gesture silently does nothing.
+        //
+        // Re-checked against the live account: `loadAccountData` is awaited, and
+        // a forced fetch takes ownership of the claimable store, so refreshing a
+        // stale account here would discard the account the user switched to.
+        if (activeAccountAddressRef.current === refreshedAddress) {
+          await fetchApprovals(refreshedAddress, { force: true });
+        }
       }
+    } finally {
+      // Never wedge the spinner: it clears whether the refresh ran, was skipped
+      // as offline, or threw.
+      setRefreshing(false);
     }
-
-    setRefreshing(false);
   };
 
   useEffect(() => {

--- a/src/screens/wallet/HomeScreen.tsx
+++ b/src/screens/wallet/HomeScreen.tsx
@@ -66,7 +66,7 @@ import { springConfigs } from '@/utils/animations';
 import ClaimableBanner from '@/components/claimable/ClaimableBanner';
 import {
   useClaimableStore,
-  useVisibleClaimableCount,
+  useVisibleClaimableCountForAccount,
 } from '@/store/claimableStore';
 import UpdateBanner from '@/components/update/UpdateBanner';
 import { useUpdateStore } from '@/store/updateStore';
@@ -111,9 +111,20 @@ export default function HomeScreen() {
   const styles = useThemedStyles(createStyles);
   const { theme } = useTheme();
 
-  // Claimable tokens
-  const visibleClaimableCount = useVisibleClaimableCount();
+  // Claimable tokens. The count is bound to the active account so the banner
+  // never shows one account's claimable total under another's name during a
+  // switch.
+  const visibleClaimableCount = useVisibleClaimableCountForAccount(
+    activeAccount?.address
+  );
   const { fetchApprovals } = useClaimableStore();
+
+  // Latest active account, readable from async refresh callbacks without
+  // re-arming them.
+  const activeAccountAddressRef = React.useRef(activeAccount?.address);
+  React.useEffect(() => {
+    activeAccountAddressRef.current = activeAccount?.address;
+  }, [activeAccount?.address]);
 
   // Remote signer mode
   const appMode = useAppMode();
@@ -1030,10 +1041,18 @@ export default function HomeScreen() {
     handleUserInteraction();
 
     if (activeAccount) {
+      const refreshedAddress = activeAccount.address;
       // Only refresh the current account, not all accounts
       await loadAccountData();
-      // Also refresh claimable tokens
-      fetchApprovals(activeAccount.address);
+      // Also refresh claimable tokens. force: pull-to-refresh must bypass the
+      // per-account TTL, otherwise the gesture silently does nothing.
+      //
+      // Re-checked against the live account: `loadAccountData` is awaited, and
+      // a forced fetch takes ownership of the claimable store, so refreshing a
+      // stale account here would discard the account the user switched to.
+      if (activeAccountAddressRef.current === refreshedAddress) {
+        await fetchApprovals(refreshedAddress, { force: true });
+      }
     }
 
     setRefreshing(false);

--- a/src/screens/wallet/__tests__/ClaimableTokensScreen.degraded.test.tsx
+++ b/src/screens/wallet/__tests__/ClaimableTokensScreen.degraded.test.tsx
@@ -1,0 +1,339 @@
+/**
+ * TASK-188 screen-level regressions for ClaimableTokensScreen.
+ *
+ * The store-timing tests cover when a fetch runs; they cover nothing about
+ * presentation, and a degraded state is worthless if it never reaches the
+ * screen. Two properties are asserted here:
+ *
+ *  1. a partial result (some owner balances unresolved) renders a degraded
+ *     banner with a working retry, and a fully successful one does not; and
+ *  2. items held for a non-active account are never rendered across a switch —
+ *     showing account A's claimables under account B's name is worse than
+ *     showing none.
+ */
+
+import React from 'react';
+import { render, fireEvent, act } from '@testing-library/react-native';
+
+import ClaimableTokensScreen from '../ClaimableTokensScreen';
+import { lightTheme } from '@/constants/themes';
+import type { ClaimableItem } from '@/types/claimable';
+
+const ACCOUNT_A = 'ACCOUNT_A_ADDRESS';
+const ACCOUNT_B = 'ACCOUNT_B_ADDRESS';
+
+const mockFetchApprovals = jest.fn(async () => {});
+
+// Mutable store view driven per test.
+let mockItems: ClaimableItem[] = [];
+let mockItemsAccountAddress: string | null = null;
+let mockHasPartialFailure = false;
+let mockActiveAddress: string | null = ACCOUNT_A;
+let mockRouteParams: Record<string, unknown> = {};
+
+const makeItem = (id: string): ClaimableItem => ({
+  id,
+  contractId: 1,
+  tokenName: `Token ${id}`,
+  tokenSymbol: 'TKN',
+  tokenDecimals: 0,
+  tokenVerified: false,
+  owner: 'OWNER',
+  amount: 10n,
+  ownerBalance: 100n,
+  isClaimable: true,
+  approval: {
+    owner: 'OWNER',
+    round: 1,
+    amount: '10',
+    spender: 'SPENDER',
+    timestamp: 1,
+    contractId: 1,
+    transactionId: 'TX',
+  },
+});
+
+jest.mock('@/store/claimableStore', () => ({
+  useClaimableStore: Object.assign(
+    () => ({
+      fetchApprovals: mockFetchApprovals,
+      hideApproval: jest.fn(),
+      unhideApproval: jest.fn(),
+      toggleShowHidden: jest.fn(),
+      hiddenApprovals: new Set<string>(),
+    }),
+    { getState: () => ({ claimableItems: [] }) }
+  ),
+  // Mirrors the real hook's account binding: items belong to exactly one
+  // account, and a mismatch renders as an empty list.
+  useClaimableItemsForAccount: (address: string | null | undefined) =>
+    address && mockItemsAccountAddress === address ? mockItems : [],
+  useClaimablePartialFailure: (address: string | null | undefined) =>
+    mockHasPartialFailure && !!address && mockItemsAccountAddress === address,
+  useShowHiddenApprovals: () => false,
+  useClaimableLoading: () => false,
+}));
+
+jest.mock('@/store/walletStore', () => ({
+  useActiveAccount: () =>
+    mockActiveAddress ? { id: 'acct', address: mockActiveAddress } : null,
+}));
+
+jest.mock('@/contexts/ThemeContext', () => ({
+  useTheme: () => ({ theme: require('@/constants/themes').lightTheme }),
+}));
+
+jest.mock('@react-navigation/native', () => ({
+  useNavigation: () => ({
+    navigate: jest.fn(),
+    goBack: jest.fn(),
+    setParams: jest.fn(),
+  }),
+  useRoute: () => ({ params: mockRouteParams }),
+  useFocusEffect: (callback: () => void) => {
+    const React = require('react');
+    React.useEffect(() => {
+      callback();
+    }, [callback]);
+  },
+}));
+
+// Hand-rolled rather than `react-native-reanimated/mock`: that mock returns a
+// NEW shared-value object on every render, which makes the screen's
+// unmount-cleanup effect (dep: `pulseOpacity`) re-run on every render and clear
+// the pending-refresh timer under test. Real `useSharedValue` is stable.
+jest.mock('react-native-reanimated', () => {
+  const ReactLib = require('react');
+  const { View } = require('react-native');
+  return {
+    __esModule: true,
+    default: { View },
+    View,
+    useSharedValue: (initial: unknown) =>
+      ReactLib.useRef({ value: initial }).current,
+    useAnimatedStyle: () => ({}),
+    withRepeat: jest.fn(),
+    withTiming: jest.fn(),
+    cancelAnimation: jest.fn(),
+  };
+});
+
+jest.mock('react-native-gesture-handler', () => {
+  const { View } = require('react-native');
+  return {
+    Swipeable: ({ children }: { children: React.ReactNode }) => (
+      <View>{children}</View>
+    ),
+  };
+});
+
+jest.mock(
+  '@expo/vector-icons',
+  () => ({
+    Ionicons: () => null,
+  }),
+  { virtual: true }
+);
+
+jest.mock('react-native-safe-area-context', () => ({
+  SafeAreaView: ({ children }: { children: React.ReactNode }) => children,
+  initialWindowMetrics: null,
+}));
+
+jest.mock('@/components/common/NFTBackground', () => ({
+  NFTBackground: ({ children }: { children: React.ReactNode }) => children,
+}));
+
+jest.mock('@/components/common/UniversalHeader', () => {
+  const { View } = require('react-native');
+  return {
+    __esModule: true,
+    default: ({ rightAction }: { rightAction?: React.ReactNode }) => (
+      <View>{rightAction}</View>
+    ),
+  };
+});
+
+jest.mock('@/components/common/GlassButton', () => {
+  const { Text } = require('react-native');
+  return {
+    GlassButton: ({ label }: { label: string }) => <Text>{label}</Text>,
+  };
+});
+
+jest.mock('@/components/common/GlassCard', () => {
+  const { View } = require('react-native');
+  return {
+    GlassCard: ({ children }: { children: React.ReactNode }) => (
+      <View>{children}</View>
+    ),
+  };
+});
+
+jest.mock('@/components/claimable/ClaimableTokenItem', () => {
+  const { Text } = require('react-native');
+  return {
+    __esModule: true,
+    default: ({ item }: { item: { id: string } }) => (
+      <Text>{`row-${item.id}`}</Text>
+    ),
+  };
+});
+
+jest.mock('@/hooks/useReducedMotion', () => ({
+  useReducedMotion: () => true,
+}));
+
+beforeEach(() => {
+  mockFetchApprovals.mockClear();
+  mockItems = [makeItem('1_OWNER')];
+  mockItemsAccountAddress = ACCOUNT_A;
+  mockHasPartialFailure = false;
+  mockActiveAddress = ACCOUNT_A;
+  mockRouteParams = {};
+  // Keep the theme import referenced so the mock factory's require resolves
+  // the same module instance the screen renders against.
+  expect(lightTheme).toBeDefined();
+});
+
+const settle = () => act(async () => {});
+
+describe('ClaimableTokensScreen degraded state (TASK-188)', () => {
+  it('renders the degraded banner with a retry when the last fetch was partial', async () => {
+    mockHasPartialFailure = true;
+
+    const { getByTestId } = render(<ClaimableTokensScreen />);
+    await settle();
+
+    expect(getByTestId('claimable-degraded-banner')).toBeTruthy();
+    expect(getByTestId('claimable-degraded-retry')).toBeTruthy();
+  });
+
+  it('retry issues a FORCED refetch — a TTL-suppressed retry button is a dead button', async () => {
+    mockHasPartialFailure = true;
+
+    const { getByTestId } = render(<ClaimableTokensScreen />);
+    await settle();
+
+    mockFetchApprovals.mockClear();
+    await act(async () => {
+      fireEvent.press(getByTestId('claimable-degraded-retry'));
+    });
+
+    expect(mockFetchApprovals).toHaveBeenCalledWith(ACCOUNT_A, { force: true });
+  });
+
+  it('does not render the degraded banner after a fully successful fetch', async () => {
+    mockHasPartialFailure = false;
+
+    const { queryByTestId } = render(<ClaimableTokensScreen />);
+    await settle();
+
+    expect(queryByTestId('claimable-degraded-banner')).toBeNull();
+  });
+
+  it("does not show account A's degraded banner over account B's list", async () => {
+    // The flag is cleared when a switch commits, but the render between the
+    // active account changing and that commit must not attribute A's failure
+    // to B.
+    mockHasPartialFailure = true;
+    mockItemsAccountAddress = ACCOUNT_A;
+    mockActiveAddress = ACCOUNT_B;
+
+    const { queryByTestId } = render(<ClaimableTokensScreen />);
+    await settle();
+
+    expect(queryByTestId('claimable-degraded-banner')).toBeNull();
+  });
+});
+
+describe('ClaimableTokensScreen account binding (TASK-188)', () => {
+  it("renders the active account's items", async () => {
+    const { queryByText } = render(<ClaimableTokensScreen />);
+    await settle();
+
+    expect(queryByText('row-1_OWNER')).toBeTruthy();
+  });
+
+  it('renders nothing from a previous account across a switch', async () => {
+    // Items still held for A while the active account is already B — the
+    // window between the switch and the new fetch committing.
+    mockItemsAccountAddress = ACCOUNT_A;
+    mockActiveAddress = ACCOUNT_B;
+
+    const { queryByText } = render(<ClaimableTokensScreen />);
+    await settle();
+
+    expect(queryByText('row-1_OWNER')).toBeNull();
+    expect(queryByText('No Claimable Tokens')).toBeTruthy();
+  });
+
+  it('pull-to-refresh forces a fetch', async () => {
+    const { UNSAFE_getByType } = render(<ClaimableTokensScreen />);
+    await settle();
+
+    const { RefreshControl } = require('react-native');
+    mockFetchApprovals.mockClear();
+    await act(async () => {
+      UNSAFE_getByType(RefreshControl).props.onRefresh();
+    });
+
+    expect(mockFetchApprovals).toHaveBeenCalledWith(ACCOUNT_A, { force: true });
+  });
+
+  it('the focus fetch is NOT forced, so the TTL can suppress it', async () => {
+    render(<ClaimableTokensScreen />);
+    await settle();
+
+    expect(mockFetchApprovals).toHaveBeenCalledWith(ACCOUNT_A);
+  });
+});
+
+describe('ClaimableTokensScreen post-claim refresh (TASK-188)', () => {
+  beforeEach(() => {
+    jest.useFakeTimers();
+  });
+
+  afterEach(() => {
+    jest.useRealTimers();
+  });
+
+  const advance = async (ms: number) => {
+    await act(async () => {
+      jest.advanceTimersByTime(ms);
+      for (let i = 0; i < 10; i += 1) {
+        await Promise.resolve();
+      }
+    });
+  };
+
+  it('forces a refresh for the claiming account after the delay', async () => {
+    mockRouteParams = { pendingRefresh: true, claimedItemIds: [] };
+
+    render(<ClaimableTokensScreen />);
+    mockFetchApprovals.mockClear();
+    await advance(8000);
+
+    expect(mockFetchApprovals).toHaveBeenCalledWith(ACCOUNT_A, { force: true });
+  });
+
+  it('abandons the delayed refresh when the account changed while it was pending', async () => {
+    mockRouteParams = { pendingRefresh: true, claimedItemIds: [] };
+
+    const { rerender } = render(<ClaimableTokensScreen />);
+    mockFetchApprovals.mockClear();
+
+    // User switches accounts inside the 8s window. A forced fetch takes
+    // ownership of the store, so refreshing the account the claim was made
+    // from would wipe the now-active account's list.
+    mockActiveAddress = ACCOUNT_B;
+    mockRouteParams = {};
+    rerender(<ClaimableTokensScreen />);
+
+    await advance(8000);
+
+    expect(mockFetchApprovals).not.toHaveBeenCalledWith(ACCOUNT_A, {
+      force: true,
+    });
+  });
+});

--- a/src/services/algorand-price/__tests__/getAssetPrices.dedup.test.ts
+++ b/src/services/algorand-price/__tests__/getAssetPrices.dedup.test.ts
@@ -1,0 +1,319 @@
+// TASK-189: per-asset in-flight dedup + PER-ENTRY cache timestamps for
+// AlgorandPriceService.getAssetPrices.
+//
+// Two failure modes are pinned here:
+//
+//  1. Dedup must be keyed per ASSET ID, not one promise per service. A single
+//     shared promise would hand a caller asking for [1,2] whichever map a
+//     concurrent [3,4] caller resolved first, silently dropping prices.
+//
+//  2. The cache must timestamp each entry INDIVIDUALLY. The previous shape
+//     replaced the whole map on every fetch (accounts with disjoint ASA sets
+//     evicted each other); the obvious repair — merging into a map that still
+//     carries ONE global timestamp — is worse, because it re-stamps every
+//     carried-over entry and an asset priced once would stay "fresh" forever.
+//     The TTL test below fails if a global timestamp is ever reintroduced.
+//
+// Expired entries are RETAINED (never deleted on read) so the stale-fallback
+// path still has something to serve when a refetch fails — also covered here.
+
+import AlgorandPriceService from '@/services/algorand-price';
+
+type Deferred = {
+  resolve: (value: unknown) => void;
+  reject: (error: unknown) => void;
+};
+
+/** Asset ids the service asked for, in call order. */
+function requestedIds(url: string): number[] {
+  const match = /asset_ids=([^&]*)/.exec(url);
+  return decodeURIComponent(match![1])
+    .split(',')
+    .map((id) => Number(id));
+}
+
+function okResponse(ids: number[], priceFor: (id: number) => number) {
+  return {
+    ok: true,
+    status: 200,
+    statusText: 'OK',
+    json: async () =>
+      ids.map((id) => ({
+        network_id: 0,
+        asset_id: id,
+        denominating_asset_id: 31566704,
+        price: priceFor(id),
+        confidence: 1,
+        total_lockup: 0,
+      })),
+  };
+}
+
+// Drain microtasks so in-flight promises reach the pending fetch.
+const flush = () => new Promise((resolve) => setTimeout(resolve, 0));
+
+describe('AlgorandPriceService.getAssetPrices dedup + per-entry TTL (TASK-189)', () => {
+  let fetchMock: jest.Mock;
+  let fetchedBatches: number[][];
+  let nowMs: number;
+
+  beforeEach(() => {
+    nowMs = 1_000_000;
+    jest.spyOn(Date, 'now').mockImplementation(() => nowMs);
+    jest.spyOn(console, 'warn').mockImplementation(() => {});
+
+    fetchedBatches = [];
+    fetchMock = jest.fn();
+    (global as unknown as { fetch: unknown }).fetch = fetchMock;
+
+    AlgorandPriceService.clearCache();
+    // Keep the retry ladder and abort timer short so failure cases don't sleep.
+    AlgorandPriceService.updateConfig({
+      retryAttempts: 1,
+      retryDelay: 0,
+      timeout: 50,
+      cacheDuration: 5 * 60 * 1000,
+    });
+  });
+
+  afterEach(() => {
+    jest.restoreAllMocks();
+  });
+
+  /** Every requested id is priced as `id * 10`, recording the batch. */
+  function respondWithTenTimesId() {
+    fetchMock.mockImplementation(async (url: string) => {
+      const ids = requestedIds(url);
+      fetchedBatches.push(ids);
+      return okResponse(ids, (id) => id * 10);
+    });
+  }
+
+  it('issues ONE request for N concurrent callers past the TTL and resolves them all with the same prices', async () => {
+    let deferred!: Deferred;
+    fetchMock.mockImplementation(
+      (url: string) =>
+        new Promise((resolve, reject) => {
+          fetchedBatches.push(requestedIds(url));
+          deferred = { resolve, reject };
+        })
+    );
+
+    // Four accounts refreshing the same holdings at once on a cold cache.
+    const calls = [
+      AlgorandPriceService.getAssetPrices([0, 7]),
+      AlgorandPriceService.getAssetPrices([0, 7]),
+      AlgorandPriceService.getAssetPrices([0, 7]),
+      AlgorandPriceService.getAssetPrices([0, 7]),
+    ];
+
+    await flush();
+
+    expect(fetchMock).toHaveBeenCalledTimes(1);
+
+    deferred.resolve(okResponse([0, 7], (id) => id * 10));
+    const results = await Promise.all(calls);
+
+    expect(fetchMock).toHaveBeenCalledTimes(1);
+    for (const result of results) {
+      expect(Array.from(result.entries()).sort()).toEqual([
+        [0, 0],
+        [7, 70],
+      ]);
+    }
+  });
+
+  it('gives concurrent [1,2] and [3,4] callers their OWN complete set (per-asset in-flight keys)', async () => {
+    const deferreds: Deferred[] = [];
+    const batches: number[][] = [];
+    fetchMock.mockImplementation(
+      (url: string) =>
+        new Promise((resolve, reject) => {
+          batches.push(requestedIds(url));
+          deferreds.push({ resolve, reject });
+        })
+    );
+
+    const first = AlgorandPriceService.getAssetPrices([1, 2]);
+    const second = AlgorandPriceService.getAssetPrices([3, 4]);
+
+    await flush();
+
+    // Two distinct outbound requests — the second caller shares no asset with
+    // the first, so it must not join (and inherit) the first request's map.
+    expect(fetchMock).toHaveBeenCalledTimes(2);
+    expect(batches[0]).toEqual(expect.arrayContaining([1, 2]));
+    expect(batches[1]).toEqual(expect.arrayContaining([3, 4]));
+    expect(batches[1]).not.toEqual(expect.arrayContaining([1]));
+
+    // Resolve out of order to prove neither caller reads the other's result.
+    deferreds[1].resolve(okResponse(batches[1], (id) => id * 10));
+    deferreds[0].resolve(okResponse(batches[0], (id) => id * 10));
+
+    const [a, b] = await Promise.all([first, second]);
+
+    expect(Array.from(a.entries()).sort()).toEqual([
+      [1, 10],
+      [2, 20],
+    ]);
+    expect(Array.from(b.entries()).sort()).toEqual([
+      [3, 30],
+      [4, 40],
+    ]);
+  });
+
+  it('joins an in-flight request for an overlapping asset instead of refetching it', async () => {
+    const deferreds: Deferred[] = [];
+    const batches: number[][] = [];
+    fetchMock.mockImplementation(
+      (url: string) =>
+        new Promise((resolve, reject) => {
+          batches.push(requestedIds(url));
+          deferreds.push({ resolve, reject });
+        })
+    );
+
+    const first = AlgorandPriceService.getAssetPrices([5]);
+    await flush();
+    const second = AlgorandPriceService.getAssetPrices([5, 6]);
+    await flush();
+
+    // Asset 5 is already in flight, so the second request carries only 6.
+    expect(batches).toHaveLength(2);
+    expect(batches[1]).not.toEqual(expect.arrayContaining([5]));
+    expect(batches[1]).toEqual(expect.arrayContaining([6]));
+
+    deferreds.forEach((deferred, index) =>
+      deferred.resolve(okResponse(batches[index], (id) => id * 10))
+    );
+
+    const [a, b] = await Promise.all([first, second]);
+    expect(a.get(5)).toBe(50);
+    // Union of the joined in-flight id and this caller's own request.
+    expect(Array.from(b.entries()).sort()).toEqual([
+      [5, 50],
+      [6, 60],
+    ]);
+  });
+
+  it('does not wedge the in-flight slots when the fetch fails (finally cleanup)', async () => {
+    fetchMock.mockRejectedValue(new Error('network down'));
+
+    // Failures are absorbed: no cache to fall back on, so the map is empty.
+    await expect(AlgorandPriceService.getAssetPrices([9])).resolves.toEqual(
+      new Map()
+    );
+    expect(fetchMock).toHaveBeenCalledTimes(1);
+
+    // The slots were released, so the next caller starts a fresh request.
+    respondWithTenTimesId();
+    const result = await AlgorandPriceService.getAssetPrices([9]);
+    expect(result.get(9)).toBe(90);
+    expect(fetchMock).toHaveBeenCalledTimes(2);
+  });
+
+  it('does not let accounts with disjoint asset sets evict each other', async () => {
+    respondWithTenTimesId();
+
+    // Account A holds asset 1; account B holds asset 2.
+    const a1 = await AlgorandPriceService.getAssetPrices([0, 1]);
+    expect(a1.get(1)).toBe(10);
+
+    const b1 = await AlgorandPriceService.getAssetPrices([0, 2]);
+    expect(b1.get(2)).toBe(20);
+    // Account B's fetch covered only the asset it was missing.
+    expect(fetchedBatches[1]).toEqual([2]);
+
+    // Account A refreshes again: its price survived B's fetch, so nothing goes
+    // out at all (the old whole-map replacement would have forced a refetch).
+    const a2 = await AlgorandPriceService.getAssetPrices([0, 1]);
+    expect(Array.from(a2.entries()).sort()).toEqual([
+      [0, 0],
+      [1, 10],
+    ]);
+    expect(fetchMock).toHaveBeenCalledTimes(2);
+  });
+
+  it('refetches an entry older than cacheDuration even when other entries were just refreshed', async () => {
+    // REGRESSION GUARD for the rejected "merge into a single-timestamp map"
+    // fix: under that shape, asset 1 would be re-stamped by asset 2's fetch and
+    // would never expire while anything else keeps refetching.
+    respondWithTenTimesId();
+
+    await AlgorandPriceService.getAssetPrices([1]);
+    const { cacheDuration } = AlgorandPriceService.getConfig();
+
+    // Asset 1 goes stale, then a DIFFERENT asset is fetched (re-stamping the
+    // whole map under a global timestamp).
+    nowMs += cacheDuration + 1;
+    await AlgorandPriceService.getAssetPrices([2]);
+    expect(fetchMock).toHaveBeenCalledTimes(2);
+
+    // Asset 2 is fresh; asset 1 is expired and must go back out.
+    const result = await AlgorandPriceService.getAssetPrices([1, 2]);
+
+    expect(fetchMock).toHaveBeenCalledTimes(3);
+    expect(fetchedBatches[2]).toEqual(expect.arrayContaining([1]));
+    expect(fetchedBatches[2]).not.toEqual(expect.arrayContaining([2]));
+    expect(Array.from(result.entries()).sort()).toEqual([
+      [1, 10],
+      [2, 20],
+    ]);
+  });
+
+  it('returns an expired-but-retained entry when the refetch fails (retain, do not delete)', async () => {
+    respondWithTenTimesId();
+    await AlgorandPriceService.getAssetPrices([3]);
+
+    // Entry 3 expires…
+    nowMs += AlgorandPriceService.getConfig().cacheDuration + 1;
+    fetchMock.mockRejectedValue(new Error('network down'));
+
+    // …and the refetch fails. The expired entry was never deleted, so the
+    // stale-fallback path can still price the asset instead of dropping it.
+    const result = await AlgorandPriceService.getAssetPrices([3]);
+
+    expect(result.get(3)).toBe(30);
+    expect(fetchMock).toHaveBeenCalledTimes(2);
+  });
+
+  it('abandons in-flight requests on clearCache so they cannot repopulate the cache', async () => {
+    let deferred!: Deferred;
+    const batches: number[][] = [];
+    fetchMock.mockImplementation(
+      (url: string) =>
+        new Promise((resolve, reject) => {
+          batches.push(requestedIds(url));
+          deferred = { resolve, reject };
+        })
+    );
+
+    const inFlight = AlgorandPriceService.getAssetPrices([8]);
+    await flush();
+
+    AlgorandPriceService.clearCache();
+    deferred.resolve(okResponse(batches[0], (id) => id * 10));
+
+    // The caller that asked for it still gets its price…
+    await expect(inFlight).resolves.toEqual(new Map([[8, 80]]));
+
+    // …but the cleared cache stays cleared, and the next caller neither joins
+    // the abandoned request nor reads its write-back.
+    respondWithTenTimesId();
+    await AlgorandPriceService.getAssetPrices([8]);
+    expect(fetchMock).toHaveBeenCalledTimes(2);
+  });
+
+  it('keeps getAlgoPrice reading asset 0 from the per-entry cache', async () => {
+    respondWithTenTimesId();
+    fetchMock.mockImplementationOnce(async (url: string) => {
+      const ids = requestedIds(url);
+      fetchedBatches.push(ids);
+      return okResponse(ids, () => 1.25);
+    });
+
+    await expect(AlgorandPriceService.getAlgoPrice()).resolves.toBe(1.25);
+    expect(fetchedBatches[0]).toEqual([0]);
+    expect(AlgorandPriceService.formatUsdValue(2_000_000)).toBe('$2.50');
+  });
+});

--- a/src/services/algorand-price/index.ts
+++ b/src/services/algorand-price/index.ts
@@ -1,3 +1,5 @@
+import { shouldSkipForOffline } from '@/services/network/offline';
+
 export interface VestigePriceData {
   network_id: number;
   asset_id: number;
@@ -294,6 +296,18 @@ export class AlgorandPriceService {
   }
 
   private async fetchWithRetry(url: string): Promise<Response> {
+    // TASK-191: offline → skip the ladder instead of burning every attempt and
+    // its backoff. Same error shape the exhausted ladder throws, so the outcome
+    // is still `failed: true` and every joined caller applies the retained
+    // stale-price fallback exactly as it does after a real failure.
+    if (shouldSkipForOffline('algorand-price')) {
+      throw new AlgorandPriceError(
+        'Offline: skipped request without attempting the network',
+        undefined,
+        'NETWORK_ERROR'
+      );
+    }
+
     let lastError: Error;
 
     for (let attempt = 1; attempt <= this.config.retryAttempts; attempt++) {

--- a/src/services/algorand-price/index.ts
+++ b/src/services/algorand-price/index.ts
@@ -31,15 +31,57 @@ export class AlgorandPriceError extends Error {
   }
 }
 
-interface CachedPrices {
-  prices: Map<number, number>;
+/**
+ * TASK-189: one timestamp PER ASSET, not one for the whole map.
+ *
+ * The previous shape kept a single global timestamp and replaced the entire map
+ * on every fetch, so accounts holding disjoint ASA sets evicted each other. The
+ * obvious repair — merging old entries into the new map — is worse: with a
+ * single global timestamp it re-stamps every carried-over entry, so an asset
+ * priced once stays "fresh" forever as long as anything else refetches inside
+ * the window. Per-entry timestamps fix the eviction without inventing a
+ * permanently-stale price.
+ */
+interface CachedAssetPrice {
+  price: number;
   timestamp: number;
 }
+
+/**
+ * Outcome of one outbound price request, shared by every caller that joined it.
+ * `failed` distinguishes "the request blew up" (→ callers fall back to their
+ * retained, expired cache entries) from "the request succeeded but the API did
+ * not price this asset" (→ omitted, as before).
+ */
+interface PriceFetchOutcome {
+  prices: Map<number, number>;
+  failed: boolean;
+}
+
+/**
+ * Upper bound on retained entries. Expired entries are deliberately KEPT (they
+ * back the stale-fallback path below), so the map only ever grows; this caps it.
+ * Eviction is purely a memory bound — it is never part of a freshness check.
+ */
+const MAX_CACHED_ASSETS = 1000;
 
 export class AlgorandPriceService {
   private static instance: AlgorandPriceService;
   private config: AlgorandPriceConfig;
-  private cachedPrices: CachedPrices | null = null;
+  private cachedPrices = new Map<number, CachedAssetPrice>();
+  /**
+   * TASK-189: in-flight state keyed PER ASSET ID, not one promise per service.
+   *
+   * `getAssetPrices` takes an id list, so a single shared promise would hand a
+   * caller asking for [1,2] whichever map a concurrent [3,4] caller resolved
+   * first — silently missing prices. Each call resolves as the union of (fresh
+   * cache entries) ∪ (awaited in-flight ids) ∪ (one request for the genuine
+   * remainder). Mirrors `balanceLoadsInFlight` in walletStore, including the
+   * `finally` cleanup so a failed fetch never wedges the slots.
+   */
+  private inFlightByAsset = new Map<number, Promise<PriceFetchOutcome>>();
+  /** Bumped by clearCache() so a fetch started before it cannot write back. */
+  private cacheGeneration = 0;
 
   private constructor() {
     this.config = {
@@ -64,72 +106,145 @@ export class AlgorandPriceService {
       return prices.get(0) || 0;
     } catch (error) {
       console.warn('Failed to fetch ALGO price:', error);
-      return this.cachedPrices?.prices.get(0) || 0;
+      return this.cachedPrices.get(0)?.price || 0;
     }
   }
 
   async getAssetPrices(assetIds: number[]): Promise<Map<number, number>> {
-    try {
-      // Check cache first
-      if (this.cachedPrices && this.isCacheValid()) {
-        // Return cached prices for requested assets
-        const cachedResults = new Map<number, number>();
-        assetIds.forEach((id) => {
-          const price = this.cachedPrices!.prices.get(id);
-          if (price !== undefined) {
-            cachedResults.set(id, price);
-          }
-        });
+    const requested = Array.from(new Set(assetIds));
+    const results = new Map<number, number>();
+    const now = Date.now();
 
-        // If we have all requested prices in cache, return them
-        if (cachedResults.size === assetIds.length) {
-          return cachedResults;
-        }
+    // Partition the request: fresh cache hits are answered immediately, ids
+    // already being fetched are joined, and only the genuine remainder goes out.
+    const joined = new Map<number, Promise<PriceFetchOutcome>>();
+    const toFetch = new Set<number>();
+
+    for (const id of requested) {
+      if (this.isEntryFresh(id, now)) {
+        // Non-null: isEntryFresh only returns true when the entry exists.
+        results.set(id, this.cachedPrices.get(id)!.price);
+        continue;
       }
 
-      // Always include ALGO (asset ID 0) in the request
-      const uniqueAssetIds = Array.from(new Set([0, ...assetIds]));
-      const priceData = await this.fetchAssetPricesFromAPI(uniqueAssetIds);
+      const inFlight = this.inFlightByAsset.get(id);
+      if (inFlight) {
+        joined.set(id, inFlight);
+        continue;
+      }
 
-      // Convert to Map and cache
-      const priceMap = new Map<number, number>();
-      priceData.forEach((asset) => {
-        priceMap.set(asset.asset_id, asset.price);
-      });
+      toFetch.add(id);
+    }
 
-      // Update cache with all fetched prices
-      this.cachedPrices = {
-        prices: priceMap,
-        timestamp: Date.now(),
-      };
+    if (toFetch.size === 0 && joined.size === 0) {
+      return results;
+    }
 
-      // Return only requested prices
-      const results = new Map<number, number>();
-      assetIds.forEach((id) => {
-        const price = priceMap.get(id);
-        if (price !== undefined) {
-          results.set(id, price);
+    let ownRequest: Promise<PriceFetchOutcome> | null = null;
+
+    if (toFetch.size > 0) {
+      // ALGO (asset ID 0) rides along with any outbound request, as before —
+      // but only when a request is going out anyway, and only if it is not
+      // already fresh or in flight.
+      if (!this.isEntryFresh(0, now) && !this.inFlightByAsset.has(0)) {
+        toFetch.add(0);
+      }
+
+      const fetchIds = Array.from(toFetch);
+      const request = this.fetchAndCachePrices(fetchIds);
+
+      for (const id of fetchIds) {
+        this.inFlightByAsset.set(id, request);
+      }
+
+      // Release every slot this request claimed once it settles — a failed
+      // fetch must not wedge them. Identity-checked so a later request for the
+      // same id is never cleared by an earlier one. `fetchAndCachePrices`
+      // absorbs its own errors, so this chain can never reject.
+      void request.finally(() => {
+        for (const id of fetchIds) {
+          if (this.inFlightByAsset.get(id) === request) {
+            this.inFlightByAsset.delete(id);
+          }
         }
       });
 
-      return results;
+      ownRequest = request;
+    }
+
+    // Await each distinct request exactly once, then resolve every outstanding
+    // id against the outcome of the request that owned it.
+    const pending = new Set<Promise<PriceFetchOutcome>>(joined.values());
+    if (ownRequest) {
+      pending.add(ownRequest);
+    }
+    const settled = new Map<Promise<PriceFetchOutcome>, PriceFetchOutcome>(
+      await Promise.all(
+        Array.from(pending).map(
+          async (promise) => [promise, await promise] as const
+        )
+      )
+    );
+
+    for (const id of requested) {
+      if (results.has(id)) continue;
+
+      const source = joined.get(id) ?? ownRequest;
+      const outcome = source ? settled.get(source) : undefined;
+
+      const price = outcome?.prices.get(id);
+      if (price !== undefined) {
+        results.set(id, price);
+        continue;
+      }
+
+      // Stale fallback: the request failed, so serve the retained (expired)
+      // entry rather than dropping the asset from the portfolio. An asset the
+      // API simply did not price on a SUCCESSFUL response stays omitted.
+      if (outcome?.failed) {
+        const stale = this.cachedPrices.get(id);
+        if (stale) {
+          results.set(id, stale.price);
+        }
+      }
+    }
+
+    return results;
+  }
+
+  /**
+   * Runs one outbound price request and writes each returned price into the
+   * cache with its OWN timestamp. Never rejects: failures are reported via
+   * `failed` so every joined caller can apply its own stale fallback.
+   */
+  private async fetchAndCachePrices(
+    assetIds: number[]
+  ): Promise<PriceFetchOutcome> {
+    const generation = this.cacheGeneration;
+
+    try {
+      const priceData = await this.fetchAssetPricesFromAPI(assetIds);
+
+      const prices = new Map<number, number>();
+      const timestamp = Date.now();
+      priceData.forEach((asset) => {
+        prices.set(asset.asset_id, asset.price);
+        // A clearCache() during the fetch bumps the generation; the callers
+        // that asked for these prices still get them, but they must not
+        // repopulate the cache that was just dropped.
+        if (this.cacheGeneration === generation) {
+          this.cachedPrices.set(asset.asset_id, {
+            price: asset.price,
+            timestamp,
+          });
+        }
+      });
+      this.evictOldestBeyondLimit();
+
+      return { prices, failed: false };
     } catch (error) {
       console.warn('Failed to fetch asset prices:', error);
-
-      // Return cached prices if available, even if stale
-      if (this.cachedPrices) {
-        const cachedResults = new Map<number, number>();
-        assetIds.forEach((id) => {
-          const price = this.cachedPrices!.prices.get(id);
-          if (price !== undefined) {
-            cachedResults.set(id, price);
-          }
-        });
-        return cachedResults;
-      }
-
-      // Return empty map as fallback
-      return new Map();
+      return { prices: new Map(), failed: true };
     }
   }
 
@@ -224,9 +339,31 @@ export class AlgorandPriceService {
     );
   }
 
-  private isCacheValid(): boolean {
-    if (!this.cachedPrices) return false;
-    return Date.now() - this.cachedPrices.timestamp < this.config.cacheDuration;
+  /**
+   * Freshness is evaluated PER ENTRY. An expired entry is not a hit — its asset
+   * joins the refetch — but it is deliberately retained so the stale-fallback
+   * path above still has something to serve when that refetch fails.
+   */
+  private isEntryFresh(assetId: number, now: number): boolean {
+    const entry = this.cachedPrices.get(assetId);
+    if (!entry) return false;
+    return now - entry.timestamp < this.config.cacheDuration;
+  }
+
+  /**
+   * Memory bound only — drops the oldest entries once the map exceeds
+   * MAX_CACHED_ASSETS. Never called from a freshness check.
+   */
+  private evictOldestBeyondLimit(): void {
+    if (this.cachedPrices.size <= MAX_CACHED_ASSETS) return;
+
+    const byAge = Array.from(this.cachedPrices.entries()).sort(
+      (a, b) => a[1].timestamp - b[1].timestamp
+    );
+    const excess = this.cachedPrices.size - MAX_CACHED_ASSETS;
+    for (let i = 0; i < excess; i++) {
+      this.cachedPrices.delete(byAge[i][0]);
+    }
   }
 
   private sleep(ms: number): Promise<void> {
@@ -242,11 +379,15 @@ export class AlgorandPriceService {
   }
 
   clearCache(): void {
-    this.cachedPrices = null;
+    this.cachedPrices.clear();
+    // Abandon in-flight requests too: a later caller must not join a request
+    // that predates the clear, and that request must not repopulate the cache.
+    this.cacheGeneration++;
+    this.inFlightByAsset.clear();
   }
 
   formatUsdValue(algoAmount: number | bigint, pricePerAlgo?: number): string {
-    const price = pricePerAlgo || (this.cachedPrices?.prices.get(0) ?? 0);
+    const price = pricePerAlgo || (this.cachedPrices.get(0)?.price ?? 0);
     if (price === 0) return '$0.00';
 
     const amount =

--- a/src/services/envoi/index.ts
+++ b/src/services/envoi/index.ts
@@ -1,5 +1,6 @@
 import algosdk from 'algosdk';
 import { NetworkId } from '@/types/network';
+import { shouldSkipForOffline } from '@/services/network/offline';
 import {
   EnvoiNameInfo,
   EnvoiTokenInfo,
@@ -591,6 +592,16 @@ export class EnvoiService {
   }
 
   private async fetchWithRetry(url: string): Promise<Response> {
+    // TASK-191: offline → skip the ladder instead of burning every attempt and
+    // its backoff. A plain Error matches what the exhausted ladder throws, so
+    // the callers that turn a failure into `null` (name unresolved) behave
+    // exactly as they do today — just sooner.
+    if (shouldSkipForOffline('envoi')) {
+      throw new Error(
+        'Offline: skipped request without attempting the network'
+      );
+    }
+
     let lastError: Error | null = null;
 
     for (let attempt = 1; attempt <= this.config.retryAttempts; attempt++) {

--- a/src/services/mimir/__tests__/batchGetArc200Balances.test.ts
+++ b/src/services/mimir/__tests__/batchGetArc200Balances.test.ts
@@ -1,0 +1,101 @@
+// TASK-188: batchGetArc200Balances must make per-owner failures observable.
+//
+// It used to write the string '0' for a pair whose lookup threw, with the
+// comment "Set to '0' on error to mark as not claimable". That is a lie the
+// caller cannot detect: a genuine zero balance and a failed request produced
+// identical output, so a transient network error rendered a claimable token as
+// "Insufficient". The contract is now {balances, failed}, with failed pairs
+// ABSENT from balances rather than present as '0'.
+
+import { MimirApiService } from '../index';
+
+const service = MimirApiService.getInstance();
+
+describe('MimirApiService.batchGetArc200Balances (TASK-188)', () => {
+  let getArc200Balance: jest.SpyInstance;
+
+  beforeEach(() => {
+    getArc200Balance = jest.spyOn(service, 'getArc200Balance');
+    jest.spyOn(console, 'error').mockImplementation(() => {});
+  });
+
+  afterEach(() => {
+    jest.restoreAllMocks();
+  });
+
+  it('returns successful balances keyed `${contractId}_${owner}`', async () => {
+    getArc200Balance.mockImplementation(
+      async (contractId: number, owner: string) =>
+        `${contractId}${owner.length}`
+    );
+
+    const result = await service.batchGetArc200Balances([
+      { contractId: 1, owner: 'AAA' },
+      { contractId: 2, owner: 'BBBB' },
+    ]);
+
+    expect(result.balances.get('1_AAA')).toBe('13');
+    expect(result.balances.get('2_BBBB')).toBe('24');
+    expect(result.failed.size).toBe(0);
+  });
+
+  it('reports a failed pair in `failed` and omits it from `balances` — never as "0"', async () => {
+    getArc200Balance.mockImplementation(
+      async (contractId: number, owner: string) => {
+        if (owner === 'BROKEN') throw new Error('network down');
+        return '500';
+      }
+    );
+
+    const result = await service.batchGetArc200Balances([
+      { contractId: 1, owner: 'OK' },
+      { contractId: 1, owner: 'BROKEN' },
+    ]);
+
+    expect(result.balances.get('1_OK')).toBe('500');
+    // The regression this task exists to prevent: a failed lookup must not be
+    // indistinguishable from "owner holds nothing".
+    expect(result.balances.has('1_BROKEN')).toBe(false);
+    expect(result.balances.get('1_BROKEN')).toBeUndefined();
+    expect([...result.failed]).toEqual(['1_BROKEN']);
+  });
+
+  it('keeps a genuine zero balance in `balances` and out of `failed`', async () => {
+    getArc200Balance.mockResolvedValue('0');
+
+    const result = await service.batchGetArc200Balances([
+      { contractId: 7, owner: 'ZERO' },
+    ]);
+
+    expect(result.balances.get('7_ZERO')).toBe('0');
+    expect(result.failed.size).toBe(0);
+  });
+
+  it('preserves the existing request shape: dedups pairs, one request per (contract, owner)', async () => {
+    getArc200Balance.mockResolvedValue('1');
+
+    await service.batchGetArc200Balances([
+      { contractId: 1, owner: 'A' },
+      { contractId: 1, owner: 'A' },
+      { contractId: 1, owner: 'B' },
+      { contractId: 2, owner: 'A' },
+    ]);
+
+    // Unchanged from before this task: duplicates collapse, but the fan-out is
+    // still one request per unique pair (collapsing it is a different task).
+    expect(getArc200Balance).toHaveBeenCalledTimes(3);
+    expect(getArc200Balance).toHaveBeenCalledWith(1, 'A');
+    expect(getArc200Balance).toHaveBeenCalledWith(1, 'B');
+    expect(getArc200Balance).toHaveBeenCalledWith(2, 'A');
+  });
+
+  it('returns empty collections for no pairs without issuing a request', async () => {
+    getArc200Balance.mockResolvedValue('1');
+
+    const result = await service.batchGetArc200Balances([]);
+
+    expect(result.balances.size).toBe(0);
+    expect(result.failed.size).toBe(0);
+    expect(getArc200Balance).not.toHaveBeenCalled();
+  });
+});

--- a/src/services/mimir/index.ts
+++ b/src/services/mimir/index.ts
@@ -86,6 +86,20 @@ export interface Arc200BalanceResponse {
   'current-round': number;
 }
 
+/**
+ * Result of a batched ARC-200 balance lookup.
+ *
+ * Both collections are keyed `${contractId}_${owner}`. A pair whose lookup
+ * failed is present in `failed` and ABSENT from `balances` — it is deliberately
+ * NOT recorded as '0', because a caller cannot tell a genuine zero balance from
+ * a failed request and would render a claimable token as un-claimable
+ * ("Insufficient") on a transient network error (TASK-188).
+ */
+export interface Arc200BatchBalancesResult {
+  balances: Map<string, string>;
+  failed: Set<string>;
+}
+
 export interface MimirApiConfig {
   baseUrl: string;
   timeout: number;
@@ -563,11 +577,17 @@ export class MimirApiService {
   /**
    * Batch fetch ARC-200 balances for multiple owner/contract pairs
    * More efficient than individual calls when validating multiple approvals
+   *
+   * Per-pair failures are reported through `failed` rather than being flattened
+   * to '0' — see `Arc200BatchBalancesResult`. Callers that do not care about
+   * failures can read `balances` alone and behave exactly as before, except
+   * that a failed pair now reads as missing instead of falsely zero.
    */
   async batchGetArc200Balances(
     pairs: { owner: string; contractId: number }[]
-  ): Promise<Map<string, string>> {
+  ): Promise<Arc200BatchBalancesResult> {
     const balanceMap = new Map<string, string>();
+    const failed = new Set<string>();
 
     // Group by contractId to minimize API calls
     const byContract = new Map<number, string[]>();
@@ -591,14 +611,15 @@ export class MimirApiService {
               `Failed to fetch balance for ${owner} on contract ${contractId}:`,
               error
             );
-            // Set to '0' on error to mark as not claimable
-            balanceMap.set(`${contractId}_${owner}`, '0');
+            // Record the failure instead of writing '0': the caller must be
+            // able to distinguish "owner holds nothing" from "we don't know".
+            failed.add(`${contractId}_${owner}`);
           }
         }
       })
     );
 
-    return balanceMap;
+    return { balances: balanceMap, failed };
   }
 }
 

--- a/src/services/mimir/index.ts
+++ b/src/services/mimir/index.ts
@@ -1,3 +1,5 @@
+import { shouldSkipForOffline } from '@/services/network/offline';
+
 export interface MimirAsset {
   name: string;
   symbol: string;
@@ -383,6 +385,19 @@ export class MimirApiService {
   }
 
   private async fetchWithRetry(url: string): Promise<Response> {
+    // TASK-191: while the device is definitely offline, skip the ladder
+    // outright rather than burning `retryAttempts` fetches plus their backoff
+    // on a request that cannot reach the network. Deliberately the SAME error
+    // shape the exhausted ladder throws (MimirApiError / NETWORK_ERROR) — this
+    // is a faster failure, not a new one callers must learn to handle.
+    if (shouldSkipForOffline('mimir')) {
+      throw new MimirApiError(
+        'Offline: skipped request without attempting the network',
+        undefined,
+        'NETWORK_ERROR'
+      );
+    }
+
     let lastError: Error;
 
     for (let attempt = 1; attempt <= this.config.retryAttempts; attempt++) {

--- a/src/services/network/__tests__/offline.test.ts
+++ b/src/services/network/__tests__/offline.test.ts
@@ -228,4 +228,49 @@ describe('offline gate (TASK-191)', () => {
       expect(unsubscribe).not.toHaveBeenCalled();
     });
   });
+
+  // Found by the full-diff Codex pass over PLAN-274. NetInfo's first emit often
+  // carries `isInternetReachable: null` — interface up, its own probe still
+  // running. `isOffline()` resolves that to the interface flag, which is the
+  // right call for gating but is a GUESS. Recording it as settled meant the
+  // one-shot getState() priming was discarded, so a cold-start offline device
+  // kept running full retry ladders until NetInfo happened to emit again.
+  describe('indeterminate first emit vs the priming probe', () => {
+    it('lets a definitive probe result override a guessed online reading', async () => {
+      mockGetState.mockResolvedValue({
+        isConnected: true,
+        isInternetReachable: false,
+        type: 'wifi',
+      });
+      resetOfflineGate();
+
+      shouldSkipForOffline('mimir'); // primes
+      // Interface up, reachability not yet determined → a guess, not a reading.
+      emit!({ isConnected: true, isInternetReachable: null, type: 'wifi' });
+
+      await Promise.resolve();
+      await Promise.resolve();
+
+      expect(getReachability()).toBe('offline');
+      expect(shouldSkipForOffline('mimir')).toBe(true);
+    });
+
+    it('does not let the probe override a SETTLED subscription reading', async () => {
+      mockGetState.mockResolvedValue({
+        isConnected: true,
+        isInternetReachable: false,
+        type: 'wifi',
+      });
+      resetOfflineGate();
+
+      shouldSkipForOffline('mimir'); // primes
+      emit!(ONLINE); // settled: isInternetReachable is a real true
+
+      await Promise.resolve();
+      await Promise.resolve();
+
+      expect(getReachability()).toBe('online');
+      expect(shouldSkipForOffline('mimir')).toBe(false);
+    });
+  });
 });

--- a/src/services/network/__tests__/offline.test.ts
+++ b/src/services/network/__tests__/offline.test.ts
@@ -1,0 +1,231 @@
+/**
+ * Offline gate (TASK-191).
+ *
+ * The gate decides whether a retry ladder runs at all, so the cold-start
+ * behaviour matters more than the steady state: `unknown` MUST read as online.
+ * A gate that guesses "offline" while it waits for its first probe would turn
+ * every cold launch into a wallet that refuses to fetch anything.
+ */
+
+import type { ConnectivityState } from '@/platform';
+
+const mockSubscribe = jest.fn();
+const mockGetState = jest.fn();
+
+jest.mock('@/platform', () => {
+  const actual = jest.requireActual('@/platform');
+  return {
+    ...actual,
+    connectivity: {
+      subscribe: (listener: (state: ConnectivityState) => void) =>
+        mockSubscribe(listener),
+      getState: () => mockGetState(),
+    },
+  };
+});
+
+import {
+  getOfflineCounters,
+  getReachability,
+  isDefinitelyOffline,
+  resetOfflineCounters,
+  resetOfflineGate,
+  shouldSkipForOffline,
+} from '../offline';
+
+const ONLINE: ConnectivityState = {
+  isConnected: true,
+  isInternetReachable: true,
+  type: 'wifi',
+};
+
+const OFFLINE: ConnectivityState = {
+  isConnected: false,
+  isInternetReachable: false,
+  type: 'none',
+};
+
+/** Never-settling probe, so subscription behaviour can be tested in isolation. */
+const pending = () => new Promise<ConnectivityState>(() => {});
+
+describe('offline gate (TASK-191)', () => {
+  let emit: ((state: ConnectivityState) => void) | null;
+  let unsubscribe: jest.Mock;
+
+  beforeEach(() => {
+    emit = null;
+    unsubscribe = jest.fn();
+    mockSubscribe.mockImplementation(
+      (listener: (state: ConnectivityState) => void) => {
+        emit = listener;
+        return unsubscribe;
+      }
+    );
+    mockGetState.mockImplementation(pending);
+    resetOfflineGate();
+  });
+
+  afterEach(() => {
+    resetOfflineGate();
+  });
+
+  describe('cold start (fail open)', () => {
+    it('reads as unknown — and therefore NOT offline — before the adapter answers', () => {
+      expect(getReachability()).toBe('unknown');
+      expect(isDefinitelyOffline()).toBe(false);
+      expect(shouldSkipForOffline('mimir')).toBe(false);
+    });
+
+    it('stays online when subscribing throws', () => {
+      resetOfflineGate();
+      mockSubscribe.mockImplementation(() => {
+        throw new Error('no adapter');
+      });
+
+      expect(getReachability()).toBe('unknown');
+      expect(isDefinitelyOffline()).toBe(false);
+    });
+
+    it('stays online when the probe rejects', async () => {
+      resetOfflineGate();
+      mockGetState.mockRejectedValue(new Error('probe failed'));
+
+      expect(isDefinitelyOffline()).toBe(false);
+      await Promise.resolve();
+      await Promise.resolve();
+      expect(isDefinitelyOffline()).toBe(false);
+      expect(getReachability()).toBe('unknown');
+    });
+
+    it('stays online when getState throws synchronously', () => {
+      resetOfflineGate();
+      mockGetState.mockImplementation(() => {
+        throw new Error('adapter exploded');
+      });
+
+      expect(() => getReachability()).not.toThrow();
+      expect(isDefinitelyOffline()).toBe(false);
+    });
+
+    it('primes lazily on first read — nothing needs to bootstrap it', () => {
+      expect(mockSubscribe).not.toHaveBeenCalled();
+      expect(mockGetState).not.toHaveBeenCalled();
+
+      getReachability();
+
+      expect(mockSubscribe).toHaveBeenCalledTimes(1);
+      expect(mockGetState).toHaveBeenCalledTimes(1);
+
+      // Repeat reads must not re-register.
+      getReachability();
+      isDefinitelyOffline();
+      expect(mockSubscribe).toHaveBeenCalledTimes(1);
+      expect(mockGetState).toHaveBeenCalledTimes(1);
+    });
+  });
+
+  describe('snapshot', () => {
+    it('goes offline and back online as the subscription reports transitions', () => {
+      getReachability();
+
+      emit!(OFFLINE);
+      expect(getReachability()).toBe('offline');
+      expect(isDefinitelyOffline()).toBe(true);
+
+      emit!(ONLINE);
+      expect(getReachability()).toBe('online');
+      expect(isDefinitelyOffline()).toBe(false);
+    });
+
+    it('treats undetermined reachability with an interface up as online', () => {
+      getReachability();
+      emit!({ isConnected: true, isInternetReachable: null, type: 'wifi' });
+      expect(getReachability()).toBe('online');
+    });
+
+    it('fills the initial gap from the one-shot probe', async () => {
+      resetOfflineGate();
+      mockSubscribe.mockImplementation(() => unsubscribe); // never emits
+      mockGetState.mockResolvedValue(OFFLINE);
+
+      expect(getReachability()).toBe('unknown');
+      await Promise.resolve();
+      await Promise.resolve();
+      expect(getReachability()).toBe('offline');
+    });
+
+    it('lets a subscription value win over a probe that resolves later', async () => {
+      resetOfflineGate();
+      let settleProbe!: (state: ConnectivityState) => void;
+      mockGetState.mockImplementation(
+        () =>
+          new Promise<ConnectivityState>((resolve) => (settleProbe = resolve))
+      );
+
+      getReachability();
+      emit!(ONLINE);
+      expect(getReachability()).toBe('online');
+
+      // Stale probe result must not clobber the fresher subscription value.
+      settleProbe(OFFLINE);
+      await Promise.resolve();
+      await Promise.resolve();
+      expect(getReachability()).toBe('online');
+    });
+
+    it('drops the subscription on reset', () => {
+      getReachability();
+      resetOfflineGate();
+      expect(unsubscribe).toHaveBeenCalledTimes(1);
+    });
+  });
+
+  describe('counters', () => {
+    it('counts nothing while online', () => {
+      getReachability();
+      emit!(ONLINE);
+
+      expect(shouldSkipForOffline('voi-price')).toBe(false);
+      expect(getOfflineCounters().offlineSkips).toBe(0);
+    });
+
+    it('counts a skip per gated call, per scope', () => {
+      getReachability();
+      emit!(OFFLINE);
+
+      expect(shouldSkipForOffline('mimir')).toBe(true);
+      expect(shouldSkipForOffline('mimir')).toBe(true);
+      expect(shouldSkipForOffline('envoi')).toBe(true);
+
+      const counters = getOfflineCounters();
+      expect(counters.offlineSkips).toBe(3);
+      expect(counters.offlineSkipsByScope.mimir).toBe(2);
+      expect(counters.offlineSkipsByScope.envoi).toBe(1);
+      expect(counters.offlineSkipsByScope['voi-price']).toBe(0);
+    });
+
+    it('exposes counts only — every value is a number', () => {
+      getReachability();
+      emit!(OFFLINE);
+      shouldSkipForOffline('home-refresh');
+
+      const counters = getOfflineCounters();
+      expect(typeof counters.offlineSkips).toBe('number');
+      for (const value of Object.values(counters.offlineSkipsByScope)) {
+        expect(typeof value).toBe('number');
+      }
+    });
+
+    it('resets counters without dropping the connectivity snapshot', () => {
+      getReachability();
+      emit!(OFFLINE);
+      shouldSkipForOffline('messages-poll');
+
+      resetOfflineCounters();
+
+      expect(getOfflineCounters().offlineSkips).toBe(0);
+      expect(getReachability()).toBe('offline');
+      expect(unsubscribe).not.toHaveBeenCalled();
+    });
+  });
+});

--- a/src/services/network/__tests__/offlineGating.test.ts
+++ b/src/services/network/__tests__/offlineGating.test.ts
@@ -1,0 +1,382 @@
+/**
+ * Offline gating of the four retry ladders (TASK-191).
+ *
+ * These exercise the REAL gate against a mocked platform connectivity adapter,
+ * so what is under test is the wiring — a service that stopped importing the
+ * gate, or one that started importing it when it should not have, fails here.
+ *
+ * Scope is exactly four services: mimir, price, algorand-price, envoi. The last
+ * describe block pins the two that are deliberately NOT gated
+ * (token-mapping, snowball) so a later change cannot silently widen it.
+ */
+
+import algosdk from 'algosdk';
+import type { ConnectivityState } from '@/platform';
+
+// token-mapping (one of the deliberately-ungated services asserted below)
+// reaches AsyncStorage, whose native module is absent under jest.
+jest.mock('@react-native-async-storage/async-storage', () =>
+  require('@react-native-async-storage/async-storage/jest/async-storage-mock')
+);
+
+const mockSubscribe = jest.fn();
+const mockGetState = jest.fn();
+
+jest.mock('@/platform', () => {
+  const actual = jest.requireActual('@/platform');
+  return {
+    ...actual,
+    connectivity: {
+      subscribe: (listener: (state: ConnectivityState) => void) =>
+        mockSubscribe(listener),
+      getState: () => mockGetState(),
+    },
+  };
+});
+
+import {
+  getOfflineCounters,
+  getReachability,
+  resetOfflineGate,
+} from '../offline';
+import MimirApiService, { MimirApiError } from '@/services/mimir';
+import VoiPriceService from '@/services/price';
+import AlgorandPriceService from '@/services/algorand-price';
+import EnvoiService from '@/services/envoi';
+import tokenMappingService from '@/services/token-mapping';
+import snowballService from '@/services/snowball';
+
+const ONLINE: ConnectivityState = {
+  isConnected: true,
+  isInternetReachable: true,
+  type: 'wifi',
+};
+
+const OFFLINE: ConnectivityState = {
+  isConnected: false,
+  isInternetReachable: false,
+  type: 'none',
+};
+
+type Deferred = {
+  resolve: (value: unknown) => void;
+  reject: (error: unknown) => void;
+};
+
+const flush = () => new Promise((resolve) => setTimeout(resolve, 0));
+
+const jsonResponse = (body: unknown) => ({
+  ok: true,
+  status: 200,
+  statusText: 'OK',
+  json: async () => body,
+});
+
+const envoi = EnvoiService.getInstance();
+const snowball = snowballService;
+
+describe('offline gating of retry ladders (TASK-191)', () => {
+  let emit: (state: ConnectivityState) => void;
+  let fetchMock: jest.Mock;
+
+  const goOffline = () => emit(OFFLINE);
+  const goOnline = () => emit(ONLINE);
+
+  beforeEach(() => {
+    mockSubscribe.mockImplementation(
+      (listener: (state: ConnectivityState) => void) => {
+        emit = listener;
+        return jest.fn();
+      }
+    );
+    // Never settles: the subscription is the only source of truth here.
+    mockGetState.mockImplementation(() => new Promise(() => {}));
+    resetOfflineGate();
+    // The gate primes lazily on first read; read once here so `emit` exists.
+    // Reachability is still `unknown` (nothing emitted yet) until a test calls
+    // goOnline()/goOffline().
+    getReachability();
+
+    fetchMock = jest.fn();
+    (global as unknown as { fetch: unknown }).fetch = fetchMock;
+
+    jest.spyOn(console, 'warn').mockImplementation(() => {});
+    jest.spyOn(console, 'error').mockImplementation(() => {});
+    jest.spyOn(console, 'log').mockImplementation(() => {});
+
+    // Short ladders so the ONLINE cases never sleep for real.
+    MimirApiService.updateConfig({
+      retryAttempts: 3,
+      retryDelay: 0,
+      timeout: 50,
+    });
+    VoiPriceService.updateConfig({
+      retryAttempts: 3,
+      retryDelay: 0,
+      timeout: 50,
+    });
+    VoiPriceService.clearCache();
+    AlgorandPriceService.updateConfig({
+      retryAttempts: 3,
+      retryDelay: 0,
+      timeout: 50,
+    });
+    AlgorandPriceService.clearCache();
+    // Envoi exposes no config setter; its ladder delay is shortened directly.
+    // Each envoi test uses a freshly generated address, so its cache needs no
+    // reset between tests. The abort timer matters too: none of these services
+    // clears it on a REJECTED fetch, so a 10s default would outlive the run.
+    const envoiConfig = (envoi as unknown as { config: Record<string, number> })
+      .config;
+    envoiConfig.retryDelay = 0;
+    envoiConfig.timeout = 50;
+  });
+
+  afterEach(() => {
+    resetOfflineGate();
+    jest.restoreAllMocks();
+  });
+
+  describe('MimirApiService', () => {
+    it('skips the ladder entirely while offline', async () => {
+      goOffline();
+
+      await expect(
+        MimirApiService.getArc200TokensMetadata([1])
+      ).rejects.toBeInstanceOf(MimirApiError);
+      expect(fetchMock).not.toHaveBeenCalled();
+      expect(getOfflineCounters().offlineSkipsByScope.mimir).toBe(1);
+    });
+
+    it('fails with the SAME shape the exhausted ladder produces', async () => {
+      goOffline();
+
+      // Deliberately not a distinguishable offline error: callers keep the one
+      // failure contract they already handle.
+      await expect(
+        MimirApiService.getArc200TokensMetadata([1])
+      ).rejects.toMatchObject({
+        name: 'MimirApiError',
+        code: 'NETWORK_ERROR',
+      });
+    });
+
+    it('leaves the ladder intact while online', async () => {
+      goOnline();
+      fetchMock.mockRejectedValue(new Error('boom'));
+
+      await expect(
+        MimirApiService.getArc200TokensMetadata([1])
+      ).rejects.toBeInstanceOf(MimirApiError);
+      expect(fetchMock).toHaveBeenCalledTimes(3);
+      expect(getOfflineCounters().offlineSkips).toBe(0);
+    });
+
+    it('leaves a successful request untouched while online', async () => {
+      goOnline();
+      fetchMock.mockResolvedValue(jsonResponse({ tokens: [] }));
+
+      await expect(
+        MimirApiService.getArc200TokensMetadata([1])
+      ).resolves.toMatchObject({ tokens: [] });
+      expect(fetchMock).toHaveBeenCalledTimes(1);
+    });
+  });
+
+  describe('VoiPriceService', () => {
+    it('skips the ladder and falls back exactly as a failed fetch does', async () => {
+      goOffline();
+
+      // No cached price → the existing fallback is 0, unchanged.
+      await expect(VoiPriceService.getVoiPrice()).resolves.toBe(0);
+      expect(fetchMock).not.toHaveBeenCalled();
+      expect(getOfflineCounters().offlineSkipsByScope['voi-price']).toBe(1);
+    });
+
+    it('serves the retained stale price while offline', async () => {
+      goOnline();
+      fetchMock.mockResolvedValue(
+        jsonResponse({
+          marketData: [],
+          aggregates: {
+            totalVolume: 0,
+            totalTvl: 0,
+            weightedAveragePrice: 0.42,
+          },
+          circulatingSupply: { circulatingSupply: 0, percentDistributed: 0 },
+        })
+      );
+      await expect(VoiPriceService.getVoiPrice()).resolves.toBe(0.42);
+
+      const nowSpy = jest
+        .spyOn(Date, 'now')
+        .mockReturnValue(Date.now() + 60 * 60 * 1000);
+      goOffline();
+      fetchMock.mockClear();
+
+      await expect(VoiPriceService.getVoiPrice()).resolves.toBe(0.42);
+      expect(fetchMock).not.toHaveBeenCalled();
+      nowSpy.mockRestore();
+    });
+
+    it('leaves the ladder intact while online', async () => {
+      goOnline();
+      fetchMock.mockRejectedValue(new Error('boom'));
+
+      await expect(VoiPriceService.getVoiPrice()).resolves.toBe(0);
+      expect(fetchMock).toHaveBeenCalledTimes(3);
+    });
+  });
+
+  describe('AlgorandPriceService', () => {
+    it('skips the ladder while offline and applies the stale fallback', async () => {
+      goOffline();
+
+      await expect(
+        AlgorandPriceService.getAssetPrices([31566704])
+      ).resolves.toBeDefined();
+      expect(fetchMock).not.toHaveBeenCalled();
+      expect(getOfflineCounters().offlineSkipsByScope['algorand-price']).toBe(
+        1
+      );
+    });
+
+    it('leaves the ladder intact while online', async () => {
+      goOnline();
+      fetchMock.mockRejectedValue(new Error('boom'));
+
+      await AlgorandPriceService.getAssetPrices([31566704]);
+      expect(fetchMock).toHaveBeenCalledTimes(3);
+    });
+
+    it('leaves a successful request untouched while online', async () => {
+      goOnline();
+      fetchMock.mockResolvedValue(
+        jsonResponse([
+          {
+            network_id: 0,
+            asset_id: 31566704,
+            denominating_asset_id: 31566704,
+            price: 1,
+            confidence: 1,
+            total_lockup: 0,
+          },
+        ])
+      );
+
+      const prices = await AlgorandPriceService.getAssetPrices([31566704]);
+      expect(prices.get(31566704)).toBe(1);
+      expect(fetchMock).toHaveBeenCalledTimes(1);
+    });
+  });
+
+  describe('EnvoiService', () => {
+    const freshAddress = () => algosdk.generateAccount().addr.toString();
+
+    it('skips the ladder while offline and still resolves to null', async () => {
+      goOffline();
+
+      await expect(envoi.getName(freshAddress())).resolves.toBeNull();
+      expect(fetchMock).not.toHaveBeenCalled();
+      expect(getOfflineCounters().offlineSkipsByScope.envoi).toBe(1);
+    });
+
+    it('leaves the ladder intact while online', async () => {
+      goOnline();
+      fetchMock.mockRejectedValue(new Error('boom'));
+
+      await expect(envoi.getName(freshAddress())).resolves.toBeNull();
+      expect(fetchMock).toHaveBeenCalledTimes(3);
+    });
+
+    it('does not leave isLoading stuck when the device goes offline mid-flight', async () => {
+      goOnline();
+      const address = freshAddress();
+
+      let deferred!: Deferred;
+      fetchMock.mockImplementation(
+        () =>
+          new Promise((resolve, reject) => {
+            deferred = { resolve, reject };
+          })
+      );
+
+      const inFlight = envoi.getName(address);
+      await flush();
+
+      // Connectivity drops while the request is outstanding. The gate is
+      // checked on entry, not mid-ladder, so the outstanding request keeps its
+      // existing behaviour: it fails and the remaining attempts fail too.
+      goOffline();
+      fetchMock.mockRejectedValue(new Error('network lost'));
+      deferred.reject(new Error('network lost'));
+
+      await expect(inFlight).resolves.toBeNull();
+
+      const cache = (
+        envoi as unknown as {
+          cache: { namesByAddress: Map<string, { isLoading: boolean }> };
+        }
+      ).cache.namesByAddress;
+      expect(cache.get(address)?.isLoading).toBe(false);
+
+      const pending = (
+        envoi as unknown as { pendingNameRequests: Map<string, unknown> }
+      ).pendingNameRequests;
+      expect(pending.has(address)).toBe(false);
+    });
+  });
+
+  describe('cold start (unknown reachability)', () => {
+    it('does not gate anything before the adapter has answered', async () => {
+      // No emit(): the snapshot is still `unknown`, which must fail OPEN.
+      fetchMock.mockResolvedValue(jsonResponse({ tokens: [] }));
+
+      await MimirApiService.getArc200TokensMetadata([1]);
+
+      expect(fetchMock).toHaveBeenCalledTimes(1);
+      expect(getOfflineCounters().offlineSkips).toBe(0);
+    });
+  });
+
+  describe('services deliberately NOT gated', () => {
+    it('token-mapping still runs its retry ladder while offline', async () => {
+      goOffline();
+
+      // Cached mappings already make an offline failure cheap here, so gating
+      // it would be scope creep. Pin that it is untouched.
+      tokenMappingService.updateConfig({
+        apiUrl: 'https://example.invalid/mappings',
+        retryAttempts: 3,
+        timeout: 50,
+      });
+      jest
+        .spyOn(
+          tokenMappingService as unknown as { sleep: () => Promise<void> },
+          'sleep'
+        )
+        .mockResolvedValue(undefined);
+      fetchMock.mockRejectedValue(new Error('boom'));
+
+      await tokenMappingService.getTokenMappings(true);
+
+      expect(fetchMock).toHaveBeenCalledTimes(3);
+      expect(getOfflineCounters().offlineSkips).toBe(0);
+    });
+
+    it('snowball still attempts the request while offline', async () => {
+      goOffline();
+
+      // User-initiated swap-quote path: failing fast is already acceptable, so
+      // it is out of scope. A non-retryable rejection keeps this assertion on
+      // "the request went out", without sitting through snowball's fixed
+      // (non-configurable) 1s/2s/3s backoff.
+      fetchMock.mockRejectedValue(new Error('boom'));
+
+      await expect(snowball.healthCheck()).rejects.toThrow();
+
+      expect(fetchMock).toHaveBeenCalledTimes(1);
+      expect(getOfflineCounters().offlineSkips).toBe(0);
+    });
+  });
+});

--- a/src/services/network/offline.ts
+++ b/src/services/network/offline.ts
@@ -57,6 +57,14 @@ export interface OfflineCounters {
 }
 
 let reachability: Reachability = 'unknown';
+// Whether `reachability` came from a DEFINITIVE reading. NetInfo's first emit
+// often carries `isInternetReachable: null` (interface up, probe still
+// running); `isOffline()` resolves that to the interface flag, which is the
+// right answer for gating but is a guess, not a determination. Without this
+// flag an indeterminate first emit looks identical to a settled one, so the
+// one-shot getState() below is discarded and a cold-start offline device keeps
+// running full retry ladders until NetInfo happens to emit again.
+let definitive = false;
 let primed = false;
 let unsubscribe: (() => void) | null = null;
 
@@ -69,6 +77,11 @@ function prime(): void {
   try {
     unsubscribe = connectivity.subscribe((state) => {
       reachability = isOffline(state) ? 'offline' : 'online';
+      // The extension/web adapter always reports `null` here by design, so it
+      // stays non-definitive and simply never benefits from the probe — it has
+      // no better source either. Mobile settles as soon as NetInfo's own probe
+      // resolves.
+      definitive = state.isInternetReachable !== null;
     });
   } catch {
     // No adapter available (or it threw on registration). Stay `unknown`,
@@ -79,10 +92,13 @@ function prime(): void {
     void connectivity
       .getState()
       .then((state) => {
-        // Only fills the initial gap. A subscription callback that already
-        // landed is fresher than this in-flight probe, so it wins.
-        if (reachability === 'unknown') {
+        // Fills the initial gap, and also corrects an indeterminate first
+        // emit: a settled subscription reading wins, but a guessed one does
+        // not. Only a definitive probe result may override.
+        const probeDefinitive = state.isInternetReachable !== null;
+        if (reachability === 'unknown' || (!definitive && probeDefinitive)) {
           reachability = isOffline(state) ? 'offline' : 'online';
+          definitive = probeDefinitive;
         }
       })
       .catch(() => {
@@ -151,5 +167,6 @@ export function resetOfflineGate(): void {
   unsubscribe = null;
   primed = false;
   reachability = 'unknown';
+  definitive = false;
   skipCounts.clear();
 }

--- a/src/services/network/offline.ts
+++ b/src/services/network/offline.ts
@@ -1,0 +1,155 @@
+/**
+ * Offline gate (TASK-191).
+ *
+ * A synchronously-readable snapshot of connectivity, so a retry ladder can be
+ * skipped outright while the device is offline instead of burning every attempt
+ * (and its backoff) on a fetch that cannot succeed.
+ *
+ * Read through the platform `ConnectivityAdapter` (PLAN-12 DR-7) only — this
+ * module is shared code, so it must never import NetInfo (a native module) or
+ * branch on `Platform.OS` itself.
+ *
+ * Three states, not two. `connectivity.getState()` is async and the first
+ * subscription callback has not necessarily fired yet, so before either
+ * settles the snapshot is `unknown`. **`unknown` reads as online (fail open)**:
+ * a probe that never resolves, or an adapter that throws, must never wedge the
+ * app into believing it is permanently offline. Only a definite `offline`
+ * gates anything. The cost is that the first few calls after a cold launch may
+ * go out ungated, which is the correct trade.
+ *
+ * Priming is lazy and self-contained: the first read registers the
+ * subscription and kicks off one `getState()`. Nothing needs to call this from
+ * app bootstrap.
+ */
+
+import { connectivity, isOffline } from '@/platform';
+
+/** `unknown` = not yet determined; treated as online everywhere below. */
+export type Reachability = 'online' | 'offline' | 'unknown';
+
+/**
+ * Call sites that can skip work while offline. A closed literal union keeps
+ * the counters below free of anything user-identifying — the only thing
+ * recorded is which code path skipped, and how many times.
+ */
+export type OfflineSkipScope =
+  | 'mimir'
+  | 'voi-price'
+  | 'algorand-price'
+  | 'envoi'
+  | 'messages-poll'
+  | 'home-refresh';
+
+const SKIP_SCOPES: readonly OfflineSkipScope[] = [
+  'mimir',
+  'voi-price',
+  'algorand-price',
+  'envoi',
+  'messages-poll',
+  'home-refresh',
+];
+
+export interface OfflineCounters {
+  /** Total network attempts skipped because the device was offline. */
+  offlineSkips: number;
+  /** Skips broken down by call site. Counts only — no identifiers. */
+  offlineSkipsByScope: Record<OfflineSkipScope, number>;
+}
+
+let reachability: Reachability = 'unknown';
+let primed = false;
+let unsubscribe: (() => void) | null = null;
+
+const skipCounts = new Map<OfflineSkipScope, number>();
+
+function prime(): void {
+  if (primed) return;
+  primed = true;
+
+  try {
+    unsubscribe = connectivity.subscribe((state) => {
+      reachability = isOffline(state) ? 'offline' : 'online';
+    });
+  } catch {
+    // No adapter available (or it threw on registration). Stay `unknown`,
+    // which reads as online, rather than guessing offline.
+  }
+
+  try {
+    void connectivity
+      .getState()
+      .then((state) => {
+        // Only fills the initial gap. A subscription callback that already
+        // landed is fresher than this in-flight probe, so it wins.
+        if (reachability === 'unknown') {
+          reachability = isOffline(state) ? 'offline' : 'online';
+        }
+      })
+      .catch(() => {
+        // Undeterminable connectivity stays `unknown` → online.
+      });
+  } catch {
+    // Same: a throwing adapter must not change the answer.
+  }
+}
+
+/**
+ * Current snapshot, priming the subscription on first read.
+ * Returns `unknown` until the adapter has answered at least once.
+ */
+export function getReachability(): Reachability {
+  prime();
+  return reachability;
+}
+
+/**
+ * True only when connectivity is *definitely* offline. `unknown` is false.
+ */
+export function isDefinitelyOffline(): boolean {
+  return getReachability() === 'offline';
+}
+
+/**
+ * The gate itself: `true` means "do not attempt the network", and records the
+ * skip. Combining the check and the counter keeps them from drifting apart.
+ */
+export function shouldSkipForOffline(scope: OfflineSkipScope): boolean {
+  if (!isDefinitelyOffline()) return false;
+  skipCounts.set(scope, (skipCounts.get(scope) ?? 0) + 1);
+  return true;
+}
+
+/**
+ * In-memory observability for the debug surface. Counts only: no addresses, no
+ * amounts, no identifiers — `babel.config.js` strips `console.log` from release
+ * bundles precisely because logs can carry those, and this must not become a
+ * way around that.
+ */
+export function getOfflineCounters(): OfflineCounters {
+  const offlineSkipsByScope = {} as Record<OfflineSkipScope, number>;
+  let offlineSkips = 0;
+
+  for (const scope of SKIP_SCOPES) {
+    const count = skipCounts.get(scope) ?? 0;
+    offlineSkipsByScope[scope] = count;
+    offlineSkips += count;
+  }
+
+  return { offlineSkips, offlineSkipsByScope };
+}
+
+/** Reset counters only, leaving the connectivity subscription in place. */
+export function resetOfflineCounters(): void {
+  skipCounts.clear();
+}
+
+/**
+ * Full reset — drops the subscription and the snapshot as well. For tests.
+ */
+export function resetOfflineGate(): void {
+  unsubscribe?.();
+  unsubscribe = null;
+  primed = false;
+  reachability = 'unknown';
+  skipCounts.clear();
+}

--- a/src/services/price/__tests__/getVoiPrice.dedup.test.ts
+++ b/src/services/price/__tests__/getVoiPrice.dedup.test.ts
@@ -1,0 +1,173 @@
+// TASK-189: in-flight dedup for VoiPriceService.getVoiPrice.
+//
+// getVoiPrice takes no arguments, so every concurrent caller wants the same
+// value — a SINGLE shared promise is the correct dedup unit here (unlike
+// AlgorandPriceService, which must key per asset id). Without it, N callers
+// past the 5-minute TTL (refreshAllBalances fanning out over N accounts, the
+// account switcher, a network switch) each launch their own fetch, each with
+// up to `retryAttempts` attempts.
+
+import VoiPriceService, { type VoiPriceResponse } from '@/services/price';
+
+type Deferred = {
+  resolve: (value: unknown) => void;
+  reject: (error: unknown) => void;
+};
+
+function marketDataResponse(price: number): VoiPriceResponse {
+  return {
+    marketData: [],
+    aggregates: {
+      totalVolume: 0,
+      totalTvl: 0,
+      weightedAveragePrice: price,
+    },
+    circulatingSupply: { circulatingSupply: 0, percentDistributed: 0 },
+  };
+}
+
+function okResponse(price: number) {
+  return {
+    ok: true,
+    status: 200,
+    statusText: 'OK',
+    json: async () => marketDataResponse(price),
+  };
+}
+
+// Drain microtasks so the shared in-flight promise reaches the pending fetch.
+const flush = () => new Promise((resolve) => setTimeout(resolve, 0));
+
+describe('VoiPriceService.getVoiPrice in-flight dedup (TASK-189)', () => {
+  let fetchMock: jest.Mock;
+  let nowMs: number;
+
+  beforeEach(() => {
+    nowMs = 1_000_000;
+    jest.spyOn(Date, 'now').mockImplementation(() => nowMs);
+    jest.spyOn(console, 'warn').mockImplementation(() => {});
+
+    fetchMock = jest.fn();
+    (global as unknown as { fetch: unknown }).fetch = fetchMock;
+
+    VoiPriceService.clearCache();
+    // Keep the retry ladder and abort timer short so failure cases don't sleep.
+    VoiPriceService.updateConfig({
+      retryAttempts: 1,
+      retryDelay: 0,
+      timeout: 50,
+      cacheDuration: 5 * 60 * 1000,
+    });
+  });
+
+  afterEach(() => {
+    jest.restoreAllMocks();
+  });
+
+  it('issues ONE request for N concurrent callers past the TTL and resolves them all with the same value', async () => {
+    let deferred!: Deferred;
+    fetchMock.mockImplementation(
+      () =>
+        new Promise((resolve, reject) => {
+          deferred = { resolve, reject };
+        })
+    );
+
+    // Five accounts refreshing at once on a cold cache.
+    const calls = [
+      VoiPriceService.getVoiPrice(),
+      VoiPriceService.getVoiPrice(),
+      VoiPriceService.getVoiPrice(),
+      VoiPriceService.getVoiPrice(),
+      VoiPriceService.getVoiPrice(),
+    ];
+
+    await flush();
+
+    // One network request, not five (and not five × retryAttempts).
+    expect(fetchMock).toHaveBeenCalledTimes(1);
+
+    deferred.resolve(okResponse(0.42));
+    const prices = await Promise.all(calls);
+
+    expect(prices).toEqual([0.42, 0.42, 0.42, 0.42, 0.42]);
+    expect(fetchMock).toHaveBeenCalledTimes(1);
+  });
+
+  it('serves later callers from the cache without a second request', async () => {
+    fetchMock.mockResolvedValue(okResponse(0.42));
+
+    await expect(VoiPriceService.getVoiPrice()).resolves.toBe(0.42);
+    await expect(VoiPriceService.getVoiPrice()).resolves.toBe(0.42);
+
+    expect(fetchMock).toHaveBeenCalledTimes(1);
+  });
+
+  it('refetches once the cached price is older than cacheDuration', async () => {
+    fetchMock.mockResolvedValue(okResponse(0.42));
+    await VoiPriceService.getVoiPrice();
+
+    nowMs += VoiPriceService.getConfig().cacheDuration + 1;
+    fetchMock.mockResolvedValue(okResponse(0.99));
+
+    await expect(VoiPriceService.getVoiPrice()).resolves.toBe(0.99);
+    expect(fetchMock).toHaveBeenCalledTimes(2);
+  });
+
+  it('does not wedge the in-flight slot when the fetch fails (finally cleanup)', async () => {
+    fetchMock.mockRejectedValue(new Error('network down'));
+
+    // No cached price yet, so the failure falls back to 0 rather than throwing.
+    await expect(VoiPriceService.getVoiPrice()).resolves.toBe(0);
+    expect(fetchMock).toHaveBeenCalledTimes(1);
+
+    // The slot was released, so the next caller starts a fresh request instead
+    // of joining a dead promise forever.
+    fetchMock.mockResolvedValue(okResponse(0.42));
+    await expect(VoiPriceService.getVoiPrice()).resolves.toBe(0.42);
+    expect(fetchMock).toHaveBeenCalledTimes(2);
+  });
+
+  it('shares the stale-price fallback with every joined caller when the fetch fails', async () => {
+    fetchMock.mockResolvedValue(okResponse(0.42));
+    await VoiPriceService.getVoiPrice();
+
+    nowMs += VoiPriceService.getConfig().cacheDuration + 1;
+    fetchMock.mockRejectedValue(new Error('network down'));
+
+    const [a, b] = await Promise.all([
+      VoiPriceService.getVoiPrice(),
+      VoiPriceService.getVoiPrice(),
+    ]);
+
+    // Both joiners get the retained stale price, and only one request went out.
+    expect(a).toBe(0.42);
+    expect(b).toBe(0.42);
+    expect(fetchMock).toHaveBeenCalledTimes(2); // 1 initial success + 1 failure
+  });
+
+  it('abandons an in-flight request on clearCache so it cannot repopulate the cache', async () => {
+    let deferred!: Deferred;
+    fetchMock.mockImplementation(
+      () =>
+        new Promise((resolve, reject) => {
+          deferred = { resolve, reject };
+        })
+    );
+
+    const inFlight = VoiPriceService.getVoiPrice();
+    await flush();
+
+    VoiPriceService.clearCache();
+    deferred.resolve(okResponse(0.42));
+
+    // The caller that asked for it still gets its price…
+    await expect(inFlight).resolves.toBe(0.42);
+
+    // …but the cleared cache stays cleared, and the next caller neither joins
+    // the abandoned request nor reads its write-back.
+    fetchMock.mockResolvedValue(okResponse(0.99));
+    await expect(VoiPriceService.getVoiPrice()).resolves.toBe(0.99);
+    expect(fetchMock).toHaveBeenCalledTimes(2);
+  });
+});

--- a/src/services/price/index.ts
+++ b/src/services/price/index.ts
@@ -68,6 +68,21 @@ export class VoiPriceService {
   private static instance: VoiPriceService;
   private config: VoiPriceConfig;
   private cachedPrice: CachedPrice | null = null;
+  /**
+   * TASK-189: shared in-flight promise for `getVoiPrice`.
+   *
+   * `getVoiPrice` takes no arguments, so every concurrent caller wants the same
+   * value and a single shared promise is the correct dedup key (unlike
+   * AlgorandPriceService, which is keyed per asset id). Without it, N callers
+   * past the TTL — e.g. refreshAllBalances fanning out over N accounts — each
+   * launch their own fetch, each with up to `retryAttempts` attempts.
+   *
+   * Mirrors the `balanceLoadsInFlight` shape in walletStore, including the
+   * `finally` cleanup so a failed fetch never wedges the slot.
+   */
+  private priceInFlight: Promise<number> | null = null;
+  /** Bumped by clearCache() so a fetch started before it cannot write back. */
+  private cacheGeneration = 0;
 
   private constructor() {
     this.config = {
@@ -87,33 +102,60 @@ export class VoiPriceService {
   }
 
   async getVoiPrice(): Promise<number> {
-    try {
-      // Check cache first
-      if (this.cachedPrice && this.isCacheValid()) {
-        return this.cachedPrice.price;
-      }
-
-      const response = await this.fetchVoiMarketData();
-      const price = response.aggregates.weightedAveragePrice;
-
-      // Cache the price
-      this.cachedPrice = {
-        price,
-        timestamp: Date.now(),
-      };
-
-      return price;
-    } catch (error) {
-      console.warn('Failed to fetch VOI price:', error);
-
-      // Return cached price if available, even if stale
-      if (this.cachedPrice) {
-        return this.cachedPrice.price;
-      }
-
-      // Default fallback price
-      return 0;
+    // Check cache first
+    if (this.cachedPrice && this.isCacheValid()) {
+      return this.cachedPrice.price;
     }
+
+    // Join the in-flight fetch rather than starting a second retry ladder.
+    if (this.priceInFlight) {
+      return this.priceInFlight;
+    }
+
+    // The request absorbs its own failures (stale-then-zero fallback) so every
+    // joiner observes the same resolved value and no joiner sees a rejection.
+    const generation = this.cacheGeneration;
+    const request: Promise<number> = (async () => {
+      try {
+        const response = await this.fetchVoiMarketData();
+        const price = response.aggregates.weightedAveragePrice;
+
+        // Cache the price — unless clearCache() ran while this was in flight,
+        // in which case the callers still get the price but the cache stays
+        // dropped as they asked.
+        if (this.cacheGeneration === generation) {
+          this.cachedPrice = {
+            price,
+            timestamp: Date.now(),
+          };
+        }
+
+        return price;
+      } catch (error) {
+        console.warn('Failed to fetch VOI price:', error);
+
+        // Return cached price if available, even if stale
+        if (this.cachedPrice) {
+          return this.cachedPrice.price;
+        }
+
+        // Default fallback price
+        return 0;
+      }
+    })();
+
+    this.priceInFlight = request;
+
+    // Always release the slot once settled — a failed fetch must not wedge it.
+    // Identity-checked so a later request is never cleared by an earlier one.
+    // `request` absorbs its own errors, so this chain can never reject.
+    void request.finally(() => {
+      if (this.priceInFlight === request) {
+        this.priceInFlight = null;
+      }
+    });
+
+    return request;
   }
 
   async getVoiMarketData(): Promise<VoiPriceResponse> {
@@ -227,6 +269,10 @@ export class VoiPriceService {
 
   clearCache(): void {
     this.cachedPrice = null;
+    // Abandon the in-flight request too: a later caller must not join a request
+    // that predates the clear, and that request must not repopulate the cache.
+    this.cacheGeneration++;
+    this.priceInFlight = null;
   }
 
   formatUsdValue(voiAmount: number | bigint, pricePerVoi?: number): string {

--- a/src/services/price/index.ts
+++ b/src/services/price/index.ts
@@ -1,3 +1,5 @@
+import { shouldSkipForOffline } from '@/services/network/offline';
+
 export interface VoiMarketData {
   trading_pair_id: number;
   exchange: string;
@@ -205,6 +207,17 @@ export class VoiPriceService {
   }
 
   private async fetchWithRetry(url: string): Promise<Response> {
+    // TASK-191: offline → skip the ladder instead of burning every attempt and
+    // its backoff. Same error shape the exhausted ladder throws, so the
+    // existing fallback (cached-but-stale price, else 0) applies unchanged.
+    if (shouldSkipForOffline('voi-price')) {
+      throw new VoiPriceError(
+        'Offline: skipped request without attempting the network',
+        undefined,
+        'NETWORK_ERROR'
+      );
+    }
+
     let lastError: Error;
 
     for (let attempt = 1; attempt <= this.config.retryAttempts; attempt++) {

--- a/src/store/__tests__/claimableStore.accountBinding.test.tsx
+++ b/src/store/__tests__/claimableStore.accountBinding.test.tsx
@@ -1,0 +1,110 @@
+/**
+ * TASK-188: claimable reads are bound to an account.
+ *
+ * `ClaimableState` is flat — one `claimableItems` array, not a per-account
+ * record — so any consumer that reads it directly can render account A's
+ * claimables (or A's count) while account B is active. These hooks make that
+ * unrepresentable: a mismatch reads as empty/zero rather than as another
+ * account's data.
+ */
+
+import { renderHook } from '@testing-library/react-native';
+
+import {
+  useClaimableStore,
+  useClaimableItemsForAccount,
+  useClaimablePartialFailure,
+  useVisibleClaimableCountForAccount,
+} from '../claimableStore';
+import type { ClaimableItem } from '@/types/claimable';
+
+jest.mock('@/services/mimir', () => ({ __esModule: true, default: {} }));
+jest.mock('@/services/envoi', () => ({ __esModule: true, default: {} }));
+jest.mock('@react-native-async-storage/async-storage', () => ({
+  __esModule: true,
+  default: {
+    getItem: jest.fn(async () => null),
+    setItem: jest.fn(async () => {}),
+    removeItem: jest.fn(async () => {}),
+  },
+}));
+
+const ACCOUNT_A = 'ACCOUNT_A';
+const ACCOUNT_B = 'ACCOUNT_B';
+
+const item = (id: string): ClaimableItem => ({
+  id,
+  contractId: 1,
+  tokenName: 'Token',
+  tokenSymbol: 'TKN',
+  tokenDecimals: 0,
+  tokenVerified: false,
+  owner: 'OWNER',
+  amount: 1n,
+  ownerBalance: 10n,
+  isClaimable: true,
+  approval: {
+    owner: 'OWNER',
+    round: 1,
+    amount: '1',
+    spender: 'SPENDER',
+    timestamp: 1,
+    contractId: 1,
+    transactionId: 'TX',
+  },
+});
+
+beforeEach(() => {
+  useClaimableStore.setState({
+    claimableItems: [item('1_A'), item('2_A')],
+    itemsAccountAddress: ACCOUNT_A,
+    hiddenApprovals: new Set<string>(),
+    hasPartialFailure: false,
+  });
+});
+
+describe('account-bound claimable reads (TASK-188)', () => {
+  it('returns the items when they belong to the requested account', () => {
+    const { result } = renderHook(() => useClaimableItemsForAccount(ACCOUNT_A));
+    expect(result.current).toHaveLength(2);
+  });
+
+  it('returns nothing for an account the held items do not belong to', () => {
+    const { result } = renderHook(() => useClaimableItemsForAccount(ACCOUNT_B));
+    expect(result.current).toEqual([]);
+  });
+
+  it('returns nothing when there is no active account', () => {
+    const { result } = renderHook(() => useClaimableItemsForAccount(undefined));
+    expect(result.current).toEqual([]);
+  });
+
+  it('counts only the requested account, and excludes hidden items', () => {
+    useClaimableStore.setState({ hiddenApprovals: new Set(['2_A']) });
+
+    const { result } = renderHook(() =>
+      useVisibleClaimableCountForAccount(ACCOUNT_A)
+    );
+    expect(result.current).toBe(1);
+  });
+
+  it('counts zero for a non-active account rather than the other account total', () => {
+    const { result } = renderHook(() =>
+      useVisibleClaimableCountForAccount(ACCOUNT_B)
+    );
+    expect(result.current).toBe(0);
+  });
+
+  it('reports the degraded flag only for the account whose fetch was partial', () => {
+    useClaimableStore.setState({ hasPartialFailure: true });
+
+    const forA = renderHook(() => useClaimablePartialFailure(ACCOUNT_A));
+    expect(forA.result.current).toBe(true);
+
+    const forB = renderHook(() => useClaimablePartialFailure(ACCOUNT_B));
+    expect(forB.result.current).toBe(false);
+
+    const forNone = renderHook(() => useClaimablePartialFailure(undefined));
+    expect(forNone.result.current).toBe(false);
+  });
+});

--- a/src/store/__tests__/claimableStore.fetchApprovals.test.ts
+++ b/src/store/__tests__/claimableStore.fetchApprovals.test.ts
@@ -1,0 +1,531 @@
+// TASK-188: per-account TTL + in-flight guard + commit-time account re-check
+// for claimableStore.fetchApprovals.
+//
+// Mirrors loadAccountBalance.dedup.test.ts, including its `finally`-cleanup
+// cases: a failed or superseded fetch must not wedge the in-flight slot.
+//
+// The two properties that matter together:
+//   1. a dedup/TTL guard WITHOUT a commit guard is strictly worse than no
+//      guard, because a stale write also refreshes the freshness stamp and
+//      thereby suppresses the correct fetch; and
+//   2. a partial failure must not be recorded as a success, or a transient
+//      error gets pinned for the whole success window.
+
+const mockGetApprovals = jest.fn();
+const mockGetMetadata = jest.fn();
+const mockBatchBalances = jest.fn();
+const mockGetNames = jest.fn();
+
+jest.mock('@/services/mimir', () => ({
+  __esModule: true,
+  default: {
+    getArc200ApprovalsForSpender: (...args: unknown[]) =>
+      mockGetApprovals(...args),
+    getArc200TokensMetadata: (...args: unknown[]) => mockGetMetadata(...args),
+    batchGetArc200Balances: (...args: unknown[]) => mockBatchBalances(...args),
+  },
+}));
+
+jest.mock('@/services/envoi', () => ({
+  __esModule: true,
+  default: {
+    getInstance: () => ({
+      isServiceEnabled: () => true,
+      setEnabled: jest.fn(),
+      getNames: (...args: unknown[]) => mockGetNames(...args),
+    }),
+  },
+}));
+
+const mockStorageGetItem = jest.fn<Promise<string | null>, [string]>(
+  async () => null
+);
+
+jest.mock('@react-native-async-storage/async-storage', () => ({
+  __esModule: true,
+  default: {
+    getItem: (key: string) => mockStorageGetItem(key),
+    setItem: jest.fn(async () => {}),
+    removeItem: jest.fn(async () => {}),
+  },
+}));
+
+import { useClaimableStore } from '../claimableStore';
+
+const ACCOUNT_A = 'AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA';
+const ACCOUNT_B = 'BBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBB';
+const OWNER = 'OWNEROWNEROWNEROWNEROWNEROWNEROWNEROWNEROWNEROWNEROWNEROW';
+
+const SUCCESS_TTL_MS = 60 * 1000;
+const ERROR_BACKOFF_MS = 30 * 1000;
+
+const approval = (contractId: number, amount = '100') => ({
+  owner: OWNER,
+  round: 1,
+  amount,
+  spender: 'SPENDER',
+  timestamp: 1,
+  contractId,
+  transactionId: 'TX',
+});
+
+const approvalsFor = (contractId: number) => ({
+  approvals: [approval(contractId)],
+  'current-round': 1,
+});
+
+// Drain microtasks so an awaited leg advances to its next (still-pending) call.
+const flush = () => new Promise((resolve) => setTimeout(resolve, 0));
+
+const okBalances = (contractId: number, balance = '1000') => ({
+  balances: new Map([[`${contractId}_${OWNER}`, balance]]),
+  failed: new Set<string>(),
+});
+
+const failedBalances = (contractId: number) => ({
+  balances: new Map<string, string>(),
+  failed: new Set([`${contractId}_${OWNER}`]),
+});
+
+const resetStore = () => {
+  useClaimableStore.setState({
+    approvals: [],
+    claimableItems: [],
+    itemsAccountAddress: null,
+    hiddenApprovals: new Set<string>(),
+    hiddenApprovalsAccount: null,
+    showHiddenApprovals: false,
+    isLoading: false,
+    isValidating: false,
+    lastFetchedAt: {},
+    errorBackoffAt: {},
+    hasPartialFailure: false,
+    currentAccountAddress: null,
+    lastError: null,
+  });
+};
+
+describe('claimableStore.fetchApprovals guards (TASK-188)', () => {
+  beforeEach(async () => {
+    jest.spyOn(console, 'error').mockImplementation(() => {});
+    mockGetApprovals.mockReset();
+    mockGetMetadata.mockReset();
+    mockBatchBalances.mockReset();
+    mockGetNames.mockReset();
+    mockStorageGetItem.mockReset();
+    mockStorageGetItem.mockResolvedValue(null);
+
+    mockGetMetadata.mockResolvedValue({ tokens: [] });
+    mockGetNames.mockResolvedValue(new Map());
+    mockBatchBalances.mockResolvedValue(okBalances(1));
+    mockGetApprovals.mockResolvedValue(approvalsFor(1));
+
+    // clearCache also drops module-level in-flight entries, so each test
+    // starts from a clean dedup slate.
+    await useClaimableStore.getState().clearCache();
+    resetStore();
+  });
+
+  afterEach(() => {
+    jest.restoreAllMocks();
+  });
+
+  describe('account-switch race', () => {
+    it("a fetch for A resolving after a switch to B leaves B's items and stamps untouched", async () => {
+      let resolveA!: (value: unknown) => void;
+      mockGetApprovals.mockImplementation(async (address: string) => {
+        if (address === ACCOUNT_A) {
+          return new Promise((resolve) => {
+            resolveA = resolve as (value: unknown) => void;
+          });
+        }
+        return approvalsFor(2);
+      });
+      mockBatchBalances.mockImplementation(
+        async (pairs: { contractId: number }[]) =>
+          okBalances(pairs[0].contractId)
+      );
+
+      const pA = useClaimableStore.getState().fetchApprovals(ACCOUNT_A);
+      await flush();
+
+      // User switches to B while A's approvals request is still in the air.
+      await useClaimableStore.getState().fetchApprovals(ACCOUNT_B);
+
+      const afterB = useClaimableStore.getState();
+      expect(afterB.itemsAccountAddress).toBe(ACCOUNT_B);
+      expect(afterB.claimableItems.map((i) => i.contractId)).toEqual([2]);
+      const bStamp = afterB.lastFetchedAt[ACCOUNT_B];
+      expect(bStamp).toBeDefined();
+
+      // A now resolves. It must not overwrite B's list…
+      resolveA(approvalsFor(1));
+      await pA;
+
+      const afterA = useClaimableStore.getState();
+      expect(afterA.itemsAccountAddress).toBe(ACCOUNT_B);
+      expect(afterA.claimableItems.map((i) => i.contractId)).toEqual([2]);
+      // …nor re-stamp B's freshness (which would suppress B's next real fetch)…
+      expect(afterA.lastFetchedAt[ACCOUNT_B]).toBe(bStamp);
+      // …nor stamp its own, since it never committed.
+      expect(afterA.lastFetchedAt[ACCOUNT_A]).toBeUndefined();
+    });
+
+    it("clears the previous account's items at the moment of the switch", async () => {
+      await useClaimableStore.getState().fetchApprovals(ACCOUNT_A);
+      expect(useClaimableStore.getState().claimableItems).toHaveLength(1);
+
+      let resolveB!: (value: unknown) => void;
+      mockGetApprovals.mockImplementation(
+        () =>
+          new Promise((resolve) => {
+            resolveB = resolve as (value: unknown) => void;
+          })
+      );
+
+      const pB = useClaimableStore.getState().fetchApprovals(ACCOUNT_B);
+      await flush();
+
+      // B's fetch has not landed yet — A's claimables must already be gone
+      // rather than sitting on screen under B's name.
+      expect(useClaimableStore.getState().claimableItems).toEqual([]);
+      expect(useClaimableStore.getState().itemsAccountAddress).toBeNull();
+
+      resolveB(approvalsFor(2));
+      await pB;
+    });
+
+    it('a stale request does not clear the spinner owned by a newer one', async () => {
+      let resolveA!: (value: unknown) => void;
+      mockGetApprovals.mockImplementationOnce(
+        () =>
+          new Promise((resolve) => {
+            resolveA = resolve as (value: unknown) => void;
+          })
+      );
+
+      const pA = useClaimableStore.getState().fetchApprovals(ACCOUNT_A);
+      await flush();
+
+      let resolveB!: (value: unknown) => void;
+      mockGetApprovals.mockImplementationOnce(
+        () =>
+          new Promise((resolve) => {
+            resolveB = resolve as (value: unknown) => void;
+          })
+      );
+      const pB = useClaimableStore.getState().fetchApprovals(ACCOUNT_B);
+      await flush();
+
+      expect(useClaimableStore.getState().isLoading).toBe(true);
+
+      resolveA(approvalsFor(1));
+      await pA;
+
+      // B is still loading; A's late arrival must not turn the spinner off.
+      expect(useClaimableStore.getState().isLoading).toBe(true);
+
+      resolveB(approvalsFor(2));
+      await pB;
+      expect(useClaimableStore.getState().isLoading).toBe(false);
+    });
+  });
+
+  describe('success TTL', () => {
+    it('stamps the success TTL and suppresses a second call inside the window', async () => {
+      const now = 1_000_000;
+      jest.spyOn(Date, 'now').mockReturnValue(now);
+
+      await useClaimableStore.getState().fetchApprovals(ACCOUNT_A);
+      expect(mockGetApprovals).toHaveBeenCalledTimes(1);
+      expect(useClaimableStore.getState().lastFetchedAt[ACCOUNT_A]).toBe(now);
+      expect(
+        useClaimableStore.getState().errorBackoffAt[ACCOUNT_A]
+      ).toBeUndefined();
+
+      (Date.now as jest.Mock).mockReturnValue(now + SUCCESS_TTL_MS - 1);
+      await useClaimableStore.getState().fetchApprovals(ACCOUNT_A);
+      expect(mockGetApprovals).toHaveBeenCalledTimes(1);
+
+      (Date.now as jest.Mock).mockReturnValue(now + SUCCESS_TTL_MS + 1);
+      await useClaimableStore.getState().fetchApprovals(ACCOUNT_A);
+      expect(mockGetApprovals).toHaveBeenCalledTimes(2);
+    });
+
+    it('force bypasses a live success TTL', async () => {
+      const now = 1_000_000;
+      jest.spyOn(Date, 'now').mockReturnValue(now);
+
+      await useClaimableStore.getState().fetchApprovals(ACCOUNT_A);
+      expect(mockGetApprovals).toHaveBeenCalledTimes(1);
+
+      await useClaimableStore
+        .getState()
+        .fetchApprovals(ACCOUNT_A, { force: true });
+      expect(mockGetApprovals).toHaveBeenCalledTimes(2);
+    });
+
+    it('is keyed per account: A being fresh never suppresses B', async () => {
+      const now = 1_000_000;
+      jest.spyOn(Date, 'now').mockReturnValue(now);
+
+      await useClaimableStore.getState().fetchApprovals(ACCOUNT_A);
+      await useClaimableStore.getState().fetchApprovals(ACCOUNT_B);
+
+      expect(mockGetApprovals).toHaveBeenCalledTimes(2);
+      expect(mockGetApprovals).toHaveBeenNthCalledWith(1, ACCOUNT_A);
+      expect(mockGetApprovals).toHaveBeenNthCalledWith(2, ACCOUNT_B);
+    });
+
+    it('refetches when switching back to a still-fresh account, because its items were dropped', async () => {
+      const now = 1_000_000;
+      jest.spyOn(Date, 'now').mockReturnValue(now);
+
+      await useClaimableStore.getState().fetchApprovals(ACCOUNT_A);
+      await useClaimableStore.getState().fetchApprovals(ACCOUNT_B);
+      // Back to A inside A's TTL: the stamp is fresh, but A's list was cleared
+      // by the switch, so honoring the TTL here would render an empty screen.
+      await useClaimableStore.getState().fetchApprovals(ACCOUNT_A);
+
+      expect(mockGetApprovals).toHaveBeenCalledTimes(3);
+      expect(useClaimableStore.getState().itemsAccountAddress).toBe(ACCOUNT_A);
+      expect(useClaimableStore.getState().claimableItems).toHaveLength(1);
+    });
+  });
+
+  describe('partial balance failure', () => {
+    it('stamps the 30s error-backoff rather than the 60s success TTL', async () => {
+      const now = 1_000_000;
+      jest.spyOn(Date, 'now').mockReturnValue(now);
+      mockBatchBalances.mockResolvedValue(failedBalances(1));
+
+      await useClaimableStore.getState().fetchApprovals(ACCOUNT_A);
+
+      const state = useClaimableStore.getState();
+      expect(state.lastFetchedAt[ACCOUNT_A]).toBeUndefined();
+      expect(state.errorBackoffAt[ACCOUNT_A]).toBe(now);
+      expect(state.hasPartialFailure).toBe(true);
+    });
+
+    it('a focus inside the backoff does not refetch; the first focus after it does', async () => {
+      const now = 1_000_000;
+      jest.spyOn(Date, 'now').mockReturnValue(now);
+      mockBatchBalances.mockResolvedValue(failedBalances(1));
+
+      await useClaimableStore.getState().fetchApprovals(ACCOUNT_A);
+      expect(mockGetApprovals).toHaveBeenCalledTimes(1);
+
+      (Date.now as jest.Mock).mockReturnValue(now + ERROR_BACKOFF_MS - 1);
+      await useClaimableStore.getState().fetchApprovals(ACCOUNT_A);
+      expect(mockGetApprovals).toHaveBeenCalledTimes(1);
+
+      (Date.now as jest.Mock).mockReturnValue(now + ERROR_BACKOFF_MS + 1);
+      await useClaimableStore.getState().fetchApprovals(ACCOUNT_A);
+      expect(mockGetApprovals).toHaveBeenCalledTimes(2);
+
+      // …and well inside what would have been the success TTL, proving the
+      // partial result was never trusted for 60s.
+      expect(now + ERROR_BACKOFF_MS + 1).toBeLessThan(now + SUCCESS_TTL_MS);
+    });
+
+    it('renders a failed balance as unknown, not as a zero balance', async () => {
+      mockBatchBalances.mockResolvedValue(failedBalances(1));
+
+      await useClaimableStore.getState().fetchApprovals(ACCOUNT_A);
+
+      const [item] = useClaimableStore.getState().claimableItems;
+      expect(item.ownerBalanceUnknown).toBe(true);
+      expect(item.isClaimable).toBe(false);
+    });
+
+    it('a whole-leg balance failure marks every row unknown', async () => {
+      mockBatchBalances.mockRejectedValue(new Error('mimir down'));
+
+      await useClaimableStore.getState().fetchApprovals(ACCOUNT_A);
+
+      const state = useClaimableStore.getState();
+      expect(state.claimableItems[0].ownerBalanceUnknown).toBe(true);
+      expect(state.hasPartialFailure).toBe(true);
+      expect(state.lastFetchedAt[ACCOUNT_A]).toBeUndefined();
+    });
+
+    it('a real zero balance is still "insufficient", not unknown', async () => {
+      mockBatchBalances.mockResolvedValue(okBalances(1, '0'));
+
+      await useClaimableStore.getState().fetchApprovals(ACCOUNT_A);
+
+      const [item] = useClaimableStore.getState().claimableItems;
+      expect(item.ownerBalanceUnknown).toBe(false);
+      expect(item.isClaimable).toBe(false);
+      expect(useClaimableStore.getState().hasPartialFailure).toBe(false);
+    });
+
+    it('a later fully successful fetch clears the backoff and the degraded flag', async () => {
+      const now = 1_000_000;
+      jest.spyOn(Date, 'now').mockReturnValue(now);
+      mockBatchBalances.mockResolvedValueOnce(failedBalances(1));
+
+      await useClaimableStore.getState().fetchApprovals(ACCOUNT_A);
+      expect(useClaimableStore.getState().hasPartialFailure).toBe(true);
+
+      mockBatchBalances.mockResolvedValue(okBalances(1));
+      await useClaimableStore
+        .getState()
+        .fetchApprovals(ACCOUNT_A, { force: true });
+
+      const state = useClaimableStore.getState();
+      expect(state.hasPartialFailure).toBe(false);
+      expect(state.lastFetchedAt[ACCOUNT_A]).toBe(now);
+      expect(state.errorBackoffAt[ACCOUNT_A]).toBeUndefined();
+    });
+
+    it('metadata and Envoi-name failures stay absorbed and do NOT count as partial', async () => {
+      mockGetMetadata.mockRejectedValue(new Error('metadata down'));
+      mockGetNames.mockRejectedValue(new Error('envoi down'));
+      const now = 1_000_000;
+      jest.spyOn(Date, 'now').mockReturnValue(now);
+
+      await useClaimableStore.getState().fetchApprovals(ACCOUNT_A);
+
+      const state = useClaimableStore.getState();
+      expect(state.hasPartialFailure).toBe(false);
+      expect(state.lastFetchedAt[ACCOUNT_A]).toBe(now);
+      expect(state.claimableItems[0].isClaimable).toBe(true);
+    });
+  });
+
+  describe('in-flight guard', () => {
+    it('concurrent non-forced callers share one fetch chain', async () => {
+      let resolveApprovals!: (value: unknown) => void;
+      mockGetApprovals.mockImplementation(
+        () =>
+          new Promise((resolve) => {
+            resolveApprovals = resolve as (value: unknown) => void;
+          })
+      );
+
+      const p1 = useClaimableStore.getState().fetchApprovals(ACCOUNT_A);
+      const p2 = useClaimableStore.getState().fetchApprovals(ACCOUNT_A);
+      await flush();
+
+      expect(mockGetApprovals).toHaveBeenCalledTimes(1);
+
+      resolveApprovals(approvalsFor(1));
+      await Promise.all([p1, p2]);
+      expect(mockGetApprovals).toHaveBeenCalledTimes(1);
+    });
+
+    it('does NOT join an in-flight request that lost ownership (B -> A -> B)', async () => {
+      const resolvers: ((value: unknown) => void)[] = [];
+      mockGetApprovals.mockImplementation(
+        (address: string) =>
+          new Promise((resolve) => {
+            resolvers.push(() =>
+              (resolve as (v: unknown) => void)(
+                approvalsFor(address === ACCOUNT_B ? 2 : 1)
+              )
+            );
+          })
+      );
+
+      const pB1 = useClaimableStore.getState().fetchApprovals(ACCOUNT_B);
+      await flush();
+
+      const pA = useClaimableStore.getState().fetchApprovals(ACCOUNT_A);
+      await flush();
+
+      // Back to B while B's original request is still pending. It can no
+      // longer commit (A superseded it), so joining it would resolve into an
+      // empty list and refetch nothing — B must start a fresh request.
+      const pB2 = useClaimableStore.getState().fetchApprovals(ACCOUNT_B);
+      await flush();
+
+      expect(mockGetApprovals).toHaveBeenCalledTimes(3);
+
+      resolvers.forEach((resolve) => resolve(undefined));
+      await Promise.all([pB1, pA, pB2]);
+
+      const state = useClaimableStore.getState();
+      expect(state.itemsAccountAddress).toBe(ACCOUNT_B);
+      expect(state.claimableItems.map((i) => i.contractId)).toEqual([2]);
+    });
+
+    it('a forced refresh during hidden-set hydration does not wipe the hidden set', async () => {
+      // Ownership is claimed synchronously but hydration is async. A forced
+      // refresh landing inside that window sees no account switch; if it keyed
+      // hydration off the switch it would skip loading, supersede the request
+      // that was loading, and commit an empty hidden set over the user's
+      // hidden tokens.
+      const storageResolvers: ((value: string | null) => void)[] = [];
+      mockStorageGetItem.mockImplementation(
+        () =>
+          new Promise((resolve) => {
+            storageResolvers.push(resolve as (v: string | null) => void);
+          })
+      );
+
+      const p1 = useClaimableStore.getState().fetchApprovals(ACCOUNT_A);
+      await flush();
+
+      const p2 = useClaimableStore
+        .getState()
+        .fetchApprovals(ACCOUNT_A, { force: true });
+      await flush();
+
+      // Both requests read storage: the forced one must NOT have skipped
+      // hydration just because ownership was already claimed.
+      expect(storageResolvers).toHaveLength(2);
+
+      storageResolvers.forEach((resolve) =>
+        resolve(JSON.stringify(['1_HIDDEN']))
+      );
+      await Promise.all([p1, p2]);
+
+      const state = useClaimableStore.getState();
+      expect(state.hiddenApprovalsAccount).toBe(ACCOUNT_A);
+      expect([...state.hiddenApprovals]).toEqual(['1_HIDDEN']);
+    });
+
+    it('clears the in-flight entry so a later fetch runs again (finally cleanup)', async () => {
+      const now = 1_000_000;
+      jest.spyOn(Date, 'now').mockReturnValue(now);
+
+      await useClaimableStore.getState().fetchApprovals(ACCOUNT_A);
+      expect(mockGetApprovals).toHaveBeenCalledTimes(1);
+
+      // The entry was removed in `finally`, so a forced refresh is free to
+      // start a fresh fetch rather than being wedged on a settled promise.
+      await useClaimableStore
+        .getState()
+        .fetchApprovals(ACCOUNT_A, { force: true });
+      expect(mockGetApprovals).toHaveBeenCalledTimes(2);
+    });
+
+    it('clears the in-flight entry even when the fetch throws (no wedged future fetches)', async () => {
+      mockGetApprovals.mockRejectedValueOnce(new Error('mimir down'));
+
+      // Errors are handled to state, never rejected to callers.
+      await expect(
+        useClaimableStore.getState().fetchApprovals(ACCOUNT_A)
+      ).resolves.toBeUndefined();
+      expect(useClaimableStore.getState().lastError).toBe('mimir down');
+      expect(useClaimableStore.getState().isLoading).toBe(false);
+
+      mockGetApprovals.mockResolvedValueOnce(approvalsFor(1));
+      await useClaimableStore.getState().fetchApprovals(ACCOUNT_A);
+      expect(mockGetApprovals).toHaveBeenCalledTimes(2);
+    });
+
+    it('a hard failure with no data on screen still self-corrects on the next focus', async () => {
+      const now = 1_000_000;
+      jest.spyOn(Date, 'now').mockReturnValue(now);
+      mockGetApprovals.mockRejectedValue(new Error('mimir down'));
+
+      await useClaimableStore.getState().fetchApprovals(ACCOUNT_A);
+      // No items were ever committed, so the backoff has nothing to protect
+      // and must not suppress the retry — today's behavior, preserved.
+      await useClaimableStore.getState().fetchApprovals(ACCOUNT_A);
+      expect(mockGetApprovals).toHaveBeenCalledTimes(2);
+    });
+  });
+});

--- a/src/store/__tests__/messagesStore.pollingOffline.test.ts
+++ b/src/store/__tests__/messagesStore.pollingOffline.test.ts
@@ -1,0 +1,120 @@
+/**
+ * Message polling must not fan out retry ladders while offline (TASK-191).
+ *
+ * The interval itself keeps running: `fetchAllThreads` drains from the durable
+ * committed cursor, so a skipped tick costs nothing and the first tick after
+ * connectivity returns catches up.
+ */
+
+import type { ConnectivityState } from '@/platform';
+
+jest.mock('@react-native-async-storage/async-storage', () =>
+  require('@react-native-async-storage/async-storage/jest/async-storage-mock')
+);
+
+const mockSubscribe = jest.fn();
+const mockGetState = jest.fn();
+
+jest.mock('@/platform', () => {
+  const actual = jest.requireActual('@/platform');
+  return {
+    ...actual,
+    connectivity: {
+      subscribe: (listener: (state: ConnectivityState) => void) =>
+        mockSubscribe(listener),
+      getState: () => mockGetState(),
+    },
+  };
+});
+
+import {
+  getOfflineCounters,
+  getReachability,
+  resetOfflineGate,
+} from '@/services/network/offline';
+import { useMessagesStore } from '@/store/messagesStore';
+
+const ONLINE: ConnectivityState = {
+  isConnected: true,
+  isInternetReachable: true,
+  type: 'wifi',
+};
+
+const OFFLINE: ConnectivityState = {
+  isConnected: false,
+  isInternetReachable: false,
+  type: 'none',
+};
+
+const ADDRESS = 'TESTADDRESS';
+
+describe('messagesStore.startPolling offline gating (TASK-191)', () => {
+  let emit: (state: ConnectivityState) => void;
+  let fetchAllThreads: jest.Mock;
+
+  beforeEach(() => {
+    jest.useFakeTimers();
+
+    mockSubscribe.mockImplementation(
+      (listener: (state: ConnectivityState) => void) => {
+        emit = listener;
+        return jest.fn();
+      }
+    );
+    mockGetState.mockImplementation(() => new Promise(() => {}));
+    resetOfflineGate();
+    getReachability(); // prime, so `emit` exists
+
+    fetchAllThreads = jest.fn();
+    useMessagesStore.setState({ fetchAllThreads });
+  });
+
+  afterEach(() => {
+    useMessagesStore.getState().stopPolling();
+    jest.useRealTimers();
+    resetOfflineGate();
+  });
+
+  it('skips a tick fired while offline', () => {
+    emit(OFFLINE);
+    useMessagesStore.getState().startPolling(ADDRESS, 1000);
+
+    jest.advanceTimersByTime(3000);
+
+    expect(fetchAllThreads).not.toHaveBeenCalled();
+    expect(getOfflineCounters().offlineSkipsByScope['messages-poll']).toBe(3);
+  });
+
+  it('keeps polling normally while online', () => {
+    emit(ONLINE);
+    useMessagesStore.getState().startPolling(ADDRESS, 1000);
+
+    jest.advanceTimersByTime(3000);
+
+    expect(fetchAllThreads).toHaveBeenCalledTimes(3);
+    expect(fetchAllThreads).toHaveBeenCalledWith(ADDRESS);
+    expect(getOfflineCounters().offlineSkips).toBe(0);
+  });
+
+  it('resumes on the next tick once connectivity returns — the interval is not cancelled', () => {
+    emit(OFFLINE);
+    useMessagesStore.getState().startPolling(ADDRESS, 1000);
+
+    jest.advanceTimersByTime(2000);
+    expect(fetchAllThreads).not.toHaveBeenCalled();
+
+    emit(ONLINE);
+    jest.advanceTimersByTime(1000);
+
+    expect(fetchAllThreads).toHaveBeenCalledTimes(1);
+  });
+
+  it('does not gate before connectivity is known (fail open)', () => {
+    // No emit(): reachability is still `unknown`.
+    useMessagesStore.getState().startPolling(ADDRESS, 1000);
+
+    jest.advanceTimersByTime(1000);
+
+    expect(fetchAllThreads).toHaveBeenCalledTimes(1);
+  });
+});

--- a/src/store/claimableStore.ts
+++ b/src/store/claimableStore.ts
@@ -18,15 +18,88 @@ const HIDDEN_STORAGE_KEY_PREFIX = '@claimable/hidden/';
 const getHiddenStorageKey = (accountAddress: string) =>
   `${HIDDEN_STORAGE_KEY_PREFIX}${accountAddress}`;
 
+/**
+ * TASK-188 freshness windows.
+ *
+ * A fully successful fetch is trusted for SUCCESS_TTL_MS. Anything less than
+ * fully successful (a failed balance leg, or a hard failure of the whole chain)
+ * gets the much shorter ERROR_BACKOFF_MS instead: short enough that a transient
+ * failure self-corrects on roughly the next screen visit — preserving today's
+ * behavior — but long enough that a persistent outage does not turn every
+ * screen focus into a fresh fan-out.
+ */
+const SUCCESS_TTL_MS = 60 * 1000;
+const ERROR_BACKOFF_MS = 30 * 1000;
+
+/**
+ * In-flight fetches, keyed by account address. Non-forced callers join the
+ * pending request instead of issuing a second fan-out; a forced caller
+ * (pull-to-refresh, post-claim refresh) deliberately starts its own, mirroring
+ * `NetworkService.checkNetworkHealth({ force })` — a user-initiated refresh
+ * must not be answered by a response that was already in the air before the
+ * gesture (or before the claim it is meant to reflect).
+ */
+const inFlightFetches = new Map<string, Promise<void>>();
+
+/**
+ * Generation guard, same idiom as `walletStore`'s `multiNetworkRequestSeq`.
+ * `fetchApprovals` awaits four networked legs; without a re-check before every
+ * commit, a fetch for account A resolving after a switch to B overwrites B's
+ * claimables *and* stamps a fresh timestamp, which then suppresses the correct
+ * fetch. A dedup guard without a commit guard is strictly worse than no guard.
+ */
+const claimableRequestSeq = new Map<string, number>();
+
+const nextClaimableRequest = (accountAddress: string): number => {
+  const next = (claimableRequestSeq.get(accountAddress) ?? 0) + 1;
+  claimableRequestSeq.set(accountAddress, next);
+  return next;
+};
+
+/**
+ * Unlike `walletStore`, `ClaimableState` is flat — one set of items, not a
+ * per-account record — so being the newest request for this address is not
+ * enough. The store must still be *owned* by this address, otherwise a fetch
+ * for A that is still the latest A-request would happily overwrite B's list.
+ */
+const isLatestClaimableRequest = (
+  accountAddress: string,
+  token: number,
+  currentAccountAddress: string | null
+): boolean =>
+  claimableRequestSeq.get(accountAddress) === token &&
+  currentAccountAddress === accountAddress;
+
 interface ClaimableState {
   // State
   approvals: TokenApproval[];
   claimableItems: ClaimableItem[];
+  /**
+   * Account the currently held `claimableItems` belong to. Rendering is bound
+   * to this so a previous account's items are never shown across a switch.
+   */
+  itemsAccountAddress: string | null;
   hiddenApprovals: Set<string>; // Set of hidden approval IDs (contractId_owner)
+  /**
+   * Account whose persisted hidden set is currently loaded. Tracked separately
+   * from `currentAccountAddress` because ownership is claimed synchronously
+   * while hydration is async: a forced refresh landing inside that window would
+   * otherwise see "no account switch", skip hydration, and commit an empty
+   * hidden set over the user's hidden tokens.
+   */
+  hiddenApprovalsAccount: string | null;
   showHiddenApprovals: boolean;
   isLoading: boolean;
   isValidating: boolean;
-  lastFetchedAt: number | null;
+  /** Per-account timestamp of the last FULLY successful fetch (ms). */
+  lastFetchedAt: Record<string, number>;
+  /** Per-account timestamp of the last partial/failed fetch (ms). */
+  errorBackoffAt: Record<string, number>;
+  /**
+   * True when the last fetch for the current account completed but at least one
+   * owner-balance lookup failed, so some rows have an unknown balance.
+   */
+  hasPartialFailure: boolean;
   currentAccountAddress: string | null;
   lastError: string | null;
 
@@ -38,7 +111,10 @@ interface ClaimableState {
   getTotalClaimableCount: () => number;
 
   // Actions
-  fetchApprovals: (accountAddress: string) => Promise<void>;
+  fetchApprovals: (
+    accountAddress: string,
+    options?: { force?: boolean }
+  ) => Promise<void>;
   hideApproval: (approvalId: string) => Promise<void>;
   unhideApproval: (approvalId: string) => Promise<void>;
   toggleShowHidden: () => void;
@@ -51,11 +127,15 @@ export const useClaimableStore = create<ClaimableState>()(
     // Initial state
     approvals: [],
     claimableItems: [],
+    itemsAccountAddress: null,
     hiddenApprovals: new Set<string>(),
+    hiddenApprovalsAccount: null,
     showHiddenApprovals: false,
     isLoading: false,
     isValidating: false,
-    lastFetchedAt: null,
+    lastFetchedAt: {},
+    errorBackoffAt: {},
+    hasPartialFailure: false,
     currentAccountAddress: null,
     lastError: null,
 
@@ -101,185 +181,57 @@ export const useClaimableStore = create<ClaimableState>()(
     },
 
     /**
-     * Fetch approvals from MimirAPI and validate owner balances
+     * Fetch approvals from MimirAPI and validate owner balances.
+     *
+     * Gated by a per-account TTL and an in-flight guard. Pass
+     * `{ force: true }` from user-initiated refreshes (pull-to-refresh,
+     * post-claim refresh) to bypass both.
      */
-    fetchApprovals: async (accountAddress: string) => {
-      const { currentAccountAddress } = get();
+    fetchApprovals: async (
+      accountAddress: string,
+      options?: { force?: boolean }
+    ) => {
+      const force = options?.force ?? false;
 
-      // If switching accounts, load hidden approvals from storage
-      if (currentAccountAddress !== accountAddress) {
-        const hiddenStorageKey = getHiddenStorageKey(accountAddress);
-        try {
-          const storedHiddenJson = await AsyncStorage.getItem(hiddenStorageKey);
-          const storedHidden = storedHiddenJson
-            ? new Set<string>(JSON.parse(storedHiddenJson))
-            : new Set<string>();
-          set({
-            hiddenApprovals: storedHidden,
-            showHiddenApprovals: false,
-            currentAccountAddress: accountAddress,
-          });
-        } catch (error) {
-          console.error('Failed to load hidden approvals:', error);
-          set({
-            hiddenApprovals: new Set<string>(),
-            showHiddenApprovals: false,
-            currentAccountAddress: accountAddress,
-          });
+      if (!force) {
+        // Only join a request that still OWNS the store. After B -> A -> B,
+        // B's original request is still pending but can no longer commit (the
+        // switch to A superseded it), so joining it would resolve into an
+        // empty list and issue no refetch at all.
+        const inFlight = inFlightFetches.get(accountAddress);
+        if (inFlight && get().currentAccountAddress === accountAddress) {
+          return inFlight;
+        }
+
+        // Freshness only counts while we still hold THIS account's data.
+        // Without that condition, switching A -> B -> A inside the window
+        // would suppress the refetch and leave the list empty, because the
+        // switch away from A dropped A's items.
+        const state = get();
+        if (state.itemsAccountAddress === accountAddress) {
+          const now = Date.now();
+          const succeededAt = state.lastFetchedAt[accountAddress];
+          if (succeededAt !== undefined && now - succeededAt < SUCCESS_TTL_MS) {
+            return;
+          }
+          const failedAt = state.errorBackoffAt[accountAddress];
+          if (failedAt !== undefined && now - failedAt < ERROR_BACKOFF_MS) {
+            return;
+          }
         }
       }
 
-      set({ isLoading: true, lastError: null });
-
-      try {
-        // Fetch approvals where user is the spender
-        const response =
-          await MimirApiService.getArc200ApprovalsForSpender(accountAddress);
-
-        // Filter out zero-amount approvals
-        const nonZeroApprovals = response.approvals.filter(
-          (approval) => approval.amount !== '0'
-        );
-
-        // Convert to TokenApproval type
-        const tokenApprovals: TokenApproval[] = nonZeroApprovals.map(
-          (approval: Arc200Approval) => ({
-            owner: approval.owner,
-            round: approval.round,
-            amount: approval.amount,
-            spender: approval.spender,
-            timestamp: approval.timestamp,
-            contractId: approval.contractId,
-            transactionId: approval.transactionId,
-          })
-        );
-
-        set({ approvals: tokenApprovals });
-
-        // Now fetch token metadata and validate owner balances
-        set({ isValidating: true });
-
-        // Get unique contract IDs for metadata fetch
-        const contractIds = [
-          ...new Set(tokenApprovals.map((a) => a.contractId)),
-        ];
-
-        // Fetch token metadata
-        let tokenMetadata: Map<
-          number,
-          {
-            name: string;
-            symbol: string;
-            decimals: number;
-            imageUrl?: string;
-            verified: boolean;
-          }
-        > = new Map();
-
-        if (contractIds.length > 0) {
-          try {
-            const metadataResponse =
-              await MimirApiService.getArc200TokensMetadata(contractIds);
-            for (const token of metadataResponse.tokens) {
-              tokenMetadata.set(token.contractId, {
-                name: token.name,
-                symbol: token.symbol,
-                decimals: token.decimals,
-                imageUrl: token.imageUrl || undefined,
-                verified: token.verified === 1,
-              });
-            }
-          } catch (error) {
-            console.error('Failed to fetch token metadata:', error);
+      const request = runFetchApprovals(accountAddress, set, get).finally(
+        () => {
+          // Identity check: a forced fetch may have replaced this entry while
+          // we were running, and it must not be cleared by our completion.
+          if (inFlightFetches.get(accountAddress) === request) {
+            inFlightFetches.delete(accountAddress);
           }
         }
-
-        // Build owner/contract pairs for balance validation
-        const balancePairs = tokenApprovals.map((approval) => ({
-          owner: approval.owner,
-          contractId: approval.contractId,
-        }));
-
-        // Batch fetch owner balances
-        let ownerBalances: Map<string, string> = new Map();
-        if (balancePairs.length > 0) {
-          try {
-            ownerBalances =
-              await MimirApiService.batchGetArc200Balances(balancePairs);
-          } catch (error) {
-            console.error('Failed to fetch owner balances:', error);
-          }
-        }
-
-        // Resolve Envoi names for owner addresses (Envoi is on Voi mainnet)
-        const uniqueOwners = [...new Set(tokenApprovals.map((a) => a.owner))];
-        let ownerNames: Map<string, string | null> = new Map();
-        if (uniqueOwners.length > 0) {
-          try {
-            const envoiService = EnvoiService.getInstance();
-            // Claimable tokens are always on Voi, so temporarily enable Envoi
-            const wasEnabled = envoiService.isServiceEnabled();
-            if (!wasEnabled) {
-              envoiService.setEnabled(true);
-            }
-            const nameResults = await envoiService.getNames(uniqueOwners);
-            // Restore previous state
-            if (!wasEnabled) {
-              envoiService.setEnabled(false);
-            }
-            for (const [address, nameInfo] of nameResults) {
-              ownerNames.set(address, nameInfo?.name || null);
-            }
-          } catch (error) {
-            console.error('Failed to fetch owner Envoi names:', error);
-          }
-        }
-
-        // Build claimable items
-        const claimableItems: ClaimableItem[] = tokenApprovals.map(
-          (approval) => {
-            const id = `${approval.contractId}_${approval.owner}`;
-            const metadata = tokenMetadata.get(approval.contractId);
-            const ownerBalanceStr =
-              ownerBalances.get(`${approval.contractId}_${approval.owner}`) ||
-              '0';
-            const approvalAmount = BigInt(approval.amount);
-            const ownerBalance = BigInt(ownerBalanceStr);
-
-            return {
-              id,
-              contractId: approval.contractId,
-              tokenName: metadata?.name || `Token ${approval.contractId}`,
-              tokenSymbol: metadata?.symbol || 'TOKEN',
-              tokenDecimals: metadata?.decimals || 0,
-              tokenImageUrl: metadata?.imageUrl,
-              tokenVerified: metadata?.verified || false,
-              owner: approval.owner,
-              ownerEnvoiName: ownerNames.get(approval.owner) || undefined,
-              amount: approvalAmount,
-              ownerBalance,
-              isClaimable: ownerBalance >= approvalAmount,
-              approval,
-            };
-          }
-        );
-
-        set({
-          claimableItems,
-          isLoading: false,
-          isValidating: false,
-          lastFetchedAt: Date.now(),
-        });
-      } catch (error) {
-        const message =
-          error instanceof Error ? error.message : 'Failed to fetch approvals';
-        console.error('Failed to fetch claimable tokens:', error);
-        set({
-          lastError: message,
-          isLoading: false,
-          isValidating: false,
-        });
-      }
+      );
+      inFlightFetches.set(accountAddress, request);
+      return request;
     },
 
     /**
@@ -332,14 +284,24 @@ export const useClaimableStore = create<ClaimableState>()(
       set({
         approvals: [],
         claimableItems: [],
+        itemsAccountAddress: null,
         hiddenApprovals: new Set<string>(),
+        hiddenApprovalsAccount: null,
         showHiddenApprovals: false,
         isLoading: false,
         isValidating: false,
-        lastFetchedAt: null,
+        lastFetchedAt: {},
+        errorBackoffAt: {},
+        hasPartialFailure: false,
         currentAccountAddress: null,
         lastError: null,
       });
+
+      // Drop the dedup entries too, so the next fetch after a cache clear
+      // starts fresh instead of joining a request from the cleared session.
+      // Any such request is already blocked from committing by the generation
+      // guard (its owning account is now null).
+      inFlightFetches.clear();
 
       if (currentAccountAddress) {
         await AsyncStorage.removeItem(
@@ -349,6 +311,280 @@ export const useClaimableStore = create<ClaimableState>()(
     },
   }))
 );
+
+type ClaimableSet = (partial: Partial<ClaimableState>) => void;
+type ClaimableGet = () => ClaimableState;
+
+/**
+ * The actual fetch chain, extracted so `fetchApprovals` reads as pure gating.
+ *
+ * Every write is preceded by a re-check that this request still owns the store
+ * (`isLatest`), not just the entry check the original had.
+ */
+async function runFetchApprovals(
+  accountAddress: string,
+  set: ClaimableSet,
+  get: ClaimableGet
+): Promise<void> {
+  const requestToken = nextClaimableRequest(accountAddress);
+  const isLatest = () =>
+    isLatestClaimableRequest(
+      accountAddress,
+      requestToken,
+      get().currentAccountAddress
+    );
+
+  const isAccountSwitch = get().currentAccountAddress !== accountAddress;
+
+  if (isAccountSwitch) {
+    // Claim ownership synchronously, before any await, and drop the previous
+    // account's list in the same commit — otherwise it stays rendered until
+    // this fetch lands, showing one account's claimables under another's name.
+    set({
+      currentAccountAddress: accountAddress,
+      approvals: [],
+      claimableItems: [],
+      itemsAccountAddress: null,
+      hiddenApprovals: new Set<string>(),
+      hiddenApprovalsAccount: null,
+      showHiddenApprovals: false,
+      hasPartialFailure: false,
+      lastError: null,
+    });
+  }
+
+  // Hydrate the persisted hidden set whenever it is not already loaded for
+  // this account. Keyed on `hiddenApprovalsAccount`, NOT on `isAccountSwitch`:
+  // ownership is claimed synchronously above but hydration is async, so a
+  // forced refresh arriving inside that window sees no switch and would
+  // otherwise skip hydration, supersede the request that was loading, and
+  // commit an empty hidden set over the user's hidden tokens.
+  if (get().hiddenApprovalsAccount !== accountAddress) {
+    const hiddenStorageKey = getHiddenStorageKey(accountAddress);
+    try {
+      const storedHiddenJson = await AsyncStorage.getItem(hiddenStorageKey);
+      const storedHidden = storedHiddenJson
+        ? new Set<string>(JSON.parse(storedHiddenJson))
+        : new Set<string>();
+      if (!isLatest()) return;
+      set({
+        hiddenApprovals: storedHidden,
+        hiddenApprovalsAccount: accountAddress,
+        showHiddenApprovals: false,
+      });
+    } catch (error) {
+      console.error('Failed to load hidden approvals:', error);
+      if (!isLatest()) return;
+      set({
+        hiddenApprovals: new Set<string>(),
+        hiddenApprovalsAccount: accountAddress,
+        showHiddenApprovals: false,
+      });
+    }
+  }
+
+  if (!isLatest()) return;
+  set({ isLoading: true, lastError: null });
+
+  try {
+    // Fetch approvals where user is the spender
+    const response =
+      await MimirApiService.getArc200ApprovalsForSpender(accountAddress);
+
+    // Filter out zero-amount approvals
+    const nonZeroApprovals = response.approvals.filter(
+      (approval) => approval.amount !== '0'
+    );
+
+    // Convert to TokenApproval type
+    const tokenApprovals: TokenApproval[] = nonZeroApprovals.map(
+      (approval: Arc200Approval) => ({
+        owner: approval.owner,
+        round: approval.round,
+        amount: approval.amount,
+        spender: approval.spender,
+        timestamp: approval.timestamp,
+        contractId: approval.contractId,
+        transactionId: approval.transactionId,
+      })
+    );
+
+    if (!isLatest()) return;
+    set({ approvals: tokenApprovals, isValidating: true });
+
+    // Get unique contract IDs for metadata fetch
+    const contractIds = [...new Set(tokenApprovals.map((a) => a.contractId))];
+
+    // Fetch token metadata. Metadata failures stay absorbed: they degrade
+    // display (name/symbol/decimals fall back), not correctness, so they do
+    // NOT count as a partial failure.
+    const tokenMetadata = new Map<
+      number,
+      {
+        name: string;
+        symbol: string;
+        decimals: number;
+        imageUrl?: string;
+        verified: boolean;
+      }
+    >();
+
+    if (contractIds.length > 0) {
+      try {
+        const metadataResponse =
+          await MimirApiService.getArc200TokensMetadata(contractIds);
+        for (const token of metadataResponse.tokens) {
+          tokenMetadata.set(token.contractId, {
+            name: token.name,
+            symbol: token.symbol,
+            decimals: token.decimals,
+            imageUrl: token.imageUrl || undefined,
+            verified: token.verified === 1,
+          });
+        }
+      } catch (error) {
+        console.error('Failed to fetch token metadata:', error);
+      }
+    }
+
+    // Build owner/contract pairs for balance validation
+    const balancePairs = tokenApprovals.map((approval) => ({
+      owner: approval.owner,
+      contractId: approval.contractId,
+    }));
+
+    // Batch fetch owner balances. This is the leg that decides claimability,
+    // so it is the only one whose failures are surfaced.
+    let ownerBalances = new Map<string, string>();
+    const failedBalanceIds = new Set<string>();
+    if (balancePairs.length > 0) {
+      try {
+        const result =
+          await MimirApiService.batchGetArc200Balances(balancePairs);
+        ownerBalances = result.balances;
+        for (const id of result.failed) {
+          failedBalanceIds.add(id);
+        }
+      } catch (error) {
+        console.error('Failed to fetch owner balances:', error);
+        // The whole leg failed: every balance is unknown, none is zero.
+        for (const pair of balancePairs) {
+          failedBalanceIds.add(`${pair.contractId}_${pair.owner}`);
+        }
+      }
+    }
+
+    // Resolve Envoi names for owner addresses (Envoi is on Voi mainnet).
+    // Like metadata, name failures are display-only and stay absorbed.
+    const uniqueOwners = [...new Set(tokenApprovals.map((a) => a.owner))];
+    const ownerNames = new Map<string, string | null>();
+    if (uniqueOwners.length > 0) {
+      try {
+        const envoiService = EnvoiService.getInstance();
+        // Claimable tokens are always on Voi, so temporarily enable Envoi
+        const wasEnabled = envoiService.isServiceEnabled();
+        if (!wasEnabled) {
+          envoiService.setEnabled(true);
+        }
+        const nameResults = await envoiService.getNames(uniqueOwners);
+        // Restore previous state
+        if (!wasEnabled) {
+          envoiService.setEnabled(false);
+        }
+        for (const [address, nameInfo] of nameResults) {
+          ownerNames.set(address, nameInfo?.name || null);
+        }
+      } catch (error) {
+        console.error('Failed to fetch owner Envoi names:', error);
+      }
+    }
+
+    // Build claimable items
+    const claimableItems: ClaimableItem[] = tokenApprovals.map((approval) => {
+      const id = `${approval.contractId}_${approval.owner}`;
+      const metadata = tokenMetadata.get(approval.contractId);
+      const rawBalance = ownerBalances.get(id);
+      // Absent implies failed under the batch contract; the explicit `failed`
+      // check keeps that from being an inference.
+      const ownerBalanceUnknown =
+        failedBalanceIds.has(id) || rawBalance === undefined;
+      const approvalAmount = BigInt(approval.amount);
+      const ownerBalance =
+        ownerBalanceUnknown || rawBalance === undefined
+          ? 0n
+          : BigInt(rawBalance);
+
+      return {
+        id,
+        contractId: approval.contractId,
+        tokenName: metadata?.name || `Token ${approval.contractId}`,
+        tokenSymbol: metadata?.symbol || 'TOKEN',
+        tokenDecimals: metadata?.decimals || 0,
+        tokenImageUrl: metadata?.imageUrl,
+        tokenVerified: metadata?.verified || false,
+        owner: approval.owner,
+        ownerEnvoiName: ownerNames.get(approval.owner) || undefined,
+        amount: approvalAmount,
+        ownerBalance,
+        ownerBalanceUnknown,
+        // An unknown balance is not evidence of a claimable token, so the row
+        // stays un-actionable — but it renders as "unknown", not "Insufficient".
+        isClaimable: !ownerBalanceUnknown && ownerBalance >= approvalAmount,
+        approval,
+      };
+    });
+
+    const hasPartialFailure = failedBalanceIds.size > 0;
+
+    if (!isLatest()) return;
+    const now = Date.now();
+    const state = get();
+    set({
+      claimableItems,
+      itemsAccountAddress: accountAddress,
+      hasPartialFailure,
+      isLoading: false,
+      isValidating: false,
+      // Only a fully successful fetch earns the long TTL. A partial one is
+      // trusted just long enough to avoid re-fanning-out on every focus.
+      lastFetchedAt: hasPartialFailure
+        ? omitAccount(state.lastFetchedAt, accountAddress)
+        : { ...state.lastFetchedAt, [accountAddress]: now },
+      errorBackoffAt: hasPartialFailure
+        ? { ...state.errorBackoffAt, [accountAddress]: now }
+        : omitAccount(state.errorBackoffAt, accountAddress),
+    });
+  } catch (error) {
+    const message =
+      error instanceof Error ? error.message : 'Failed to fetch approvals';
+    console.error('Failed to fetch claimable tokens:', error);
+    // A superseded request must not replace a newer result with an error, nor
+    // clear a spinner it no longer owns.
+    if (!isLatest()) return;
+    const state = get();
+    set({
+      lastError: message,
+      isLoading: false,
+      isValidating: false,
+      lastFetchedAt: omitAccount(state.lastFetchedAt, accountAddress),
+      errorBackoffAt: { ...state.errorBackoffAt, [accountAddress]: Date.now() },
+    });
+  }
+}
+
+/**
+ * Return a copy of `stamps` without `accountAddress`, so a stale success stamp
+ * can never outlive the failure that superseded it.
+ */
+function omitAccount(
+  stamps: Record<string, number>,
+  accountAddress: string
+): Record<string, number> {
+  if (!(accountAddress in stamps)) return stamps;
+  const next = { ...stamps };
+  delete next[accountAddress];
+  return next;
+}
 
 /**
  * Persist hidden approvals to AsyncStorage for a specific account
@@ -456,6 +692,70 @@ export function useClaimableError(): string | null {
  */
 export function useAllClaimableItems(): ClaimableItem[] {
   return useClaimableStore((state) => state.claimableItems);
+}
+
+// Stable identity so an account-bound miss doesn't re-render consumers.
+const NO_CLAIMABLE_ITEMS: ClaimableItem[] = [];
+
+/**
+ * Hook to get all claimable items for a specific account (reactive).
+ *
+ * Returns an empty list unless the items currently held belong to
+ * `accountAddress`. The store already clears the previous account's items on a
+ * switch and guards every commit, but binding the render to account identity
+ * makes "another account's claimables are on screen" unrepresentable rather
+ * than merely unlikely.
+ */
+export function useClaimableItemsForAccount(
+  accountAddress: string | null | undefined
+): ClaimableItem[] {
+  const claimableItems = useClaimableStore((state) => state.claimableItems);
+  const itemsAccountAddress = useClaimableStore(
+    (state) => state.itemsAccountAddress
+  );
+  if (!accountAddress || itemsAccountAddress !== accountAddress) {
+    return NO_CLAIMABLE_ITEMS;
+  }
+  return claimableItems;
+}
+
+/**
+ * Hook to get the visible (non-hidden) claimable count for a specific account
+ * (reactive). Returns 0 unless the held items belong to `accountAddress`, so a
+ * badge or banner never reports one account's total under another's name.
+ */
+export function useVisibleClaimableCountForAccount(
+  accountAddress: string | null | undefined
+): number {
+  const claimableItems = useClaimableItemsForAccount(accountAddress);
+  const hiddenApprovals = useClaimableStore((state) => state.hiddenApprovals);
+  return claimableItems.filter((item) => !hiddenApprovals.has(item.id)).length;
+}
+
+/**
+ * Hook to check whether the last fetch for `accountAddress` completed with
+ * unresolved owner balances, i.e. some of its rows are showing an unknown
+ * claim status (reactive).
+ *
+ * Account-bound for the same reason the item hooks are: the flag is reset when
+ * a switch commits, but between the active account changing and that commit
+ * landing there is a render where account A's degraded banner would sit above
+ * account B's (empty) list.
+ */
+export function useClaimablePartialFailure(
+  accountAddress: string | null | undefined
+): boolean {
+  const hasPartialFailure = useClaimableStore(
+    (state) => state.hasPartialFailure
+  );
+  const itemsAccountAddress = useClaimableStore(
+    (state) => state.itemsAccountAddress
+  );
+  return (
+    hasPartialFailure &&
+    !!accountAddress &&
+    itemsAccountAddress === accountAddress
+  );
 }
 
 /**

--- a/src/store/messagesStore.ts
+++ b/src/store/messagesStore.ts
@@ -22,6 +22,7 @@ import {
 import MessagingService from '@/services/messaging';
 import { computeSyncCursor } from '@/services/messaging/syncCursor';
 import { AppLockSignal } from '@/services/secure/appLockState';
+import { shouldSkipForOffline } from '@/services/network/offline';
 import { useFriendsStore } from './friendsStore';
 
 const STORAGE_KEY_PREFIX = '@messages/';
@@ -800,6 +801,11 @@ export const useMessagesStore = create<MessagesState>()(
       // sync cursor, so once the initial sync commits a cursor, steady-state
       // polls only fetch/decrypt new messages.
       const interval = setInterval(() => {
+        // TASK-191: a tick fired while the device is definitely offline can
+        // only fail, so skip it rather than paying a retry ladder per tick.
+        // The interval keeps running — the next tick after connectivity
+        // returns syncs from the same committed cursor, so nothing is lost.
+        if (shouldSkipForOffline('messages-poll')) return;
         get().fetchAllThreads(userAddress);
       }, intervalMs);
 

--- a/src/types/claimable.ts
+++ b/src/types/claimable.ts
@@ -49,8 +49,15 @@ export interface ClaimableItem {
   ownerEnvoiName?: string;
   /** Approved amount as bigint */
   amount: bigint;
-  /** Current owner balance as bigint */
+  /** Current owner balance as bigint (0n when `ownerBalanceUnknown`) */
   ownerBalance: bigint;
+  /**
+   * True when the owner's balance could not be fetched (TASK-188). Distinct
+   * from a real zero balance: the item must render as "unknown", never as
+   * "Insufficient", because a transient network error is not evidence that the
+   * token cannot be claimed.
+   */
+  ownerBalanceUnknown?: boolean;
   /** Whether the claim can be executed (owner has sufficient balance) */
   isClaimable: boolean;
   /** Original approval data */
@@ -113,6 +120,7 @@ export interface SerializableClaimableItem {
   ownerEnvoiName?: string;
   amount: string;
   ownerBalance: string;
+  ownerBalanceUnknown?: boolean;
   isClaimable: boolean;
   approval: TokenApproval;
 }


### PR DESCRIPTION
Implements **PLAN-274** (child of PLAN-183, Voi Wallet Audit II — Network & Data Efficiency).

Stops three classes of repeated or doomed network work: the claimable-approvals chain re-running with no freshness check, price services firing N identical concurrent fetches, and retry ladders burning three attempts while the device is offline.

## Tasks
- [x] **TASK-188** — claimables: per-account TTL + in-flight guard, partial-failure semantics (`22ee7d4`)
- [x] **TASK-189** — price: in-flight dedup + per-entry cache timestamps (`10faf78`)
- [x] **TASK-191** — offline gating on four enumerated retry paths (`e3d4295`, `15e5db4`)

## Release vehicle
**OTA (JS-only).** No native module, config plugin, `app.config.js` native key, or new dependency. No `runtimeVersion` bump, no store submission.

⚠️ Production uses a **single shared EAS channel** (`eas.json:57`), so this and #181 coalesce into whatever bundle publishes next. Publish once from merged `main` per wave — not per PR — validate on `preview` first, and record the prior update ID before publishing or rollback is guesswork.

## Behaviour worth knowing
- **A failed claimable balance no longer renders as "Insufficient".** `batchGetArc200Balances` wrote `'0'` on error, which the UI showed as insufficient funds — actively telling users a claimable token was not claimable. It now returns `{ balances, failed }` with failed pairs *absent*, surfaced as an explicit unavailable state plus a screen-level degraded banner with retry.
- **A dedup guard without a commit guard is worse than none.** `fetchApprovals` checked the account at entry but committed unguarded, so a stale fetch overwrote another account's claimables *and* refreshed the freshness stamp, suppressing the correct fetch. Guarded at every `set()`.
- **The Algorand price cache uses per-entry timestamps, not a merged map.** A single global timestamp would renew the TTL on every old entry — permanently stale portfolio values. Expired entries are *retained* so the offline stale-fallback still has something to serve.
- **Offline skips the attempt; it does not introduce a new error type.** Price and Envoi deliberately absorb failures, so each gate throws the shape its exhausted ladder already threw. While offline a price reads stale and a name reads unresolved — same as after any failed fetch today.
- **Excluded by design and pinned by tests:** `token-mapping` and `snowball` still retry while offline. The reconnect-refresh coordinator was cut (unmeasured value, attached to the lowest-priority finding).

## Test plan
`npm run typecheck` 0 errors · `npm run lint` 0 errors / 157 warnings (unchanged baseline) · `npm test -- --ci` **129 suites / 1859 tests** (main: 123 / 1796). Both required CI checks green.

New coverage in `services/{mimir,price,algorand-price,network}` and `claimableStore` — all had **zero** tests before. Includes the A→B account-switch race, the expired-entry stale fallback (proving TASK-189 and TASK-191 compose), and the exclusion pins.

**Web export gate run:** `npx expo export -p web` completes; NetInfo reference count 43 = baseline; no new direct NetInfo import in shared code. Note NetInfo is *already* in the web bundle on `main` despite two comments claiming otherwise — tracked as TASK-286.

Device verification is batched before release, not per PR.

## Known gaps, filed not hidden
TASK-292 (Envoi logs a wallet address via `console.error`, which survives the production strip) · TASK-288 (`react-native-reanimated/mock` can hide dead assertions). The two `HomeScreen` fixes have no render test — the file is 2100 lines with a large mock surface; the underlying patterns are covered by `ClaimableTokensScreen` and `renderHook` tests.

🤖 Planned across 14 Codex review rounds; each task ran its own review loop, plus full-diff passes over the integrated branch.
