### PR TITLE
Device regression wave: swap quote, startup stall, back-nav flash, dark cards (TASK-311/312/313/314, 319/320/321)

### DIFF
--- a/__mocks__/txnlab-deflex.js
+++ b/__mocks__/txnlab-deflex.js
@@ -1,0 +1,32 @@
+/**
+ * `@txnlab/deflex` stub for jest.
+ *
+ * The package is ESM-only — its package.json `exports` map declares just
+ * `import`/`types` with no `require` condition — so jest-expo's CJS resolver
+ * cannot load it and throws "Cannot find module '@txnlab/deflex'". Because
+ * src/services/swap/index.ts imports src/services/deflex/index.ts eagerly (to
+ * register the Algorand provider), that failure blocked ANY test that touched
+ * the unified swap service, which is why the Snowball adapter had no coverage
+ * when the quote regression landed.
+ *
+ * Pinned via `moduleNameMapper` rather than haste resolution, matching netinfo
+ * and react-native-quick-crypto, so a sibling worktree's copy can never win.
+ *
+ * The stub only has to satisfy the import: the Deflex provider is a separate
+ * code path (Algorand), and no test drives it. A suite that does should mock
+ * DeflexClient itself with the behaviour it needs.
+ */
+
+class DeflexClient {
+  constructor() {
+    throw new Error(
+      'DeflexClient is stubbed under jest (@txnlab/deflex is ESM-only). ' +
+        'Mock it explicitly in the suite that needs it.'
+    );
+  }
+}
+
+module.exports = {
+  __esModule: true,
+  DeflexClient,
+};

