### PR TITLE
perf(mimir): collapse the ARC-200 balance fan-out to one request per contract (TASK-309 / F-20)

### DIFF
--- a/src/services/mimir/__tests__/batchGetArc200Balances.test.ts
+++ b/src/services/mimir/__tests__/batchGetArc200Balances.test.ts
@@ -1,34 +1,55 @@
-// TASK-188: batchGetArc200Balances must make per-owner failures observable.
+// batchGetArc200Balances collapses the per-(contract, owner) fan-out into one
+// request per contract via the server's `accountIds` batch parameter (F-20 /
+// PLAN-279 Phase E), while preserving two contracts established by TASK-188:
 //
-// It used to write the string '0' for a pair whose lookup threw, with the
-// comment "Set to '0' on error to mark as not claimable". That is a lie the
-// caller cannot detect: a genuine zero balance and a failed request produced
-// identical output, so a transient network error rendered a claimable token as
-// "Insufficient". The contract is now {balances, failed}, with failed pairs
-// ABSENT from balances rather than present as '0'.
+//   * A pair whose lookup fails is reported in `failed` and ABSENT from
+//     `balances` — never written as '0'. A genuine zero and a failed request
+//     must stay distinguishable, or a transient error renders a claimable token
+//     as "Insufficient".
+//   * A genuine zero balance stays in `balances` and out of `failed`.
+//
+// The batched request is `fetchArc200BalancesForOwners`. When it throws, the
+// method falls back to per-owner `getArc200Balance`, so one failed request
+// cannot make a whole contract's balances unknown.
 
 import { MimirApiService } from '../index';
 
 const service = MimirApiService.getInstance();
 