--- a/app.config.js
+++ b/app.config.js
@@ -71,6 +71,33 @@ const ANDROID_PROGUARD_RULES = `
 # react-native-image-colors is an Expo Module() in its own package, so the
 # expo.modules.** rule above does not reach it.
 -keep class com.reactnativeimagecolors.** { *; }
+
+# --- react-native-screens (TASK-312) ---
+# Back-navigation flashed a frame of the screen just departed. Bisected on
+# device: Test A (minify OFF + shrinkResources OFF) removed the flash, proving
+# R8 rather than release-build semantics; Test B (minify ON + shrinkResources
+# OFF) reproduced it, isolating CODE shrinking as the cause and exonerating
+# resource shrinking.
+#
+# react-native-screens ships NO consumer proguard rules of its own (no *.pro in
+# the package, no consumerProguardFiles in its build.gradle), so nothing keeps
+# its classes under R8 — the whole native stack/fragment machinery that drives
+# the pop transition is subject to shrinking and renaming. RN's own rules do not
+# reach it: proguard-rules.pro covers NativeModules, and the ViewManager rule
+# above is -keepnames, which prevents renaming but still ALLOWS shrinking.
+-keep class com.swmansion.rnscreens.** { *; }
+
+# --- Enum values()/valueOf() ---
+# The standard rule, absent from RN's shipped file. Kotlin/Java enums whose
+# constants are resolved from a string via valueOf() break silently when R8
+# strips the synthetic accessors. No direct Enum.valueOf was found in
+# com.swmansion.rnscreens (its stack/presentation/animation enums are matched
+# structurally), so this is defence-in-depth for transitive dependencies rather
+# than a proven fix — it is cheap, and its absence is a real gap either way.
+-keepclassmembers enum * {
+    public static **[] values();
+    public static ** valueOf(java.lang.String);
+}
 `;
 
 export default {
@@ -214,6 +241,13 @@ export default {
             // --assets-dest <build/generated/res/react/VARIANT>, and @expo/cli
             // persistMetroAssets.js createKeepFileAsync emits <res>/raw/keep.xml
             // listing every Metro asset by its generated identifier.
+            // Both restored to `true` after the TASK-312 bisect. Test A (both
+            // OFF) removed the back-nav flash, proving R8 rather than
+            // release-build semantics; Test B (minify ON, shrinkResources OFF)
+            // reproduced it, isolating CODE shrinking and exonerating resource
+            // shrinking. The fix is therefore a keep rule, not a flag — see the
+            // react-native-screens block in ANDROID_PROGUARD_RULES above — so
+            // both wins from TASK-209 are kept rather than traded away.
             enableMinifyInReleaseBuilds: true,
             enableShrinkResourcesInReleaseBuilds: true,
             extraProguardRules: ANDROID_PROGUARD_RULES,

--- a/jest.config.js
+++ b/jest.config.js
@@ -14,6 +14,10 @@ module.exports = {
     // tests replace. Force the stub; suites that need real NetInfo semantics
     // re-mock it themselves (src/platform/__tests__/connectivity.test.ts).
     '^@react-native-community/netinfo$': '<rootDir>/__mocks__/netinfo.js',
+    // ESM-only package (no `require` condition in its exports map), so the CJS
+    // resolver can't load it — and src/services/swap imports it transitively,
+    // which blocked every test of the unified swap service.
+    '^@txnlab/deflex$': '<rootDir>/__mocks__/txnlab-deflex.js',
   },
   // jest-expo's default only allow-transpiles RN/Expo packages; several deps
   // these utils import ship as untranspiled ESM and must also be transformed.

--- a/src/components/common/BlurredContainer.tsx
+++ b/src/components/common/BlurredContainer.tsx
@@ -65,8 +65,14 @@ export const BlurredContainer: React.FC<BlurredContainerProps> = ({
   disableBlur = false,
 }) => {
   const { theme } = useTheme();
-  // Disable blur when requested (e.g., inside FlatList) to avoid Android crashes
-  const hasNFTBackground = !disableBlur && !!theme.backgroundImageUrl;
+  // Whether an NFT image is painted behind this container. This is a property
+  // of the THEME and is independent of whether we may blur.
+  const hasBackgroundImage = !!theme.backgroundImageUrl;
+  // Blur is suppressed on request (e.g. rows of a virtualized list, where a
+  // mounted BlurView crashes on Android view recycling — see SafeBlurView).
+  // Suppressing the blur does NOT remove the image behind us, so the no-blur
+  // branch below still has to stay legible over it (TASK-314).
+  const shouldBlur = !disableBlur && hasBackgroundImage;
 
   // Get glass config from theme based on variant
   const glassConfig: GlassEffect = theme.glass[variant];
@@ -135,18 +141,41 @@ export const BlurredContainer: React.FC<BlurredContainerProps> = ({
   // Overlay background color with glass effect
   const overlayBackgroundColor = useMemo(() => {
     if (backgroundColor) return backgroundColor;
-    if (!hasNFTBackground) return glassConfig.backgroundColor;
+    if (!shouldBlur) return glassConfig.backgroundColor;
 
     // Enhanced overlay for NFT backgrounds
     return theme.mode === 'dark'
       ? `rgba(0, 0, 0, 0.25)`
       : `rgba(255, 255, 255, 0.05)`;
-  }, [
-    backgroundColor,
-    hasNFTBackground,
-    glassConfig.backgroundColor,
-    theme.mode,
-  ]);
+  }, [backgroundColor, shouldBlur, glassConfig.backgroundColor, theme.mode]);
+
+  // Surface for the no-blur branch when an NFT image sits behind us (TASK-314).
+  //
+  // `theme.colors.glassBackground` is a WHITE veil — 0.06 alpha in the built-in
+  // dark theme, 0.20 in a generated NFT theme (themeGenerator.ts:103). It is
+  // designed to sit ON TOP OF a blur, not to be the whole surface. Painted
+  // straight onto an NFT image with no blur under it, it reads as washed out,
+  // which is the regression a6ce5c6 (TASK-39) introduced when it routed
+  // virtualized rows down this branch.
+  //
+  // A dark scrim is the blur-less stand-in: it holds text contrast over an
+  // arbitrary image while still letting the artwork read through, which is what
+  // BlurView(tint='dark') + the rgba(0,0,0,0.25) overlay above achieved together.
+  //
+  // Deliberately a literal pair rather than a new `theme.colors` key: the whole
+  // Theme object is JSON-serialized into AsyncStorage by themeStorage.ts and
+  // rehydrated verbatim (loadNFTTheme validates only top-level fields and never
+  // re-runs the generator), so a newly-added colour key would come back
+  // `undefined` for every user with an NFT theme saved before the upgrade — a
+  // transparent card, strictly worse than a washed-out one. Matches the existing
+  // literals in this file (the overlay above, the highlight gradients below).
+  const noBlurSurface = useMemo(
+    () =>
+      theme.mode === 'dark'
+        ? 'rgba(12, 12, 16, 0.62)'
+        : 'rgba(255, 255, 255, 0.72)',
+    [theme.mode]
+  );
 
   // Highlight gradient colors (subtle top edge highlight for depth)
   const highlightGradientColors = useMemo((): [string, string] => {
@@ -172,15 +201,21 @@ export const BlurredContainer: React.FC<BlurredContainerProps> = ({
     };
   }, [showInnerBorder, resolvedBorderRadius, theme.colors.glassHighlight]);
 
-  // Non-NFT background fallback with glass styling
-  if (!hasNFTBackground) {
+  // No-blur branch: either the theme has no NFT image at all, or blur was
+  // suppressed via `disableBlur` while an image is still painted behind us.
+  // Those two cases need different surfaces — see `noBlurSurface` above.
+  if (!shouldBlur) {
     return (
       <View
         style={[
           styles.container,
           {
             borderRadius: resolvedBorderRadius,
-            backgroundColor: backgroundColor ?? theme.colors.glassBackground,
+            backgroundColor:
+              backgroundColor ??
+              (hasBackgroundImage
+                ? noBlurSurface
+                : theme.colors.glassBackground),
           },
           containerStyle,
           style,

--- a/src/components/navigation/FABRadialMenu.tsx
+++ b/src/components/navigation/FABRadialMenu.tsx
@@ -32,6 +32,7 @@ import { springConfigs } from '@/utils/animations';
 import { GlassCard } from '@/components/common/GlassCard';
 import { useActiveAccount } from '@/store/walletStore';
 import { useTotalUnreadCount } from '@/store/messagesStore';
+import { buildStackScreenParams } from './fabMenuParams';
 
 // Menu item configuration
 interface MenuItem {
@@ -235,11 +236,13 @@ export const FABRadialMenu: React.FC<FABRadialMenuProps> = ({
     (item: MenuItem) => {
       const navigateToScreen = () => {
         if (item.stackScreen) {
-          // Navigate to nested stack screen
-          const params =
-            item.stackScreen === 'Swap' && activeAccount
-              ? { accountId: activeAccount.address }
-              : {};
+          // Navigate to nested stack screen. The ID-vs-address distinction that
+          // broke Swap (TASK-313) lives in buildStackScreenParams, where it is
+          // unit-tested — see the comment there.
+          const params = buildStackScreenParams(
+            item.stackScreen,
+            activeAccount
+          );
 
           // Use Main -> Tab -> Stack screen navigation path
           navigation.navigate('Main', {

--- a/src/components/navigation/__tests__/fabMenuParams.test.ts
+++ b/src/components/navigation/__tests__/fabMenuParams.test.ts
@@ -1,0 +1,44 @@
+/**
+ * Regression tests for the FAB radial menu's stack-screen params (TASK-313).
+ *
+ * The bug: Swap was navigated to with `{ accountId: activeAccount.address }`.
+ * Both fields are `string`, so the compiler was blind to it, and the failure
+ * was silent and downstream — SwapScreen's lookups all miss, the balance never
+ * loads, and TokenSelector spins on "Loading tokens..." forever. These tests
+ * assert on the ID specifically, with an account whose id and address are
+ * clearly distinguishable, so the swap can never come back unnoticed.
+ */
+import { buildStackScreenParams } from '../fabMenuParams';
+
+const ACCOUNT = {
+  id: 'account_1730000000000_abc123',
+  address: 'BUD2763FMK6EYVKGHWWUN4QKHPSPCVFUEPPI4PQCPGYVPGQ6GNKBX6IXCQ',
+};
+
+describe('buildStackScreenParams', () => {
+  it('passes the account ID — not the address — to Swap', () => {
+    const params = buildStackScreenParams('Swap', ACCOUNT);
+
+    expect(params).toEqual({ accountId: ACCOUNT.id });
+    // Stated separately from the toEqual above: this is the actual regression.
+    expect((params as { accountId: string }).accountId).not.toBe(
+      ACCOUNT.address
+    );
+  });
+
+  it('returns empty params for Swap when there is no active account', () => {
+    expect(buildStackScreenParams('Swap', null)).toEqual({});
+    expect(buildStackScreenParams('Swap', undefined)).toEqual({});
+  });
+
+  it.each(['Send', 'Receive', 'ClaimableTokens', 'Messages'])(
+    'returns empty params for %s, which reads the active account itself',
+    (stackScreen) => {
+      expect(buildStackScreenParams(stackScreen, ACCOUNT)).toEqual({});
+    }
+  );
+
+  it('returns empty params when there is no stack screen', () => {
+    expect(buildStackScreenParams(undefined, ACCOUNT)).toEqual({});
+  });
+});

--- a/src/components/navigation/fabMenuParams.ts
+++ b/src/components/navigation/fabMenuParams.ts
@@ -1,0 +1,46 @@
+/**
+ * Route params for the FAB radial menu's nested stack destinations.
+ *
+ * Extracted from FABRadialMenu so it can be unit-tested without rendering the
+ * component — a render test would need jest mocks for both react-native-
+ * reanimated and react-native-gesture-handler, which the suite does not have.
+ * The bug this guards (TASK-313) lived entirely in this expression, so a pure
+ * helper covers it exactly.
+ */
+
+/** The minimum shape of an account this module needs. */
+export interface FabMenuAccount {
+  /** Account ID (`account_<ts>_<rand>`) — NOT the address. */
+  id: string;
+  address: string;
+}
+
+/** Params handed to a nested stack screen. Empty for screens that take none. */
+export type FabStackScreenParams =
+  | { accountId: string }
+  | Record<string, never>;
+
+/**
+ * Build the params for a nested stack destination.
+ *
+ * SwapScreen requires an `accountId`, and it must be the account ID, NOT the
+ * address. Everything downstream keys on the ID —
+ * `wallet.accounts.find(acc => acc.id === accountId)`,
+ * `accountStates[accountId]`, `loadAccountBalance(accountId)` — so an address
+ * silently misses every lookup: the balance never loads, and TokenSelector
+ * (which gates its entire token load on that balance) spins on "Loading
+ * tokens..." forever with the From token unset. Both fields are `string`, so
+ * the type system cannot catch the swap; this helper plus its tests can.
+ *
+ * Every other destination navigates with no params and reads the active
+ * account from the store itself.
+ */
+export function buildStackScreenParams(
+  stackScreen: string | undefined,
+  activeAccount: FabMenuAccount | null | undefined
+): FabStackScreenParams {
+  if (stackScreen === 'Swap' && activeAccount) {
+    return { accountId: activeAccount.id };
+  }
+  return {};
+}

--- a/src/config/__tests__/androidR8Config.test.ts
+++ b/src/config/__tests__/androidR8Config.test.ts
@@ -107,6 +107,19 @@ describe('Android R8 build configuration (TASK-209)', () => {
       // react-native-image-colors is an Expo Module() in its own package, so
       // the expo.modules.** rule does not reach it.
       '-keep class com.reactnativeimagecolors.** { *; }',
+
+      // TASK-312: react-native-screens ships NO consumer proguard rules, so
+      // nothing keeps its classes under R8. Bisected on device — Test A (minify
+      // OFF) removed the back-nav flash, Test B (minify ON, shrinkResources OFF)
+      // reproduced it — which isolates CODE shrinking as the cause. Note the
+      // ViewManager rule above is -keepnames, which prevents renaming but still
+      // permits shrinking, so it does not cover this.
+      '-keep class com.swmansion.rnscreens.** { *; }',
+
+      // The standard enum rule, absent from RN's shipped file. Defence-in-depth
+      // for transitive dependencies that resolve enum constants by name.
+      'public static **[] values();',
+      'public static ** valueOf(java.lang.String);',
     ];
 
     for (const rule of requiredRules) {

--- a/src/screens/wallet/SwapScreen.tsx
+++ b/src/screens/wallet/SwapScreen.tsx
@@ -109,18 +109,26 @@ export default function SwapScreen() {
   const [networkBalance, setNetworkBalance] = useState<AccountBalance | null>(
     null
   );
+  // Failure of the network-specific fetch below. It served a non-VOI selection
+  // entirely on its own and reported nothing but a console.error, so an
+  // Algorand balance failure left the same dead end the store path used to.
+  const [networkBalanceError, setNetworkBalanceError] = useState<string | null>(
+    null
+  );
+  // Bumped by Retry to re-run the network-specific effect, which has no other
+  // trigger once its inputs have settled.
+  const [networkBalanceReloadToken, setNetworkBalanceReloadToken] = useState(0);
 
   // Load balance if not available
   const loadAccountBalance = useWalletStore(
     (state) => state.loadAccountBalance
   );
 
-  // A failed balance load is a dead end on this screen unless it is shown. The
-  // effect below is one-shot — keyed on `!singleNetworkBalance`, which does not
-  // change when the load fails — so the screen would sit with no From token
-  // while TokenSelector, which gates its entire token load on that balance,
-  // spins on "Loading tokens..." forever, with nothing on screen saying why.
-  const balanceError = useWalletStore((state) =>
+  // Failure of the STORE-backed load. This describes `loadAccountBalance`, which
+  // fetches on the app's current network — the same source `accountBalance`
+  // below falls back to, and only for VOI. Scoping matters: see
+  // `balanceErrorForSelectedNetwork`.
+  const storeBalanceError = useWalletStore((state) =>
     accountId ? state.accountStates[accountId]?.balanceError : undefined
   );
 
@@ -129,15 +137,6 @@ export default function SwapScreen() {
       loadAccountBalance(accountId);
     }
   }, [accountId, singleNetworkBalance, loadAccountBalance]);
-
-  // Force: the unforced path early-returns on a fresh cache, and after a
-  // failure there is no balance to be fresh — but a retry must also survive a
-  // partially-populated state.
-  const retryBalanceLoad = useCallback(() => {
-    if (accountId) {
-      void loadAccountBalance(accountId, true);
-    }
-  }, [accountId, loadAccountBalance]);
 
   // Load network-specific balance when network or account changes
   useEffect(() => {
@@ -154,16 +153,21 @@ export default function SwapScreen() {
           const balance = await networkService.getAccountBalance(address);
           if (!isCancelled) {
             setNetworkBalance(balance);
+            setNetworkBalanceError(null);
           }
         } else {
           // For VOI network, use the store balance
           if (!isCancelled) {
             setNetworkBalance(singleNetworkBalance || null);
+            setNetworkBalanceError(null);
           }
         }
       } catch (error) {
         if (!isCancelled) {
           console.error('Error loading network balance:', error);
+          setNetworkBalanceError(
+            error instanceof Error ? error.message : 'Failed to load balance'
+          );
         }
       }
     };
@@ -173,13 +177,40 @@ export default function SwapScreen() {
     return () => {
       isCancelled = true;
     };
-  }, [currentAccount, selectedNetwork, singleNetworkBalance]);
+  }, [
+    currentAccount,
+    selectedNetwork,
+    singleNetworkBalance,
+    networkBalanceReloadToken,
+  ]);
 
   // Use network-specific balance - only fall back to store balance for VOI
   const accountBalance =
     selectedNetwork === NetworkId.VOI_MAINNET
       ? networkBalance || singleNetworkBalance
       : networkBalance;
+
+  // Report the failure that belongs to the network being swapped on, not
+  // whichever one the store happens to hold. The store is only consulted for
+  // VOI (see `accountBalance` above), so on an Algorand selection a stale VOI
+  // failure would raise an alarm about a swap that is working fine — and its
+  // Retry would re-run the wrong request. Each branch retries its own loader.
+  const isStoreBackedNetwork = selectedNetwork === NetworkId.VOI_MAINNET;
+  const balanceErrorForSelectedNetwork = isStoreBackedNetwork
+    ? storeBalanceError
+    : networkBalanceError;
+
+  const retryBalanceLoad = useCallback(() => {
+    if (isStoreBackedNetwork) {
+      // Force: the unforced path early-returns on a fresh cache, and a retry
+      // must survive a partially-populated state.
+      if (accountId) {
+        void loadAccountBalance(accountId, true);
+      }
+      return;
+    }
+    setNetworkBalanceReloadToken((token) => token + 1);
+  }, [isStoreBackedNetwork, accountId, loadAccountBalance]);
 
   // Token selection state
   const [inputToken, setInputToken] = useState<SwapToken | null>(null);
@@ -1092,13 +1123,13 @@ export default function SwapScreen() {
             networks={[NetworkId.VOI_MAINNET, NetworkId.ALGORAND_MAINNET]}
           />
 
-          {/* Balance load failure. Shown only while there is still no balance:
-              a stale-refresh failure over a balance we already have is not
-              worth interrupting the swap for. */}
-          {balanceError && !singleNetworkBalance ? (
+          {/* Balance load failure for the selected network. Shown only while
+              there is still no balance: a stale-refresh failure over a balance
+              we already have is not worth interrupting the swap for. */}
+          {balanceErrorForSelectedNetwork && !accountBalance ? (
             <ErrorStateView
               variant="inline"
-              error={balanceError}
+              error={balanceErrorForSelectedNetwork}
               onRetry={retryBalanceLoad}
               fallbackMessage="We couldn't load this account's balance."
               style={styles.balanceErrorNotice}

--- a/src/screens/wallet/SwapScreen.tsx
+++ b/src/screens/wallet/SwapScreen.tsx
@@ -3,7 +3,7 @@
  * Allows users to swap tokens on Voi Network using Snowball DEX aggregator
  */
 
-import React, { useState, useEffect, useRef } from 'react';
+import React, { useState, useEffect, useRef, useCallback } from 'react';
 import {
   View,
   Text,
@@ -58,6 +58,7 @@ import { GlassButton } from '@/components/common/GlassButton';
 import NetworkSelector from '@/components/network/NetworkSelector';
 import { useIsSwapEnabled } from '@/store/experimentalStore';
 import { registerNavigationCallbacks } from '@/services/navigation/callbackRegistry';
+import { ErrorStateView } from '@/components/common/ErrorStateView';
 
 interface SwapScreenRouteParams {
   assetName?: string;
@@ -114,11 +115,29 @@ export default function SwapScreen() {
     (state) => state.loadAccountBalance
   );
 
+  // A failed balance load is a dead end on this screen unless it is shown. The
+  // effect below is one-shot — keyed on `!singleNetworkBalance`, which does not
+  // change when the load fails — so the screen would sit with no From token
+  // while TokenSelector, which gates its entire token load on that balance,
+  // spins on "Loading tokens..." forever, with nothing on screen saying why.
+  const balanceError = useWalletStore((state) =>
+    accountId ? state.accountStates[accountId]?.balanceError : undefined
+  );
+
   useEffect(() => {
     if (accountId && !singleNetworkBalance) {
       loadAccountBalance(accountId);
     }
   }, [accountId, singleNetworkBalance, loadAccountBalance]);
+
+  // Force: the unforced path early-returns on a fresh cache, and after a
+  // failure there is no balance to be fresh — but a retry must also survive a
+  // partially-populated state.
+  const retryBalanceLoad = useCallback(() => {
+    if (accountId) {
+      void loadAccountBalance(accountId, true);
+    }
+  }, [accountId, loadAccountBalance]);
 
   // Load network-specific balance when network or account changes
   useEffect(() => {
@@ -1073,6 +1092,20 @@ export default function SwapScreen() {
             networks={[NetworkId.VOI_MAINNET, NetworkId.ALGORAND_MAINNET]}
           />
 
+          {/* Balance load failure. Shown only while there is still no balance:
+              a stale-refresh failure over a balance we already have is not
+              worth interrupting the swap for. */}
+          {balanceError && !singleNetworkBalance ? (
+            <ErrorStateView
+              variant="inline"
+              error={balanceError}
+              onRetry={retryBalanceLoad}
+              fallbackMessage="We couldn't load this account's balance."
+              style={styles.balanceErrorNotice}
+              testID="swap-balance-error"
+            />
+          ) : null}
+
           {/* Input Token Section */}
           <View style={styles.tokenSection}>
             <Text style={styles.sectionLabel}>You pay</Text>
@@ -1346,6 +1379,9 @@ const createStyles = (theme: Theme) =>
     errorText: {
       fontSize: 16,
       color: theme.colors.error,
+    },
+    balanceErrorNotice: {
+      marginBottom: theme.spacing.sm,
     },
     tokenSection: {
       marginBottom: theme.spacing.xs,

--- a/src/services/secure/AccountSecureStorage.ts
+++ b/src/services/secure/AccountSecureStorage.ts
@@ -49,6 +49,7 @@ import type { SecretSource } from './SessionKeyVault';
 import { clearPinSetupPending } from './pinSetupPending';
 import { SECURITY_CONFIG } from '../../config/security';
 import { invalidateAccountSubscribePasses } from '@/services/notifications/subscribePass';
+import { pbkdf2Hex } from './pbkdf2Kdf';
 
 // ─────────────────────────────────────────────────────────────────────────────
 // PIN THROTTLE — THREAT MODEL (DOC-137 §8 / TASK-26). READ BEFORE CHANGING.
@@ -150,21 +151,18 @@ interface AccountSecretPayload {
  */
 export type MigrationResult = 'MIGRATED' | 'ALREADY_V2' | 'NOT_MIGRATED';
 
-// PBKDF2 using CryptoJS with SHA256; returns hex string of keyLength bytes
-const customPBKDF2 = (
+// PBKDF2-HMAC-SHA256; returns hex string of keyLength bytes.
+//
+// Delegates to the native-first shim (TASK-311). It was `CryptoJS.PBKDF2`
+// inline here, which is pure JS and cost ~1.2s per call at PIN_ITERATIONS on
+// Android Hermes — five calls per cold start pinned the JS thread for ~6.3s.
+// Output is byte-identical across backends, so stored hashes stay valid.
+const customPBKDF2 = async (
   password: string,
   saltHex: string,
   iterations: number,
   keyLength: number
-): string => {
-  const saltWA = CryptoJS.enc.Hex.parse(saltHex);
-  const derived = CryptoJS.PBKDF2(password, saltWA, {
-    keySize: keyLength / 4, // CryptoJS keySize is in 32-bit words
-    iterations,
-    hasher: (CryptoJS.algo as any).SHA256,
-  });
-  return derived.toString(CryptoJS.enc.Hex);
-};
+): Promise<string> => pbkdf2Hex(password, saltHex, iterations, keyLength);
 
 // Platform options are now handled internally by the platform adapters
 
@@ -2254,7 +2252,7 @@ export class AccountSecureStorage {
 
       // Derive key using custom PBKDF2 with high iteration count
       const saltHex = Buffer.from(salt).toString('hex');
-      const key = customPBKDF2(
+      const key = await customPBKDF2(
         baseEntropy,
         saltHex,
         this.ENCRYPTION_KEY_ITERATIONS,
@@ -2279,7 +2277,7 @@ export class AccountSecureStorage {
       const baseEntropy = await platformCrypto.sha256(entropyString);
 
       const saltHex = Buffer.from(salt).toString('hex');
-      const key = customPBKDF2(
+      const key = await customPBKDF2(
         baseEntropy,
         saltHex,
         this.ENCRYPTION_KEY_ITERATIONS,
@@ -2826,14 +2824,22 @@ export class AccountSecureStorage {
 
     if (storedData.format === 'json') {
       this.legacyCheckRequired = false;
-      const candidateHash = this.hashPin(pin, salt, storedData.iterations);
+      const candidateHash = await this.hashPin(
+        pin,
+        salt,
+        storedData.iterations
+      );
       if (storedData.hash === candidateHash) {
         if (
           storedData.iterations !== this.PIN_ITERATIONS ||
           storedData.salt === undefined
         ) {
           try {
-            const upgradedHash = this.hashPin(pin, salt, this.PIN_ITERATIONS);
+            const upgradedHash = await this.hashPin(
+              pin,
+              salt,
+              this.PIN_ITERATIONS
+            );
             await this.persistPinCredential({
               hash: upgradedHash,
               iterations: this.PIN_ITERATIONS,
@@ -2852,10 +2858,14 @@ export class AccountSecureStorage {
     const iterationCandidates = this.getIterationCandidates();
 
     for (const iterations of iterationCandidates) {
-      const candidateHash = this.hashPin(pin, salt, iterations);
+      const candidateHash = await this.hashPin(pin, salt, iterations);
       if (storedData.hash === candidateHash) {
         try {
-          const upgradedHash = this.hashPin(pin, salt, this.PIN_ITERATIONS);
+          const upgradedHash = await this.hashPin(
+            pin,
+            salt,
+            this.PIN_ITERATIONS
+          );
           await this.persistPinCredential({
             hash: upgradedHash,
             iterations: this.PIN_ITERATIONS,
@@ -3145,7 +3155,7 @@ export class AccountSecureStorage {
       // PHASE 4 — COMMIT: flip the PIN credential in ONE folded write (§5.2).
       // POINT OF NO RETURN.
       const newSalt = await this.generateRandomHex(32);
-      const hash = this.hashPin(newSecret, newSalt, this.PIN_ITERATIONS);
+      const hash = await this.hashPin(newSecret, newSalt, this.PIN_ITERATIONS);
       await this.persistPinCredential({
         hash,
         iterations: this.PIN_ITERATIONS,
@@ -3588,11 +3598,11 @@ export class AccountSecureStorage {
     ).join('');
   }
 
-  private static hashPin(
+  private static async hashPin(
     pin: string,
     salt: string,
     iterations: number
-  ): string {
+  ): Promise<string> {
     return customPBKDF2(pin, salt, iterations, 32);
   }
 

--- a/src/services/secure/__tests__/keyWriterChangePin.test.ts
+++ b/src/services/secure/__tests__/keyWriterChangePin.test.ts
@@ -289,7 +289,7 @@ function useFastWriter(): void {
 async function seedCredential(pin: string): Promise<void> {
   const salt = 'a'.repeat(64);
   await asPriv.persistPinCredential({
-    hash: asPriv.hashPin(pin, salt, PIN_ITERATIONS),
+    hash: await asPriv.hashPin(pin, salt, PIN_ITERATIONS),
     iterations: PIN_ITERATIONS,
     salt,
     secretSource: 'pin',
@@ -470,7 +470,7 @@ describe('changePin — atomic re-wrap of every account (§5.3)', () => {
     // Establish the OLD credential (no accounts unwrapped here since they are
     // already v2 — persist the credential directly).
     await asPriv.persistPinCredential({
-      hash: asPriv.hashPin('111111', 'a'.repeat(64), PIN_ITERATIONS),
+      hash: await asPriv.hashPin('111111', 'a'.repeat(64), PIN_ITERATIONS),
       iterations: PIN_ITERATIONS,
       salt: 'a'.repeat(64),
       secretSource: 'pin',
@@ -509,7 +509,7 @@ describe('changePin crash-injection — verify-before-delete, never strands (§4
     await seedV2('acct-a', a.sk, oldPin);
     await seedV2('acct-b', b.sk, oldPin);
     await asPriv.persistPinCredential({
-      hash: asPriv.hashPin(oldPin, 'a'.repeat(64), PIN_ITERATIONS),
+      hash: await asPriv.hashPin(oldPin, 'a'.repeat(64), PIN_ITERATIONS),
       iterations: PIN_ITERATIONS,
       salt: 'a'.repeat(64),
       secretSource: 'pin',
@@ -667,7 +667,7 @@ describe('deletePin policy (§5.5)', () => {
     const a = makeAlgoKey();
     await seedV2('acct-a', a.sk, '111111');
     await asPriv.persistPinCredential({
-      hash: asPriv.hashPin('111111', 'a'.repeat(64), PIN_ITERATIONS),
+      hash: await asPriv.hashPin('111111', 'a'.repeat(64), PIN_ITERATIONS),
       iterations: PIN_ITERATIONS,
       salt: 'a'.repeat(64),
       secretSource: 'pin',
@@ -691,7 +691,7 @@ describe('deletePin policy (§5.5)', () => {
   it('ALLOWS removing the PIN on a watch-only wallet (no key material)', async () => {
     addToList('acct-watch'); // no secret payload
     await asPriv.persistPinCredential({
-      hash: asPriv.hashPin('111111', 'a'.repeat(64), PIN_ITERATIONS),
+      hash: await asPriv.hashPin('111111', 'a'.repeat(64), PIN_ITERATIONS),
       iterations: PIN_ITERATIONS,
       salt: 'a'.repeat(64),
       secretSource: 'pin',
@@ -896,7 +896,7 @@ describe('changePin verify gate is throttle-aware (§8)', () => {
     const a = makeAlgoKey();
     await seedV2('acct-a', a.sk, '111111');
     await asPriv.persistPinCredential({
-      hash: asPriv.hashPin('111111', 'a'.repeat(64), PIN_ITERATIONS),
+      hash: await asPriv.hashPin('111111', 'a'.repeat(64), PIN_ITERATIONS),
       iterations: PIN_ITERATIONS,
       salt: 'a'.repeat(64),
       secretSource: 'pin',

--- a/src/services/secure/__tests__/migrationEngine.test.ts
+++ b/src/services/secure/__tests__/migrationEngine.test.ts
@@ -318,7 +318,7 @@ function useFastWriter(): void {
 async function seedCredential(pin: string): Promise<void> {
   const salt = 'a'.repeat(64);
   await asPriv.persistPinCredential({
-    hash: asPriv.hashPin(pin, salt, PIN_ITERATIONS),
+    hash: await asPriv.hashPin(pin, salt, PIN_ITERATIONS),
     iterations: PIN_ITERATIONS,
     salt,
     secretSource: 'pin',

--- a/src/services/secure/__tests__/pbkdf2Kdf.test.ts
+++ b/src/services/secure/__tests__/pbkdf2Kdf.test.ts
@@ -1,0 +1,98 @@
+/**
+ * PBKDF2 backend shim (TASK-311).
+ *
+ * The whole point of this module is that it is a PURE BACKEND SWAP: whatever
+ * runs, the bytes must equal what `CryptoJS.PBKDF2` produced before, or every
+ * stored PIN hash and wrapped blob on every existing install becomes
+ * unreadable. These tests pin exactly that.
+ *
+ * Under jest there is no native runtime, so `pbkdf2Hex` resolves to the CryptoJS
+ * backend — which is the pre-existing implementation. That makes these tests a
+ * regression gate on the fallback path and on the KAT itself; the native path is
+ * gated at runtime by the same KAT and verified on-device.
+ */
+import CryptoJS from 'crypto-js';
+import 'crypto-js/pbkdf2';
+
+import {
+  pbkdf2Hex,
+  getPbkdf2Backend,
+  PBKDF2_PARITY_KAT,
+  __resetPbkdf2BackendForTests,
+} from '../pbkdf2Kdf';
+
+/** The exact call the old inline `customPBKDF2` made, kept as the oracle. */
+const legacyCryptoJsPbkdf2 = (
+  password: string,
+  saltHex: string,
+  iterations: number,
+  keyLength: number
+): string => {
+  const saltWA = CryptoJS.enc.Hex.parse(saltHex);
+  return CryptoJS.PBKDF2(password, saltWA, {
+    keySize: keyLength / 4,
+    iterations,
+    hasher: CryptoJS.algo.SHA256,
+  }).toString(CryptoJS.enc.Hex);
+};
+
+beforeEach(() => {
+  __resetPbkdf2BackendForTests();
+});
+
+describe('pbkdf2Kdf', () => {
+  it('reproduces the hardcoded known-answer vector', async () => {
+    const out = await pbkdf2Hex(
+      PBKDF2_PARITY_KAT.pw,
+      PBKDF2_PARITY_KAT.saltHex,
+      PBKDF2_PARITY_KAT.iterations,
+      PBKDF2_PARITY_KAT.dkLen
+    );
+    expect(out).toBe(PBKDF2_PARITY_KAT.expectedHex);
+  });
+
+  it('the KAT itself matches what CryptoJS produces', () => {
+    // Guards against a typo'd vector silently disabling the native path
+    // forever: if this drifts, the parity gate would reject a CORRECT native
+    // backend and every device would fall back to the slow implementation.
+    expect(
+      legacyCryptoJsPbkdf2(
+        PBKDF2_PARITY_KAT.pw,
+        PBKDF2_PARITY_KAT.saltHex,
+        PBKDF2_PARITY_KAT.iterations,
+        PBKDF2_PARITY_KAT.dkLen
+      )
+    ).toBe(PBKDF2_PARITY_KAT.expectedHex);
+  });
+
+  it.each([
+    ['1234', 'aabbccddeeff00112233445566778899', 1000, 32],
+    ['a-much-longer-passphrase with spaces', '00'.repeat(16), 500, 32],
+    ['unicode-✓-secret', 'ff'.repeat(16), 250, 16],
+  ])(
+    'is byte-identical to the previous CryptoJS implementation (%s)',
+    async (pw, salt, iters, len) => {
+      const expected = legacyCryptoJsPbkdf2(
+        pw as string,
+        salt as string,
+        iters as number,
+        len as number
+      );
+      await expect(
+        pbkdf2Hex(pw as string, salt as string, iters as number, len as number)
+      ).resolves.toBe(expected);
+    }
+  );
+
+  it('falls back to the JS backend when no native module is present', async () => {
+    expect(getPbkdf2Backend()).toBe('unresolved');
+    await pbkdf2Hex('x', '00'.repeat(16), 10, 32);
+    // jest has no react-native-quick-crypto runtime, so the require fails safely.
+    expect(getPbkdf2Backend()).toBe('js');
+  });
+
+  it('returns lowercase hex of exactly keyLength bytes', async () => {
+    const out = await pbkdf2Hex('secret', '00'.repeat(16), 10, 32);
+    expect(out).toMatch(/^[0-9a-f]{64}$/);
+  });
+});

--- a/src/services/secure/pbkdf2Kdf.ts
+++ b/src/services/secure/pbkdf2Kdf.ts
@@ -1,0 +1,226 @@
+/**
+ * PBKDF2 backend — native-first with a self-validating CryptoJS fallback.
+ *
+ * WHY: `CryptoJS.PBKDF2` is pure JavaScript. At the PIN params (8000 iterations
+ * of HMAC-SHA256) it costs ~1.2-1.36 SECONDS per derivation on Android Hermes
+ * (measured on-device, TASK-311), and the unlock path runs it five times — once
+ * per account plus the initial verification. That is ~6.3s of a ~7s window in
+ * which the JS thread is pinned and the whole app is unresponsive.
+ *
+ * This is the same fix HT-138 applied to scrypt one layer over in `scryptKdf.ts`
+ * (13-19s → 60-70ms). PBKDF2 sat on the SAME unlock path and was never migrated,
+ * so it ended up costing ~20× the scrypt it runs next to. This module is
+ * deliberately shaped like `scryptKdf.ts` so the two read as one pattern.
+ *
+ * SAFETY — the byte-parity gate: PBKDF2-HMAC-SHA256 is deterministic and
+ * standard, so native output is BYTE-IDENTICAL to CryptoJS for the same
+ * (password, salt, iterations, dkLen). Verified against both OpenSSL and
+ * crypto-js while writing this. That makes it a pure backend swap: existing
+ * stored hashes and wrapped blobs stay readable, with NO re-hash, NO re-wrap and
+ * NO format change.
+ *
+ * Even so, a WRONG native backend (digest mismatch, encoding quirk, bad build)
+ * used to WRITE a PIN hash would lock the user out of their own wallet. So
+ * native is trusted ONLY after reproducing a hardcoded known-answer vector
+ * exactly, once per session. On any mismatch, load failure or runtime error we
+ * fall back to CryptoJS — always correct, just slow.
+ *
+ * FALLBACK CONTEXTS: jest (no native runtime) and any build without the native
+ * module resolve to the CryptoJS path automatically.
+ *
+ * SECURITY: never logs the password, salt or derived bytes — only the backend
+ * name and the parity result.
+ */
+import CryptoJS from 'crypto-js';
+import 'crypto-js/pbkdf2';
+
+export type Pbkdf2Backend = 'native' | 'js';
+
+/**
+ * Known-answer vector: PBKDF2-HMAC-SHA256(utf8(pw), hex(saltHex), 1000, 32).
+ * Cross-checked to be identical under OpenSSL (`crypto.pbkdf2Sync`) and
+ * `CryptoJS.PBKDF2` before being hardcoded here. Iterations are low so the
+ * one-time parity check stays cheap even when it runs on the pure-JS backend.
+ * Byte-parity is iteration-independent for correct PBKDF2, so a low-iteration
+ * match proves the algorithm, digest and encoding all agree.
+ */
+export const PBKDF2_PARITY_KAT = {
+  pw: 'voi-pbkdf2-parity-vector/v1',
+  saltHex: '0123456789abcdef0123456789abcdef',
+  iterations: 1000,
+  dkLen: 32,
+  expectedHex:
+    '20457c536326859d20ce06a6422ecd283dab810e502acc2fd3abd689c916be66',
+} as const;
+
+/** Node-compatible native pbkdf2 signature (react-native-quick-crypto). */
+type NativePbkdf2 = (
+  password: Uint8Array,
+  salt: Uint8Array,
+  iterations: number,
+  keylen: number,
+  digest: string,
+  callback: (err: Error | null, derivedKey: Uint8Array) => void
+) => void;
+
+let resolvedBackend: Pbkdf2Backend | undefined;
+let backendResolution: Promise<Pbkdf2Backend> | undefined;
+let nativeFn: NativePbkdf2 | null = null;
+
+const hexToBytes = (hex: string): Uint8Array => {
+  const out = new Uint8Array(hex.length / 2);
+  for (let i = 0; i < out.length; i++) {
+    out[i] = parseInt(hex.substr(i * 2, 2), 16);
+  }
+  return out;
+};
+
+const bytesToHex = (bytes: Uint8Array): string => {
+  let s = '';
+  for (let i = 0; i < bytes.length; i++) {
+    s += bytes[i].toString(16).padStart(2, '0');
+  }
+  return s;
+};
+
+/**
+ * Static-literal require so Metro bundles the native module on device; throws in
+ * jest / non-native contexts, where we transparently fall back to CryptoJS.
+ */
+function loadNativePbkdf2(): NativePbkdf2 | null {
+  try {
+    // eslint-disable-next-line @typescript-eslint/no-require-imports
+    const qc = require('react-native-quick-crypto');
+    const fn = (qc?.pbkdf2 ?? qc?.default?.pbkdf2) as NativePbkdf2 | undefined;
+    return typeof fn === 'function' ? fn : null;
+  } catch {
+    return null;
+  }
+}
+
+function callNative(
+  fn: NativePbkdf2,
+  pw: Uint8Array,
+  salt: Uint8Array,
+  iterations: number,
+  keyLength: number
+): Promise<Uint8Array> {
+  return new Promise((resolve, reject) => {
+    try {
+      fn(pw, salt, iterations, keyLength, 'sha256', (err, derivedKey) => {
+        if (err) reject(err);
+        else resolve(Uint8Array.from(derivedKey));
+      });
+    } catch (syncErr) {
+      reject(syncErr);
+    }
+  });
+}
+
+/** The original pure-JS path, kept verbatim as the fallback. */
+function jsPbkdf2(
+  password: string,
+  saltHex: string,
+  iterations: number,
+  keyLength: number
+): string {
+  const saltWA = CryptoJS.enc.Hex.parse(saltHex);
+  const derived = CryptoJS.PBKDF2(password, saltWA, {
+    keySize: keyLength / 4, // CryptoJS keySize is in 32-bit words
+    iterations,
+
+    hasher: (CryptoJS.algo as any).SHA256,
+  });
+  return derived.toString(CryptoJS.enc.Hex);
+}
+
+/** Resolve (once per session) whether native pbkdf2 is present AND byte-correct. */
+async function resolveBackend(): Promise<Pbkdf2Backend> {
+  if (resolvedBackend) return resolvedBackend;
+  if (backendResolution) return backendResolution;
+
+  backendResolution = (async (): Promise<Pbkdf2Backend> => {
+    const native = loadNativePbkdf2();
+    if (!native) {
+      resolvedBackend = 'js';
+      return 'js';
+    }
+    try {
+      const out = await callNative(
+        native,
+        new TextEncoder().encode(PBKDF2_PARITY_KAT.pw),
+        hexToBytes(PBKDF2_PARITY_KAT.saltHex),
+        PBKDF2_PARITY_KAT.iterations,
+        PBKDF2_PARITY_KAT.dkLen
+      );
+      if (bytesToHex(out) === PBKDF2_PARITY_KAT.expectedHex) {
+        nativeFn = native;
+        resolvedBackend = 'native';
+        if (__DEV__) console.log('[pbkdf2Kdf] backend=native (byte-parity OK)');
+        return 'native';
+      }
+      // Present but WRONG — must never write a PIN hash with it.
+      console.warn(
+        '[pbkdf2Kdf] native pbkdf2 failed byte-parity; using CryptoJS fallback'
+      );
+    } catch (e) {
+      if (__DEV__) {
+        console.log(
+          '[pbkdf2Kdf] native pbkdf2 unavailable; CryptoJS fallback',
+          e
+        );
+      }
+    }
+    resolvedBackend = 'js';
+    return 'js';
+  })();
+
+  return backendResolution;
+}
+
+/**
+ * PBKDF2-HMAC-SHA256, returned as a lowercase hex string of `keyLength` bytes.
+ * Byte-identical across backends, so callers cannot observe which one ran.
+ */
+export async function pbkdf2Hex(
+  password: string,
+  saltHex: string,
+  iterations: number,
+  keyLength: number
+): Promise<string> {
+  const backend = await resolveBackend();
+  if (backend === 'native' && nativeFn) {
+    try {
+      const out = await callNative(
+        nativeFn,
+        new TextEncoder().encode(password),
+        hexToBytes(saltHex),
+        iterations,
+        keyLength
+      );
+      return bytesToHex(out);
+    } catch (e) {
+      // Passed parity but failed at runtime — degrade to CryptoJS for THIS call
+      // (correctness over speed). Never surface an unwrapped native error.
+      if (__DEV__) {
+        console.log(
+          '[pbkdf2Kdf] native call failed; CryptoJS for this call',
+          e
+        );
+      }
+    }
+  }
+  return jsPbkdf2(password, saltHex, iterations, keyLength);
+}
+
+/** Which backend is active ('unresolved' before the first pbkdf2Hex). Dev/tests. */
+export function getPbkdf2Backend(): Pbkdf2Backend | 'unresolved' {
+  return resolvedBackend ?? 'unresolved';
+}
+
+/** Test-only: reset the memoized backend so a suite can re-resolve. */
+export function __resetPbkdf2BackendForTests(): void {
+  resolvedBackend = undefined;
+  backendResolution = undefined;
+  nativeFn = null;
+}

--- a/src/services/snowball/__tests__/quoteWireFormat.test.ts
+++ b/src/services/snowball/__tests__/quoteWireFormat.test.ts
@@ -1,0 +1,208 @@
+// The Snowball API requires every asset/app ID as a STRING of digits and
+// rejects the whole request otherwise:
+//
+//   POST /quote {"inputToken":410419,...}
+//     → 400 {"error":"Invalid inputToken/outputToken: must be a string of
+//                     digits (asset/app id) <= 9007199254740891"}
+//
+// The app carries IDs as numbers (/config/tokens returns them inconsistently —
+// "0" as a string, 300279 as a number — so getTokens normalizes to number), and
+// the request objects were passed to JSON.stringify verbatim. Every Voi quote
+// therefore 400'd. Worse, the 400 was unreadable: makeRequest read only
+// `errorData.message`, but the API answers with `errorData.error`, and RN's
+// fetch leaves `statusText` empty — so the reason collapsed to the literal
+// string "HTTP 400: " and the real explanation was thrown away unread.
+//
+// These tests pin both halves: what goes out on the wire, and what comes back
+// out of a failure.
+
+import SnowballApiService, { SnowballApiError } from '@/services/snowball';
+
+const ADDRESS = 'BUD2763FMK6EYVKGHWWUN4QKHPSPCVFUEPPI4PQCPGYVPGQ6GNKBX6IXCQ';
+
+const okResponse = (body: unknown) => ({
+  ok: true,
+  status: 200,
+  statusText: '',
+  json: async () => body,
+});
+
+const errorResponse = (status: number, body: unknown, statusText = '') => ({
+  ok: false,
+  status,
+  statusText,
+  json: async () => body,
+});
+
+/** The request body the service actually put on the wire, parsed. */
+const sentBody = (fetchMock: jest.Mock, call = 0) =>
+  JSON.parse(fetchMock.mock.calls[call][1].body as string);
+
+describe('Snowball wire format (TASK-313)', () => {
+  let fetchMock: jest.Mock;
+
+  beforeEach(() => {
+    fetchMock = jest.fn();
+    (global as unknown as { fetch: unknown }).fetch = fetchMock;
+    SnowballApiService.clearCache();
+  });
+
+  describe('getQuote', () => {
+    it('sends token IDs as strings of digits, not numbers', async () => {
+      fetchMock.mockResolvedValue(okResponse({ quote: {} }));
+
+      await SnowballApiService.getQuote({
+        inputToken: 410419,
+        outputToken: 0,
+        amount: '100000000',
+        address: ADDRESS,
+        slippageTolerance: 0.01,
+      });
+
+      const body = sentBody(fetchMock);
+      expect(body.inputToken).toBe('410419');
+      expect(body.outputToken).toBe('0');
+      // The native token is ID 0 — it must survive as "0", not become 0 or "".
+      expect(typeof body.inputToken).toBe('string');
+      expect(typeof body.outputToken).toBe('string');
+    });
+
+    it('stringifies poolId, which the API rejects as a number too', async () => {
+      fetchMock.mockResolvedValue(okResponse({ quote: {} }));
+
+      await SnowballApiService.getQuote({
+        inputToken: 0,
+        outputToken: 420069,
+        amount: '1000000',
+        poolId: 429999,
+      });
+
+      expect(sentBody(fetchMock).poolId).toBe('429999');
+    });
+
+    it('omits poolId entirely when it was not requested', async () => {
+      fetchMock.mockResolvedValue(okResponse({ quote: {} }));
+
+      await SnowballApiService.getQuote({
+        inputToken: 0,
+        outputToken: 420069,
+        amount: '1000000',
+      });
+
+      expect(sentBody(fetchMock)).not.toHaveProperty('poolId');
+    });
+
+    it('passes the non-ID fields through untouched', async () => {
+      fetchMock.mockResolvedValue(okResponse({ quote: {} }));
+
+      await SnowballApiService.getQuote({
+        inputToken: 410419,
+        outputToken: 0,
+        amount: '100000000',
+        address: ADDRESS,
+        slippageTolerance: 0.01,
+        dex: ['humbleswap'],
+      });
+
+      const body = sentBody(fetchMock);
+      expect(body.amount).toBe('100000000');
+      expect(body.address).toBe(ADDRESS);
+      expect(body.slippageTolerance).toBe(0.01);
+      expect(body.dex).toEqual(['humbleswap']);
+    });
+
+    it('rejects an unrepresentable ID before it reaches the network', async () => {
+      await expect(
+        SnowballApiService.getQuote({
+          inputToken: Number.MAX_SAFE_INTEGER + 2,
+          outputToken: 0,
+          amount: '1',
+        })
+      ).rejects.toThrow(/inputToken/);
+
+      expect(fetchMock).not.toHaveBeenCalled();
+    });
+  });
+
+  describe('unwrap', () => {
+    it('sends wrappedTokenId as a string of digits', async () => {
+      fetchMock.mockResolvedValue(okResponse({ transactions: [] }));
+
+      await SnowballApiService.unwrap({
+        address: ADDRESS,
+        items: [
+          { wrappedTokenId: 410419, amount: '1' },
+          { wrappedTokenId: 420069, amount: '2' },
+        ],
+      });
+
+      const body = sentBody(fetchMock);
+      expect(body.items).toEqual([
+        { wrappedTokenId: '410419', amount: '1' },
+        { wrappedTokenId: '420069', amount: '2' },
+      ]);
+      expect(body.address).toBe(ADDRESS);
+    });
+  });
+
+  describe('error surfacing', () => {
+    it("reports the API's `error` field instead of an empty status line", async () => {
+      const apiReason =
+        'Invalid inputToken/outputToken: must be a string of digits (asset/app id) <= 9007199254740991';
+      fetchMock.mockResolvedValue(errorResponse(400, { error: apiReason }));
+
+      await expect(
+        SnowballApiService.getQuote({
+          inputToken: 410419,
+          outputToken: 0,
+          amount: '1',
+        })
+      ).rejects.toMatchObject({
+        name: 'SnowballApiError',
+        message: apiReason,
+        statusCode: 400,
+      });
+    });
+
+    it('still prefers `message` when the API sends one', async () => {
+      fetchMock.mockResolvedValue(
+        errorResponse(400, { message: 'from message', error: 'from error' })
+      );
+
+      await expect(
+        SnowballApiService.getQuote({
+          inputToken: 1,
+          outputToken: 0,
+          amount: '1',
+        })
+      ).rejects.toThrow('from message');
+    });
+
+    it('does not leave a dangling colon when statusText is empty', async () => {
+      // RN's fetch gives an empty statusText; the old fallback produced the
+      // bare, uninformative "HTTP 400: " that sent this bug to a device.
+      fetchMock.mockResolvedValue(errorResponse(400, {}));
+
+      const error = await SnowballApiService.getQuote({
+        inputToken: 1,
+        outputToken: 0,
+        amount: '1',
+      }).catch((e: unknown) => e);
+
+      expect(error).toBeInstanceOf(SnowballApiError);
+      expect((error as Error).message).toBe('HTTP 400');
+    });
+
+    it('keeps statusText when the platform provides one', async () => {
+      fetchMock.mockResolvedValue(errorResponse(404, {}, 'Not Found'));
+
+      await expect(
+        SnowballApiService.getQuote({
+          inputToken: 1,
+          outputToken: 0,
+          amount: '1',
+        })
+      ).rejects.toThrow('HTTP 404: Not Found');
+    });
+  });
+});

--- a/src/services/snowball/index.ts
+++ b/src/services/snowball/index.ts
@@ -30,6 +30,35 @@ export class SnowballApiError extends Error {
   }
 }
 
+/**
+ * Serialize an asset/app ID for the wire.
+ *
+ * The API rejects numeric IDs outright:
+ *   {"error":"Invalid inputToken/outputToken: must be a string of digits
+ *             (asset/app id) <= 9007199254740991"}
+ * and applies the same rule to `poolId` and to `items[].wrappedTokenId` on
+ * /unwrap. It is strict about the whole payload — one numeric field is enough
+ * for a 400, so every ID goes through here.
+ *
+ * The app carries IDs as numbers (see QuoteRequest's note), and the API's
+ * ceiling is exactly Number.MAX_SAFE_INTEGER, so `String(id)` is lossless for
+ * every ID the API will accept. Non-integer or out-of-range input would
+ * serialize to something the API rejects with an opaque 400, so it is caught
+ * here instead, where the message can name the field.
+ */
+const toWireId = (id: number | string, field: string): string => {
+  if (typeof id === 'string') {
+    if (!/^\d+$/.test(id)) {
+      throw new SnowballApiError(`Invalid ${field}: expected an asset/app ID`);
+    }
+    return id;
+  }
+  if (!Number.isSafeInteger(id) || id < 0) {
+    throw new SnowballApiError(`Invalid ${field}: expected an asset/app ID`);
+  }
+  return String(id);
+};
+
 export class SnowballApiService {
   private static instance: SnowballApiService;
   private tokensCache: CachedData<SnowballToken[]> | null = null;
@@ -70,9 +99,16 @@ export class SnowballApiService {
 
       if (!response.ok) {
         const errorData = await response.json().catch(() => ({}));
+        // The API reports failures as {"error": "..."}, not {"message": ...},
+        // and RN's fetch leaves `statusText` empty — so reading only `message`
+        // collapsed every 400 to the literal, useless string "HTTP 400: "
+        // while the actual reason sat unread in the body.
         throw new SnowballApiError(
           errorData.message ||
-            `HTTP ${response.status}: ${response.statusText}`,
+            errorData.error ||
+            `HTTP ${response.status}${
+              response.statusText ? `: ${response.statusText}` : ''
+            }`,
           response.status
         );
       }
@@ -186,9 +222,15 @@ export class SnowballApiService {
    * Get swap quote
    */
   public async getQuote(request: QuoteRequest): Promise<SwapQuote> {
+    const { inputToken, outputToken, poolId, ...rest } = request;
     return await this.makeRequest<SwapQuote>('/quote', {
       method: 'POST',
-      body: JSON.stringify(request),
+      body: JSON.stringify({
+        ...rest,
+        inputToken: toWireId(inputToken, 'inputToken'),
+        outputToken: toWireId(outputToken, 'outputToken'),
+        ...(poolId !== undefined ? { poolId: toWireId(poolId, 'poolId') } : {}),
+      }),
     });
   }
 
@@ -200,7 +242,16 @@ export class SnowballApiService {
   ): Promise<{ transactions: string[] }> {
     return await this.makeRequest<{ transactions: string[] }>('/unwrap', {
       method: 'POST',
-      body: JSON.stringify(request),
+      body: JSON.stringify({
+        ...request,
+        items: request.items.map((item, i) => ({
+          ...item,
+          wrappedTokenId: toWireId(
+            item.wrappedTokenId,
+            `items[${i}].wrappedTokenId`
+          ),
+        })),
+      }),
     });
   }
 

--- a/src/services/snowball/types.ts
+++ b/src/services/snowball/types.ts
@@ -95,17 +95,35 @@ export interface PlatformFee {
 
 /**
  * Swap quote response from Snowball API
+ *
+ * NOTE: the API answers HTTP 200 even when it priced the swap but could not
+ * BUILD it — `unsignedTransactions` comes back empty and the reason is carried
+ * in `error`/`simulationError`. See `SnowballSwapAdapter.getQuote`.
  */
 export interface SwapQuote {
   quote: QuoteDetails;
   unsignedTransactions: string[]; // Base64 encoded unsigned transactions
   route: Route;
-  poolId: string;
+  poolId: string | null; // null when the route is multi-hop or unpinned
   platformFee: PlatformFee;
+  /** Why transaction building failed, on an otherwise-200 response. */
+  error?: string | null;
+  /** Why simulating the built group failed, on an otherwise-200 response. */
+  simulationError?: string | null;
+  /** True when the quote was priced over a reduced set of pools. */
+  routeDegraded?: boolean;
+  skippedPools?: unknown[];
 }
 
 /**
- * Quote request parameters
+ * Quote request parameters.
+ *
+ * IDs are numbers here — the app normalizes every token ID to a number
+ * (`SnowballToken.id`, `SwapToken.id`), because /config/tokens returns them
+ * inconsistently ("0" as a string, 300279 as a number). The API requires them
+ * as strings of digits on the wire; that conversion happens once, in
+ * `SnowballApiService`, so the wire format stays a concern of the service that
+ * owns the wire.
  */
 export interface QuoteRequest {
   inputToken: number;
@@ -118,7 +136,8 @@ export interface QuoteRequest {
 }
 
 /**
- * Unwrap request parameters
+ * Unwrap request parameters. `wrappedTokenId` is stringified on the wire for
+ * the same reason as `QuoteRequest`'s IDs.
  */
 export interface UnwrapRequest {
   address: string;

--- a/src/services/swap/__tests__/degradedQuote.test.ts
+++ b/src/services/swap/__tests__/degradedQuote.test.ts
@@ -1,0 +1,164 @@
+// A Snowball 200 does NOT mean the swap is executable.
+//
+// The API prices the route and builds the transaction group in one call. When
+// only the second half fails it still answers 200: `unsignedTransactions` comes
+// back empty and the reason sits in `error`/`simulationError`. Observed on a
+// live multi-hop route (410419 → 420069 → 0):
+//
+//   "Failed to generate swap transactions: Failed to build a fully-verified
+//    transaction group: Strict resource verification did not converge after 8
+//    iterations: tx references exceed MaxAppTotalTxnReferences = 8"
+//
+// Unguarded, the adapter copied that empty array through, SwapScreen rendered a
+// healthy-looking quote, and Review navigated to UniversalTransactionSigning
+// with ZERO transactions to sign.
+//
+// The guard is gated on userAddress because an empty array is legitimate
+// without one — an address-less request is a price-only quote.
+
+// AsyncStorage — force the community jest mock so networkStore, which
+// src/services/swap imports for provider selection, resolves.
+jest.mock('@react-native-async-storage/async-storage', () =>
+  require('@react-native-async-storage/async-storage/jest/async-storage-mock')
+);
+
+import { SwapService, SwapServiceError } from '@/services/swap';
+import SnowballApiService from '@/services/snowball';
+import { NetworkId } from '@/types/network';
+
+const ADDRESS = 'BUD2763FMK6EYVKGHWWUN4QKHPSPCVFUEPPI4PQCPGYVPGQ6GNKBX6IXCQ';
+
+const BUILD_FAILURE =
+  'Failed to generate swap transactions: Failed to build a fully-verified ' +
+  'transaction group: Strict resource verification did not converge after 8 ' +
+  'iterations: tx references exceed MaxAppTotalTxnReferences = 8';
+
+const QUOTE_DETAILS = {
+  inputAmount: '100000000',
+  outputAmount: '39918194',
+  minimumOutputAmount: '39519012',
+  rate: 0.39918194,
+  priceImpact: 0.00008537382481471524,
+  networkFee: '0',
+};
+
+const ROUTE = {
+  type: 'direct' as const,
+  pools: [
+    {
+      poolId: '429999',
+      dex: 'humbleswap',
+      inputAmount: '100000000',
+      outputAmount: '39918194',
+    },
+  ],
+};
+
+function quoteResponse(overrides: Record<string, unknown> = {}) {
+  return {
+    ok: true,
+    status: 200,
+    statusText: '',
+    json: async () => ({
+      quote: QUOTE_DETAILS,
+      unsignedTransactions: ['dHhu'],
+      route: ROUTE,
+      poolId: null,
+      platformFee: {
+        gain: '0',
+        feeAmount: '0',
+        feeBps: 0,
+        feeAddress: null,
+        applied: false,
+      },
+      ...overrides,
+    }),
+  };
+}
+
+const REQUEST = {
+  inputTokenId: 410419,
+  outputTokenId: 0,
+  amount: '100000000',
+  userAddress: ADDRESS,
+  slippageTolerance: 1,
+};
+
+describe('SnowballSwapAdapter degraded-quote guard', () => {
+  let fetchMock: jest.Mock;
+
+  beforeEach(() => {
+    fetchMock = jest.fn();
+    (global as unknown as { fetch: unknown }).fetch = fetchMock;
+    SnowballApiService.clearCache();
+  });
+
+  const provider = () => SwapService.getProvider(NetworkId.VOI_MAINNET);
+
+  it('rejects a 200 whose transaction group could not be built', async () => {
+    fetchMock.mockResolvedValue(
+      quoteResponse({
+        unsignedTransactions: [],
+        error: BUILD_FAILURE,
+        simulationError: BUILD_FAILURE,
+      })
+    );
+
+    const error = await provider()
+      .getQuote(REQUEST)
+      .catch((e: unknown) => e);
+
+    expect(error).toBeInstanceOf(SwapServiceError);
+    expect((error as SwapServiceError).message).toBe(BUILD_FAILURE);
+    expect((error as SwapServiceError).provider).toBe('snowball');
+  });
+
+  it('falls back to simulationError when only that is populated', async () => {
+    fetchMock.mockResolvedValue(
+      quoteResponse({ unsignedTransactions: [], simulationError: 'sim failed' })
+    );
+
+    await expect(provider().getQuote(REQUEST)).rejects.toThrow('sim failed');
+  });
+
+  it('explains itself when the API gives no reason at all', async () => {
+    fetchMock.mockResolvedValue(quoteResponse({ unsignedTransactions: [] }));
+
+    await expect(provider().getQuote(REQUEST)).rejects.toThrow(
+      /could not be built/
+    );
+  });
+
+  it('allows an empty transaction list for a price-only quote', async () => {
+    // No userAddress: the API never returns transactions for these, so an
+    // empty array is the expected shape, not a failure.
+    fetchMock.mockResolvedValue(quoteResponse({ unsignedTransactions: [] }));
+
+    const quote = await provider().getQuote({
+      ...REQUEST,
+      userAddress: undefined,
+    });
+
+    expect(quote.unsignedTransactions).toEqual([]);
+    expect(quote.outputAmount).toBe('39918194');
+  });
+
+  it('passes a healthy quote through untouched', async () => {
+    fetchMock.mockResolvedValue(quoteResponse());
+
+    const quote = await provider().getQuote(REQUEST);
+
+    expect(quote.unsignedTransactions).toEqual(['dHhu']);
+    expect(quote.provider).toBe('snowball');
+    expect(quote.minimumOutputAmount).toBe('39519012');
+  });
+
+  it('converts percentage slippage to the decimal the API expects', async () => {
+    fetchMock.mockResolvedValue(quoteResponse());
+
+    await provider().getQuote({ ...REQUEST, slippageTolerance: 1 });
+
+    const body = JSON.parse(fetchMock.mock.calls[0][1].body as string);
+    expect(body.slippageTolerance).toBe(0.01);
+  });
+});

--- a/src/services/swap/index.ts
+++ b/src/services/swap/index.ts
@@ -110,6 +110,27 @@ class SnowballSwapAdapter implements SwapProvider {
         : undefined,
     });
 
+    // A 200 does NOT mean the swap is executable. The API prices the route and
+    // builds the transaction group in the same call, and when only the second
+    // half fails it still answers 200 — `unsignedTransactions` comes back empty
+    // and the reason sits in `error`/`simulationError` (observed: "Strict
+    // resource verification did not converge after 8 iterations: tx references
+    // exceed MaxAppTotalTxnReferences = 8" on a multi-hop route). Unguarded,
+    // that quote renders as healthy and SwapScreen's Review button navigates
+    // into UniversalTransactionSigning with ZERO transactions to sign.
+    //
+    // Gated on userAddress because an empty array is legitimate without one:
+    // an address-less request is a price-only quote and never carries
+    // transactions. SwapScreen always sends an address.
+    if (request.userAddress && quote.unsignedTransactions?.length === 0) {
+      throw new SwapServiceError(
+        quote.error ||
+          quote.simulationError ||
+          'This route could not be built into a swap transaction.',
+        'snowball'
+      );
+    }
+
     return {
       inputAmount: quote.quote.inputAmount,
       outputAmount: quote.quote.outputAmount,

--- a/src/store/__tests__/accountErrorScoping.test.ts
+++ b/src/store/__tests__/accountErrorScoping.test.ts
@@ -90,7 +90,11 @@ const accountState = (id: string) =>
   useWalletStore.getState().accountStates[id];
 
 describe('operation-scoped account errors (TASK-40)', () => {
+  let consoleError: jest.SpyInstance;
+
   beforeEach(() => {
+    // Silenced, and asserted on below — a failed balance load must LOG.
+    consoleError = jest.spyOn(console, 'error').mockImplementation(() => {});
     mockGetAccountBalance.mockReset();
     mockGetTransactionHistory.mockReset();
     mockGetAllTransactionHistory.mockReset();
@@ -109,6 +113,21 @@ describe('operation-scoped account errors (TASK-40)', () => {
 
     expect(accountState('acc-1').balanceError).toBe('algod is down');
     expect(accountState('acc-1').transactionsError).toBeNull();
+  });
+
+  it('logs a balance failure instead of swallowing it', async () => {
+    // The catch wrote balanceError and nothing else — no console output. Every
+    // screen that does not render balanceError (SwapScreen among them) was left
+    // with a permanently balance-less account and no trace of why, which is
+    // what forced this bug onto a device to be found at all.
+    mockGetAccountBalance.mockRejectedValue(new Error('algod is down'));
+
+    await useWalletStore.getState().loadAccountBalance('acc-1', true);
+
+    expect(consoleError).toHaveBeenCalledWith(
+      expect.stringContaining('acc-1'),
+      expect.objectContaining({ message: 'algod is down' })
+    );
   });
 
   it('records a transaction failure under transactionsError, not balanceError', async () => {

--- a/src/store/walletStore.ts
+++ b/src/store/walletStore.ts
@@ -1327,6 +1327,17 @@ export const useWalletStore = create<WalletState>()(
             }, 0);
           }
         } catch (error) {
+          // A failed balance load used to be completely silent: it wrote
+          // balanceError into state, but nothing logged and — outside HomeScreen,
+          // which renders that error — nothing displayed it either. The account
+          // just stayed balance-less. SwapScreen's one-shot load effect is keyed
+          // on `!singleNetworkBalance`, which never changes after a failure, so
+          // it could not even retry. Diagnosing that took device instrumentation
+          // for want of one line.
+          console.error(
+            `Failed to load balance for account ${accountId}:`,
+            error
+          );
           const { accountStates: latestAccountStates } = get();
           set({
             accountStates: {


### PR DESCRIPTION
Post-Audit-II device regression triage (PLAN-310), plus two bugs found while fixing the swap path. Seven commits, one per task.

## Swap quote — two independent bugs

`ERROR Error fetching quote: [SnowballApiError: HTTP 400: ]`. Both causes reproduced against the live API.

**1. App side (TASK-313).** `FABRadialMenu` navigated to Swap with `{ accountId: activeAccount.address }` instead of `.id`. Everything downstream keys on the ID — `wallet.accounts.find(acc => acc.id === accountId)`, `accountStates[accountId]`, `loadAccountBalance(accountId)` — so an address silently missed every lookup. The balance never loaded, and `TokenSelector`, which gates its entire token load on that balance, spun on "Loading tokens…" forever. Both fields are `string`, so the compiler was blind to it.

**2. API side (TASK-319).** Snowball requires every asset/app ID as a **string of digits**:

```
POST /quote {"inputToken":410419,...}
  → 400 {"error":"Invalid inputToken/outputToken: must be a string of digits (asset/app id) <= 9007199254740991"}
POST /quote {"inputToken":"410419",...}
  → 200
```

The rule also covers `poolId` and `/unwrap`'s `items[].wrappedTokenId`, and the API is strict about the whole payload — one numeric field is enough for a 400. The app carries IDs as numbers on purpose (`/config/tokens` returns them inconsistently: `"0"` as a string, `300279` as a number), so the conversion happens once, in the service that owns the wire.

**Why the error was unreadable:** `makeRequest` read only `errorData.message`, but the API answers with `errorData.error`, and RN's `fetch` leaves `statusText` empty — so the reason collapsed to the literal `"HTTP 400: "` and the real explanation was discarded unread.

## Degraded 200 reaching the signing screen (TASK-320)

Snowball prices the route and builds the transaction group in one call; when only the second half fails it still answers **200**, with an empty `unsignedTransactions` and the reason in `error`/`simulationError`. Observed live on a multi-hop route: *"Strict resource verification did not converge after 8 iterations: tx references exceed MaxAppTotalTxnReferences = 8"*. The adapter copied that empty array through, so Review navigated into `UniversalTransactionSigning` with zero transactions. Now rejected — gated on `userAddress`, since an address-less price-only quote legitimately carries none.

## Startup stall (TASK-311)

`CryptoJS.PBKDF2` is pure JS: ~1.2–1.36s per derivation at the PIN params on Android Hermes, and unlock runs it five times — ~6.3s of a ~7s window with the JS thread pinned. New `pbkdf2Kdf.ts` shim, shaped after the existing `scryptKdf.ts` (HT-138). PBKDF2-HMAC-SHA256 is deterministic, so native output is byte-identical: **no re-hash, no re-wrap, no format change**. Native is trusted only after reproducing a hardcoded known-answer vector once per session — a wrong backend used to *write* a PIN hash would lock a user out of their own wallet — and falls back to CryptoJS on any mismatch.

## Back-navigation flash (TASK-312)

Bisected on device: Test A (minify OFF + shrinkResources OFF) removed the flash, proving R8; Test B (minify ON, shrinkResources OFF) reproduced it, isolating **code** shrinking and exonerating resource shrinking. `react-native-screens` ships no consumer proguard rules, and RN's own rules don't reach it (`-keepnames` prevents renaming but still allows shrinking). Fixed with a keep rule, so both TASK-209 size wins stay enabled rather than being traded away.

## Washed-out dark cards (TASK-314)

`BlurredContainer` conflated "has an NFT background" with "may blur", so `disableBlur` (used by virtualized rows to avoid the Android BlurView recycling crash) painted a white veil straight onto the artwork. Split the conditions and gave the no-blur-but-image case a dark scrim. Kept as a literal rather than a new `theme.colors` key on purpose: `themeStorage.ts` rehydrates the serialized Theme verbatim, so a new key would come back `undefined` for everyone with an NFT theme saved before the upgrade.

## Silent balance failures (TASK-321)

`loadAccountBalance`'s catch wrote `balanceError` and nothing else — no console output. Only HomeScreen renders that field, so elsewhere a failed load left the account permanently balance-less with no trace of why. That silence is why the FAB bug needed device instrumentation to find. Now logged, and surfaced on SwapScreen with a forced retry (its load effect is one-shot and could not recover).

## Test infrastructure

`@txnlab/deflex` is ESM-only (no `require` condition in its exports map) and `src/services/swap` imports it transitively — so **no test of the unified swap service could load at all**, which is why the adapter had zero coverage when this regression landed. Added a jest shim alongside the existing netinfo / quick-crypto ones.

## Gates

- `tsc --noEmit`: 0 errors
- `eslint`: 0 errors, 157 warnings (baseline unchanged)
- `jest`: **1936 passing**, up from 1912 — 138 suites, all green

New coverage: 10 tests on the Snowball wire format and error surfacing, 6 on the degraded-quote guard, 7 on the FAB nav params, 1 on the balance-failure log.

## Not covered by automated gates

Every fix in this branch was found on a device, and three are only observable there: the R8 keep rule needs a **release** Android build (the flash does not reproduce in debug), the PBKDF2 speedup needs Hermes on real hardware, and the dark-card scrim needs an NFT theme in dark mode. Worth a device pass before release.

https://claude.ai/code/session_0179q9Ztt73XH5YHGMdpcwtX