-describe('MimirApiService.batchGetArc200Balances (TASK-188)', () => {
+describe('MimirApiService.batchGetArc200Balances (F-20 fan-out collapse)', () => {
+  let fetchForOwners: jest.SpyInstance;
   let getArc200Balance: jest.SpyInstance;
 
   beforeEach(() => {
+    // The batched path. Default: echo a deterministic balance per owner so the
+    // happy-path assertions are stable.
+    fetchForOwners = jest
+      .spyOn(
+        service as unknown as {
+          fetchArc200BalancesForOwners: (
+            c: number,
+            o: string[]
+          ) => Promise<Map<string, string>>;
+        },
+        'fetchArc200BalancesForOwners'
+      )
+      .mockImplementation(async (contractId: number, owners: string[]) => {
+        const m = new Map<string, string>();
+        for (const owner of owners)
+          m.set(owner, `${contractId}${owner.length}`);
+        return m;
+      });
+    // The per-owner fallback path.
     getArc200Balance = jest.spyOn(service, 'getArc200Balance');
     jest.spyOn(console, 'error').mockImplementation(() => {});
+    jest.spyOn(console, 'warn').mockImplementation(() => {});
   });
 
   afterEach(() => {
     jest.restoreAllMocks();
   });
 
-  it('returns successful balances keyed `${contractId}_${owner}`', async () => {
-    getArc200Balance.mockImplementation(
-      async (contractId: number, owner: string) =>
-        `${contractId}${owner.length}`
-    );
-
+  it('returns balances keyed `${contractId}_${owner}` from one request per contract', async () => {
     const result = await service.batchGetArc200Balances([
       { contractId: 1, owner: 'AAA' },
       { contractId: 2, owner: 'BBBB' },
@@ -37,11 +58,47 @@ describe('MimirApiService.batchGetArc200Balances (TASK-188)', () => {
     expect(result.balances.get('1_AAA')).toBe('13');
     expect(result.balances.get('2_BBBB')).toBe('24');
     expect(result.failed.size).toBe(0);
+    // The collapse: one batched request per contract, NOT per pair, and no
+    // per-owner fallback on the happy path.
+    expect(fetchForOwners).toHaveBeenCalledTimes(2);
+    expect(getArc200Balance).not.toHaveBeenCalled();
   });
 
-  it('reports a failed pair in `failed` and omits it from `balances` — never as "0"', async () => {
+  it('dedups owners and sends one batched request per contract', async () => {
+    await service.batchGetArc200Balances([
+      { contractId: 1, owner: 'A' },
+      { contractId: 1, owner: 'A' },
+      { contractId: 1, owner: 'B' },
+      { contractId: 2, owner: 'A' },
+    ]);
+
+    expect(fetchForOwners).toHaveBeenCalledTimes(2);
+    expect(fetchForOwners).toHaveBeenCalledWith(1, ['A', 'B']);
+    expect(fetchForOwners).toHaveBeenCalledWith(2, ['A']);
+  });
+
+  it('maps an owner absent from a successful batch response to "0", not failed', async () => {
+    fetchForOwners.mockImplementation(async () => {
+      // ZERO held nothing, so the server omits it (excludes zero balances).
+      const m = new Map<string, string>();
+      m.set('HELD', '500');
+      return m;
+    });
+
+    const result = await service.batchGetArc200Balances([
+      { contractId: 7, owner: 'HELD' },
+      { contractId: 7, owner: 'ZERO' },
+    ]);
+
+    expect(result.balances.get('7_HELD')).toBe('500');
+    expect(result.balances.get('7_ZERO')).toBe('0');
+    expect(result.failed.size).toBe(0);
+  });
+
+  it('falls back to per-owner when the batched request fails, keeping successes', async () => {
+    fetchForOwners.mockRejectedValue(new Error('batch endpoint 500'));
     getArc200Balance.mockImplementation(
-      async (contractId: number, owner: string) => {
+      async (_contractId: number, owner: string) => {
         if (owner === 'BROKEN') throw new Error('network down');
         return '500';
       }
@@ -52,16 +109,17 @@ describe('MimirApiService.batchGetArc200Balances (TASK-188)', () => {
       { contractId: 1, owner: 'BROKEN' },
     ]);
 
+    // Fallback fired for the whole chunk.
+    expect(getArc200Balance).toHaveBeenCalledWith(1, 'OK');
+    expect(getArc200Balance).toHaveBeenCalledWith(1, 'BROKEN');
     expect(result.balances.get('1_OK')).toBe('500');
-    // The regression this task exists to prevent: a failed lookup must not be
-    // indistinguishable from "owner holds nothing".
+    // TASK-188: a failed lookup must not read as "owner holds nothing".
     expect(result.balances.has('1_BROKEN')).toBe(false);
-    expect(result.balances.get('1_BROKEN')).toBeUndefined();
     expect([...result.failed]).toEqual(['1_BROKEN']);
   });
 
   it('keeps a genuine zero balance in `balances` and out of `failed`', async () => {
-    getArc200Balance.mockResolvedValue('0');
+    fetchForOwners.mockResolvedValue(new Map([['ZERO', '0']]));
 
     const result = await service.batchGetArc200Balances([
       { contractId: 7, owner: 'ZERO' },
@@ -71,31 +129,27 @@ describe('MimirApiService.batchGetArc200Balances (TASK-188)', () => {
     expect(result.failed.size).toBe(0);
   });
 
-  it('preserves the existing request shape: dedups pairs, one request per (contract, owner)', async () => {
-    getArc200Balance.mockResolvedValue('1');
+  it('chunks a contract with more than MAX_BATCH_ACCOUNTS owners across requests', async () => {
+    const owners = Array.from({ length: 150 }, (_, i) => `OWNER${i}`);
+    const pairs = owners.map((owner) => ({ contractId: 9, owner }));
 
-    await service.batchGetArc200Balances([
-      { contractId: 1, owner: 'A' },
-      { contractId: 1, owner: 'A' },
-      { contractId: 1, owner: 'B' },
-      { contractId: 2, owner: 'A' },
-    ]);
+    const result = await service.batchGetArc200Balances(pairs);
 
-    // Unchanged from before this task: duplicates collapse, but the fan-out is
-    // still one request per unique pair (collapsing it is a different task).
-    expect(getArc200Balance).toHaveBeenCalledTimes(3);
-    expect(getArc200Balance).toHaveBeenCalledWith(1, 'A');
-    expect(getArc200Balance).toHaveBeenCalledWith(1, 'B');
-    expect(getArc200Balance).toHaveBeenCalledWith(2, 'A');
+    // 150 owners -> two batched requests (100 + 50), not 150 per-owner calls.
+    expect(fetchForOwners).toHaveBeenCalledTimes(2);
+    expect(fetchForOwners.mock.calls[0][1]).toHaveLength(100);
+    expect(fetchForOwners.mock.calls[1][1]).toHaveLength(50);
+    expect(getArc200Balance).not.toHaveBeenCalled();
+    expect(result.balances.size).toBe(150);
+    expect(result.failed.size).toBe(0);
   });
 
   it('returns empty collections for no pairs without issuing a request', async () => {
-    getArc200Balance.mockResolvedValue('1');
-
     const result = await service.batchGetArc200Balances([]);
 
     expect(result.balances.size).toBe(0);
     expect(result.failed.size).toBe(0);
+    expect(fetchForOwners).not.toHaveBeenCalled();
     expect(getArc200Balance).not.toHaveBeenCalled();
   });
 });

--- a/src/services/mimir/index.ts
+++ b/src/services/mimir/index.ts
@@ -384,7 +384,10 @@ export class MimirApiService {
     }
   }
 
-  private async fetchWithRetry(url: string): Promise<Response> {
+  private async fetchWithRetry(
+    url: string,
+    init?: RequestInit
+  ): Promise<Response> {
     // TASK-191: while the device is definitely offline, skip the ladder
     // outright rather than burning `retryAttempts` fetches plus their backoff
     // on a request that cannot reach the network. Deliberately the SAME error
@@ -410,9 +413,15 @@ export class MimirApiService {
 
         const response = await fetch(url, {
           signal: controller.signal,
+          // Caller-supplied method/body (e.g. a POST batch) override the
+          // GET default; headers below are merged over any the caller passes so
+          // Accept/Content-Type stay set. Existing GET callers pass no init and
+          // are unaffected.
+          ...init,
           headers: {
             Accept: 'application/json',
             'Content-Type': 'application/json',
+            ...init?.headers,
           },
         });
 
@@ -590,8 +599,78 @@ export class MimirApiService {
   }
 
   /**
+   * Maximum accounts sent in one batched balance request. Matches the
+   * documented cap of the server's `accountIds` parameter and keeps the POST
+   * body well under its 64 KB limit (~100 × 58-char address ≈ 6 KB). Owners
+   * beyond this are split across additional requests.
+   */
+  private static readonly MAX_BATCH_ACCOUNTS = 100;
+
+  /**
+   * Fetch balances for many owners of ONE contract in a single request, using
+   * the server's `accountIds` batch parameter (mimir-api TASK-282).
+   *
+   * Returns a map of owner → balance. An owner ABSENT from the map held a zero
+   * balance or had no row — the caller maps that to '0', exactly as the
+   * single-account `getArc200Balance` returns '0' for a missing account. `limit`
+   * is set to the chunk size so the result is never truncated (the response
+   * excludes zero balances, so at most `owners.length` rows can come back).
+   *
+   * `owners` must be non-empty and no larger than MAX_BATCH_ACCOUNTS; callers
+   * chunk before calling. Throws on network/HTTP/shape errors so the caller can
+   * fall back to per-owner requests.
+   */
+  private async fetchArc200BalancesForOwners(
+    contractId: number,
+    owners: string[]
+  ): Promise<Map<string, string>> {
+    const response = await this.fetchWithRetry(
+      `${this.config.baseUrl}/arc200/balances`,
+      {
+        method: 'POST',
+        body: JSON.stringify({
+          contractId,
+          accountIds: owners,
+          limit: owners.length,
+        }),
+      }
+    );
+
+    if (!response.ok) {
+      throw new MimirApiError(
+        `Failed to fetch ARC-200 balances: ${response.statusText}`,
+        response.status
+      );
+    }
+
+    const data: Arc200BalanceResponse = await response.json();
+
+    if (!data.balances || !Array.isArray(data.balances)) {
+      throw new MimirApiError(
+        'Invalid response format from Mimir API balances endpoint'
+      );
+    }
+
+    const result = new Map<string, string>();
+    for (const b of data.balances) {
+      if (b.contractId === contractId) {
+        result.set(b.accountId, b.balance);
+      }
+    }
+    return result;
+  }
+
+  /**
    * Batch fetch ARC-200 balances for multiple owner/contract pairs
    * More efficient than individual calls when validating multiple approvals
+   *
+   * Issues ONE request per contract (chunked at MAX_BATCH_ACCOUNTS) via the
+   * server's `accountIds` parameter, collapsing the previous per-(contract,
+   * owner) fan-out — the claimable-approvals path that fired on every Home
+   * account-change, ClaimableTokens focus and pull-to-refresh (F-20 / PLAN-279
+   * Phase E). If a batched request fails, it falls back to per-owner requests
+   * for that chunk, so one failure cannot make a whole contract's balances
+   * unknown and per-owner failures stay isolated.
    *
    * Per-pair failures are reported through `failed` rather than being flattened
    * to '0' — see `Arc200BatchBalancesResult`. Callers that do not care about
@@ -604,7 +683,7 @@ export class MimirApiService {
     const balanceMap = new Map<string, string>();
     const failed = new Set<string>();
 
-    // Group by contractId to minimize API calls
+    // Group by contractId and dedup owners (unchanged from before).
     const byContract = new Map<number, string[]>();
     for (const pair of pairs) {
       const owners = byContract.get(pair.contractId) || [];
@@ -614,21 +693,52 @@ export class MimirApiService {
       byContract.set(pair.contractId, owners);
     }
 
-    // Fetch balances for each contract
     await Promise.all(
       Array.from(byContract.entries()).map(async ([contractId, owners]) => {
-        for (const owner of owners) {
+        for (
+          let i = 0;
+          i < owners.length;
+          i += MimirApiService.MAX_BATCH_ACCOUNTS
+        ) {
+          const chunk = owners.slice(i, i + MimirApiService.MAX_BATCH_ACCOUNTS);
           try {
-            const balance = await this.getArc200Balance(contractId, owner);
-            balanceMap.set(`${contractId}_${owner}`, balance);
+            // ONE request for the whole chunk, replacing chunk.length requests.
+            const balances = await this.fetchArc200BalancesForOwners(
+              contractId,
+              chunk
+            );
+            for (const owner of chunk) {
+              // Absent from the response == zero / no row, matching what the
+              // single getArc200Balance path returns for a missing account.
+              balanceMap.set(
+                `${contractId}_${owner}`,
+                balances.get(owner) ?? '0'
+              );
+            }
           } catch (error) {
-            console.error(
-              `Failed to fetch balance for ${owner} on contract ${contractId}:`,
+            // Batch failed: fall back to per-owner so one bad request cannot
+            // make a whole contract's balances unknown, and per-owner failures
+            // stay isolated in `failed` (TASK-188 semantics preserved).
+            console.warn(
+              `Batch balance fetch failed for contract ${contractId}; falling back to per-owner:`,
               error
             );
-            // Record the failure instead of writing '0': the caller must be
-            // able to distinguish "owner holds nothing" from "we don't know".
-            failed.add(`${contractId}_${owner}`);
+            for (const owner of chunk) {
+              try {
+                balanceMap.set(
+                  `${contractId}_${owner}`,
+                  await this.getArc200Balance(contractId, owner)
+                );
+              } catch (err) {
+                console.error(
+                  `Failed to fetch balance for ${owner} on contract ${contractId}:`,
+                  err
+                );
+                // Record the failure instead of writing '0': the caller must be
+                // able to distinguish "owner holds nothing" from "we don't know".
+                failed.add(`${contractId}_${owner}`);
+              }
+            }
           }
         }
       })


### PR DESCRIPTION
The wallet-side payoff of today's mimir batch stack. `batchGetArc200Balances` looped one `/arc200/balances` request **per (contract, owner) pair** — the claimable-approvals path that fires on every Home account-change, ClaimableTokens focus, and pull-to-refresh (F-20 / PLAN-279 Phase E). It now sends **one request per contract** via the server's `accountIds` parameter, live since mimir-db TASK-281 and mimir-api TASK-282.

For a contract with N holders: **N requests → 1.**

## Change

- New private `fetchArc200BalancesForOwners` POSTs `{contractId, accountIds, limit}` and returns owner→balance. An owner absent from the response maps to `'0'`, matching what single `getArc200Balance` returns for a missing account.
- Chunked at **100 accounts/request** — the server param's documented cap; POST body stays well under 64 KB; `limit` = chunk size so results are never truncated (the response excludes zero balances, so at most `chunk.length` rows return). A contract with >100 owners splits across requests.
- On a batched-request failure, **falls back to per-owner** `getArc200Balance` for that chunk. One bad request can't blank a whole contract's balances, and per-owner failures stay isolated. This preserves **TASK-188** exactly: a failed lookup is in `failed` and absent from `balances`, never written as `'0'`.
- `fetchWithRetry` gains an optional `RequestInit` for the POST; existing GET callers pass nothing and are unaffected (offline-skip, retry ladder, timeout all still apply).

The `{balances, failed}` contract is unchanged, so `claimableStore` is untouched.

## On the fallback

Version-skew isn't the concern — the server change is already live, so there's no "server doesn't support it yet" window. The fallback exists for a different reason: batching introduces a new failure mode (one bad address or transient error fails a whole contract group, where per-owner isolated it). Falling back preserves exactly the pre-collapse resilience.

## Verification

- Batch suite rewritten for the collapse: one request/contract, dedup, chunking (150 owners → 2 requests), fallback isolation, absent→`'0'`, genuine-zero kept, empty-input issues no request. **7/7 pass.**
- **33** mimir + claimableStore tests pass (caller contract unchanged).
- `tsc --noEmit` clean; eslint clean.
- The POST batch path was verified end-to-end against the live deployed endpoint during TASK-282 (3 balances in one call).

Ships on the wallet's own release; no server dependency remains.
